### PR TITLE
Add stem-based transition variants with CLI-controlled generation

### DIFF
--- a/poc/review_transitions.py
+++ b/poc/review_transitions.py
@@ -213,18 +213,24 @@ def display_transition_info(transition, index):
     # Variants available
     print(f"\nAvailable Variants:")
     for idx, variant in enumerate(transition['variants'], 1):
-        variant_type = variant['variant_type'].upper()
+        variant_type = variant['variant_type']
+        variant_type_upper = variant_type.upper()
         duration = variant['total_duration']
         size = variant['file_size_mb']
 
-        if variant_type == 'SHORT':
-            desc = "Crossfade only"
-        elif variant_type == 'MEDIUM':
+        # Description based on variant type
+        if variant_type == 'medium-crossfade':
             desc = "Full sections with crossfade"
-        else:  # LONG
-            desc = "Extended context (2 sections each)"
+        elif variant_type == 'medium-silence':
+            desc = f"Full sections with {variant.get('silence_beats', 4)}-beat silence gap"
+        elif variant_type == 'vocal-fade':
+            desc = f"Vocal-only bridge ({variant.get('transition_beats', 8)}-beat transition)"
+        elif variant_type == 'drum-fade':
+            desc = f"Drum-only bridge ({variant.get('transition_beats', 8)}-beat transition)"
+        else:
+            desc = "Unknown variant type"
 
-        print(f"  [{idx}] {variant_type:<6} ({duration:5.1f}s, {size:5.2f} MB) - {desc}")
+        print(f"  [{idx}] {variant_type_upper:<18} ({duration:5.1f}s, {size:5.2f} MB) - {desc}")
 
     # Review status
     review = transition['review']
@@ -242,7 +248,7 @@ def get_variant_path(transition, variant_type):
 
     Args:
         transition: Transition metadata dict
-        variant_type: 'medium-crossfade' or 'medium-silence'
+        variant_type: 'medium-crossfade', 'medium-silence', 'vocal-fade', or 'drum-fade'
 
     Returns:
         Path object or None if not found
@@ -474,7 +480,7 @@ def show_help():
     print(f"\n{'─'*70}")
     print("COMMANDS:")
     print(f"{'─'*70}")
-    print("  p <variant>  - Play variant (e.g., 'p 1', 'p crossfade', 'p silence')")
+    print("  p <variant>  - Play variant (e.g., 'p 1', 'p crossfade', 'p vocal', 'p drum')")
     print("  s            - Stop playback")
     print("  r            - Rate this transition")
     print("  n            - Next transition (without rating)")
@@ -569,16 +575,21 @@ def main():
                             else:
                                 print(f"  Invalid variant number. Choose 1-{len(transition['variants'])}")
                                 continue
-                        elif variant_spec in ['medium-crossfade', 'medium-silence', 'crossfade', 'silence']:
+                        elif variant_spec in ['medium-crossfade', 'medium-silence', 'vocal-fade', 'drum-fade',
+                                              'crossfade', 'silence', 'vocal', 'drum']:
                             # Support both full names and short names
                             if variant_spec == 'crossfade':
                                 variant_type = 'medium-crossfade'
                             elif variant_spec == 'silence':
                                 variant_type = 'medium-silence'
+                            elif variant_spec == 'vocal':
+                                variant_type = 'vocal-fade'
+                            elif variant_spec == 'drum':
+                                variant_type = 'drum-fade'
                             else:
                                 variant_type = variant_spec
                         else:
-                            print(f"  Invalid variant. Use 1-2, 'crossfade', 'silence', 'medium-crossfade', or 'medium-silence'")
+                            print(f"  Invalid variant. Use 1-4, 'crossfade', 'silence', 'vocal', 'drum', or full names")
                             continue
 
                         # Get file path and play

--- a/poc/review_transitions.py
+++ b/poc/review_transitions.py
@@ -224,7 +224,8 @@ def display_transition_info(transition, index):
         elif variant_type == 'medium-silence':
             desc = f"Full sections with {variant.get('silence_beats', 4)}-beat silence gap"
         elif variant_type == 'vocal-fade':
-            desc = f"Vocal-only bridge ({variant.get('transition_beats', 8)}-beat transition)"
+            silence = variant.get('silence_beats', 1)
+            desc = f"Vocal-only bridge ({variant.get('transition_beats', 8)}-beat transition, {silence}-beat gap)"
         elif variant_type == 'drum-fade':
             desc = f"Drum-only bridge ({variant.get('transition_beats', 8)}-beat transition)"
         else:


### PR DESCRIPTION
## Summary

This PR adds **stem-based music transitions** with intelligent fade transitions using AI-separated audio stems (vocals, drums, bass, other). Introduces two new transition variants and a CLI interface for controlling stem generation in the analysis pipeline.

### New Features

- **Vocal-Fade Transitions**: 8-beat transitions that fade out instrumental stems while keeping vocals prominent, creating a smooth vocal bridge between songs with a 1-beat silence gap
- **Drum-Fade Transitions**: 4-beat transitions that fade out non-drum stems while keeping drums prominent, creating a rhythmic bridge between songs with a 1-beat silence gap  
- **CLI-Controlled Stem Generation**: Added command-line interface to `poc_analysis_allinone.py` with argparse support for:
  - `--generate-stems`: Generate Demucs stem separations
  - `--stems-only`: Skip analysis, only generate stems
  - `--stem-model`: Choose Demucs model (htdemucs, demucs, etc.)
  - `--stem-device`: Select CPU or CUDA processing
  - `--force-stems`: Regenerate existing stems
- **Interrupt-Resilient Processing**: Stems are processed one-at-a-time, allowing safe interruption without losing all progress

### Technical Details

**Vocal-Fade Algorithm**:
1. Last 8 beats of Song A: fade out bass/drums/other over 4 beats, then 4 beats vocals-only
2. 1 beat of silence (using Song A tempo)
3. First 8 beats of Song B: 4 beats vocals-only, then fade in bass/drums/other over 4 beats

**Drum-Fade Algorithm**:
1. Last 4 beats of Song A: fade out bass/vocals/other over 2 beats, then 2 beats drums-only
2. 1 beat of silence (using Song A tempo)
3. First 4 beats of Song B: 2 beats drums-only, then fade in bass/vocals/other over 2 beats

**Implementation Highlights**:
- Equal-power fade curves for smooth transitions
- Tempo-aware beat calculations for each song
- Comprehensive metadata tracking for each variant
- Stem loading with proper error handling and file validation

### Files Changed

- `poc/generate_section_transitions.py` (+543 lines): Core transition generation with vocal-fade and drum-fade implementations
- `poc/poc_analysis_allinone.py` (+273 lines): CLI argument parsing and stem generation integration
- `poc/review_transitions.py` (+34 lines): Support for reviewing new transition variants

### Usage Examples

```bash
# Generate stems during analysis
python poc/poc_analysis_allinone.py --generate-stems

# Generate only stems (use cached analysis)
python poc/poc_analysis_allinone.py --stems-only

# Force regenerate stems with GPU
python poc/poc_analysis_allinone.py --generate-stems --force-stems --stem-device cuda

# Generate transitions (automatically detects available stems)
python poc/generate_section_transitions.py
```

### Output Structure

Transitions are organized by variant type:
```
poc_output_allinone/audio/
├── medium-crossfade/     # Original full-section crossfades
├── medium-silence/       # Original silence-gap transitions
├── vocal-fade/           # NEW: Vocal-bridge transitions
└── drum-fade/            # NEW: Drum-bridge transitions
```

### Migration Notes

- Existing transitions (medium-crossfade, medium-silence) remain unchanged
- New variants require stem generation: `--generate-stems` flag
- Stems are cached and reused across runs
- Graceful fallback: If stems unavailable, vocal-fade and drum-fade variants are skipped with informative warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)