### PR TITLE
fix(admin): auto-recover from metadata corruption and add Turso readonly token support

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,28 +132,39 @@ sow-admin songset export --songset-id <id>         # Export to JSON
 Create `~/.config/sow-admin/config.toml`:
 
 ```toml
-[database]
-path = "/Users/you/.local/share/sow-admin/sow.db"
-
-[r2]
-bucket = "your-r2-bucket"
-endpoint_url = "https://your-account.r2.cloudflarestorage.com"
-region = "auto"
-
 [service]
 analysis_url = "http://localhost:8000"
 
+[r2]
+bucket = "your-r2-bucket"
+endpoint_url = "https://<account-id>.r2.cloudflarestorage.com"
+region = "auto"
+
 [turso]
-database_url = "https://your-db.turso.io"
+database_url = "libsql://<database-name>.turso.io"
+sync_on_startup = true
+
+[database]
+path = "/Users/you/.config/sow-admin/db/sow.db"
+
+[paths]
+cache_dir = "/Users/you/.cache/sow-admin"
 ```
 
-Environment variables (take precedence over config):
+**Required Environment Variables** (for sensitive credentials):
 ```bash
-export SOW_R2_BUCKET="your-bucket"
-export SOW_R2_ENDPOINT_URL="https://xxx.r2.cloudflarestorage.com"
+# Turso full-access token (Admin CLI only - never store in config)
+export SOW_TURSO_TOKEN="your-turso-token"
+
+# R2 credentials
 export SOW_R2_ACCESS_KEY_ID="your-access-key"
 export SOW_R2_SECRET_ACCESS_KEY="your-secret-key"
+
+# Analysis service API key
+export SOW_ANALYSIS_API_KEY="your-api-key"
 ```
+
+**Note:** Non-sensitive settings like `turso.database_url`, `r2.bucket`, and `r2.endpoint_url` should be configured in the config file. Only sensitive credentials use environment variables for security.
 
 ### Workflow Example
 
@@ -216,9 +227,13 @@ db_path = "/Users/you/.config/sow/db/sow.db"
 songsets_db_path = "/Users/you/.config/sow/db/songsets.db"
 
 [turso]
-database_url = "libsql://your-db.turso.io"
-readonly_token = "your-token"
+database_url = "libsql://<database-name>.turso.io"
 sync_on_startup = true
+
+[r2]
+bucket = "your-r2-bucket"
+endpoint_url = "https://<account-id>.r2.cloudflarestorage.com"
+region = "auto"
 
 [app]
 cache_dir = "/Users/you/.cache/sow"
@@ -228,6 +243,18 @@ default_gap_beats = 2.0
 default_video_template = "dark"
 default_video_resolution = "1080p"
 ```
+
+**Required Environment Variables** (for sensitive credentials):
+```bash
+# Turso read-only token (required - env var only for security)
+export SOW_TURSO_READONLY_TOKEN="your-readonly-token"
+
+# R2 credentials (required for downloading audio assets)
+export SOW_R2_ACCESS_KEY_ID="your-access-key"
+export SOW_R2_SECRET_ACCESS_KEY="your-secret-key"
+```
+
+**Note:** The Turso read-only token is read from the `SOW_TURSO_READONLY_TOKEN` environment variable only and is never stored in the config file for security.
 
 ### Commands
 

--- a/services/analysis/README.md
+++ b/services/analysis/README.md
@@ -67,6 +67,10 @@ SOW_WHISPER_DEVICE=cpu              # "cpu" or "cuda" (default: cpu)
 SOW_AUDIO_SEPARATOR_MODEL_ROOT="/path/to/audio-separator-models"  # Host path to pre-downloaded models
 SOW_BS_ROFORMER_MODEL="model_bs_roformer_ep_317_sdr_12.9755.ckpt"  # BS-Roformer model filename
 SOW_DEREVERB_MODEL="UVR-De-Echo-Normal.pth"  # UVR-De-Echo model filename
+
+# Qwen3 Model Configuration (Required for LRC refinement with forced alignment)
+SOW_QWEN3_MODEL_ROOT="/home/user/.cache/huggingface/hub/models--Qwen--Qwen3-ForcedAligner-0.6B"
+SOW_QWEN3_MODEL_SNAPSHOT="c7cbfc2048c462b0d63a45797104fc9db3ad62b7"
 ```
 
 ## Quick Start
@@ -261,6 +265,47 @@ export SOW_AUDIO_SEPARATOR_MODEL_ROOT="$HOME/.cache/audio-separator"
 ```
 
 The docker-compose.yml automatically mounts this directory to `/models/audio-separator:ro` in the container.
+
+## Qwen3 Model Setup (for LRC Refinement)
+
+The LRC generation feature uses Qwen3 Forced Aligner for precise lyric-to-audio alignment. The model must be pre-downloaded on the host machine and bind-mounted into the container.
+
+### One-Time Model Download
+
+```bash
+# Install huggingface-cli if not already installed
+pip install huggingface-hub
+
+# Download the Qwen3 Forced Aligner model
+huggingface-cli download Qwen/Qwen3-ForcedAligner-0.6B
+```
+
+### Find Model Paths
+
+After downloading, locate the model root and snapshot hash:
+
+```bash
+# Find the model root directory
+ls ~/.cache/huggingface/hub/ | grep Qwen
+
+# Output example: models--Qwen--Qwen3-ForcedAligner-0.6B
+
+# Find the snapshot hash
+ls ~/.cache/huggingface/hub/models--Qwen--Qwen3-ForcedAligner-0.6B/snapshots/
+
+# Output example: c7cbfc2048c462b0d63a45797104fc9db3ad62b7
+```
+
+### Configure Environment
+
+Add to your `.env` file:
+
+```bash
+SOW_QWEN3_MODEL_ROOT="/home/user/.cache/huggingface/hub/models--Qwen--Qwen3-ForcedAligner-0.6B"
+SOW_QWEN3_MODEL_SNAPSHOT="c7cbfc2048c462b0d63a45797104fc9db3ad62b7"
+```
+
+**Note:** The snapshot hash changes when the model is updated. If LRC jobs fail with model loading errors, check for a new snapshot hash after re-downloading.
 
 ## Platform-Specific Builds
 

--- a/src/stream_of_worship/admin/README.md
+++ b/src/stream_of_worship/admin/README.md
@@ -104,22 +104,21 @@ path = "/custom/path/sow.db"
 
 ### Environment Variables
 
-Configuration values can be set via environment variables (takes precedence over config file):
+Sensitive credentials should be set via environment variables:
 
 ```bash
-# R2 Configuration (non-sensitive)
-export SOW_R2_BUCKET="your-bucket-name"
-export SOW_R2_ENDPOINT_URL="https://xxx.r2.cloudflarestorage.com"
-export SOW_R2_REGION="auto"
+# Turso full-access token (Admin CLI only - env var only for security)
+export SOW_TURSO_TOKEN="your-turso-token"
 
 # R2 Credentials (sensitive - never commit these)
 export SOW_R2_ACCESS_KEY_ID="your-access-key"
 export SOW_R2_SECRET_ACCESS_KEY="your-secret-key"
 
-# Other services
+# Analysis service API key
 export SOW_ANALYSIS_API_KEY="your-api-key"
-export SOW_TURSO_AUTH_TOKEN="your-turso-token"
 ```
+
+**Note:** Non-sensitive settings like `turso.database_url`, `r2.bucket`, and `r2.endpoint_url` should be configured in the config file. Only sensitive credentials use environment variables for security.
 
 ## Database Commands
 

--- a/src/stream_of_worship/admin/commands/db.py
+++ b/src/stream_of_worship/admin/commands/db.py
@@ -351,6 +351,11 @@ def sync_db(
     else:
         console.print("Last sync: [dim]Never[/dim]")
 
+    # Check for metadata corruption that would require recovery
+    if config.db_path.exists() and not sync_status.last_sync_at:
+        console.print("\n[yellow]Note: Local database exists but has no sync metadata.[/yellow]")
+        console.print("[yellow]Will attempt recovery by syncing fresh from Turso...[/yellow]")
+
     console.print("\n[yellow]Syncing with Turso...[/yellow]")
 
     # Execute sync
@@ -367,9 +372,21 @@ def sync_db(
         console.print(f"\n[red]Configuration error: {e}[/red]")
         raise typer.Exit(1)
     except SyncNetworkError as e:
+        error_msg = str(e).lower()
         console.print(f"\n[red]Network error: {e}[/red]")
         if e.status_code:
             console.print(f"Status code: {e.status_code}")
+        
+        # Provide helpful messages for common errors
+        if "write" in error_msg and ("forbidden" in error_msg or "blocked" in error_msg or "permission" in error_msg):
+            console.print("\n[yellow]Tip: Your Turso token has read-only permissions.[/yellow]")
+            console.print("[yellow]Sync operations require a token with write access.[/yellow]")
+            console.print("[dim]Generate a full-access token with:[/dim]")
+            console.print("  [dim]turso db tokens create sow-catalog-mhuang --full-access[/dim]")
+        elif "metadata file" in error_msg:
+            console.print("\n[yellow]Tip: Database metadata is corrupted.[/yellow]")
+            console.print("[yellow]Run 'sow-admin db reset' to reset local database, then sync again.[/yellow]")
+        
         raise typer.Exit(1)
     except SyncError as e:
         console.print(f"\n[red]Sync error: {e}[/red]")

--- a/src/stream_of_worship/admin/commands/db.py
+++ b/src/stream_of_worship/admin/commands/db.py
@@ -44,12 +44,10 @@ def get_db_client(config: AdminConfig) -> DatabaseClient:
     Returns:
         DatabaseClient instance
     """
-    # Token priority: SOW_TURSO_TOKEN env var > config.turso_readonly_token
-    turso_token = os.environ.get("SOW_TURSO_TOKEN") or config.turso_readonly_token
     return DatabaseClient(
         db_path=config.db_path,
         turso_url=config.turso_database_url,
-        turso_token=turso_token,
+        turso_token=os.environ.get("SOW_TURSO_TOKEN"),
     )
 
 

--- a/src/stream_of_worship/admin/commands/db.py
+++ b/src/stream_of_worship/admin/commands/db.py
@@ -44,10 +44,12 @@ def get_db_client(config: AdminConfig) -> DatabaseClient:
     Returns:
         DatabaseClient instance
     """
+    # Token priority: SOW_TURSO_TOKEN env var > config.turso_readonly_token
+    turso_token = os.environ.get("SOW_TURSO_TOKEN") or config.turso_readonly_token
     return DatabaseClient(
         db_path=config.db_path,
         turso_url=config.turso_database_url,
-        turso_token=os.environ.get("SOW_TURSO_TOKEN"),
+        turso_token=turso_token,
     )
 
 

--- a/src/stream_of_worship/admin/commands/db.py
+++ b/src/stream_of_worship/admin/commands/db.py
@@ -349,10 +349,10 @@ def sync_db(
     else:
         console.print("Last sync: [dim]Never[/dim]")
 
-    # Check for metadata corruption that would require recovery
+    # Check for missing sync history (fresh installation or metadata corruption)
     if config.db_path.exists() and not sync_status.last_sync_at:
-        console.print("\n[yellow]Note: Local database exists but has no sync metadata.[/yellow]")
-        console.print("[yellow]Will attempt recovery by syncing fresh from Turso...[/yellow]")
+        console.print("\n[yellow]Note: Local database exists but has no sync history.[/yellow]")
+        console.print("[yellow]Will perform initial sync from Turso...[/yellow]")
 
     console.print("\n[yellow]Syncing with Turso...[/yellow]")
 
@@ -380,7 +380,7 @@ def sync_db(
             console.print("\n[yellow]Tip: Your Turso token has read-only permissions.[/yellow]")
             console.print("[yellow]Sync operations require a token with write access.[/yellow]")
             console.print("[dim]Generate a full-access token with:[/dim]")
-            console.print("  [dim]turso db tokens create sow-catalog-mhuang --full-access[/dim]")
+            console.print("  [dim]turso db tokens create sow-catalog --full-access[/dim]")
         elif "metadata file" in error_msg:
             console.print("\n[yellow]Tip: Database metadata is corrupted.[/yellow]")
             console.print("[yellow]Run 'sow-admin db reset' to reset local database, then sync again.[/yellow]")

--- a/src/stream_of_worship/admin/config.py
+++ b/src/stream_of_worship/admin/config.py
@@ -26,6 +26,8 @@ class AdminConfig:
         r2_endpoint_url: R2 endpoint URL
         r2_region: R2 region (usually "auto")
         turso_database_url: Turso database URL for sync
+        turso_readonly_token: Turso read-only token for embedded replica
+        sync_on_startup: Whether to sync at startup
         db_path: Local SQLite database path
         cache_dir: Local cache directory for admin operations
     """
@@ -40,6 +42,8 @@ class AdminConfig:
 
     # Turso (for sync)
     turso_database_url: str = ""
+    turso_readonly_token: str = ""
+    sync_on_startup: bool = True
 
     # Local Database
     db_path: Path = field(default_factory=lambda: get_default_db_path())
@@ -97,9 +101,19 @@ class AdminConfig:
 
         # Load Turso config
         if "turso" in data:
-            config.turso_database_url = data["turso"].get(
-                "database_url", config.turso_database_url
-            )
+            turso = data["turso"]
+            config.turso_database_url = turso.get("database_url", config.turso_database_url)
+            config.turso_readonly_token = turso.get("readonly_token", config.turso_readonly_token)
+            config.sync_on_startup = turso.get("sync_on_startup", config.sync_on_startup)
+
+        # Override Turso from environment
+        env_url = os.environ.get("SOW_TURSO_DATABASE_URL")
+        if env_url:
+            config.turso_database_url = env_url
+
+        env_token = os.environ.get("SOW_TURSO_READONLY_TOKEN")
+        if env_token:
+            config.turso_readonly_token = env_token
 
         # Load database path
         if "database" in data:
@@ -119,6 +133,15 @@ class AdminConfig:
             config.cache_dir = Path(env_cache_dir)
 
         return config
+
+    @property
+    def is_turso_configured(self) -> bool:
+        """Check if Turso sync is configured.
+
+        Returns:
+            True if Turso URL and token are configured
+        """
+        return bool(self.turso_database_url and self.turso_readonly_token)
 
     def save(self, path: Optional[Path] = None) -> None:
         """Save configuration to TOML file.
@@ -140,7 +163,11 @@ class AdminConfig:
                 "endpoint_url": self.r2_endpoint_url,
                 "region": self.r2_region,
             },
-            "turso": {"database_url": self.turso_database_url},
+            "turso": {
+                "database_url": self.turso_database_url,
+                "readonly_token": self.turso_readonly_token,
+                "sync_on_startup": self.sync_on_startup,
+            },
             "database": {"path": str(self.db_path)},
             "paths": {"cache_dir": str(self.cache_dir)},
         }

--- a/src/stream_of_worship/admin/config.py
+++ b/src/stream_of_worship/admin/config.py
@@ -26,7 +26,6 @@ class AdminConfig:
         r2_endpoint_url: R2 endpoint URL
         r2_region: R2 region (usually "auto")
         turso_database_url: Turso database URL for sync
-        turso_readonly_token: Turso read-only token for embedded replica
         sync_on_startup: Whether to sync at startup
         db_path: Local SQLite database path
         cache_dir: Local cache directory for admin operations
@@ -42,7 +41,6 @@ class AdminConfig:
 
     # Turso (for sync)
     turso_database_url: str = ""
-    turso_readonly_token: str = ""
     sync_on_startup: bool = True
 
     # Local Database
@@ -103,17 +101,12 @@ class AdminConfig:
         if "turso" in data:
             turso = data["turso"]
             config.turso_database_url = turso.get("database_url", config.turso_database_url)
-            config.turso_readonly_token = turso.get("readonly_token", config.turso_readonly_token)
             config.sync_on_startup = turso.get("sync_on_startup", config.sync_on_startup)
 
         # Override Turso from environment
         env_url = os.environ.get("SOW_TURSO_DATABASE_URL")
         if env_url:
             config.turso_database_url = env_url
-
-        env_token = os.environ.get("SOW_TURSO_READONLY_TOKEN")
-        if env_token:
-            config.turso_readonly_token = env_token
 
         # Load database path
         if "database" in data:
@@ -133,15 +126,6 @@ class AdminConfig:
             config.cache_dir = Path(env_cache_dir)
 
         return config
-
-    @property
-    def is_turso_configured(self) -> bool:
-        """Check if Turso sync is configured.
-
-        Returns:
-            True if Turso URL and token are configured
-        """
-        return bool(self.turso_database_url and self.turso_readonly_token)
 
     def save(self, path: Optional[Path] = None) -> None:
         """Save configuration to TOML file.
@@ -165,7 +149,6 @@ class AdminConfig:
             },
             "turso": {
                 "database_url": self.turso_database_url,
-                "readonly_token": self.turso_readonly_token,
                 "sync_on_startup": self.sync_on_startup,
             },
             "database": {"path": str(self.db_path)},

--- a/src/stream_of_worship/admin/config.py
+++ b/src/stream_of_worship/admin/config.py
@@ -84,29 +84,11 @@ class AdminConfig:
             config.r2_endpoint_url = r2.get("endpoint_url", config.r2_endpoint_url)
             config.r2_region = r2.get("region", config.r2_region)
 
-        # Override R2 config from environment variables (takes precedence)
-        env_bucket = os.environ.get("SOW_R2_BUCKET")
-        if env_bucket:
-            config.r2_bucket = env_bucket
-
-        env_endpoint = os.environ.get("SOW_R2_ENDPOINT_URL")
-        if env_endpoint:
-            config.r2_endpoint_url = env_endpoint
-
-        env_region = os.environ.get("SOW_R2_REGION")
-        if env_region:
-            config.r2_region = env_region
-
         # Load Turso config
         if "turso" in data:
             turso = data["turso"]
             config.turso_database_url = turso.get("database_url", config.turso_database_url)
             config.sync_on_startup = turso.get("sync_on_startup", config.sync_on_startup)
-
-        # Override Turso from environment
-        env_url = os.environ.get("SOW_TURSO_DATABASE_URL")
-        if env_url:
-            config.turso_database_url = env_url
 
         # Load database path
         if "database" in data:
@@ -119,11 +101,6 @@ class AdminConfig:
             toml_cache_dir = data["paths"].get("cache_dir")
             if toml_cache_dir:
                 config.cache_dir = Path(toml_cache_dir)
-
-        # Env override wins over TOML (SOW_ADMIN_CACHE_DIR)
-        env_cache_dir = os.environ.get("SOW_ADMIN_CACHE_DIR")
-        if env_cache_dir:
-            config.cache_dir = Path(env_cache_dir)
 
         return config
 
@@ -222,15 +199,9 @@ class AdminConfig:
 def get_cache_dir() -> Path:
     """Get the platform-specific cache directory for sow-admin.
 
-    Resolution order: SOW_ADMIN_CACHE_DIR env > platform default.
-
     Returns:
         Path to the cache directory for sow-admin.
     """
-    env_override = os.environ.get("SOW_ADMIN_CACHE_DIR")
-    if env_override:
-        return Path(env_override)
-
     if sys.platform == "darwin" or sys.platform == "linux":
         xdg_cache = os.environ.get("XDG_CACHE_HOME")
         if xdg_cache:

--- a/src/stream_of_worship/admin/db/client.py
+++ b/src/stream_of_worship/admin/db/client.py
@@ -73,8 +73,7 @@ class DatabaseClient:
         """
         self.db_path = db_path
         self.turso_url = turso_url
-        # Token priority: parameter > SOW_TURSO_TOKEN env var > SOW_TURSO_READONLY_TOKEN env var
-        self.turso_token = turso_token or os.environ.get("SOW_TURSO_TOKEN") or os.environ.get("SOW_TURSO_READONLY_TOKEN")
+        self.turso_token = turso_token or os.environ.get("SOW_TURSO_TOKEN")
         self._connection: Optional[Union[sqlite3.Connection, "libsql.Connection"]] = None
 
     @property

--- a/src/stream_of_worship/admin/db/client.py
+++ b/src/stream_of_worship/admin/db/client.py
@@ -4,6 +4,7 @@ Provides SQLite database operations for local storage of song catalog
 and recording metadata. Supports libsql/Turso for embedded replica sync.
 """
 
+import os
 import sqlite3
 import uuid
 from contextlib import contextmanager
@@ -68,11 +69,12 @@ class DatabaseClient:
         Args:
             db_path: Path to the SQLite database file
             turso_url: Turso database URL for sync (optional)
-            turso_token: Turso auth token (optional)
+            turso_token: Turso auth token (optional, falls back to SOW_TURSO_TOKEN env var)
         """
         self.db_path = db_path
         self.turso_url = turso_url
-        self.turso_token = turso_token
+        # Token priority: parameter > SOW_TURSO_TOKEN env var > SOW_TURSO_READONLY_TOKEN env var
+        self.turso_token = turso_token or os.environ.get("SOW_TURSO_TOKEN") or os.environ.get("SOW_TURSO_READONLY_TOKEN")
         self._connection: Optional[Union[sqlite3.Connection, "libsql.Connection"]] = None
 
     @property

--- a/src/stream_of_worship/admin/services/sync.py
+++ b/src/stream_of_worship/admin/services/sync.py
@@ -186,7 +186,26 @@ class SyncService:
             error_msg = "; ".join(errors)
             raise SyncConfigError(error_msg)
 
-        # Execute sync
+        # Execute sync with metadata recovery handling
+        return self._execute_sync_with_recovery()
+
+    def _execute_sync_with_recovery(self, attempt: int = 1, max_attempts: int = 2) -> SyncResult:
+        """Execute sync with automatic recovery from metadata corruption.
+
+        If sync fails due to missing metadata file, automatically recovers
+        by deleting the local db file and re-syncing from Turso.
+
+        Args:
+            attempt: Current attempt number (for recursion tracking)
+            max_attempts: Maximum number of attempts before giving up
+
+        Returns:
+            SyncResult with operation outcome
+
+        Raises:
+            SyncConfigError: If configuration is invalid
+            SyncNetworkError: If network operation fails
+        """
         client = DatabaseClient(
             self.db_path,
             turso_url=self.turso_url,
@@ -196,18 +215,58 @@ class SyncService:
         try:
             client.sync()
 
-            # Get updated stats
-            stats = client.get_stats()
-
             return SyncResult(
                 success=True,
                 message="Sync completed successfully",
                 records_synced=None,  # libsql doesn't expose this
             )
         except SyncError as e:
+            error_msg = str(e)
+
+            # Check if this is a metadata file corruption error
+            if "metadata file does not" in error_msg.lower() and attempt < max_attempts:
+                # Close client before deleting files
+                client.close()
+
+                # Recovery: Delete local db and let libsql recreate from Turso
+                self._recover_from_missing_metadata()
+
+                # Retry sync
+                return self._execute_sync_with_recovery(attempt=attempt + 1, max_attempts=max_attempts)
+
             raise SyncNetworkError(f"Sync failed: {e}")
         finally:
             client.close()
+
+    def _recover_from_missing_metadata(self) -> None:
+        """Recover from missing metadata file by removing local db.
+
+        libsql embedded replicas require both a db file and metadata file.
+        If metadata is missing, we must delete the local db and let libsql
+        recreate everything from Turso.
+        """
+        # Close any open connections first
+        # Delete the local database file - libsql will recreate from Turso
+        if self.db_path.exists():
+            self.db_path.unlink()
+
+        # Also delete any related libsql metadata files
+        db_dir = self.db_path.parent
+        db_name = self.db_path.stem
+
+        # Look for common metadata file patterns
+        meta_patterns = [
+            self.db_path.with_suffix(".meta"),
+            self.db_path.with_suffix(".db-shm"),
+            self.db_path.with_suffix(".db-wal"),
+            db_dir / f".{db_name}-journal",
+            db_dir / f".{db_name}-shm",
+            db_dir / f".{db_name}-wal",
+        ]
+
+        for meta_file in meta_patterns:
+            if meta_file.exists():
+                meta_file.unlink()
 
     def _ensure_device_id(self) -> str:
         """Ensure local device ID exists in database.

--- a/src/stream_of_worship/admin/services/sync.py
+++ b/src/stream_of_worship/admin/services/sync.py
@@ -319,10 +319,8 @@ def get_sync_service_from_config(config) -> SyncService:
     Returns:
         Configured SyncService
     """
-    # Token priority: SOW_TURSO_TOKEN env var > config.turso_readonly_token
-    turso_token = os.environ.get("SOW_TURSO_TOKEN") or config.turso_readonly_token
     return SyncService(
         db_path=config.db_path,
         turso_url=config.turso_database_url,
-        turso_token=turso_token,
+        turso_token=os.environ.get("SOW_TURSO_TOKEN"),
     )

--- a/src/stream_of_worship/admin/services/sync.py
+++ b/src/stream_of_worship/admin/services/sync.py
@@ -260,8 +260,10 @@ def get_sync_service_from_config(config) -> SyncService:
     Returns:
         Configured SyncService
     """
+    # Token priority: SOW_TURSO_TOKEN env var > config.turso_readonly_token
+    turso_token = os.environ.get("SOW_TURSO_TOKEN") or config.turso_readonly_token
     return SyncService(
         db_path=config.db_path,
         turso_url=config.turso_database_url,
-        turso_token=os.environ.get("SOW_TURSO_TOKEN"),
+        turso_token=turso_token,
     )

--- a/src/stream_of_worship/admin/services/sync.py
+++ b/src/stream_of_worship/admin/services/sync.py
@@ -5,6 +5,7 @@ embedded replica synchronization.
 """
 
 import os
+import shutil
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
@@ -252,21 +253,21 @@ class SyncService:
 
         # Also delete any related libsql metadata files
         db_dir = self.db_path.parent
-        db_name = self.db_path.stem
 
-        # Look for common metadata file patterns
+        # Look for common metadata file/directory patterns
         meta_patterns = [
-            self.db_path.with_suffix(".meta"),
-            self.db_path.with_suffix(".db-shm"),
-            self.db_path.with_suffix(".db-wal"),
-            db_dir / f".{db_name}-journal",
-            db_dir / f".{db_name}-shm",
-            db_dir / f".{db_name}-wal",
+            db_dir / (self.db_path.name + "-shm"),
+            db_dir / (self.db_path.name + "-wal"),
+            db_dir / (self.db_path.name + "-journal"),
+            db_dir / (self.db_path.name + "-info"),
         ]
 
-        for meta_file in meta_patterns:
-            if meta_file.exists():
-                meta_file.unlink()
+        for meta_path in meta_patterns:
+            if meta_path.exists():
+                if meta_path.is_dir():
+                    shutil.rmtree(meta_path)
+                else:
+                    meta_path.unlink()
 
     def _ensure_device_id(self) -> str:
         """Ensure local device ID exists in database.

--- a/src/stream_of_worship/app/config.py
+++ b/src/stream_of_worship/app/config.py
@@ -83,8 +83,10 @@ class AppConfig:
         songsets_backup_retention: Number of songset backups to keep
         songsets_export_dir: Directory for songset JSON exports
         turso_database_url: Turso database URL for sync
-        turso_readonly_token: Turso read-only token
         sync_on_startup: Whether to sync at app startup
+        r2_bucket: R2 bucket name for audio storage
+        r2_endpoint_url: R2 endpoint URL
+        r2_region: R2 region
         cache_dir: Local directory for cached R2 assets
         output_dir: Directory for exported audio/video files
         preview_buffer_ms: Audio buffer size for playback in milliseconds
@@ -92,6 +94,10 @@ class AppConfig:
         default_gap_beats: Default gap duration between songs (in beats)
         default_video_template: Default video template name
         default_video_resolution: Default video resolution (e.g., "1080p")
+
+    Note:
+        Turso read-only token is read from SOW_TURSO_READONLY_TOKEN environment
+        variable only (not stored in config file for security).
     """
 
     # Database paths
@@ -102,10 +108,14 @@ class AppConfig:
     songsets_backup_retention: int = 5
     songsets_export_dir: Path = field(default_factory=get_default_export_dir)
 
-    # Turso sync settings
+    # Turso sync settings (token via SOW_TURSO_READONLY_TOKEN env var only)
     turso_database_url: str = ""
-    turso_readonly_token: str = ""
     sync_on_startup: bool = True
+
+    # R2 storage settings
+    r2_bucket: str = "sow-audio"
+    r2_endpoint_url: str = ""
+    r2_region: str = "auto"
 
     # App-specific paths
     cache_dir: Path = field(default_factory=_get_core_cache_dir)
@@ -162,21 +172,18 @@ class AppConfig:
             if "export_dir" in songsets:
                 config.songsets_export_dir = Path(songsets["export_dir"]).expanduser()
 
-        # Load Turso settings
+        # Load Turso settings (database_url from config, token from env var only)
         if "turso" in data:
             turso = data["turso"]
             config.turso_database_url = turso.get("database_url", config.turso_database_url)
-            config.turso_readonly_token = turso.get("readonly_token", config.turso_readonly_token)
             config.sync_on_startup = turso.get("sync_on_startup", config.sync_on_startup)
 
-        # Override from environment
-        env_url = os.environ.get("SOW_TURSO_DATABASE_URL")
-        if env_url:
-            config.turso_database_url = env_url
-
-        env_token = os.environ.get("SOW_TURSO_READONLY_TOKEN")
-        if env_token:
-            config.turso_readonly_token = env_token
+        # Load R2 settings
+        if "r2" in data:
+            r2 = data["r2"]
+            config.r2_bucket = r2.get("bucket", config.r2_bucket)
+            config.r2_endpoint_url = r2.get("endpoint_url", config.r2_endpoint_url)
+            config.r2_region = r2.get("region", config.r2_region)
 
         # Load app-specific settings
         if "app" in data:
@@ -196,11 +203,6 @@ class AppConfig:
             config.default_video_resolution = app_data.get(
                 "default_video_resolution", config.default_video_resolution
             )
-
-        # SOW_CACHE_DIR env var wins over TOML cache_dir
-        env_cache_dir = os.environ.get("SOW_CACHE_DIR")
-        if env_cache_dir:
-            config.cache_dir = Path(env_cache_dir)
 
         return config
 
@@ -228,8 +230,12 @@ class AppConfig:
             },
             "turso": {
                 "database_url": self.turso_database_url,
-                "readonly_token": self.turso_readonly_token,
                 "sync_on_startup": self.sync_on_startup,
+            },
+            "r2": {
+                "bucket": self.r2_bucket,
+                "endpoint_url": self.r2_endpoint_url,
+                "region": self.r2_region,
             },
             "app": {
                 "cache_dir": str(self.cache_dir),
@@ -256,6 +262,15 @@ class AppConfig:
         self.songsets_export_dir.mkdir(parents=True, exist_ok=True)
 
     @property
+    def turso_readonly_token(self) -> str:
+        """Get Turso read-only token from environment variable.
+
+        Returns:
+            Turso read-only token from SOW_TURSO_READONLY_TOKEN env var
+        """
+        return os.environ.get("SOW_TURSO_READONLY_TOKEN", "")
+
+    @property
     def is_turso_configured(self) -> bool:
         """Check if Turso sync is configured.
 
@@ -263,33 +278,6 @@ class AppConfig:
             True if Turso URL and token are configured
         """
         return bool(self.turso_database_url and self.turso_readonly_token)
-
-    @property
-    def r2_bucket(self) -> str:
-        """Get R2 bucket (from environment or default).
-
-        Returns:
-            R2 bucket name
-        """
-        return os.environ.get("SOW_R2_BUCKET", "sow-audio")
-
-    @property
-    def r2_endpoint_url(self) -> str:
-        """Get R2 endpoint (from environment).
-
-        Returns:
-            R2 endpoint URL
-        """
-        return os.environ.get("SOW_R2_ENDPOINT_URL", "")
-
-    @property
-    def r2_region(self) -> str:
-        """Get R2 region (from environment or default).
-
-        Returns:
-            R2 region
-        """
-        return os.environ.get("SOW_R2_REGION", "auto")
 
 
 def ensure_app_config_exists() -> AppConfig:

--- a/src/stream_of_worship/app/services/sync.py
+++ b/src/stream_of_worship/app/services/sync.py
@@ -198,9 +198,8 @@ class AppSyncService:
         elif not self.turso_url.startswith("libsql://"):
             errors.append(f"Invalid Turso URL format: {self.turso_url}")
 
-        # Check Turso token
-        token = self.turso_token or os.environ.get("SOW_TURSO_READONLY_TOKEN")
-        if not token:
+        # Check Turso token (from SOW_TURSO_READONLY_TOKEN env var)
+        if not self.turso_token:
             errors.append("Turso token not configured (set SOW_TURSO_READONLY_TOKEN)")
 
         return len(errors) == 0, errors

--- a/tests/admin/test_config.py
+++ b/tests/admin/test_config.py
@@ -71,49 +71,6 @@ path = "/custom/path/sow.db"
         with pytest.raises(FileNotFoundError):
             AdminConfig.load(tmp_path / "nonexistent.toml")
 
-    def test_load_from_file_with_env_override(self, tmp_path, monkeypatch):
-        """Test that environment variables override file config."""
-        config_file = tmp_path / "config.toml"
-        config_file.write_text(
-            """
-[r2]
-bucket = "file-bucket"
-endpoint_url = "https://file.r2.cloudflarestorage.com"
-region = "file-region"
-"""
-        )
-
-        # Set environment variables
-        monkeypatch.setenv("SOW_R2_BUCKET", "env-bucket")
-        monkeypatch.setenv("SOW_R2_ENDPOINT_URL", "https://env.r2.cloudflarestorage.com")
-        monkeypatch.setenv("SOW_R2_REGION", "env-region")
-
-        config = AdminConfig.load(config_file)
-
-        # Environment variables should take precedence
-        assert config.r2_bucket == "env-bucket"
-        assert config.r2_endpoint_url == "https://env.r2.cloudflarestorage.com"
-        assert config.r2_region == "env-region"
-
-    def test_load_env_vars_only(self, tmp_path, monkeypatch):
-        """Test loading config when only env vars are set (no file values)."""
-        config_file = tmp_path / "config.toml"
-        config_file.write_text("""
-[service]
-analysis_url = "http://localhost:8000"
-""")
-
-        # Set environment variables
-        monkeypatch.setenv("SOW_R2_BUCKET", "env-only-bucket")
-        monkeypatch.setenv("SOW_R2_ENDPOINT_URL", "https://env-only.r2.cloudflarestorage.com")
-
-        config = AdminConfig.load(config_file)
-
-        # Should use env vars for R2, defaults for others
-        assert config.r2_bucket == "env-only-bucket"
-        assert config.r2_endpoint_url == "https://env-only.r2.cloudflarestorage.com"
-        assert config.r2_region == "auto"  # default
-
     def test_save_and_load(self, tmp_path, monkeypatch):
         """Test saving and loading config preserves values."""
         # Clear environment variables that might override file config
@@ -243,15 +200,8 @@ class TestAdminCacheDir:
         assert isinstance(config.cache_dir, Path)
         assert "sow-admin" in str(config.cache_dir)
 
-    def test_sow_admin_cache_dir_env_override(self, monkeypatch):
-        """SOW_ADMIN_CACHE_DIR env var overrides the default."""
-        monkeypatch.setenv("SOW_ADMIN_CACHE_DIR", "/env/admin-cache")
-        result = get_cache_dir()
-        assert result == Path("/env/admin-cache")
-
     def test_toml_cache_dir_loaded(self, tmp_path, monkeypatch):
         """cache_dir from TOML [paths] section is loaded."""
-        monkeypatch.delenv("SOW_ADMIN_CACHE_DIR", raising=False)
         config_file = tmp_path / "config.toml"
         config_file.write_text(
             """
@@ -264,16 +214,3 @@ cache_dir = "/toml/admin-cache"
         )
         config = AdminConfig.load(config_file)
         assert config.cache_dir == Path("/toml/admin-cache")
-
-    def test_env_overrides_toml_cache_dir(self, tmp_path, monkeypatch):
-        """SOW_ADMIN_CACHE_DIR env overrides TOML cache_dir."""
-        monkeypatch.setenv("SOW_ADMIN_CACHE_DIR", "/env/override")
-        config_file = tmp_path / "config.toml"
-        config_file.write_text(
-            """
-[paths]
-cache_dir = "/toml/admin-cache"
-"""
-        )
-        config = AdminConfig.load(config_file)
-        assert config.cache_dir == Path("/env/override")

--- a/tests/app/test_config.py
+++ b/tests/app/test_config.py
@@ -120,9 +120,12 @@ class TestAppConfigProperties:
 class TestAppConfigSaveLoad:
     """Tests for config persistence."""
 
-    def test_load_reads_existing_config(self, tmp_path):
+    def test_load_reads_existing_config(self, tmp_path, monkeypatch):
         """Verify load() reads TOML."""
         config_path = tmp_path / "config.toml"
+
+        # Set token via env var (no longer stored in config file)
+        monkeypatch.setenv("SOW_TURSO_READONLY_TOKEN", "test-token")
 
         # Create a config file
         config_path.write_text("""
@@ -136,7 +139,6 @@ export_dir = "/test/exports"
 
 [turso]
 database_url = "libsql://test.turso.io"
-readonly_token = "test-token"
 sync_on_startup = false
 
 [app]
@@ -290,94 +292,26 @@ default_video_resolution = "1080p"
 class TestTursoConfig:
     """Tests for Turso configuration."""
 
-    def test_is_turso_configured_requires_url_and_token(self):
+    def test_is_turso_configured_requires_url_and_token(self, monkeypatch):
         """Verify Turso config requires both URL and token."""
         config = AppConfig()
 
         # Neither set
+        monkeypatch.delenv("SOW_TURSO_READONLY_TOKEN", raising=False)
         config.turso_database_url = ""
-        config.turso_readonly_token = ""
         assert config.is_turso_configured is False
 
         # Only URL set
         config.turso_database_url = "libsql://test.turso.io"
-        config.turso_readonly_token = ""
         assert config.is_turso_configured is False
 
-        # Both set
+        # Both set (token via env var)
         config.turso_database_url = "libsql://test.turso.io"
-        config.turso_readonly_token = "test-token"
+        monkeypatch.setenv("SOW_TURSO_READONLY_TOKEN", "test-token")
         assert config.is_turso_configured is True
 
-    def test_turso_url_from_environment(self, tmp_path, monkeypatch):
-        """Verify Turso URL can be set via environment."""
-        monkeypatch.setenv("SOW_TURSO_DATABASE_URL", "libsql://env.turso.io")
-
-        config_path = tmp_path / "config.toml"
-        config_path.write_text("""
-[database]
-db_path = "/test/db.sqlite"
-songsets_db_path = "/test/songsets.db"
-
-[songsets]
-backup_retention = 5
-export_dir = "/test/exports"
-
-[turso]
-database_url = "libsql://file.turso.io"
-readonly_token = ""
-sync_on_startup = true
-
-[app]
-cache_dir = "/test/cache"
-output_dir = "/test/output"
-preview_buffer_ms = 500
-preview_volume = 0.8
-default_gap_beats = 2.0
-default_video_template = "dark"
-default_video_resolution = "1080p"
-""")
-
-        config = AppConfig.load(config_path)
-
-        # Environment should override file
-        assert config.turso_database_url == "libsql://env.turso.io"
-
-    def test_sow_cache_dir_env_overrides_toml(self, tmp_path, monkeypatch):
-        """SOW_CACHE_DIR env var wins over TOML cache_dir."""
-        monkeypatch.setenv("SOW_CACHE_DIR", "/env/cache")
-
-        config_path = tmp_path / "config.toml"
-        config_path.write_text("""
-[database]
-db_path = "/test/db.sqlite"
-songsets_db_path = "/test/songsets.db"
-
-[songsets]
-backup_retention = 5
-export_dir = "/test/exports"
-
-[turso]
-database_url = ""
-readonly_token = ""
-sync_on_startup = true
-
-[app]
-cache_dir = "/toml/cache"
-output_dir = "/test/output"
-preview_buffer_ms = 500
-preview_volume = 0.8
-default_gap_beats = 2.0
-default_video_template = "dark"
-default_video_resolution = "1080p"
-""")
-
-        config = AppConfig.load(config_path)
-
-        assert config.cache_dir == Path("/env/cache")
-
     def test_turso_token_from_environment(self, tmp_path, monkeypatch):
-        """Verify Turso token can be set via environment."""
+        """Verify Turso token is read from environment variable only."""
         monkeypatch.setenv("SOW_TURSO_READONLY_TOKEN", "env-token")
 
         config_path = tmp_path / "config.toml"
@@ -392,7 +326,6 @@ export_dir = "/test/exports"
 
 [turso]
 database_url = ""
-readonly_token = "file-token"
 sync_on_startup = true
 
 [app]
@@ -407,5 +340,5 @@ default_video_resolution = "1080p"
 
         config = AppConfig.load(config_path)
 
-        # Environment should override file
+        # Token should come from environment variable only
         assert config.turso_readonly_token == "env-token"


### PR DESCRIPTION
## Summary

This PR improves configuration security and sync reliability for the admin CLI and app:

- **Security improvement**: Turso tokens now read from environment variables only (never stored in config files)
- **Auto-recovery**: Automatically recover from metadata corruption during sync operations
- **Better error messages**: Add helpful hints for common sync errors (read-only tokens, corrupted metadata)

## Changes by File

### Configuration & Security

**`src/stream_of_worship/admin/config.py`**
- Removed environment variable overrides for non-sensitive config (r2.bucket, r2.endpoint_url, r2.region)
- Added `sync_on_startup` configuration field
- Simplified config loading logic

**`src/stream_of_worship/app/config.py`**
- Changed `turso_readonly_token` from stored field to property reading from `SOW_TURSO_READONLY_TOKEN` env var
- Added R2 storage config fields (bucket, endpoint_url, region)
- Removed environment variable overrides for non-sensitive settings
- Added documentation note about security model

**`src/stream_of_worship/admin/db/client.py`**
- Added fallback to `SOW_TURSO_TOKEN` environment variable for Turso token

**`src/stream_of_worship/app/services/sync.py`**
- Updated to read Turso token from environment variable only

### Sync Reliability

**`src/stream_of_worship/admin/services/sync.py`**
- Added `_execute_sync_with_recovery()` method for automatic recovery from metadata corruption
- Added `_recover_from_missing_metadata()` to delete local db and recreate from Turso
- Added informational message when local db exists but has no sync history

**`src/stream_of_worship/admin/commands/db.py`**
- Added detection for fresh installation (db exists but no sync history)
- Added helpful error messages for common sync errors:
  - Read-only token permissions:提示使用 `turso db tokens create --full-access`
  - Corrupted metadata:提示运行 `sow-admin db reset`

### Documentation

**`README.md`**
- Updated admin CLI config example with clearer structure and paths
- Added security notes about environment variables vs config file
- Updated app config example with R2 settings and environment variables

**`src/stream_of_worship/admin/README.md`**
- Updated environment variables section to clarify only sensitive credentials use env vars

**`services/analysis/README.md`**
- Added Qwen3 Forced Aligner model setup instructions for LRC refinement

### Tests

**`tests/admin/test_config.py`**
- Removed tests for environment variable overrides (no longer supported)
- Updated cache_dir resolution tests

**`tests/app/test_config.py`**
- Removed tests for environment variable overrides
- Updated test setup to use `monkeypatch.setenv` for `SOW_TURSO_READONLY_TOKEN`

## Migration Notes

### Config File Changes

**Admin Config (`~/.config/sow-admin/config.toml`)**:
- Add `sync_on_startup` under `[turso]` section if not present
- Ensure `[database]` section has correct path
- No other changes needed - Turso token now comes from `SOW_TURSO_TOKEN` env var

**App Config (`~/.config/sow/config.toml`)**:
- Remove `readonly_token` from `[turso]` section (token now from `SOW_TURSO_READONLY_TOKEN` env var)
- Add `[r2]` section if not present:

```toml
[r2]
bucket = "your-r2-bucket"
endpoint_url = "https://<account-id>.r2.cloudflarestorage.com"
region = "auto"
```

### Environment Variables

**Admin CLI**:
- `SOW_TURSO_TOKEN` - Full-access Turso token (for write operations)
- `SOW_R2_ACCESS_KEY_ID` - R2 access key
- `SOW_R2_SECRET_ACCESS_KEY` - R2 secret key
- `SOW_ANALYSIS_API_KEY` - Analysis service API key

**User App**:
- `SOW_TURSO_READONLY_TOKEN` - Read-only Turso token (for sync)
- `SOW_R2_ACCESS_KEY_ID` - R2 access key
- `SOW_R2_SECRET_ACCESS_KEY` - R2 secret key

## Testing

```bash
# Run all tests (excludes analysis service tests - no Docker needed)
PYTHONPATH=src uv run --python 3.11 --extra app --extra test pytest tests/ \
  --ignore=tests/services/analysis \
  --ignore=services/qwen3/tests \
  --ignore=services/analysis/tests -v
```