### PR TITLE
Add logging for LRC-ready song count and update health check

### DIFF
--- a/examples/sow-admin-config.toml
+++ b/examples/sow-admin-config.toml
@@ -1,0 +1,105 @@
+# Admin CLI Configuration Example
+# Stream of Worship (sow-admin)
+# ================================================
+
+# The Admin CLI is the backend management tool that manages the song catalog,
+# downloads audio, and coordinates with the Analysis Service.
+#
+# Place this file at: ~/.config/sow-admin/config.toml
+# Or use the --config flag: sow-admin --config /path/to/config.toml
+
+# ================================================
+# [database] - SQLite Database Settings
+# ================================================
+[database]
+# Path to the local SQLite database file.
+# This stores song metadata, catalog info, and download status.
+# The database can sync with Turso cloud for multi-device access.
+path = "/Users/you/.local/share/sow-admin/sow.db"
+
+# ================================================
+# [r2] - Cloudflare R2 Object Storage Settings
+# ================================================
+[r2]
+# Your R2 bucket name (e.g., "stream-of-worship-audio")
+# Used for storing audio files and analysis artifacts
+bucket = "your-r2-bucket"
+
+# R2 endpoint URL - specific to your Cloudflare account
+# Format: https://<account-id>.r2.cloudflarestorage.com
+endpoint_url = "https://your-account.r2.cloudflarestorage.com"
+
+# Region - typically "auto" for R2, but can be set if needed
+region = "auto"
+
+# Note: R2 credentials (access key and secret key) should be set via
+# environment variables for security (see below)
+
+# ================================================
+# [service] - External Service URLs
+# ================================================
+[service]
+# URL of the Analysis Service (microservice running in Docker)
+# The Admin CLI submits audio analysis jobs to this service
+analysis_url = "http://localhost:8000"
+
+# ================================================
+# [turso] - Turso Database Sync Settings
+# ================================================
+[turso]
+# Turso cloud database URL for syncing
+# Format: https://<database-name>-<username>.turso.io
+# or libsql://<database-name>-<username>.turso.io
+# The Admin CLI syncs TO Turso (write operations)
+# The User App syncs FROM Turso (read-only)
+database_url = "https://your-db.turso.io"
+
+# ================================================
+# [logging] - Logging Configuration
+# ================================================
+[logging]
+# Log level: DEBUG, INFO, WARNING, ERROR, CRITICAL
+# Use DEBUG for troubleshooting, INFO for normal operation
+level = "INFO"
+
+# Optional: Log file path (if not set, logs to console only)
+# file = "/Users/you/.local/share/sow-admin/logs/sow-admin.log"
+
+# ================================================
+# Environment Variables (Override Config File)
+# ================================================
+# For security, sensitive values can be set via environment variables.
+# Environment variables take precedence over values in this file.
+#
+# Required Environment Variables:
+#   SOW_R2_ACCESS_KEY_ID       - Your R2 access key ID
+#   SOW_R2_SECRET_ACCESS_KEY   - Your R2 secret access key
+#
+# Optional Environment Variables:
+#   SOW_R2_BUCKET              - Override R2 bucket name
+#   SOW_R2_ENDPOINT_URL        - Override R2 endpoint URL
+#   SOW_TURSO_AUTH_TOKEN       - Turso authentication token (for admin writes)
+#
+# Example .bashrc/.zshrc additions:
+#   export SOW_R2_ACCESS_KEY_ID="your-access-key-id"
+#   export SOW_R2_SECRET_ACCESS_KEY="your-secret-access-key"
+
+# ================================================
+# Quick Reference: Common Commands
+# ================================================
+# db init                      - Initialize the database
+# db status                    - Check database and sync status
+# catalog scrape               - Scrape all songs from sop.org
+# catalog scrape --incremental - Only scrape new songs
+# audio download --song-id "xx"  - Download audio for a specific song
+# audio analyze --recording-id   - Submit audio for ML analysis
+# songset create --name "xxx"    - Create a new songset
+
+# ================================================
+# Security Best Practices
+# ================================================
+# 1. NEVER commit this file with real credentials to version control
+# 2. Add ~/.config/sow-admin/ to your .gitignore
+# 3. Use environment variables for all sensitive values
+# 4. Rotate R2 access keys regularly
+# 5. Use read-only Turso tokens for User App, full access for Admin CLI

--- a/examples/sow-app-config.toml
+++ b/examples/sow-app-config.toml
@@ -1,0 +1,194 @@
+# User App Configuration Example
+# Stream of Worship (sow-app)
+# ================================================
+
+# The User App is the interactive TUI for worship leaders to browse songs,
+# create multi-song sets with smooth transitions, and export lyrics videos.
+#
+# Place this file at: ~/.config/sow/config.toml
+# Or use the --config flag: sow-app run --config /path/to/config.toml
+
+# ================================================
+# [database] - Local Database Paths
+# ================================================
+[database]
+# Path to the main database (synced from Turso cloud).
+# This is a read-only local cache of the cloud catalog.
+# The User App never writes directly to Turso - it only syncs FROM Turso.
+db_path = "/Users/you/.config/sow/db/sow.db"
+
+# Path to the songsets database (local-only, stores your created songsets).
+# This stores your custom songsets, transition settings, and export history.
+# This database is NOT synced to cloud - it's personal to your device.
+songsets_db_path = "/Users/you/.config/sow/db/songsets.db"
+
+# ================================================
+# [turso] - Turso Cloud Database Sync Settings
+# ================================================
+[turso]
+# Turso database URL for syncing FROM cloud.
+# Format: libsql://<database-name>-<username>.turso.io
+# NOTE: Use the libsql:// protocol for embedded replicas (faster sync)
+database_url = "libsql://your-db.turso.io"
+
+# READ-ONLY authentication token (safety feature).
+# The User App only needs to READ from Turso, never write.
+# This token should have read-only permissions.
+# 
+# To generate this token:
+#   turso db tokens create sow-catalog --read-only
+#
+# IMPORTANT: Never use a full-access token here - it could accidentally
+# corrupt the catalog if there's a bug in the sync logic.
+readonly_token = "your-readonly-token-here"
+
+# Automatically sync with Turso when the app starts.
+# If false, you'll need to manually run: sow-app db sync
+# Recommended: true for most users
+sync_on_startup = true
+
+# Sync interval in minutes (0 = only sync on startup/manual sync).
+# Background sync keeps your local cache up to date.
+sync_interval = 30
+
+# ================================================
+# [app] - Application Settings
+# ================================================
+[app]
+# Directory for caching downloaded files (audio previews, images, etc.).
+# This can grow large - consider using a path with sufficient space.
+cache_dir = "/Users/you/.cache/sow"
+
+# Output directory for generated files (transitions, songs, videos).
+# All exports will be saved here by default.
+output_dir = "/Users/you/sow/output"
+
+# Default volume for audio preview (0.0 - 1.0).
+# Lower this if previews are too loud, raise if too quiet.
+preview_volume = 0.8
+
+# Default gap between songs in beats.
+# This is the silence between the end of one song and start of transition.
+# 2.0 beats = 2 quarter notes at the target tempo.
+default_gap_beats = 2.0
+
+# Default video template for lyrics video generation.
+# Available options: "dark", "gradient_warm", "gradient_blue"
+default_video_template = "dark"
+
+# Default video resolution for exports.
+# Available options: "720p", "1080p", "1440p", "4K"
+# Higher resolutions take longer to render and create larger files.
+default_video_resolution = "1080p"
+
+# ================================================
+# [transition] - Default Transition Parameters
+# ================================================
+[transition]
+# Default crossfade duration in seconds.
+# Longer crossfades = smoother but more overlap.
+# Recommended: 2.0 - 4.0 for worship music.
+crossfade_duration = 3.0
+
+# Default tempo matching strategy.
+# "auto" - Automatically align tempos (recommended)
+# "none" - Don't adjust tempo
+# "manual" - Use manually specified BPM
+tempo_matching = "auto"
+
+# Default key matching strategy.
+# "auto" - Automatically find best key transition
+# "none" - Keep original keys
+# "manual" - Use manually specified key
+key_matching = "auto"
+
+# ================================================
+# [audio] - Audio Processing Settings
+# ================================================
+[audio]
+# Default output format for audio exports.
+# Options: "mp3", "ogg", "flac", "wav"
+# mp3 = good compression, widely compatible
+# ogg = better quality at smaller size
+# flac = lossless, large files
+# wav = uncompressed, very large
+output_format = "ogg"
+
+# Audio bitrate for compressed formats (mp3, ogg).
+# Higher = better quality but larger files.
+# Recommended: "192k" for general use, "320k" for highest quality
+bitrate = "192k"
+
+# ================================================
+# [video] - Video Generation Settings
+# ================================================
+[video]
+# FFmpeg preset for encoding speed vs compression.
+# "fast" = quicker rendering, larger files
+# "slow" = slower rendering, smaller files
+# Options: ultrafast, superfast, veryfast, faster, fast, medium, slow, slower, veryslow
+ffmpeg_preset = "medium"
+
+# Font settings for lyrics display.
+# Path to a TrueType/OpenType font file.
+# If not set, uses system default.
+# font_path = "/System/Library/Fonts/PingFang.ttc"
+
+# Font size for lyrics (in pixels).
+# Automatically scaled based on resolution if not set.
+# font_size = 64
+
+# ================================================
+# Environment Variables (Override Config File)
+# ================================================
+# Environment variables take precedence over values in this file.
+#
+# Optional Environment Variables:
+#   SOW_TURSO_DATABASE_URL        - Override Turso database URL
+#   SOW_TURSO_READONLY_TOKEN      - Override Turso read-only token
+#   SOW_CACHE_DIR                 - Override cache directory
+#   SOW_OUTPUT_DIR                - Override output directory
+#
+# Example .bashrc/.zshrc additions:
+#   export SOW_TURSO_READONLY_TOKEN="your-token-here"
+
+# ================================================
+# Quick Reference: Common Commands
+# ================================================
+# run                          - Start the interactive TUI
+# db sync                      - Manually sync with Turso
+# db status                    - Check sync status
+# songset list                 - List all your songsets
+# songset create "Name"        - Create a new songset
+# songset export <id>          - Export a songset to JSON
+# songset import <file>        - Import a songset from JSON
+# config show                  - Display current configuration
+
+# ================================================
+# File Organization Tips
+# ================================================
+# Recommended directory structure:
+#
+# ~/.config/sow/
+# ├── config.toml          # This file
+# └── db/
+#     ├── sow.db           # Synced catalog (read-only)
+#     └── songsets.db      # Your personal songsets
+#
+# ~/.cache/sow/            # Temporary files (can be deleted anytime)
+# └── previews/
+#     └── ...
+#
+# ~/sow/output/            # Generated files
+# ├── transitions/         # Transition audio files
+# ├── songs/              # Full song exports
+# └── videos/             # Lyrics videos
+
+# ================================================
+# Security Best Practices
+# ================================================
+# 1. NEVER commit this file with real tokens to version control
+# 2. Add ~/.config/sow/ to your .gitignore
+# 3. Use a READ-ONLY Turso token (the User App doesn't need write access)
+# 4. Rotate tokens periodically
+# 5. Keep your songsets database backed up (it contains your work!)

--- a/src/stream_of_worship/app/app.py
+++ b/src/stream_of_worship/app/app.py
@@ -225,7 +225,6 @@ class SowApp(App):
 
         # Show exit message with catalog stats
         try:
-            catalog = CatalogService(self.read_client)
             lrc_ready = self.read_client.get_lrc_ready_count()
             logger.info(f"App exiting: {lrc_ready} song(s) with lyrics available")
         except Exception:

--- a/src/stream_of_worship/app/app.py
+++ b/src/stream_of_worship/app/app.py
@@ -110,19 +110,19 @@ class SowApp(App):
         logger.info("App mounted, navigating to initial screen: SONGSET_LIST")
 
         if self.config.sync_on_startup and self.config.is_turso_configured:
-            self.run_worker(self._sync_in_background, thread=True, exclusive=True)
+            self.run_worker(self._sync_in_background, exclusive=True)
 
         self.navigate_to(AppScreen.SONGSET_LIST)
 
-    def _sync_in_background(self) -> None:
+    async def _sync_in_background(self) -> None:
         """Run sync in background thread with error handling."""
         try:
             result = self.sync_service.execute_sync()
             logger.info(f"Background sync completed: {result.message}")
-            self.call_from_thread(self.notify, f"Sync completed: {result.message}")
+            self.notify(f"Sync completed: {result.message}")
         except Exception as e:
             logger.warning(f"Background sync failed: {e}")
-            self.call_from_thread(self.notify, f"Sync failed: {e}", severity="error")
+            self.notify(f"Sync failed: {e}", severity="error")
 
     def action_sync_catalog(self) -> None:
         """Sync catalog on demand (capital S key)."""
@@ -130,14 +130,14 @@ class SowApp(App):
             self.notify("Turso sync not configured", severity="warning")
             return
 
-        def do_sync():
+        async def do_sync():
             try:
                 result = self.sync_service.execute_sync()
-                self.call_from_thread(self.notify, f"Sync completed: {result.message}")
+                self.notify(f"Sync completed: {result.message}")
             except Exception as e:
-                self.call_from_thread(self.notify, f"Sync failed: {e}", severity="error")
+                self.notify(f"Sync failed: {e}", severity="error")
 
-        self.run_worker(do_sync, thread=True, exclusive=True)
+        self.run_worker(do_sync, exclusive=True)
 
     def _create_screen(self, screen: AppScreen):
         """Create a fresh screen instance.
@@ -222,6 +222,15 @@ class SowApp(App):
     def action_quit(self) -> None:
         """Quit the application with cleanup."""
         self.playback.stop()
+
+        # Show exit message with catalog stats
+        try:
+            catalog = CatalogService(self.read_client)
+            lrc_ready = self.read_client.get_lrc_ready_count()
+            logger.info(f"App exiting: {lrc_ready} song(s) with lyrics available")
+        except Exception:
+            pass  # Don't fail on logging
+
         self.read_client.close()
         self.songset_client.close()
         self.exit()

--- a/src/stream_of_worship/app/config.py
+++ b/src/stream_of_worship/app/config.py
@@ -149,9 +149,9 @@ class AppConfig:
         if "database" in data:
             db = data["database"]
             if "db_path" in db:
-                config.db_path = Path(db["db_path"])
+                config.db_path = Path(db["db_path"]).expanduser()
             if "songsets_db_path" in db:
-                config.songsets_db_path = Path(db["songsets_db_path"])
+                config.songsets_db_path = Path(db["songsets_db_path"]).expanduser()
 
         # Load songset settings
         if "songsets" in data:
@@ -160,7 +160,7 @@ class AppConfig:
                 "backup_retention", config.songsets_backup_retention
             )
             if "export_dir" in songsets:
-                config.songsets_export_dir = Path(songsets["export_dir"])
+                config.songsets_export_dir = Path(songsets["export_dir"]).expanduser()
 
         # Load Turso settings
         if "turso" in data:
@@ -182,11 +182,11 @@ class AppConfig:
         if "app" in data:
             app_data = data["app"]
             if "cache_dir" in app_data:
-                config.cache_dir = Path(app_data["cache_dir"])
+                config.cache_dir = Path(app_data["cache_dir"]).expanduser()
             if "output_dir" in app_data:
-                config.output_dir = Path(app_data["output_dir"])
+                config.output_dir = Path(app_data["output_dir"]).expanduser()
             if "log_dir" in app_data:
-                config.log_dir = Path(app_data["log_dir"])
+                config.log_dir = Path(app_data["log_dir"]).expanduser()
             config.preview_buffer_ms = app_data.get("preview_buffer_ms", config.preview_buffer_ms)
             config.preview_volume = app_data.get("preview_volume", config.preview_volume)
             config.default_gap_beats = app_data.get("default_gap_beats", config.default_gap_beats)

--- a/src/stream_of_worship/app/db/read_client.py
+++ b/src/stream_of_worship/app/db/read_client.py
@@ -4,11 +4,14 @@ Provides read-only access to songs and recordings tables managed by the admin CL
 Supports libsql/Turso embedded replicas for sync with the cloud database.
 """
 
+import logging
 import sqlite3
 from pathlib import Path
 from typing import Optional, Union
 
 from stream_of_worship.admin.db.models import Recording, Song
+
+logger = logging.getLogger("sow_app.db")
 
 # Optional libsql import for Turso support
 try:
@@ -436,4 +439,24 @@ class ReadOnlyClient:
         cursor = self.connection.cursor()
         cursor.execute("SELECT COUNT(*) FROM songs WHERE deleted_at IS NULL")
         result = cursor.fetchone()
-        return result[0] if result else 0
+        count = result[0] if result else 0
+        logger.debug(f"Total songs in database: {count}")
+        return count
+
+    def get_lrc_ready_count(self) -> int:
+        """Get number of songs with LRC ready (completed + published).
+
+        Returns:
+            Count of LRC-ready songs
+        """
+        cursor = self.connection.cursor()
+        cursor.execute(
+            """SELECT COUNT(*) FROM songs s
+            JOIN recordings r ON s.id = r.song_id
+            WHERE r.lrc_status = 'completed' AND r.visibility_status = 'published'
+            AND r.deleted_at IS NULL AND s.deleted_at IS NULL"""
+        )
+        result = cursor.fetchone()
+        count = result[0] if result else 0
+        logger.debug(f"Songs with LRC ready: {count}")
+        return count

--- a/src/stream_of_worship/app/main.py
+++ b/src/stream_of_worship/app/main.py
@@ -4,6 +4,7 @@ Provides the `sow-app` command for launching the Textual interface,
 syncing with Turso, and managing songset exports/imports.
 """
 
+import logging
 from pathlib import Path
 from typing import Optional
 
@@ -117,9 +118,18 @@ def _check_catalog_health(config: AppConfig) -> None:
         catalog = CatalogService(read_client)
         health = catalog.get_catalog_health()
 
+        # Log detailed stats for transparency
+        lrc_ready = health.get("lrc_ready", 0)
+        logging.getLogger("sow_app").info(
+            f"Catalog health check: status={health['status']}, "
+            f"total_songs={health['total_songs']}, "
+            f"total_recordings={health['total_recordings']}, "
+            f"lrc_ready={lrc_ready}"
+        )
+
         if health["status"] == "ready":
             console.print(
-                f"[green]✓[/green] Catalog ready: {health['analyzed_recordings']} analyzed recording(s)"
+                f"[green]✓[/green] Catalog ready: {lrc_ready} song(s) with lyrics available"
             )
             return
 
@@ -129,7 +139,7 @@ def _check_catalog_health(config: AppConfig) -> None:
                 f"[bold yellow]Catalog Incomplete[/bold yellow]\n\n"
                 f"Songs: {health['total_songs']}\n"
                 f"Recordings: {health['total_recordings']}\n"
-                f"Analyzed: {health['analyzed_recordings']}\n\n"
+                f"LRC Ready: {lrc_ready}\n\n"
                 f"[cyan]{health['guidance']}[/cyan]\n\n"
                 "You can still launch the app, but the Browse screen will be empty.",
                 title="Warning",
@@ -172,13 +182,13 @@ def run(
     if not _check_database(config):
         raise typer.Exit(1)
 
-    # Check catalog health
-    _check_catalog_health(config)
-
-    # Set up logging
+    # Set up logging first
     log_dir = config.log_dir
     logger = setup_logging(log_dir)
     logger.info(f"App configuration loaded from: {config_path if config_path else 'default'}")
+
+    # Check catalog health
+    _check_catalog_health(config)
     logger.info(f"Database: {config.db_path}")
     logger.info(f"Songsets DB: {config.songsets_db_path}")
     logger.info(f"Cache dir: {config.cache_dir}")

--- a/src/stream_of_worship/app/main.py
+++ b/src/stream_of_worship/app/main.py
@@ -235,6 +235,7 @@ def sync(
         turso_token=config.turso_readonly_token,
     )
     songset_client = SongsetClient(config.songsets_db_path)
+    songset_client.initialize_schema()  # Ensure _sync_metadata table exists
 
     sync_service = AppSyncService(
         read_client=read_client,

--- a/src/stream_of_worship/app/screens/browse.py
+++ b/src/stream_of_worship/app/screens/browse.py
@@ -3,9 +3,12 @@
 Allows browsing and searching the song catalog to add songs to a songset.
 """
 
+import logging
 from typing import Optional
 
 from textual.app import ComposeResult
+
+logger = logging.getLogger("sow_app.screens.browse")
 from textual.containers import Horizontal, Vertical
 from textual.screen import Screen
 from textual.widgets import Button, DataTable, Footer, Header, Input, Label, Static
@@ -148,15 +151,32 @@ class BrowseScreen(Screen):
         Args:
             query: Optional search query
         """
+        # Get catalog stats for logging
+        stats = self.catalog.get_stats()
+        logger.info(
+            f"Catalog stats: total_songs={stats['total_songs']}, "
+            f"total_recordings={stats['total_recordings']}, "
+            f"analyzed={stats['analyzed_recordings']}"
+        )
+        logger.info(
+            f"LRC ready count: {self.catalog.db_client.get_lrc_ready_count()}"
+        )
+
         if query:
             search_query, field = self._parse_search_query(query)
+            logger.info(f"Searching: query='{search_query}', field={field}")
             self.songs = self.catalog.search_songs_with_recordings(
                 search_query, field=field, limit=50
             )
         else:
+            logger.info("Loading all LRC-ready songs (limit=50)")
             self.songs = self.catalog.list_songs_with_recordings(
                 only_with_lrc=True, limit=50
             )
+
+        logger.info(f"Loaded {len(self.songs)} songs for display")
+        for i, song in enumerate(self.songs[:20]):  # Log first 20 for debugging
+            logger.info(f"  Song {i+1}: {song.song.title} (analysis={song.recording.analysis_status if song.recording else 'none'})")
 
         table = self.query_one("#song_table", DataTable)
         table.clear()

--- a/src/stream_of_worship/app/services/catalog.py
+++ b/src/stream_of_worship/app/services/catalog.py
@@ -4,10 +4,13 @@ Provides high-level catalog operations combining songs and recordings data
 for display in the TUI. Acts as a facade over the read-only database client.
 """
 
+import logging
 from dataclasses import dataclass
 from typing import Optional
 
 from stream_of_worship.admin.db.models import Recording, Song
+
+logger = logging.getLogger("sow_app.catalog")
 from stream_of_worship.admin.db.schema import (
     RECORDING_COLUMNS_FOR_JOIN,
     SONG_COLUMNS_FOR_JOIN,
@@ -285,18 +288,25 @@ class CatalogService:
             recording = Recording.from_row(row_tuple[SONG_COLUMN_COUNT:])
             result.append(SongWithRecording(song=song, recording=recording))
 
+        logger.debug(
+            f"LRC songs query: album={album}, key={key}, limit={limit}, offset={offset} -> {len(result)} results"
+        )
         return result
 
     def search_songs_with_recordings(
         self, query: str, field: str = "all", limit: int = 20, only_with_lrc: bool = True
     ) -> list[SongWithRecording]:
         """Search songs with their recordings."""
+        logger.debug(
+            f"Search songs: query='{query}', field={field}, limit={limit}, only_with_lrc={only_with_lrc}"
+        )
         if not only_with_lrc:
             songs = self.db_client.search_songs(query, field=field, limit=limit)
             result = []
             for song in songs:
                 recording = self.db_client.get_recording_by_song_id(song.id)
                 result.append(SongWithRecording(song=song, recording=recording))
+            logger.debug(f"Search returned {len(result)} results")
             return result
 
         return self._search_lrc_songs(query, field=field, limit=limit)
@@ -405,13 +415,14 @@ class CatalogService:
         total_songs = stats["total_songs"]
         total_recordings = stats["total_recordings"]
         analyzed = stats["analyzed_recordings"]
+        lrc_ready = self.db_client.get_lrc_ready_count()
 
         if total_songs == 0:
             return {
                 "status": "empty",
                 "total_songs": 0,
                 "total_recordings": 0,
-                "analyzed_recordings": 0,
+                "lrc_ready": 0,
                 "guidance": "No songs found. Run: sow-admin catalog scrape",
             }
 
@@ -420,25 +431,25 @@ class CatalogService:
                 "status": "no_recordings",
                 "total_songs": total_songs,
                 "total_recordings": 0,
-                "analyzed_recordings": 0,
+                "lrc_ready": 0,
                 "guidance": f"Found {total_songs} songs but no audio files. Download audio: sow-admin audio download <song_id>",
             }
 
-        if analyzed == 0:
+        if lrc_ready == 0:
             return {
-                "status": "no_analysis",
+                "status": "no_lrc",
                 "total_songs": total_songs,
                 "total_recordings": total_recordings,
-                "analyzed_recordings": 0,
-                "guidance": f"Found {total_songs} songs and {total_recordings} recording(s), but no analysis completed. Run: sow-admin audio analyze <song_id>",
+                "lrc_ready": 0,
+                "guidance": f"Found {total_songs} songs and {total_recordings} recording(s), but no LRC lyrics ready. Run: sow-admin audio lrc <song_id>",
             }
 
         return {
             "status": "ready",
             "total_songs": total_songs,
             "total_recordings": total_recordings,
-            "analyzed_recordings": analyzed,
-            "guidance": f"Catalog ready: {analyzed} analyzed recording(s) available",
+            "lrc_ready": lrc_ready,
+            "guidance": f"Catalog ready: {lrc_ready} song(s) with lyrics available",
         }
 
     def get_songset_with_items(


### PR DESCRIPTION
## Summary

This PR adds comprehensive logging to make the song database counts transparent and updates the health check to show LRC-ready song count (what the User App actually displays) instead of analysis-ready count.

## Problem

Users were seeing inconsistent numbers:
- Database has **581 songs**, **73 recordings**
- Only **13 songs** have full analysis (beats, segments)
- But **20 songs** have LRC lyrics ready (completed + published)
- The browse screen shows songs with LRC, but the startup message showed "13 analyzed recording(s)" - causing confusion

## Changes

### 1. New: `get_lrc_ready_count()` in `read_client.py`
- Returns count of songs with `lrc_status = 'completed'` AND `visibility_status = 'published'`
- Added debug logging for total songs and LRC-ready counts

### 2. Updated `get_catalog_health()` in `catalog.py`
- Changed to use `lrc_ready` count instead of `analyzed_recordings`
- New status "no_lrc" when no LRC-ready songs exist
- Guidance message now says "X song(s) with lyrics available"

### 3. Updated startup message in `main.py`
- Changed from: "✓ Catalog ready: 13 analyzed recording(s)"
- Changed to: "✓ Catalog ready: 20 song(s) with lyrics available"
- Warning panel now shows "LRC Ready" instead of "Analyzed"
- Added `import logging` to fix NameError

### 4. Added logging in `browse.py`
- Logs catalog stats when loading browse screen
- Logs LRC-ready count
- Logs how many songs are loaded for display
- Logs first 20 songs with their analysis status for debugging

### 5. Added exit logging in `app.py`
- Logs "App exiting: X song(s) with lyrics available" on quit

## Verification

Run `sow-user run` and you should see:
```
✓ Catalog ready: 20 song(s) with lyrics available
```

And in the logs (`~/.config/sow/logs/sow_app.log`):
```
Catalog stats: total_songs=581, total_recordings=73, analyzed=13
LRC ready count: 20
Loaded 20 songs for display
  Song 1: <title> (analysis=completed)
  Song 2: <title> (analysis=pending)
  ...
```

## Files Changed

- `src/stream_of_worship/app/db/read_client.py` - Add `get_lrc_ready_count()`
- `src/stream_of_worship/app/services/catalog.py` - Update health check to use LRC count
- `src/stream_of_worship/app/main.py` - Update startup message, add logging import
- `src/stream_of_worship/app/screens/browse.py` - Add logging for loaded songs
- `src/stream_of_worship/app/app.py` - Add exit logging