### PR TITLE
POC: Cleanup, optimizations, and silence-based transitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,7 +98,7 @@ ipython_config.py
 #   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
 #   This is especially recommended for binary packages to ensure reproducibility, and is more
 #   commonly ignored for libraries.
-#uv.lock
+uv.lock
 
 # poetry
 #   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.

--- a/poc/analyze_sections.py
+++ b/poc/analyze_sections.py
@@ -163,7 +163,7 @@ def extract_section_features(song_result, section_idx, audio_path, verbose=True)
         f"({section['start']:.1f}s - {section['end']:.1f}s)", verbose)
 
     # === AUDIO EXTRACTION ===
-    y, sr = librosa.load(audio_path, sr=44100, mono=False)
+    y, sr = librosa.load(str(audio_path), sr=44100, mono=False)
 
     # Convert to mono for analysis
     if y.ndim > 1:
@@ -543,6 +543,11 @@ def load_all_song_results(audio_dir, cache_dir, verbose=True):
                         h = compute_file_hash(audio_file)
                         full_result = load_from_cache(h, cache_dir)
                         if full_result:
+                            # Ensure _beats and _embeddings fields exist (cache format uses 'beats', code expects '_beats')
+                            if 'beats' in full_result and '_beats' not in full_result:
+                                full_result['_beats'] = full_result['beats']
+                            if 'embeddings' in full_result and '_embeddings' not in full_result:
+                                full_result['_embeddings'] = full_result['embeddings']
                             results.append(full_result)
                         else:
                             # Fallback if cache missing

--- a/poc/generate_section_transitions.py
+++ b/poc/generate_section_transitions.py
@@ -245,8 +245,8 @@ def generate_section_transition(song_a_path, song_b_path, section_a, section_b,
         (transition_audio, sample_rate)
     """
     # Load stereo audio for higher quality transition
-    y_a, sr = librosa.load(song_a_path, sr=CONFIG['sample_rate'], mono=False)
-    y_b, sr_b = librosa.load(song_b_path, sr=CONFIG['sample_rate'], mono=False)
+    y_a, sr = librosa.load(str(song_a_path), sr=CONFIG['sample_rate'], mono=False)
+    y_b, sr_b = librosa.load(str(song_b_path), sr=CONFIG['sample_rate'], mono=False)
 
     # Ensure stereo (2 channels)
     if y_a.ndim == 1:
@@ -311,8 +311,8 @@ def generate_medium_transition(song_a_path, song_b_path, section_a, section_b, c
         (transition_audio, sample_rate, actual_duration)
     """
     # Load stereo audio
-    y_a, sr = librosa.load(song_a_path, sr=CONFIG['sample_rate'], mono=False)
-    y_b, sr_b = librosa.load(song_b_path, sr=CONFIG['sample_rate'], mono=False)
+    y_a, sr = librosa.load(str(song_a_path), sr=CONFIG['sample_rate'], mono=False)
+    y_b, sr_b = librosa.load(str(song_b_path), sr=CONFIG['sample_rate'], mono=False)
 
     # Ensure stereo
     if y_a.ndim == 1:
@@ -377,8 +377,8 @@ def generate_long_transition(song_a_path, song_b_path, sections_a, sections_b,
         (transition_audio, sample_rate, actual_duration, sections_used_a, sections_used_b)
     """
     # Load stereo audio
-    y_a, sr = librosa.load(song_a_path, sr=CONFIG['sample_rate'], mono=False)
-    y_b, sr_b = librosa.load(song_b_path, sr=CONFIG['sample_rate'], mono=False)
+    y_a, sr = librosa.load(str(song_a_path), sr=CONFIG['sample_rate'], mono=False)
+    y_b, sr_b = librosa.load(str(song_b_path), sr=CONFIG['sample_rate'], mono=False)
 
     # Ensure stereo
     if y_a.ndim == 1:

--- a/poc/generate_transitions.py
+++ b/poc/generate_transitions.py
@@ -207,8 +207,8 @@ def create_simple_crossfade(song_a_path, song_b_path, crossfade_duration=8.0):
     Returns: (transition_audio, sample_rate)
     """
     # Load stereo audio for higher quality transition
-    y_a, sr = librosa.load(song_a_path, sr=CONFIG['sample_rate'], mono=False)
-    y_b, sr_b = librosa.load(song_b_path, sr=CONFIG['sample_rate'], mono=False)
+    y_a, sr = librosa.load(str(song_a_path), sr=CONFIG['sample_rate'], mono=False)
+    y_b, sr_b = librosa.load(str(song_b_path), sr=CONFIG['sample_rate'], mono=False)
 
     # Ensure stereo (2 channels)
     if y_a.ndim == 1:

--- a/poc/poc_analysis_allinone.py
+++ b/poc/poc_analysis_allinone.py
@@ -299,7 +299,7 @@ def analyze_song_allinone(filepath, cache_dir=None, use_cache=True):
         if cached_result is not None:
             # Cache HIT - need to recompute raw data for visualizations
             print(f"  Loading audio for visualization data...")
-            y, sr = librosa.load(filepath, sr=22050, mono=True)
+            y, sr = librosa.load(str(filepath), sr=22050, mono=True)
 
             # Add raw visualization data back
             cached_result['_y'] = y
@@ -325,7 +325,7 @@ def analyze_song_allinone(filepath, cache_dir=None, use_cache=True):
 
     # === LOAD AUDIO FOR KEY/ENERGY ANALYSIS ===
     # We still need librosa for key detection and energy metrics
-    y, sr = librosa.load(filepath, sr=22050, mono=True)
+    y, sr = librosa.load(str(filepath), sr=22050, mono=True)
     duration = librosa.get_duration(y=y, sr=sr)
     print(f"✓ Loaded: {duration:.1f}s @ {sr} Hz")
 
@@ -560,8 +560,8 @@ def create_simple_crossfade(song_a_path, song_b_path, crossfade_duration=8.0):
     print(f"\nCreating {crossfade_duration}s crossfade...")
 
     # Load stereo audio for higher quality transition
-    y_a, sr = librosa.load(song_a_path, sr=44100, mono=False)
-    y_b, sr_b = librosa.load(song_b_path, sr=44100, mono=False)
+    y_a, sr = librosa.load(str(song_a_path), sr=44100, mono=False)
+    y_b, sr_b = librosa.load(str(song_b_path), sr=44100, mono=False)
 
     # Ensure stereo (2 channels)
     if y_a.ndim == 1:

--- a/poc/poc_analysis_allinone.py
+++ b/poc/poc_analysis_allinone.py
@@ -17,6 +17,8 @@ import warnings
 warnings.filterwarnings('ignore')
 
 # Silence NATTEN deprecation warnings
+import os
+os.environ['NATTEN_LOG_LEVEL'] = 'error'
 import logging
 logging.getLogger('natten.functional').setLevel(logging.ERROR)
 

--- a/poc/review_transitions.py
+++ b/poc/review_transitions.py
@@ -513,6 +513,7 @@ def main():
     current_index = progress['current_index']
     reviewed_in_session = 0
     session_start = datetime.now()
+    quit_requested = False  # Flag to track intentional quit
 
     # Summary
     reviewed_count = sum(1 for t in transitions if t['review']['status'] != 'pending')
@@ -535,7 +536,8 @@ def main():
                     command = input("> ").strip().lower()
 
                     if command == 'q':
-                        # Quit
+                        # Quit - set flag and raise to exit both loops
+                        quit_requested = True
                         raise KeyboardInterrupt
 
                     elif command == 'h':
@@ -614,7 +616,10 @@ def main():
                         print(f"  Unknown command: {command}. Type 'h' for help")
 
                 except KeyboardInterrupt:
-                    # Handle Ctrl+C during playback
+                    # Re-raise if this was an intentional quit
+                    if quit_requested:
+                        raise
+                    # Otherwise, handle Ctrl+C during playback
                     stop_playback()
                     print()  # New line after ^C
                     continue

--- a/poc/review_transitions.py
+++ b/poc/review_transitions.py
@@ -242,7 +242,7 @@ def get_variant_path(transition, variant_type):
 
     Args:
         transition: Transition metadata dict
-        variant_type: 'short', 'medium', or 'long'
+        variant_type: 'medium-crossfade' or 'medium-silence'
 
     Returns:
         Path object or None if not found
@@ -563,10 +563,16 @@ def main():
                             else:
                                 print(f"  Invalid variant number. Choose 1-{len(transition['variants'])}")
                                 continue
-                        elif variant_spec in ['short', 'medium', 'long']:
-                            variant_type = variant_spec
+                        elif variant_spec in ['medium-crossfade', 'medium-silence', 'crossfade', 'silence']:
+                            # Support both full names and short names
+                            if variant_spec == 'crossfade':
+                                variant_type = 'medium-crossfade'
+                            elif variant_spec == 'silence':
+                                variant_type = 'medium-silence'
+                            else:
+                                variant_type = variant_spec
                         else:
-                            print(f"  Invalid variant. Use 1-3, 'short', 'medium', or 'long'")
+                            print(f"  Invalid variant. Use 1-2, 'crossfade', 'silence', 'medium-crossfade', or 'medium-silence'")
                             continue
 
                         # Get file path and play

--- a/poc/review_transitions.py
+++ b/poc/review_transitions.py
@@ -474,11 +474,12 @@ def show_help():
     print(f"\n{'─'*70}")
     print("COMMANDS:")
     print(f"{'─'*70}")
-    print("  p <variant>  - Play variant (e.g., 'p 1', 'p short', 'p long')")
+    print("  p <variant>  - Play variant (e.g., 'p 1', 'p crossfade', 'p silence')")
     print("  s            - Stop playback")
     print("  r            - Rate this transition")
     print("  n            - Next transition (without rating)")
     print("  b            - Previous transition")
+    print("  j <number>   - Jump to specific transition (e.g., 'j 5')")
     print("  i            - Show transition info again")
     print("  q            - Quit and save progress")
     print("  h            - Help")
@@ -523,7 +524,10 @@ def main():
     print(f"Type 'h' for help, 'q' to quit\n")
 
     try:
-        while current_index < len(transitions):
+        while True:
+            # Ensure current_index stays within bounds (wrap around)
+            current_index = current_index % len(transitions)
+
             transition = transitions[current_index]
 
             # Display transition info
@@ -606,11 +610,25 @@ def main():
 
                     elif command == 'b':
                         # Previous transition
-                        if current_index > 0:
-                            current_index -= 1
-                            break
-                        else:
-                            print("  Already at first transition")
+                        current_index -= 1
+                        break
+
+                    elif command.startswith('j'):
+                        # Jump to specific transition
+                        parts = command.split()
+                        if len(parts) < 2:
+                            print(f"  Usage: j <number> (e.g., 'j 5' to jump to transition 5)")
+                            continue
+
+                        try:
+                            target = int(parts[1])
+                            if 1 <= target <= len(transitions):
+                                current_index = target - 1
+                                break
+                            else:
+                                print(f"  Invalid transition number. Choose 1-{len(transitions)}")
+                        except ValueError:
+                            print("  Please enter a valid number")
 
                     else:
                         print(f"  Unknown command: {command}. Type 'h' for help")

--- a/process_songs_native.sh
+++ b/process_songs_native.sh
@@ -1,0 +1,4 @@
+python poc/poc_analysis_allinone.py
+python poc/analyze_sections.py
+python poc/generate_transitions.py
+python poc/generate_section_transitions.py


### PR DESCRIPTION
## Summary

This PR introduces several cleanup improvements, performance optimizations, and a new silence-based transition variant for the worship music transition system.

## Key Changes

### 🎵 Transition System Refactoring (v2.1.0)
- **Remove** short (crossfade-only) and long (extended context) transition variants
- **Rename** medium → medium-crossfade for clarity
- **Add** medium-silence variant with tempo-based silence gaps
  - Silence duration calculated from Song A tempo: `(60 / BPM) * beats`
  - Configurable via `--silence-beats` CLI argument (default: 4)
  - Equal-power fades (1s) around silence gap
- Update metadata schema and reporting for new variant types
- Update review tool to support new variant names (accepts 'crossfade', 'silence', etc.)

### 🚀 Performance Optimizations
- Optimize section analysis loading via cache consolidation
- First checks for existing `poc_full_results.json` output
- Falls back to individual cache files or re-analysis only if needed
- Significantly faster startup when analysis already exists

### 🐛 Bug Fixes
- Fix librosa.load() path handling for corrupted MP3 files
  - Convert Path objects to strings before passing to librosa
  - Ensures audioread library fallback works correctly
- Silence NATTEN deprecation warnings
  - Set `NATTEN_LOG_LEVEL` environment variable to 'error'
  - Required because NATTEN overrides logger levels during initialization

### 🔧 Environment & Config
- Use local uv venv for dependency management
- Add uv.lock to .gitignore

## Test Plan

- [x] Verify transition generation works with new variants
- [x] Test `--silence-beats` CLI argument with different values
- [x] Confirm metadata schema is correct
- [x] Check review tool accepts new variant names
- [x] Validate cache loading optimization works

## Breaking Changes

⚠️ **Transition variant types have changed:**
- Old: `short`, `medium`, `long`
- New: `medium-crossfade`, `medium-silence`

Existing transition metadata files will need regeneration.

## Examples

Generate transitions with 8 beats of silence:
```bash
python poc/generate_section_transitions.py --silence-beats 8
```

Review transitions (accepts short names):
```bash
python poc/review_transitions.py
# Play variants: 'crossfade' or 'silence'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)