### PR TITLE
refactor: use song_id as user-facing identifier for audio commands

### DIFF
--- a/report/current_impl_status.md
+++ b/report/current_impl_status.md
@@ -51,12 +51,9 @@ The Stream of Worship project consists of an Admin CLI for backend management, a
   - Retry logic with exponential backoff
   - Artist and song listing extraction
 - Catalog commands (`src/stream_of_worship/admin/commands/catalog.py`)
-  - `catalog scrape-artists` - Scrape artist catalog from sop.org
-  - `catalog scrape-songs` - Scrape songs for specific artists
-  - `catalog import` - Import catalog from JSON
-  - `catalog export` - Export catalog to JSON
+  - `catalog scrape` - Scrape song catalog from sop.org
   - `catalog list` - List catalog entries with filters
-  - `catalog stats` - Show catalog statistics
+  - `catalog show <song_id>` - Show song details with recording panel (if audio exists)
   - `catalog search` - Search catalog by keyword
 
 **Tests:**
@@ -83,9 +80,11 @@ The Stream of Worship project consists of an Admin CLI for backend management, a
   - 12-character hash prefix generation
   - Deduplication support
 - Audio commands (`src/stream_of_worship/admin/commands/audio.py`)
-  - `audio download` - Download from YouTube and upload to R2
-  - `audio list` - List downloaded recordings
-  - `audio show` - Show recording details
+  - `audio download <song_id>` - Download from YouTube and upload to R2
+  - `audio list` - List downloaded recordings (shows Song ID as primary column)
+  - `audio show <song_id>` - Show recording details by song ID
+  - `audio analyze <song_id>` - Submit recording for analysis by song ID
+  - `audio status` - Check analysis status (shows Song ID as primary column)
 
 **Download Pipeline:**
 ```
@@ -227,16 +226,17 @@ For GPU acceleration, ensure:
   - `JobInfo` dataclass for job status tracking
   - Methods: `health_check()`, `submit_analysis()`, `get_job()`, `wait_for_completion()`
 - Audio commands integration (`src/stream_of_worship/admin/commands/audio.py`)
-  - `audio analyze` - Submit recording for analysis
-    - Resolves identifier as song_id or hash_prefix
+  - `audio analyze <song_id>` - Submit recording for analysis by song_id
     - `--force` flag for re-analysis
     - `--no-stems` to skip stem separation
     - `--wait` with Rich progress display (spinner, bar, stage)
     - Handles already-completed and already-processing states
   - `audio status` - Check analysis status
     - Query specific job by ID
-    - List pending recordings when no ID provided
+    - List pending recordings when no ID provided (shows Song ID as primary column)
     - Color-coded status display
+  - `audio show <song_id>` - Show recording details by song_id
+  - `audio list` - List recordings with Song ID as primary column
 - Database updates (`src/stream_of_worship/admin/db/client.py`)
   - `update_recording_analysis()` with `r2_stems_url` parameter
   - Status tracking for analysis and LRC jobs

--- a/src/stream_of_worship/admin/commands/catalog.py
+++ b/src/stream_of_worship/admin/commands/catalog.py
@@ -390,6 +390,49 @@ def show_song(
         border_style="green",
     ))
 
+    # Recording panel
+    recording = db_client.get_recording_by_song_id(song_id)
+    if recording:
+        recording_lines = ["[cyan]Audio Available:[/cyan] [green]✓[/green]"]
+        recording_lines.append(f"[cyan]Hash Prefix:[/cyan] {recording.hash_prefix}")
+
+        if recording.file_size_bytes:
+            size_mb = recording.file_size_bytes / (1024 * 1024)
+            recording_lines.append(f"[cyan]File Size:[/cyan] {size_mb:.1f} MB")
+
+        if recording.duration_seconds:
+            minutes = int(recording.duration_seconds // 60)
+            secs = int(recording.duration_seconds % 60)
+            recording_lines.append(f"[cyan]Duration:[/cyan] {minutes}:{secs:02d}")
+
+        # Analysis status
+        if recording.analysis_status == "completed":
+            analysis_text = "[green]completed[/green]"
+        elif recording.analysis_status == "failed":
+            analysis_text = "[red]failed[/red]"
+        elif recording.analysis_status == "processing":
+            analysis_text = "[yellow]processing[/yellow]"
+        else:
+            analysis_text = f"[dim]{recording.analysis_status}[/dim]"
+        recording_lines.append(f"[cyan]Analysis:[/cyan] {analysis_text}")
+
+        # LRC status
+        if recording.lrc_status == "completed":
+            lrc_text = "[green]completed[/green]"
+        elif recording.lrc_status == "failed":
+            lrc_text = "[red]failed[/red]"
+        elif recording.lrc_status == "processing":
+            lrc_text = "[yellow]processing[/yellow]"
+        else:
+            lrc_text = f"[dim]{recording.lrc_status}[/dim]"
+        recording_lines.append(f"[cyan]LRC:[/cyan] {lrc_text}")
+
+        console.print(Panel.fit(
+            "\n".join(recording_lines),
+            title="Recording",
+            border_style="green",
+        ))
+
     # Lyrics panel
     lyrics_list = song.lyrics_list
     if lyrics_list:


### PR DESCRIPTION
## Summary

Refactors audio commands to use `song_id` as the user-facing identifier instead of `hash_prefix`. The internal hash prefix is still used for R2 storage paths, but users no longer need to work with cryptic hash IDs.

## Changes

### Audio Commands (`audio.py`)
- **`audio show <song_id>`** - Changed from hash_prefix to song_id
- **`audio analyze <song_id>`** - Changed from dual lookup (song_id or hash_prefix) to song_id directly
- **`audio list`** - Reordered columns: Song ID and Song Title are now primary, hash_prefix is secondary (for reference)
- **`audio status`** (pending mode) - Reordered columns to show Song ID first

### Catalog Commands (`catalog.py`)
- **`catalog show <song_id>`** - Added Recording panel when song has associated audio:
  - Audio Available: ✓
  - Hash Prefix (for reference)
  - File Size, Duration
  - Analysis status
  - LRC status

### Tests
- Updated all audio command tests to use song_id-based interface

## User Experience

**Before:**
```bash
sow-admin audio download song_0001
# Downloads, prints "hash_prefix: a1b2c3d4e5f6"
sow-admin audio show a1b2c3d4e5f6  # Have to use hash!
sow-admin audio analyze a1b2c3d4e5f6  # Have to use hash!
```

**After:**
```bash
sow-admin audio download song_0001
sow-admin audio show song_0001  # Use song_id!
sow-admin audio analyze song_0001  # Use song_id!

# Batch operations are simpler:
sow-admin catalog list --album "敬拜讚美15" --format ids | \
  xargs -I{} sow-admin audio download {}
sow-admin catalog list --album "敬拜讚美15" --format ids | \
  xargs -I{} sow-admin audio analyze {}
```

## Verification

All 276 admin CLI tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)