### PR TITLE
fix: Qwen3 service Docker and R2 URL fixes

### DIFF
--- a/services/analysis/docker-compose.yml
+++ b/services/analysis/docker-compose.yml
@@ -78,12 +78,13 @@ services:
     ports:
       - "8001:8000"  # Different port to avoid conflict with analysis service
     environment:
-      SOW_QWEN3_MODEL_PATH: /models/qwen3-forced-aligner
       SOW_QWEN3_DEVICE: ${SOW_QWEN3_DEVICE:-auto}
       SOW_QWEN3_DTYPE: ${SOW_QWEN3_DTYPE:-float32}
       SOW_QWEN3_MAX_CONCURRENT: ${SOW_QWEN3_MAX_CONCURRENT:-1}
       SOW_QWEN3_CACHE_DIR: /cache
       SOW_QWEN3_API_KEY: ${SOW_QWEN3_API_KEY:-}
+      # Model path inside container - points to snapshot within the mounted HF cache
+      SOW_QWEN3_MODEL_PATH: /models/hf-model/snapshots/${SOW_QWEN3_MODEL_SNAPSHOT}
       # R2 credentials (reuse from common env)
       SOW_QWEN3_R2_BUCKET: ${SOW_R2_BUCKET}
       SOW_QWEN3_R2_ENDPOINT_URL: ${SOW_R2_ENDPOINT_URL}
@@ -91,7 +92,8 @@ services:
       SOW_QWEN3_R2_SECRET_ACCESS_KEY: ${SOW_R2_SECRET_ACCESS_KEY}
     volumes:
       - qwen3-cache:/cache
-      - ${SOW_QWEN3_MODEL_VOLUME}:/models/qwen3-forced-aligner:ro
+      # Mount entire HuggingFace model directory to preserve symlink structure
+      - ${SOW_QWEN3_MODEL_ROOT}:/models/hf-model:ro
     deploy:
       resources:
         limits:
@@ -108,14 +110,19 @@ services:
         - DEV_MODE=true
     ports:
       - "8001:8000"
+    networks:
+      default:
+        aliases:
+          - qwen3  # Allow analysis service to connect via "qwen3" hostname
     environment:
-      SOW_QWEN3_MODEL_PATH: /models/qwen3-forced-aligner
       SOW_QWEN3_DEVICE: ${SOW_QWEN3_DEVICE:-auto}
       SOW_QWEN3_DTYPE: ${SOW_QWEN3_DTYPE:-float32}
       SOW_QWEN3_MAX_CONCURRENT: ${SOW_QWEN3_MAX_CONCURRENT:-1}
       SOW_QWEN3_CACHE_DIR: /cache
       SOW_QWEN3_API_KEY: ${SOW_QWEN3_API_KEY:-}
       DEV_MODE: "true"
+      # Model path inside container - points to snapshot within the mounted HF cache
+      SOW_QWEN3_MODEL_PATH: /models/hf-model/snapshots/${SOW_QWEN3_MODEL_SNAPSHOT}
       # R2 credentials (reuse from common env)
       SOW_QWEN3_R2_BUCKET: ${SOW_R2_BUCKET}
       SOW_QWEN3_R2_ENDPOINT_URL: ${SOW_R2_ENDPOINT_URL}
@@ -123,7 +130,8 @@ services:
       SOW_QWEN3_R2_SECRET_ACCESS_KEY: ${SOW_R2_SECRET_ACCESS_KEY}
     volumes:
       - qwen3-cache:/cache
-      - ${SOW_QWEN3_MODEL_VOLUME}:/models/qwen3-forced-aligner:ro
+      # Mount entire HuggingFace model directory to preserve symlink structure
+      - ${SOW_QWEN3_MODEL_ROOT}:/models/hf-model:ro
       - ../qwen3/src:/workspace/src:ro
     deploy:
       resources:

--- a/services/analysis/src/sow_analysis/workers/lrc.py
+++ b/services/analysis/src/sow_analysis/workers/lrc.py
@@ -532,11 +532,11 @@ def _parse_qwen3_lrc(lrc_content: str) -> List[LRCLine]:
     return lines
 
 
-async def _qwen3_refine(hash_prefix: str, lyrics_text: str) -> str:
+async def _qwen3_refine(content_hash: str, lyrics_text: str) -> str:
     """Run Qwen3 forced alignment for timestamp refinement.
 
     Args:
-        hash_prefix: Audio file hash prefix for R2 URL construction
+        content_hash: Full content hash (will be truncated to 12-char prefix)
         lyrics_text: Lyrics text to align with audio
 
     Returns:
@@ -546,7 +546,9 @@ async def _qwen3_refine(hash_prefix: str, lyrics_text: str) -> str:
         Exception: If Qwen3 service call fails
     """
     # Construct R2 URL in s3:// format
-    audio_url = f"s3://{settings.SOW_R2_BUCKET}/audio/{hash_prefix}.mp3"
+    # Audio files are stored at: s3://{bucket}/{12-char-hash-prefix}/audio.mp3
+    hash_prefix = content_hash[:12]
+    audio_url = f"s3://{settings.SOW_R2_BUCKET}/{hash_prefix}/audio.mp3"
     logger.info(f"Constructing R2 audio URL: {audio_url}")
 
     # Instantiate Qwen3 client
@@ -731,7 +733,7 @@ async def generate_lrc(
                 # Proceed with Qwen3 refinement
                 try:
                     refined_lrc_text = await _qwen3_refine(
-                        hash_prefix=content_hash,
+                        content_hash=content_hash,
                         lyrics_text=lyrics_text,
                     )
                     # Parse refined LRC to update lrc_lines

--- a/services/qwen3/.env.example
+++ b/services/qwen3/.env.example
@@ -80,7 +80,22 @@ TARGETPLATFORM=linux/amd64
 # Options: linux/amd64, linux/arm64
 # Docker Compose only: used in build args for multi-platform support
 
-SOW_QWEN3_MODEL_VOLUME=/models/qwen3-forced-aligner
-# Docker Compose volume mount path for model directory
-# Maps host path to container path for model files
-# Only used in docker-compose.yml, not read by the application
+# ========================================
+# Docker Volume Mount (for HuggingFace cache)
+# ========================================
+# HuggingFace caches models with symlinks (snapshots/ -> blobs/).
+# To preserve symlinks in Docker, mount the PARENT directory.
+
+SOW_QWEN3_MODEL_ROOT=/home/user/.cache/huggingface/hub/models--Qwen--Qwen3-ForcedAligner-0.6B
+# Parent HuggingFace cache directory (contains blobs/ and snapshots/)
+# Find this path after downloading the model:
+#   ls ~/.cache/huggingface/hub/ | grep Qwen
+
+SOW_QWEN3_MODEL_SNAPSHOT=c7cbfc2048c462b0d63a45797104fc9db3ad62b7
+# Snapshot hash from HuggingFace cache
+# Find this by listing the snapshots directory:
+#   ls ~/.cache/huggingface/hub/models--Qwen--Qwen3-ForcedAligner-0.6B/snapshots/
+
+# These are used in docker-compose.yml to set:
+#   - Volume mount: ${SOW_QWEN3_MODEL_ROOT}:/models/hf-model:ro
+#   - Environment: SOW_QWEN3_MODEL_PATH=/models/hf-model/snapshots/${SOW_QWEN3_MODEL_SNAPSHOT}

--- a/services/qwen3/Dockerfile
+++ b/services/qwen3/Dockerfile
@@ -20,8 +20,12 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 ENV UV_SYSTEM_PYTHON=1
 ENV UV_COMPILE_BYTECODE=1
 
+# Install CPU-only PyTorch first to avoid CUDA dependencies
+# (qwen3 service typically runs on CPU-only hosts)
+RUN uv pip install --no-cache torch --index-url https://download.pytorch.org/whl/cpu
+
 # Copy and install service dependencies
-# qwen-asr includes PyTorch as a dependency
+# qwen-asr includes PyTorch as a dependency - CPU version already installed above
 COPY pyproject.toml .
 RUN uv pip install --no-cache --no-build-isolation -e ".[service]"
 

--- a/services/qwen3/docker-compose.yml
+++ b/services/qwen3/docker-compose.yml
@@ -3,7 +3,6 @@ version: '3.8'
 
 # Common environment variables (YAML anchor for reuse)
 x-common-env: &common-env
-  SOW_QWEN3_MODEL_PATH: /models/qwen3-forced-aligner
   SOW_QWEN3_DEVICE: ${SOW_QWEN3_DEVICE:-auto}
   SOW_QWEN3_DTYPE: ${SOW_QWEN3_DTYPE:-float32}
   SOW_QWEN3_MAX_CONCURRENT: ${SOW_QWEN3_MAX_CONCURRENT:-1}
@@ -48,6 +47,10 @@ services:
         - DEV_MODE=true
     ports:
       - "8000:8000"
+    networks:
+      default:
+        aliases:
+          - qwen3  # Allow clients to connect via "qwen3" hostname
     environment:
       <<: *common-env
       DEV_MODE: "true"


### PR DESCRIPTION
## Summary
- Fix Docker networking and model mount issues for Qwen3 service
- Correct R2 audio URL path construction (files stored at `{hash_prefix}/audio.mp3`)

## Test plan
- [ ] Run LRC generation with Qwen3 refinement enabled
- [ ] Verify Qwen3 service can access audio files from R2