### PR TITLE
Migrate from Poetry to uv for faster dependency management

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,70 +29,271 @@ Seamless Chinese worship music playback system for Stream of Praise (SOP) and si
 
 ### Prerequisites
 
-1. **Docker Desktop** installed ([Download](https://www.docker.com/products/docker-desktop/))
+1. **Docker Desktop** installed and running ([Download](https://www.docker.com/products/docker-desktop/))
 2. **3-5 worship songs** in MP3 or FLAC format (test files)
+3. **Terminal/Command Prompt** access
 
-### Setup Steps
+### Step-by-Step Setup and Execution
+
+#### Step 1: Prepare Your Audio Files
 
 ```bash
-# 1. Clone repository (if not already done)
-git clone <your-repo-url>
-cd stream_of_worship
-
-# 2. Place your test songs in poc_audio/
+# Create the poc_audio directory if it doesn't exist (already exists in repo)
+# Place your test worship songs (MP3 or FLAC format) into poc_audio/
 cp /path/to/your/songs/*.mp3 poc_audio/
 
-# 3. Build Docker container
-docker-compose build
+# Verify files were copied
+ls poc_audio/
 ```
 
-### Running the Analysis
+**Expected output:** List of your audio files (e.g., `song1.mp3`, `song2.mp3`, etc.)
 
-**Option 1: Command-Line Script (Recommended)**
+#### Step 2: Build the Docker Image
+
+```bash
+# Build the Docker image (first time only, or after dependencies change)
+docker-compose build
+
+# This will take 3-5 minutes as it:
+# - Downloads Python 3.11 base image
+# - Installs system dependencies (ffmpeg, audio libraries)
+# - Installs Python packages (librosa, madmom, etc.)
+```
+
+**Expected output:**
+- Build progress messages
+- Final line: `Successfully tagged stream_of_worship_librosa:latest` or similar
+
+#### Step 3: Run the POC Analysis
+
+Choose **ONE** of the following two methods:
+
+---
+
+**Method A: Command-Line Script (Recommended)**
 
 Best for: Quick analysis, automation, debugging, CI/CD
 
 ```bash
-# Run the standalone POC analysis script
-docker-compose run --rm jupyter python poc/poc_analysis.py
-
-# Or, if container is already running:
-docker-compose exec jupyter python poc/poc_analysis.py
+# Run the POC analysis script in a one-off container
+docker-compose run --rm librosa python poc/poc_analysis.py
 ```
 
-**Option 2: Interactive Jupyter Notebook**
+**What happens:**
+1. Docker starts a new container from the built image
+2. Mounts your local `poc_audio/` and `poc_output/` directories
+3. Runs the analysis script
+4. Saves results to `poc_output/`
+5. Container automatically removed after completion (`--rm` flag)
+
+**Expected output:**
+```
+============================================================
+POC ANALYSIS - Worship Music Transition System
+============================================================
+
+Stage 1/7: Setup and Discovery
+--------------------------------------------------------------
+Found 3 audio files in poc_audio/
+Output directory: poc_output/
+
+Stage 2/7: Feature Extraction
+--------------------------------------------------------------
+[1/3] Analyzing: song1.mp3
+  ✓ Tempo: 120.0 BPM
+  ✓ Key: C major
+  ✓ Structure: 5 sections detected
+...
+```
+
+**Runtime:** ~30-60 seconds per song (e.g., 3 songs = ~2-3 minutes total)
+
+**Alternative (if container is already running):**
+```bash
+# If you have a running container from Method B, use exec instead:
+docker-compose exec librosa python poc/poc_analysis.py
+```
+
+---
+
+**Method B: Interactive Jupyter Notebook**
 
 Best for: Exploration, visualization, experimentation, learning
 
 ```bash
-# 1. Start Jupyter Lab
+# Step 1: Start Jupyter Lab server
 docker-compose up
 
-# 2. Open browser to: http://localhost:8888
-
-# 3. Navigate to notebooks/01_POC_Analysis.ipynb
-
-# 4. Run all cells: Menu → Run → Run All Cells
-
-# 5. Wait 2-5 minutes for analysis to complete
+# Keep this terminal window open - it shows server logs
 ```
 
-**Review outputs in `poc_output/` directory**
-
-### Expected Outputs
-
-After running the analysis (either method), you should see:
-
+**Expected output:**
 ```
-poc_output/
-├── poc_summary.csv                        # Summary table
-├── poc_full_results.json                  # Full analysis data
-├── poc_analysis_visualizations.png        # Song visualizations
-├── poc_compatibility_scores.csv           # Compatibility matrix
-├── poc_compatibility_heatmap.png          # Heatmap visualization
-├── transition_<songA>_to_<songB>.flac    # Sample transition audio
-└── transition_waveform.png                # Transition visualization
+[I 2024-01-01 12:00:00.000 ServerApp] Jupyter Server is running at:
+[I 2024-01-01 12:00:00.000 ServerApp] http://0.0.0.0:8888/lab
 ```
+
+```bash
+# Step 2: Open your web browser and navigate to:
+http://localhost:8888
+
+# Step 3: In the Jupyter Lab file browser (left sidebar):
+# - Click on "notebooks" folder
+# - Click on "01_POC_Analysis.ipynb"
+
+# Step 4: Run the analysis
+# - Menu → Run → Run All Cells
+# - Or press Shift+Enter repeatedly to run each cell
+
+# Step 5: Wait for analysis to complete
+# - Watch for completion indicators in each cell
+# - Final cell will print "POC Analysis Complete!"
+```
+
+**Runtime:** ~2-5 minutes for 3-5 songs (same as Method A, but with interactive visualization)
+
+```bash
+# Step 6: Stop Jupyter Lab when done
+# Press Ctrl+C in the terminal where docker-compose up is running
+# Then run:
+docker-compose down
+```
+
+---
+
+#### Step 4: Review Results
+
+```bash
+# Check the generated outputs
+ls -lh poc_output/
+
+# Expected files:
+# - poc_summary.csv                     (summary table)
+# - poc_full_results.json               (detailed data)
+# - poc_analysis_visualizations.png     (song charts)
+# - poc_compatibility_scores.csv        (compatibility matrix)
+# - poc_compatibility_heatmap.png       (heatmap)
+# - transition_<songA>_to_<songB>.flac (sample transition)
+# - transition_waveform.png             (transition visualization)
+```
+
+**View results:**
+```bash
+# Open summary CSV in spreadsheet app
+open poc_output/poc_summary.csv        # macOS
+xdg-open poc_output/poc_summary.csv    # Linux
+start poc_output/poc_summary.csv       # Windows
+
+# View visualizations
+open poc_output/poc_analysis_visualizations.png
+```
+
+---
+
+### Alternative: All-In-One Deep Learning Analysis
+
+The project includes an **experimental deep learning approach** using the `allin1` library for more advanced music analysis. This alternative method provides:
+
+- **ML-based beat/downbeat/tempo detection** (instead of librosa's signal processing)
+- **Automatic segment labeling** (intro, verse, chorus, bridge, outro)
+- **Audio embeddings** (24-dimensional feature vectors per stem)
+- **Comparison baseline** for evaluating traditional vs. deep learning approaches
+
+#### Prerequisites for All-In-One
+
+1. Same as above (Docker Desktop, audio files)
+2. **More disk space**: ~2-3 GB for PyTorch and deep learning models
+3. **Longer build time**: 10-20 minutes for first build (downloads models)
+
+#### Step 1: Build the All-In-One Docker Image
+
+```bash
+# Build the allinone Docker image using the separate docker-compose file
+docker compose -f docker-compose.allinone.yml build
+
+# This will take 10-20 minutes as it:
+# - Installs PyTorch (CPU-only for x86_64, standard for ARM64/M-series)
+# - Installs NATTEN library (neighborhood attention)
+# - Installs allin1 music analysis library
+# - Downloads pre-trained models on first run
+```
+
+**Expected output:**
+- Build progress messages for allinone image
+- Final line: `Successfully tagged allinone:latest` or similar
+
+#### Step 2: Run All-In-One POC Analysis
+
+```bash
+# Run the POC analysis using all-in-one deep learning models
+docker compose -f docker-compose.allinone.yml run --rm allinone python poc/poc_analysis_allinone.py
+```
+
+**What happens:**
+1. Docker starts container from allinone image
+2. Mounts `poc_audio/` (input) and `poc_output_allinone/` (output)
+3. Runs deep learning analysis with all-in-one models
+4. Saves results to `poc_output_allinone/`
+5. Container automatically removed after completion
+
+**Expected output:**
+```
+✓ All-in-one library loaded successfully
+============================================================
+POC ANALYSIS (All-In-One) - Worship Music Transition System
+============================================================
+
+Stage 1/7: Setup and Discovery
+--------------------------------------------------------------
+Found 3 audio files in poc_audio/
+Output directory: poc_output_allinone/
+
+Stage 2/7: Feature Extraction (Deep Learning)
+--------------------------------------------------------------
+[1/3] Analyzing: song1.mp3
+  Loading all-in-one models...
+  ✓ Beat tracking (ML): 120.5 BPM (confidence: 0.95)
+  ✓ Segment labels: intro → verse → chorus → verse → outro
+  ✓ Embeddings extracted (24-dim per stem)
+...
+```
+
+**Runtime:** ~2-3 minutes per song (longer than librosa due to model inference)
+- First run: Additional 1-2 minutes to download pre-trained models
+
+**Note:** Model weights are cached in `~/.cache/` and persisted between runs.
+
+#### Step 3: Review All-In-One Results
+
+```bash
+# Check the generated outputs
+ls -lh poc_output_allinone/
+
+# Expected files (similar to librosa output, plus embeddings):
+# - poc_allinone_summary.csv                (summary with ML predictions)
+# - poc_allinone_full_results.json          (detailed data + embeddings)
+# - poc_allinone_visualizations.png         (visualizations with ML labels)
+# - poc_allinone_compatibility_scores.csv   (compatibility matrix)
+# - poc_allinone_compatibility_heatmap.png  (heatmap)
+# - transition_allinone_<songA>_to_<songB>.flac
+# - transition_allinone_waveform.png
+```
+
+#### Comparison: Librosa vs. All-In-One
+
+| Feature | Librosa (Traditional) | All-In-One (Deep Learning) |
+|---------|----------------------|---------------------------|
+| **Tempo Detection** | Signal processing (onset envelopes) | Neural network (trained on labeled data) |
+| **Beat Tracking** | Dynamic programming | Transformer-based model |
+| **Segment Labels** | Generic (section_0, section_1) | Semantic (intro, verse, chorus) |
+| **Embeddings** | Hand-crafted features (MFCCs) | Learned 24-dim embeddings |
+| **Speed** | Fast (~30-60s per song) | Slower (~2-3 min per song) |
+| **Accuracy** | Good for most songs | Better on complex songs |
+| **Setup** | Lightweight | Requires PyTorch + models |
+
+**When to use each:**
+- **Librosa**: Quick POC, simpler setup, good enough for most worship music
+- **All-In-One**: Production system, complex song structures, need semantic labels
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 
 services:
-  jupyter:
+  librosa:
     build:
       context: .
       dockerfile: Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   librosa:
     build:

--- a/poc/README.md
+++ b/poc/README.md
@@ -13,10 +13,10 @@ python poc/poc_analysis.py
 ### Running from Host Machine
 ```bash
 # Option 1: Execute in running container
-docker-compose exec jupyter python poc/poc_analysis.py
+docker-compose exec librosa python poc/poc_analysis.py
 
 # Option 2: Run one-off command
-docker-compose run --rm jupyter python poc/poc_analysis.py
+docker-compose run --rm librosa python poc/poc_analysis.py
 ```
 
 ## Prerequisites

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,36 +1,13 @@
-[tool.poetry]
+[project]
 name = "worship-music-system"
 version = "0.1.0"
 description = "POC for seamless Chinese worship music transition system"
-authors = ["Your Name <your.email@example.com>"]
+authors = [{name = "Your Name", email = "your.email@example.com"}]
 readme = "README.md"
-license = "MIT"
+license = {text = "MIT"}
+requires-python = ">=3.11"
 
-[tool.poetry.dependencies]
-python = "^3.11"
-
-# Core audio analysis
-numpy = "^1.26.2"
-scipy = "^1.11.4"
-cython = "^3.0.0"
-librosa = "^0.10.1"
-soundfile = "^0.12.1"
-
-# Data manipulation and visualization
-pandas = "^2.1.4"
-matplotlib = "^3.8.2"
-seaborn = "^0.13.0"
-
-# Jupyter environment
-jupyterlab = "^4.0.9"
-ipykernel = "^6.27.1"
-ipywidgets = "^8.1.1"
-
-[tool.poetry.group.dev.dependencies]
-pytest = "^7.4.3"
-black = "^23.12.1"
-ruff = "^0.1.8"
-ipython = "^8.18.1"
+# Dependencies are now managed in requirements.txt
 
 [tool.black]
 line-length = 100
@@ -41,5 +18,5 @@ line-length = 100
 target-version = "py311"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["setuptools>=68.0"]
+build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,27 @@
+# Core audio analysis
+numpy>=1.26.2
+scipy>=1.11.4
+Cython>=3.0.0
+# librosa with compatible dependencies for Python 3.11
+numba>=0.58.0  # Ensure Python 3.11 compatible numba
+librosa>=0.10.1
+soundfile>=0.12.1
+
+# Music analysis (installed separately with --no-build-isolation)
+# madmom==0.16.1
+
+# Data manipulation and visualization
+pandas>=2.1.4
+matplotlib>=3.8.2
+seaborn>=0.13.0
+
+# Jupyter environment
+jupyterlab>=4.0.9
+ipykernel>=6.27.1
+ipywidgets>=8.1.1
+
+# Development tools (optional, included for convenience)
+pytest>=7.4.3
+black>=23.12.1
+ruff>=0.1.8
+ipython>=8.18.1

--- a/setup_poc.sh
+++ b/setup_poc.sh
@@ -69,7 +69,7 @@ fi
 echo ""
 echo "   OPTION A: Command-Line Script (Recommended)"
 echo "   ----------------------------------------"
-echo "   docker-compose run --rm jupyter python poc/poc_analysis.py"
+echo "   docker-compose run --rm librosa python poc/poc_analysis.py"
 echo ""
 echo "   OPTION B: Interactive Jupyter Notebook"
 echo "   ----------------------------------------"


### PR DESCRIPTION
## Summary
- Replace Poetry with uv package manager for 10-100x faster builds
- Convert dependency management to requirements.txt format
- Update pyproject.toml to PEP 621 standard format

## Changes
- **Dockerfile**: Replace Poetry installation with uv, simplify dependency installation
- **requirements.txt**: New file containing all project dependencies with explicit version constraints
- **pyproject.toml**: Convert from Poetry format to standard PEP 621 project metadata format

## Benefits
- **Faster builds**: uv is 10-100x faster than Poetry for package installation
- **Simpler configuration**: No virtualenv setup needed in Docker
- **Better compatibility**: Explicit numba version constraint fixes Python 3.11 compatibility issues
- **Improved control**: Separate handling for problematic packages like madmom

## Test Plan
- [x] Docker image builds successfully
- [ ] Jupyter Lab starts correctly with all dependencies
- [ ] Audio processing libraries (librosa, madmom) work as expected
- [ ] Development tools (black, ruff, pytest) function properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)