### PR TITLE
feat: implement batch mode for admin CLI (v2)

### DIFF
--- a/docs/research-admin-cli-turso-sync.md
+++ b/docs/research-admin-cli-turso-sync.md
@@ -1,0 +1,125 @@
+# Research: Admin CLI Database & Turso Sync Architecture
+
+## Turso Database Connection Setup
+
+**Connection architecture:** The system uses `libsql` (the Turso SDK) as an embedded replica that maintains a local SQLite file synced with the Turso cloud database. The `libsql` package is an optional dependency.
+
+**Key file: `src/stream_of_worship/admin/db/client.py`**
+
+- Lines 30-36: `libsql` is imported with a try/except. If unavailable, `LIBSQL_AVAILABLE = False` and the client falls back to standard `sqlite3`.
+- Lines 61-66: `DatabaseClient.__init__` accepts `db_path`, `turso_url`, and `turso_token`. The token falls back to the `SOW_TURSO_TOKEN` environment variable (line 76).
+- Lines 79-86: `is_turso_enabled` property returns `True` only when both `turso_url` is set AND `libsql` is importable.
+- Lines 89-117: The `connection` property lazily creates the connection:
+  - **With Turso**: calls `libsql.connect(str(self.db_path), sync_url=self.turso_url, auth_token=self.turso_token)` -- this creates an embedded replica at the local path that can sync with the remote.
+  - **Without Turso**: uses standard `sqlite3.connect()` with row factory and foreign keys enabled.
+
+**Key file: `src/stream_of_worship/admin/config.py`**
+
+- Lines 20-50: `AdminConfig` dataclass holds `turso_database_url` (default empty string) and `sync_on_startup` (default `True`).
+- Lines 87-91: Turso config loaded from the `[turso]` section of the TOML config file (`database_url` and `sync_on_startup`).
+- Lines 248, 255: Config path is `~/.config/sow-admin/config.toml`; default DB path is `~/.config/sow-admin/db/sow.db`.
+
+**Key file: `src/stream_of_worship/admin/commands/db.py`**
+
+- Lines 38-51: `get_db_client()` helper constructs `DatabaseClient` using config values and `SOW_TURSO_TOKEN` from the environment.
+
+**Environment variables for credentials:**
+
+| Variable | Purpose | Used by |
+|---|---|---|
+| `SOW_TURSO_TOKEN` | Full-access Turso token | Admin CLI |
+| `SOW_TURSO_READONLY_TOKEN` | Read-only Turso token | User App |
+| `SOW_R2_ACCESS_KEY_ID` | R2 access key | Admin CLI |
+| `SOW_R2_SECRET_ACCESS_KEY` | R2 secret key | Admin CLI |
+
+**Example config file: `examples/sow-admin-config.toml`**
+```toml
+[turso]
+database_url = "https://your-db.turso.io"
+
+[database]
+path = "/Users/you/.local/share/sow-admin/sow.db"
+```
+
+**pyproject.toml dependency extras:**
+- `turso` extra: `libsql>=0.1.0` (deprecated, now included in `app` extra)
+- `app` extra includes `libsql>=0.1.0` directly
+- `admin` extra does NOT include `libsql` -- you must install `turso` or `app` extra separately
+
+## How `audio list --lrc incomplete` and `audio lrc` Commands Work
+
+### `sow_admin audio list --lrc incomplete`
+
+**File: `src/stream_of_worship/admin/commands/audio.py`**
+
+- Lines 972-1005: The `list` command accepts `--lrc` option with valid values: `pending`, `processing`, `completed`, `failed`, `incomplete`.
+- Lines 1049-1059: Creates a `DatabaseClient` (plain sqlite3, no Turso URL passed) and calls `db_client.list_recordings_with_songs(lrc_status=lrc, ...)`.
+
+**The `incomplete` magic filter** is in `DatabaseClient.list_recordings_with_songs()` (client.py, lines 696-705):
+```python
+if lrc_status == "incomplete":
+    query += " AND r.lrc_status IN ('pending', 'processing', 'failed')"
+```
+This means `--lrc incomplete` matches recordings where `lrc_status` is any of `pending`, `processing`, or `failed`.
+
+- Lines 1076-1078: With `--format ids`, it outputs one `song_id` per line, making it pipeable to `audio lrc --stdin`.
+
+### `sow_admin audio lrc`
+
+**File: `src/stream_of_worship/admin/commands/audio.py`**
+
+- Lines 1456-1557: The `lrc` command accepts `song_id` (or `--stdin`), `--force`, `--model`, `--lang`, `--wait`, etc.
+
+**Single song flow** (`_submit_lrc_single`, lines 284-419):
+1. Looks up the `Recording` by `song_id`
+2. Looks up the `Song` for lyrics
+3. Validates `r2_audio_url` exists
+4. Checks if already completed (skips unless `--force`)
+5. Submits to the Analysis Service via `analysis_client.submit_lrc()`
+6. Updates local DB to `lrc_status = "processing"` with the job ID
+7. With `--wait`: polls the Analysis Service (30s interval, 600s timeout), then updates DB with result URL
+
+**Batch flow** (`_submit_lrc_batch`, lines 422-500):
+- Reads song IDs from stdin, iterates over each, submitting jobs without waiting
+- Skips already-completed or in-progress recordings
+
+## Sync Mechanisms and Sync Frequency
+
+### A. Turso Embedded Replica Sync (libsql `.sync()`)
+
+**Admin CLI sync service: `src/stream_of_worship/admin/services/sync.py`**
+
+- `SyncService` class (lines 70-311) wraps `DatabaseClient.sync()` with validation, error handling, and automatic recovery from metadata corruption.
+- `execute_sync()` (line 174): Validates config, then calls `_execute_sync_with_recovery()`.
+- `_execute_sync_with_recovery()` (lines 193-239): Calls `client.sync()`, which calls `conn.sync()` on the libsql connection. If metadata is corrupted, it auto-recovers by deleting the local DB files and retrying.
+
+**IMPORTANT: The Admin CLI has NO automatic/periodic sync.** The `sync_on_startup` config field exists but is never consumed by the Admin CLI -- it is only used by the User App. The Admin CLI requires manual `sow-admin db sync` invocation.
+
+### B. Analysis Service Job Status Sync
+
+**`sow-admin audio status --sync`** (audio.py lines 1918-2020):
+1. Finds all recordings with `analysis_status` or `lrc_status` in (`pending`, `processing`)
+2. For each, queries the Analysis Service API for the job status
+3. Updates the local DB if the job has completed or failed
+
+This is also entirely manual.
+
+### C. User App Sync (for reference)
+
+- On app mount, if `sync_on_startup` is `True` and Turso is configured, runs sync in a background worker.
+- Manual sync action bound to `Shift+S` in the TUI.
+- No periodic timer -- the V2 spec explicitly says: "No periodic timer."
+
+## Key Files Reference
+
+| File | Role |
+|---|---|
+| `src/stream_of_worship/admin/db/client.py` | DatabaseClient with libsql/sqlite3 dual-mode connection and sync |
+| `src/stream_of_worship/admin/config.py` | Admin TOML config with `turso_database_url` and `sync_on_startup` |
+| `src/stream_of_worship/admin/commands/db.py` | `db sync`, `db init`, `db status`, `db turso-bootstrap` commands |
+| `src/stream_of_worship/admin/commands/audio.py` | `audio list`, `audio lrc`, `audio status` commands |
+| `src/stream_of_worship/admin/services/sync.py` | SyncService with validation, execution, and metadata recovery |
+| `src/stream_of_worship/admin/db/schema.py` | SQL schema including sync_metadata table |
+| `src/stream_of_worship/admin/db/models.py` | Song, Recording, DatabaseStats dataclasses |
+| `src/stream_of_worship/app/db/read_client.py` | App-side read-only client with Turso sync |
+| `src/stream_of_worship/app/services/sync.py` | App-side AppSyncService with pre-sync snapshots |

--- a/docs/research-analysis-service-lrc-completion-flow.md
+++ b/docs/research-analysis-service-lrc-completion-flow.md
@@ -1,0 +1,108 @@
+# Research: Analysis Service LRC Completion Flow
+
+## Architecture Overview
+
+The system uses a **two-tier architecture** for database management. The Analysis Service has its own local SQLite job store, while the catalog database (with Turso sync) lives in the Admin CLI. The Analysis Service **never writes to Turso directly**. Instead, it writes to its own local SQLite database and to R2, and the Admin CLI is responsible for pulling results and updating its own local SQLite (which syncs to Turso).
+
+## How the Analysis Service Writes LRC Results
+
+The LRC generation pipeline is in `services/analysis/src/sow_analysis/workers/lrc.py`. The `generate_lrc()` function (line 664) returns a tuple of `(Path, int, List[WhisperPhrase])` -- the LRC file path, line count, and Whisper phrases. It writes the LRC file to a local temporary path via `_write_lrc()` (line 490).
+
+The orchestration happens in `_process_lrc_job()` in `services/analysis/src/sow_analysis/workers/queue.py` (line 509). This method:
+
+1. Sets job status to `PROCESSING` in the local SQLite job store (line 529)
+2. Calls `generate_lrc()` to produce the LRC file locally
+3. Uploads the LRC to R2 (line 852)
+4. Saves the result to the local disk cache (line 856)
+5. Sets job status to `COMPLETED` in the local SQLite job store with the `lrc_url` and `line_count` in `result_json` (lines 860-878)
+
+## Database Storage: Local SQLite, NOT Turso
+
+The Analysis Service writes to a **local SQLite database** at `{CACHE_DIR}/jobs.db` (default `/cache/jobs.db`). This is defined in:
+
+- `services/analysis/src/sow_analysis/storage/db.py` -- the `JobStore` class uses `aiosqlite`
+- `services/analysis/src/sow_analysis/workers/queue.py` line 116 -- `db_path = db_path if db_path is not None else cache_dir / "jobs.db"`
+
+There are **zero references** to Turso, libsql, or any Turso connection strings anywhere in the `services/analysis/` directory. The Analysis Service has no knowledge of Turso whatsoever.
+
+## How LRC Files Are Uploaded to R2
+
+The R2 upload happens in `_process_lrc_job()` at queue.py line 852:
+
+```python
+lrc_url = await self.r2_client.upload_lrc(hash_prefix, lrc_path)
+```
+
+The `upload_lrc()` method in `services/analysis/src/sow_analysis/storage/r2.py` (line 135) uploads the local LRC file to the key `{hash_prefix}/lyrics.lrc` and returns the S3 URL `s3://{bucket}/{hash_prefix}/lyrics.lrc`.
+
+After R2 upload, two things happen:
+
+1. **Local disk cache** is updated (queue.py line 856): `cache_manager.save_lrc_result(lrc_cache_key, {"lrc_url": lrc_url, "line_count": line_count})`
+2. **Local SQLite job store** is updated (queue.py lines 869-878): `job_store.update_job(job.id, status="completed", progress=1.0, stage="complete", result_json=...)`
+
+## Complete Flow: LRC Job Submission to Database Update
+
+### Phase A: Admin CLI submits job and records intent
+
+1. Admin CLI (`_submit_lrc_single()` at `src/stream_of_worship/admin/commands/audio.py` line 341) calls `analysis_client.submit_lrc()` via HTTP POST to `/api/v1/jobs/lrc`
+2. Admin CLI immediately updates its own local SQLite catalog: `db_client.update_recording_status(hash_prefix=..., lrc_status="processing", lrc_job_id=job_id)` (line 360-364)
+
+### Phase B: Analysis Service processes the job
+
+3. Analysis Service's `_process_lrc_job()` runs the LRC pipeline:
+   - Downloads audio from R2
+   - Optionally downloads/generates vocals stem
+   - Runs Whisper transcription + LLM alignment (or YouTube transcript path)
+   - Optionally runs Qwen3 refinement
+   - Writes LRC file locally
+4. Uploads LRC to R2 via `r2_client.upload_lrc()` -- stored at `{hash_prefix}/lyrics.lrc`
+5. Saves LRC result to local disk cache
+6. Updates the Analysis Service's own `jobs.db`: `status=completed`, `result_json` contains `{lrc_url, line_count}`
+
+### Phase C: Admin CLI retrieves results and updates catalog
+
+This happens through **two mechanisms**:
+
+**Mechanism 1: Synchronous wait (single job with `--wait`)**
+- `_submit_lrc_single()` calls `analysis_client.wait_for_completion()` (audio.py line 387) which polls `GET /api/v1/jobs/{job_id}` every 30s
+- When the job returns `status=completed`, the Admin CLI calls `db_client.update_recording_lrc(hash_prefix, r2_lrc_url=job.result.lrc_url)` (audio.py lines 411-415)
+- This writes to the Admin CLI's local SQLite catalog: sets `r2_lrc_url`, `lrc_status='completed'`, and auto-publishes via `visibility_status = COALESCE(visibility_status, 'published')` (client.py lines 893-922)
+
+**Mechanism 2: Async sync via `sow-admin audio status --sync`**
+- The `status` command (audio.py line 1920) iterates over recordings with `lrc_status IN ('pending', 'processing')`
+- For each, queries the Analysis Service API for the job status
+- If completed with an `lrc_url`, calls `db_client.update_recording_lrc()` (audio.py lines 1996-2004)
+- If failed, calls `db_client.update_recording_status(lrc_status="failed")` (audio.py lines 2006-2010)
+
+### Phase D: Turso sync (separate manual step)
+
+7. The Admin CLI's `DatabaseClient` can optionally use `libsql` embedded replicas to sync with Turso cloud
+8. Triggered by `sow-admin db sync` command
+9. Calls `conn.sync()` on the libsql connection, which pushes local writes to Turso cloud
+10. This is a **manual operation**
+
+## Data Flow Diagram
+
+```
+Analysis Service (local SQLite jobs.db + R2)
+       |
+       | HTTP API (GET /api/v1/jobs/{id})
+       v
+Admin CLI (local SQLite catalog.db)
+       |
+       | libsql embedded replica sync
+       v
+Turso Cloud Database
+```
+
+## Turso Write Operations in the Analysis Service
+
+**There are none.** The Analysis Service never writes to Turso. The path to Turso goes through the Admin CLI.
+
+## Storage Layer Summary (`services/analysis/src/sow_analysis/storage/`)
+
+- **`db.py`** (`JobStore`): Local SQLite via `aiosqlite` for job state persistence. The `jobs` table tracks id, type, status, progress, stage, error_message, request_json, result_json, content_hash, timestamps.
+
+- **`r2.py`** (`R2Client`): S3-compatible storage client for R2. `upload_lrc()` (line 135) stores LRC files at `{hash_prefix}/lyrics.lrc`. Also handles audio downloads, stem uploads, and analysis result uploads.
+
+- **`cache.py`** (`CacheManager`): Local disk cache for deduplication. Stores LRC results as `{hash_prefix}_lrc.json` containing `{lrc_url, line_count}`. Also caches Whisper transcriptions. Cache key for LRC results is a composite hash of `content_hash + lyrics_hash`.

--- a/docs/research-turso-r2-database-architecture.md
+++ b/docs/research-turso-r2-database-architecture.md
@@ -1,0 +1,130 @@
+# Research: Turso Sync & R2 Database Architecture
+
+## Turso Configuration
+
+The project uses Turso (a hosted libSQL service) as the cloud database for the song catalog. There are two distinct roles with separate tokens:
+
+**Admin CLI (`sow-admin`)** -- read-write access:
+- Config file: `~/.config/sow-admin/config.toml` (TOML `[turso]` section)
+- Config class: `src/stream_of_worship/admin/config.py` -- `AdminConfig.turso_database_url` (line 43)
+- Auth token: `SOW_TURSO_TOKEN` environment variable (full-access / read-write token)
+- Database client: `src/stream_of_worship/admin/db/client.py` -- `DatabaseClient` class
+- Sync service: `src/stream_of_worship/admin/services/sync.py` -- `SyncService` class
+
+**User App (`sow-app`)** -- read-only access:
+- Config file: `~/.config/sow/config.toml` (TOML `[turso]` section)
+- Config class: `src/stream_of_worship/app/config.py` -- `AppConfig.turso_database_url` (line 112) and `AppConfig.turso_readonly_token` property (line 264-271)
+- Auth token: `SOW_TURSO_READONLY_TOKEN` environment variable (read-only token)
+- Database client: `src/stream_of_worship/app/db/read_client.py` -- `ReadOnlyClient` class
+- Sync service: `src/stream_of_worship/app/services/sync.py` -- `AppSyncService` class
+
+**Turso URL format**: `libsql://<database-name>-<username>.turso.io`
+
+**Token generation commands** (shown in `src/stream_of_worship/admin/commands/db.py` lines 617-629):
+- Admin: `turso db tokens create sow-catalog --read-write`
+- User app: `turso db tokens create sow-catalog --read-only`
+
+## Database Schema
+
+**Schema definition**: `src/stream_of_worship/admin/db/schema.py`
+
+Three tables:
+- **`songs`** -- scraped catalog entries (id, title, title_pinyin, composer, lyricist, album_name, album_series, musical_key, lyrics_raw, lyrics_lines, sections, source_url, table_row_number, scraped_at, created_at, updated_at, deleted_at)
+- **`recordings`** -- audio recordings linked to songs via `song_id` FK (content_hash PK, hash_prefix UNIQUE, song_id, original_filename, file_size_bytes, imported_at, r2_audio_url, r2_stems_url, r2_lrc_url, analysis metadata, processing status fields, youtube_url, visibility_status, deleted_at)
+- **`sync_metadata`** -- key/value metadata for sync tracking (key PK, value, updated_at). Default keys: `last_sync_at`, `sync_version` ("2"), `local_device_id`
+
+**Indexes** (8 total): on `recordings.song_id`, `recordings.analysis_status`, `recordings.hash_prefix`, `songs.album_name`, `songs.title_pinyin`, `recordings.visibility_status`, `songs.deleted_at`, `recordings.deleted_at`
+
+**Triggers**: auto-update `updated_at` on both `songs` and `recordings` tables.
+
+## Local Replica Architecture and Sync
+
+The architecture follows an embedded-replica pattern:
+
+```
+Admin machine (RW)  -->  Turso master DB  <--  User machines (RO)
+  sow-admin writes          cloud            sow-app reads
+  local embedded replica                     local embedded replica
+```
+
+**How libsql embedded replicas work:**
+
+Both the admin and user app connect using `libsql.connect()` with a local file path AND a `sync_url` + `auth_token`:
+
+- **Admin client** (`admin/db/client.py` lines 99-105):
+  ```python
+  self._connection = libsql.connect(
+      str(self.db_path),
+      sync_url=self.turso_url,
+      auth_token=self.turso_token or "",
+  )
+  ```
+
+- **User app client** (`app/db/read_client.py` lines 85-91): identical pattern.
+
+**Sync call sites:**
+
+1. **Admin sync command** (`admin/commands/db.py` line 294): Manual CLI command `sow-admin db sync`
+2. **Admin sync service** with recovery (`admin/services/sync.py` lines 193-238): auto-recovery from metadata corruption
+3. **User app background sync** (`app/app.py` lines 112-125): On TUI startup if `sync_on_startup=True`
+4. **User app manual sync** (`app/app.py` lines 127-140): `Shift+S` keybinding
+5. **User app CLI sync**: `sow-app db sync` command
+
+**Turso bootstrap** (`admin/commands/db.py` line 399): One-time `sow-admin db turso-bootstrap` command that initializes the Turso cloud database, creates schema, and optionally seeds data.
+
+## Database File Locations
+
+- **Admin catalog DB**: `~/.config/sow-admin/db/sow.db`
+- **User app catalog DB** (Turso replica): `~/.config/sow/db/sow.db`
+- **User app songsets DB** (local-only, plain SQLite): `~/.config/sow/db/songsets.db`
+
+## R2 (Cloudflare) Storage Setup
+
+**R2 Client**: `src/stream_of_worship/admin/services/r2.py` -- `R2Client` class
+
+**Configuration**:
+- Admin config (`admin/config.py` lines 37-40): `r2_bucket` (default "sow-audio"), `r2_endpoint_url`, `r2_region` (default "auto")
+- App config (`app/config.py` lines 116-118): same fields
+- TOML section: `[r2]` with keys `bucket`, `endpoint_url`, `region`
+
+**Credentials** (env vars only, never in config files):
+- `SOW_R2_ACCESS_KEY_ID`
+- `SOW_R2_SECRET_ACCESS_KEY`
+
+**R2 uses boto3 S3-compatible client** (line 52-58).
+
+**Storage layout in R2** (all keyed by `hash_prefix`, the first 12 chars of the audio file's SHA-256):
+- Audio: `{hash_prefix}/audio.mp3`
+- LRC lyrics: `{hash_prefix}/lyrics.lrc`
+- Stems: `{hash_prefix}/stems/{stem_name}.flac`
+
+**R2 URLs stored in DB**: The `recordings` table stores `r2_audio_url`, `r2_stems_url`, and `r2_lrc_url` as `s3://sow-audio/{hash_prefix}/...` format strings.
+
+## Cache Invalidation and Data Freshness
+
+**There is NO automated cache invalidation mechanism.** Here is what currently exists:
+
+**Database sync freshness**:
+- `sync_on_startup` config option (default `True`) triggers one sync when the app starts
+- Manual `Shift+S` keybinding in TUI or `sow-app db sync` CLI command
+- The example config file mentions `sync_interval = 30`, but this is NOT implemented in code
+- The V2 spec explicitly says: "No periodic timer."
+- `last_sync_at` timestamp is tracked in the songsets database `_sync_metadata` table
+
+**R2 asset cache freshness**:
+- The `AssetCache` has NO TTL, ETag, or last-modified checking
+- Files are cached indefinitely once downloaded
+- Only invalidation is via `force=True` parameter (explicit re-download)
+- `clear_cache(older_than_days=N)` can remove old cached files but must be called explicitly
+
+**Soft-delete freshness**: Both `songs` and `recordings` use `deleted_at` for soft deletes. User app filters `WHERE deleted_at IS NULL`.
+
+## Key Environment Variables
+
+| Variable | Used By | Purpose |
+|---|---|---|
+| `SOW_TURSO_TOKEN` | Admin CLI | Full-access Turso auth token (read-write) |
+| `SOW_TURSO_READONLY_TOKEN` | User App | Read-only Turso auth token |
+| `SOW_R2_ACCESS_KEY_ID` | Admin CLI + App | R2 access key |
+| `SOW_R2_SECRET_ACCESS_KEY` | Admin CLI + App | R2 secret key |
+| `SOW_ANALYSIS_API_KEY` | Admin CLI | Analysis service API key |

--- a/specs/batch-mode-plan-v2.md
+++ b/specs/batch-mode-plan-v2.md
@@ -1,0 +1,655 @@
+# Batch Mode: End-to-End Song Processing (v2)
+
+## Problem Summary
+
+Processing a song from catalog to usable state requires multiple manual steps: download audio, submit LRC job, wait for completion, check status, retry failures. For a catalog of 50+ songs, this is tedious and error-prone. There is no coordination layer that submits jobs, monitors progress, and reconciles status automatically across Analysis Service restarts/crashes/hangs.
+
+### Current Workflow (Manual)
+
+```bash
+# For each song:
+sow-admin audio download <song_id>     # download MP3 from YouTube
+sow-admin audio lrc <song_id>          # submit LRC job
+sow-admin audio status <job_id> --wait # wait (single-song only)
+# If failed:
+sow-admin audio lrc <song_id> --force  # retry
+```
+
+### Desired Workflow (Batch)
+
+```bash
+# Process all songs in an album that need LRC:
+sow-admin audio batch --album "敬拜精选"
+
+# Or resubmit all failed LRC jobs:
+sow-admin audio list --lrc-status failed --format ids | sow-admin audio batch --stdin
+```
+
+## Design
+
+### Core Concept
+
+Batch mode is a **submit-all-then-poll** orchestrator that:
+
+1. Selects songs via filters (album, song name, status, etc.)
+2. Downloads audio for all songs that need it (sequential, R2-first check)
+3. Submits all LRC jobs at once (no waiting between submissions)
+4. Polls all jobs in round-robin using **hybrid polling** (service-first, R2-fallback)
+5. Reconciles on Ctrl+C: check R2, mark completed or failed
+6. Prints summary stats when all songs reach terminal state
+
+### Key Design Decisions (v2 Changes)
+
+1. **Submit-all-then-poll**: No per-song sequential wait. Submit all jobs, then poll all in a loop. Jobs queue on the service and are processed according to service concurrency limits.
+2. **Hybrid polling**: Poll Analysis Service first (detects `failed` with reasons, detects `completed` quickly). Fall back to R2 poll on connection errors. Resubmit on 404 (job purged or lost).
+3. **No per-song timeout**: Use batch-level staleness timer instead (warns after 2hr of no completions, resets on any completion).
+4. **Staleness timeout for `processing`**: Songs stuck in `lrc_status='processing'` for >2hr are treated as lost and resubmitted.
+5. **`download_status` column**: New DB column to track download state separately from LRC state. Prevents conflating download failures with LRC failures.
+6. **Ctrl+C reconciliation**: On interrupt, check R2 for each in-progress song. Mark completed if R2 has the file, failed otherwise.
+7. **R2 confirmation check**: After service reports `completed`, verify R2 has the file (3 retries at 5s intervals) to handle eventual consistency.
+8. **No schema changes for LRC failure tracking**: Failure details logged to stdout only. `download_status` is the only new column.
+
+### Why Submit-All-Then-Poll (vs. per-song sequential)
+
+The Analysis Service uses a SQLite-backed `JobQueue` with:
+- `max_concurrent_lrc=2` (only 2 LRC jobs process simultaneously)
+- Job persistence across restarts (same job ID, stage="requeued")
+- 7-day purge window for completed/failed jobs
+
+Submitting all jobs upfront means the service can start processing the first jobs immediately while the admin CLI is still submitting the rest. Per-song sequential waiting would leave the service idle between submissions.
+
+### Why Hybrid Polling (vs. Option A or B from v1)
+
+| Approach | Detects `failed`? | Survives service restart? | Detects completion? |
+|----------|--------------------|---------------------------|---------------------|
+| Poll service only (v1 Option A) | Yes, with reason | No (404 on restart) | Fast |
+| Poll R2 only (v1 Option B) | No (silent timeout) | Yes | Slow (poll interval) |
+| **Hybrid (v2)** | **Yes, with reason** | **Yes (R2 fallback + resubmit on 404)** | **Fast** |
+
+## Command Interface
+
+```bash
+sow-admin audio batch [OPTIONS]
+```
+
+### Filter Options
+
+| Option | Description |
+|--------|-------------|
+| `--album TEXT` | Filter by album name (exact match) |
+| `--song TEXT` | Filter by song name (partial match, case-insensitive) |
+| `--lrc-status TEXT` | Filter by LRC status (`pending`, `processing`, `failed`, `incomplete`) |
+| `--download-status TEXT` | Filter by download status (`pending`, `processing`, `failed`) |
+| `--analysis-status TEXT` | Filter by analysis status |
+| `--stdin` | Read song IDs from stdin (pipe-friendly) |
+| `--limit INT` | Maximum number of songs to process |
+
+### Processing Options
+
+| Option | Description |
+|--------|-------------|
+| `--skip-download` | Skip download step (assume audio already on R2) |
+| `--skip-lrc` | Skip LRC step |
+| `--stale-after INT` | Minutes after which a `processing` song is treated as lost (default: 120) |
+| `--dry-run` | Show what would be processed without executing |
+
+### Output Options
+
+| Option | Description |
+|--------|-------------|
+| `--format TEXT` | Output format: `rich` (default), `json` |
+
+## File Changes
+
+| File | Change |
+|------|--------|
+| `src/stream_of_worship/admin/commands/audio.py` | Add `batch()` command |
+| `src/stream_of_worship/admin/db/client.py` | Add `download_status` column, `update_recording_download()` method |
+| `src/stream_of_worship/admin/db/models.py` | Add `download_status` field to `Recording` model, update `from_row()` indices |
+| `src/stream_of_worship/admin/services/r2.py` | No changes (uses `lrc_exists()`, `audio_exists()` from reconciliation v2) |
+
+## Detailed Design
+
+### Step Pipeline
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  Phase 1: Download (sequential per-song)                            │
+│                                                                     │
+│  For each song:                                                     │
+│    Check R2: audio_exists? ──yes──▶ skip                            │
+│                    │                                                │
+│                   no                                                 │
+│                    ▼                                                │
+│    download_audio() → upload to R2 → set download_status=completed │
+│    (on failure: set download_status=failed, skip LRC for this song)│
+└─────────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│  Phase 2: Submit All LRC Jobs                                      │
+│                                                                     │
+│  For each song needing LRC:                                        │
+│    Check R2: lrc_exists? ──yes──▶ update_recording_lrc(), skip     │
+│                    │                                                │
+│                   no                                                 │
+│                    ▼                                                │
+│    lrc_status=processing + not stale? ──yes──▶ reuse existing job_id│
+│                    │                                                │
+│                   no (or stale/lost)                                │
+│                    ▼                                                │
+│    analysis_client.submit_lrc() → set lrc_status=processing        │
+└─────────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│  Phase 3: Poll All Jobs (hybrid polling)                           │
+│                                                                     │
+│  while has_incomplete_jobs():                                       │
+│    for each (song_id, job_id) in incomplete_jobs:                   │
+│      try:                                                           │
+│        job = analysis_client.get_job(job_id)                        │
+│        if job.status == "completed":                                │
+│          confirm R2 has LRC (3x retry @ 5s)                        │
+│          update_recording_lrc()                                     │
+│          mark song done                                             │
+│        elif job.status == "failed":                                 │
+│          set lrc_status="failed", log error_message                │
+│          mark song done                                             │
+│        else: (queued/processing)                                    │
+│          continue polling                                           │
+│      except 404:                                                    │
+│        Job lost — check R2: if found → completed, else resubmit   │
+│      except ConnectionError:                                        │
+│        Fall back to R2 check for this cycle                        │
+│                                                                     │
+│    Staleness check:                                                 │
+│      if no completions for 2hr → print WARNING, reset timer       │
+│                                                                     │
+│    sleep(poll_interval)  # 30s                                      │
+│                                                                     │
+│  On Ctrl+C → reconcile all in-progress via R2                     │
+└─────────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│  Phase 4: Print Stats                                              │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### Processing Loop
+
+```python
+def batch(
+    filters, skip_download, skip_lrc, stale_after_minutes, dry_run, format
+):
+    songs = resolve_song_ids(filters)
+    if dry_run:
+        print_dry_run(songs)
+        return
+
+    results = {}
+
+    # Phase 1: Download
+    if not skip_download:
+        for song_id in songs:
+            recording = get_or_create_recording(song_id)
+            result = download_if_needed(song_id, recording)
+            results[song_id] = result  # may be skipped, completed, or failed
+
+    # Phase 2: Submit LRC jobs
+    active_jobs = {}  # song_id -> job_id
+    if not skip_lrc:
+        songs_needing_lrc = [
+            sid for sid in songs
+            if results.get(sid, {}).get("download") != "failed"
+            and results.get(sid, {}).get("lrc") != "completed"
+        ]
+        for song_id in songs_needing_lrc:
+            recording = get_recording(song_id)
+            job_id = submit_or_attach_lrc(song_id, recording, stale_after_minutes)
+            if job_id:
+                active_jobs[song_id] = job_id
+
+    # Phase 3: Poll all jobs
+    poll_all_jobs(active_jobs, results, stale_after_minutes)
+
+    # Phase 4: Print stats
+    print_stats(results)
+
+
+def download_if_needed(song_id, recording):
+    """Download audio if not on R2. Sets download_status in DB."""
+    hash_prefix = recording.hash_prefix
+
+    if r2_client.audio_exists(hash_prefix):
+        db_client.update_recording_download(hash_prefix, "completed")
+        return {"download": "skipped_r2"}
+
+    db_client.update_recording_download(hash_prefix, "processing")
+    try:
+        download_audio(song_id)  # includes R2 upload
+        db_client.update_recording_download(hash_prefix, "completed")
+        return {"download": "completed"}
+    except Exception as e:
+        db_client.update_recording_download(hash_prefix, "failed")
+        return {"download": "failed", "error": str(e)}
+
+
+def submit_or_attach_lrc(song_id, recording, stale_after_minutes):
+    """Submit LRC job or attach to existing one. Returns job_id or None."""
+    hash_prefix = recording.hash_prefix
+
+    # R2 already has LRC
+    lrc_url = r2_client.lrc_exists(hash_prefix)
+    if lrc_url:
+        db_client.update_recording_lrc(hash_prefix, lrc_url)
+        return None  # nothing to poll
+
+    # Existing job — check if stale
+    if recording.lrc_status == "processing" and recording.lrc_job_id:
+        staleness = datetime.now(timezone.utc) - recording.updated_at
+        if staleness < timedelta(minutes=stale_after_minutes):
+            return recording.lrc_job_id  # attach to existing
+        else:
+            log(f"Job {recording.lrc_job_id} is stale ({staleness}), resubmitting")
+
+    # Submit new job
+    job = analysis_client.submit_lrc(...)
+    db_client.update_recording_status(
+        hash_prefix=hash_prefix,
+        lrc_status="processing",
+        lrc_job_id=job.job_id,
+    )
+    return job.job_id
+
+
+def poll_all_jobs(active_jobs, results, stale_after_minutes):
+    """Poll all active jobs until terminal state or Ctrl+C."""
+    poll_interval = 30.0
+    last_completion_time = time.time()
+    STALE_WARNING_SECONDS = stale_after_minutes * 60
+
+    try:
+        while active_jobs:
+            any_completed_this_cycle = False
+
+            for song_id in list(active_jobs.keys()):
+                job_id = active_jobs[song_id]
+                try:
+                    job = analysis_client.get_job(job_id)
+
+                    if job.status == "completed":
+                        # R2 confirmation check (eventual consistency)
+                        recording = get_recording(song_id)
+                        lrc_url = confirm_r2_lrc(recording.hash_prefix)
+                        if lrc_url:
+                            db_client.update_recording_lrc(
+                                recording.hash_prefix, lrc_url
+                            )
+                            results[song_id]["lrc"] = "completed"
+                        else:
+                            # Rare: service says done but R2 doesn't have it yet
+                            log(f"WARNING: Job {job_id} completed but LRC not on R2 yet")
+                            continue  # will retry R2 check next cycle
+                        del active_jobs[song_id]
+                        any_completed_this_cycle = True
+
+                    elif job.status == "failed":
+                        db_client.update_recording_status(
+                            hash_prefix=recording.hash_prefix,
+                            lrc_status="failed",
+                        )
+                        results[song_id]["lrc"] = "failed"
+                        results[song_id]["lrc_error"] = job.error_message
+                        del active_jobs[song_id]
+                        any_completed_this_cycle = True
+
+                    # else: queued/processing — continue polling
+
+                except AnalysisServiceError as e:
+                    if e.status_code == 404:
+                        # Job lost — check R2, resubmit if needed
+                        recording = get_recording(song_id)
+                        lrc_url = r2_client.lrc_exists(recording.hash_prefix)
+                        if lrc_url:
+                            db_client.update_recording_lrc(
+                                recording.hash_prefix, lrc_url
+                            )
+                            results[song_id]["lrc"] = "completed"
+                            del active_jobs[song_id]
+                            any_completed_this_cycle = True
+                        else:
+                            log(f"Job {job_id} lost (404), resubmitting...")
+                            new_job_id = submit_or_attach_lrc(
+                                song_id, recording, stale_after_minutes
+                            )
+                            if new_job_id:
+                                active_jobs[song_id] = new_job_id
+                            else:
+                                del active_jobs[song_id]
+                    else:
+                        log(f"Service error polling {job_id}: {e}")
+                        # Fall back to R2 check
+                        recording = get_recording(song_id)
+                        lrc_url = r2_client.lrc_exists(recording.hash_prefix)
+                        if lrc_url:
+                            db_client.update_recording_lrc(
+                                recording.hash_prefix, lrc_url
+                            )
+                            results[song_id]["lrc"] = "completed"
+                            del active_jobs[song_id]
+                            any_completed_this_cycle = True
+
+                except (ConnectionError, RequestException):
+                    # Service unreachable — fall back to R2 check
+                    recording = get_recording(song_id)
+                    lrc_url = r2_client.lrc_exists(recording.hash_prefix)
+                    if lrc_url:
+                        db_client.update_recording_lrc(
+                            recording.hash_prefix, lrc_url
+                        )
+                        results[song_id]["lrc"] = "completed"
+                        del active_jobs[song_id]
+                        any_completed_this_cycle = True
+
+            if any_completed_this_cycle:
+                last_completion_time = time.time()
+
+            # Staleness warning
+            elapsed_since_completion = time.time() - last_completion_time
+            if elapsed_since_completion > STALE_WARNING_SECONDS:
+                console.print(
+                    f"[yellow]WARNING: No jobs completed in "
+                    f"{int(elapsed_since_completion // 3600)}h "
+                    f"{int((elapsed_since_completion % 3600) // 60)}m. "
+                    f"Analysis Service may be hung or restarting.[/yellow]"
+                )
+                console.print(
+                    "[yellow]Press Ctrl+C to stop and reconcile, "
+                    "or wait for service recovery.[/yellow]"
+                )
+                last_completion_time = time.time()  # reset to avoid spam
+
+            print_progress(active_jobs, results)
+
+            if active_jobs:
+                time.sleep(poll_interval)
+
+    except KeyboardInterrupt:
+        reconcile_on_interrupt(active_jobs, results)
+
+
+def confirm_r2_lrc(hash_prefix, max_retries=3, retry_delay=5.0):
+    """Confirm LRC file exists on R2 after service reports completion.
+
+    Handles R2 eventual consistency by retrying.
+    Returns lrc_url if found, None if not confirmed.
+    """
+    for attempt in range(max_retries):
+        lrc_url = r2_client.lrc_exists(hash_prefix)
+        if lrc_url:
+            return lrc_url
+        if attempt < max_retries - 1:
+            time.sleep(retry_delay)
+    return None
+
+
+def reconcile_on_interrupt(active_jobs, results):
+    """Reconcile status for in-progress jobs on Ctrl+C."""
+    console.print("\n[yellow]Batch interrupted. Reconciling status...[/yellow]")
+
+    for song_id, job_id in active_jobs.items():
+        recording = get_recording(song_id)
+        hash_prefix = recording.hash_prefix
+
+        # Check R2 for LRC
+        lrc_url = r2_client.lrc_exists(hash_prefix)
+        if lrc_url:
+            db_client.update_recording_lrc(hash_prefix, lrc_url)
+            results[song_id]["lrc"] = "completed"
+            console.print(f"  {song_id}: LRC found on R2 (completed)")
+        else:
+            db_client.update_recording_status(
+                hash_prefix=hash_prefix, lrc_status="failed"
+            )
+            results[song_id]["lrc"] = "failed"
+            results[song_id]["lrc_error"] = "Batch interrupted, LRC not on R2"
+            console.print(f"  {song_id}: LRC not on R2 (marked failed)")
+
+    console.print(
+        "[dim]Tip: Run 'sow-admin audio status --reconcile' later to catch "
+        "late completions after the service finishes processing.[/dim]"
+    )
+```
+
+### Polling Progress Display
+
+Each polling cycle prints a concise status line:
+
+```
+⏳ Polling 38 jobs... 5 completed, 2 failed, 31 in progress (elapsed: 12m 30s)
+```
+
+When a job transitions to terminal state:
+
+```
+✅ 敬拜之歌1 — LRC completed (45.2s)
+❌ 敬拜之歌2 — LRC failed: Audio too short for transcription
+```
+
+### R2 Confirmation Check
+
+After the Analysis Service reports a job as `completed`, the LRC file may not be immediately visible on R2 due to eventual consistency. The confirmation check retries:
+
+```
+attempt 1: lrc_exists() → None
+wait 5s
+attempt 2: lrc_exists() → None
+wait 5s
+attempt 3: lrc_exists() → s3://bucket/abc123/lyrics.lrc ✓
+```
+
+If all 3 retries fail, the job stays in `active_jobs` and will be re-checked on the next polling cycle (30s later). This avoids falsely marking a completed job as failed.
+
+### Ctrl+C Reconciliation
+
+On `KeyboardInterrupt`, the batch loop:
+
+1. Stops polling immediately
+2. For each song still in `active_jobs` (in-progress):
+   - Checks R2 for LRC file
+   - If found → `update_recording_lrc()` (completed + auto-publish)
+   - If not found → `update_recording_status(lrc_status="failed")`
+3. Prints partial stats
+4. Prints tip about running `--reconcile` later for late completions
+
+**Important**: A job may complete on the service moments after Ctrl+C. The admin should know `--reconcile` can catch these.
+
+### Retry Policy (simplified from v1)
+
+v1 had per-step exponential backoff retries. v2 simplifies:
+
+- **Download**: No automatic retry (single attempt per song). If download fails, set `download_status="failed"` and skip LRC for that song. Admin can re-run batch after fixing the issue.
+- **LRC**: No per-song retry. Submit once, poll until terminal. On service 404 (job lost), resubmit once. On service hang, staleness timer warns admin who decides whether to Ctrl+C.
+- **Rationale**: The Analysis Service has its own internal retry/requeue on restart. The batch orchestrator doesn't need to duplicate this. Per-song retries with exponential backoff added complexity without improving resilience — the staleness timer + Ctrl+C reconciliation covers the real failure modes.
+
+### Stats Output
+
+When all songs reach terminal state (or after Ctrl+C reconciliation), print:
+
+```
+╭─ Batch Summary ──────────────────────────╮
+│ Songs processed:    42                    │
+│                                          │
+│ Downloads:                               │
+│   Completed:          30                  │
+│   Skipped (R2):       10                  │
+│   Failed:             2                   │
+│                                          │
+│ LRC:                                     │
+│   Completed:          38                  │
+│   Failed:             2                   │
+│   Skipped (R2):       8                   │
+│   Skipped (dl failed):2                   │
+│                                          │
+│ LRC source:                              │
+│   R2 pre-existing:    8                   │
+│   ASR (generated):   30                   │
+│                                          │
+│ LRC timing (ASR jobs only):              │
+│   Average:           45.2s                │
+│   Median:            38.1s                │
+│   Min/Max:           12.3s / 180.5s       │
+│                                          │
+│ Failed downloads:                        │
+│   - 敬拜之歌 1: YouTube download error   │
+│   - 敬拜之歌 3: No YouTube URL           │
+│                                          │
+│ Failed LRC:                              │
+│   - 敬拜之歌 2: Audio too short           │
+│   - 敬拜之歌 4: Whisper transcription err │
+╰──────────────────────────────────────────╯
+```
+
+### LRC Source Tracking
+
+Stats distinguish "LRC already existed on R2" vs "LRC generated by ASR":
+
+- If `lrc_exists()` returned a URL before any job was submitted → "R2 pre-existing"
+- If `lrc_exists()` returned a URL after job submission + completion → "ASR (generated)"
+
+No new DB column needed — tracked in-memory during the batch run.
+
+## `--stdin` Pipe Integration
+
+Enables flexible song selection:
+
+```bash
+# Resubmit all failed LRC jobs
+sow-admin audio list --lrc-status failed --format ids | sow-admin audio batch --stdin
+
+# Process specific songs
+echo -e "song1\nsong2\nsong3" | sow-admin audio batch --stdin
+
+# Combine with grep
+sow-admin audio list --format csv | grep "敬拜" | cut -d, -f1 | sow-admin audio batch --stdin
+```
+
+## Database Schema Change
+
+### New Column: `download_status`
+
+```sql
+ALTER TABLE recordings ADD COLUMN download_status TEXT DEFAULT 'pending';
+```
+
+Values: `pending | processing | completed | failed`
+
+### New Method: `update_recording_download()`
+
+```python
+def update_recording_download(
+    self,
+    hash_prefix: str,
+    download_status: str,
+) -> None:
+    """Update download status for a recording."""
+    # Validates download_status against allowed values
+    # Sets updated_at = datetime('now')
+```
+
+### Model Update: `Recording`
+
+Add `download_status: str = "pending"` field and update `from_row()` column index.
+
+## Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| Song has no recording yet | Create recording (import step), then proceed |
+| Song has no YouTube URL | Skip download with warning, set `download_status="failed"`, skip LRC |
+| Download succeeds but upload to R2 fails | Set `download_status="failed"`, skip LRC. R2 upload is part of download step. |
+| LRC job submitted, service crashes, then restarts | Service re-queues the job (same job_id). Batch polls using same job_id — will see `queued/processing` again. |
+| LRC job submitted, service DB is wiped (catastrophic) | `get_job()` returns 404. Batch checks R2 → no file → resubmits. |
+| Job completed but R2 eventual consistency | `confirm_r2_lrc()` retries 3x at 5s. If still not found, re-check next polling cycle (30s). Never falsely marks as failed. |
+| Song stuck in `lrc_status="processing"` for hours | Staleness timeout (default 2hr). If `updated_at` is older than threshold, resubmit. |
+| Multiple batch runs on same songs | R2 pre-check makes this idempotent — skips steps with existing R2 output. Existing `processing` jobs are reused (not duplicated). |
+| Batch interrupted (Ctrl+C) | Reconcile via R2: mark completed if file exists, failed if not. Print partial stats. |
+| `--skip-download` but audio not on R2 | Skip download step, LRC step will likely fail (no audio to transcribe). Service will report job as `failed` with error. |
+| Service 7-day purge deletes completed job | `get_job()` returns 404. Batch checks R2 first → if LRC file exists, marks completed. Only problematic if purge happens AND R2 file is deleted. |
+| Service connection timeout during poll | Fall back to R2 check for that cycle. Next cycle retries service. |
+| Two batch runs simultaneously on overlapping songs | Allowed (idempotent). R2 pre-check + processing status check prevent duplicate work. First to write R2 wins. |
+
+## Relationship to `--reconcile`
+
+Batch mode and `--reconcile` are complementary:
+
+| Feature | `--reconcile` | `batch` |
+|---------|--------------|---------|
+| Purpose | Check if jobs are done | Process songs end-to-end |
+| Submits new jobs | No | Yes |
+| Updates DB | Yes (status only) | Yes (status + download_status) |
+| Handles `failed` state | No (only → completed) | Yes (sets `lrc_status="failed"`) |
+| Resilience | R2-only check | Hybrid (service + R2) |
+| Ctrl+C handling | N/A | Reconciles via R2 |
+| Use case | Cron, manual status check | Bulk processing |
+| Typical trigger | Automated (cron) | Manual (admin action) |
+
+After a batch run (especially after Ctrl+C), `--reconcile` can be used as a cron job to pick up any completions that happened after the batch run ended.
+
+## Design Walkthrough: Failure Scenarios
+
+### Scenario: Analysis Service hangs mid-job
+
+```
+1. Batch submits 50 LRC jobs
+2. Service processes 10, then hangs on job #11
+3. Batch polls every 30s — sees jobs #1-10 completed, #11 still processing, #12-50 queued
+4. After 2hr with no completions → WARNING printed
+5. Admin presses Ctrl+C
+6. Reconcile: R2 check for jobs #11-50
+   - Jobs #12-20 actually completed while admin was reading the warning → found on R2 → marked completed
+   - Job #11 and #21-50 not on R2 → marked failed
+7. Admin restarts Analysis Service
+8. Admin runs: sow-admin audio list --lrc-status failed --format ids | sow-admin audio batch --stdin
+9. Batch resubmits failed jobs, service processes them
+```
+
+### Scenario: Analysis Service crashes and restarts
+
+```
+1. Batch submits 50 LRC jobs, sets lrc_status="processing" in DB
+2. Service crashes while processing job #5
+3. Batch polls — ConnectionError on all jobs
+4. Batch falls back to R2 check — no new completions
+5. Service restarts — JobQueue.initialize() recovers all jobs:
+   - Job #5 was processing → re-queued (same job_id, stage="requeued")
+   - Jobs #6-50 were queued → still queued (same job_ids)
+6. Batch's next poll cycle — get_job() succeeds again
+7. Job #5 completes (re-processed from scratch)
+8. All jobs eventually complete normally
+```
+
+### Scenario: Ctrl+C then late completion
+
+```
+1. Batch has 10 jobs in-progress
+2. Admin presses Ctrl+C
+3. Reconcile: R2 check for all 10 — none found yet → all marked "failed"
+4. 5 minutes later, service finishes processing 5 of those jobs
+5. Admin runs: sow-admin audio status --reconcile
+6. --reconcile finds LRC files on R2 for 5 songs → marks them "completed"
+7. Remaining 5 songs stay "failed" → admin can re-batch them
+```
+
+## Future Enhancements (Out of Scope)
+
+- **Parallel downloads**: Download multiple songs concurrently with `ThreadPoolExecutor`
+- **Parallel LRC processing**: Process multiple songs concurrently on the service side (requires increasing `max_concurrent_lrc`)
+- **Analysis step**: Add `analyze` step to the pipeline (requires Docker + ML dependencies)
+- **Resume interrupted batch**: Save batch state to file, allow resuming from last checkpoint
+- **Progress bar**: Rich progress bar for long-running batches
+- **Notification**: Send email/webhook when batch completes
+- **Failure details in DB**: Add `lrc_failed_at` / `lrc_failure_reason` columns for persistent failure tracking (requires schema change — deferred)
+- **Clear stale `lrc_job_id`**: Method to clear stale job IDs from DB (cosmetic — poll logic handles it)

--- a/specs/batch-mode-plan.md
+++ b/specs/batch-mode-plan.md
@@ -1,0 +1,282 @@
+# Batch Mode: End-to-End Song Processing
+
+## Problem Summary
+
+Processing a song from catalog to usable state requires multiple manual steps: download audio, submit LRC job, wait for completion, check status, retry failures. For a catalog of 50+ songs, this is tedious and error-prone. There is no coordination layer that submits jobs, monitors progress, and retries failures automatically.
+
+### Current Workflow (Manual)
+
+```bash
+# For each song:
+sow-admin audio download <song_id>     # download MP3 from YouTube
+sow-admin audio lrc <song_id>          # submit LRC job
+sow-admin audio status <job_id> --wait # wait (single-song only)
+# If failed:
+sow-admin audio lrc <song_id> --force  # retry
+```
+
+### Desired Workflow (Batch)
+
+```bash
+# Process all songs in an album that need LRC:
+sow-admin audio batch --album "敬拜精选" --max-retries 3
+
+# Or resubmit all failed LRC jobs:
+sow-admin audio list --lrc-status failed --format ids | sow-admin audio batch --stdin
+```
+
+## Design
+
+### Core Concept
+
+Batch mode is an **orchestration loop** that:
+
+1. Selects songs via filters (album, song name, status, etc.)
+2. For each song, runs steps in order: download → LRC
+3. Checks R2 before each step (skip if output already exists)
+4. Submits jobs and polls for completion
+5. Retries failed steps up to N times
+6. Marks final failures as `lrc_status='failed'` in DB
+7. Prints summary stats when all songs reach terminal state
+
+### Key Design Decisions
+
+1. **No schema changes**: Uses existing `lrc_status`, `update_recording_status()` for failure marking. Failure details are logged to stdout only.
+2. **R2-first checks**: Before running any step, check if output already exists on R2 (avoid duplicate work)
+3. **Sequential per-song, parallel across songs**: Each song's steps run sequentially, but multiple songs can be processed concurrently (out of scope for v1 — future enhancement)
+4. **Terminal states only**: Batch loop continues until every song reaches `completed` or `failed`
+5. **Download + LRC only**: Analysis is out of scope for v1 (different dependencies, timing)
+
+## Command Interface
+
+```bash
+sow-admin audio batch [OPTIONS]
+```
+
+### Filter Options
+
+| Option | Description |
+|--------|-------------|
+| `--album TEXT` | Filter by album name (exact match) |
+| `--song TEXT` | Filter by song name (partial match, case-insensitive) |
+| `--lrc-status TEXT` | Filter by LRC status (`pending`, `processing`, `failed`, `incomplete`) |
+| `--analysis-status TEXT` | Filter by analysis status |
+| `--stdin` | Read song IDs from stdin (pipe-friendly) |
+| `--limit INT` | Maximum number of songs to process |
+
+### Processing Options
+
+| Option | Description |
+|--------|-------------|
+| `--max-retries INT` | Max retry attempts per step (default: 3) |
+| `--skip-download` | Skip download step (assume audio already on R2) |
+| `--skip-lrc` | Skip LRC step |
+| `--dry-run` | Show what would be processed without executing |
+
+### Output Options
+
+| Option | Description |
+|--------|-------------|
+| `--format TEXT` | Output format: `rich` (default), `json` |
+
+## File Changes
+
+| File | Change |
+|------|--------|
+| `src/stream_of_worship/admin/commands/audio.py` | Add `batch()` command |
+| `src/stream_of_worship/admin/services/r2.py` | No changes (uses `lrc_exists()`, `audio_exists()` from reconciliation v2) |
+| `src/stream_of_worship/admin/db/client.py` | No changes |
+
+## Detailed Design
+
+### Step Pipeline
+
+```
+┌─────────────┐     ┌─────────────┐
+│  Download   │────▶│     LRC     │
+│  (YouTube)  │     │  (ASR API)  │┌──────────┐
+└──────┬──────┘     └──────┬──────┘│  FAILED  │
+       │                  │      └──────────┘
+       ▼                  ▼
+  Check R2:          Check R2:
+  audio.mp3?         lyrics.lrc?
+  (skip if exists)   (skip if exists)
+```
+
+### Processing Loop
+
+```python
+def batch(...):
+    songs = resolve_song_ids(filters)
+    results = {}
+
+    for song_id in songs:
+        result = process_song(song_id, max_retries)
+        results[song_id] = result
+
+    print_stats(results)
+
+def process_song(song_id, max_retries) -> SongResult:
+    recording = get_or_create_recording(song_id)
+    hash_prefix = recording.hash_prefix
+
+    # Step 1: Download
+    if not skip_download:
+        if r2_client.audio_exists(hash_prefix):
+            log(f"Audio already on R2, skipping download")
+        else:
+            for attempt in range(1, max_retries + 1):
+                try:
+                    download_audio(song_id)
+                    break
+                except Exception as e:
+                    if attempt == max_retries:
+                        mark_failed(recording, "download", e)
+                        return SongResult(status="failed", step="download", error=str(e))
+                    log(f"Download attempt {attempt} failed: {e}, retrying...")
+
+    # Step 2: LRC
+    if not skip_lrc:
+        if r2_client.lrc_exists(hash_prefix):
+            log(f"LRC already on R2, skipping")
+            update_recording_lrc(hash_prefix, lrc_url)  # reconcile in case DB is stale
+        else:
+            for attempt in range(1, max_retries + 1):
+                try:
+                    submit_lrc_job(song_id)
+                    wait_for_lrc_completion(song_id, timeout=...)
+                    break
+                except Exception as e:
+                    if attempt == max_retries:
+                        db_client.update_recording_status(
+                            hash_prefix=hash_prefix, lrc_status="failed"
+                        )
+                        return SongResult(status="failed", step="lrc", error=str(e))
+                    log(f"LRC attempt {attempt} failed: {e}, retrying...")
+
+    return SongResult(status="completed")
+```
+
+### Job Completion Waiting
+
+After submitting an LRC job, batch mode needs to detect when it completes. Two approaches:
+
+#### Option A: Poll Analysis Service (current `--wait` pattern)
+
+```python
+while not timed_out:
+    job = analysis_client.get_job(job_id)
+    if job.status in ("completed", "failed"):
+        break
+    time.sleep(poll_interval)
+```
+
+**Pro**: Fast detection (job status updates immediately on completion)
+**Con**: Fragile if Analysis Service restarts and loses job state
+
+#### Option B: Poll R2 (reconcile pattern)
+
+```python
+while not timed_out:
+    if r2_client.lrc_exists(hash_prefix):
+        break
+    time.sleep(poll_interval)
+```
+
+**Pro**: Robust against Analysis Service restarts
+**Con**: Slightly higher latency (poll interval + R2 eventual consistency)
+
+**Recommended**: Use Option B (poll R2) for consistency with `--reconcile`. After R2 confirms the file, call `update_recording_lrc()` to update DB. Poll interval: 30s for first 5 min, 60s thereafter.
+
+### Retry Policy
+
+- **Per-step retries**: Each step (download, LRC) retries independently up to `max_retries`
+- **Backoff**: Exponential — 10s, 30s, 90s between retries
+- **Final failure**: Set `lrc_status='failed'` via `update_recording_status()`, log reason to stdout
+- **Continue on failure**: Batch mode does NOT stop when one song fails — it marks it failed and moves on
+
+### Stats Output
+
+When all songs reach terminal state, print:
+
+```
+╭─ Batch Summary ──────────────────────────╮
+│ Songs processed:    42                    │
+│ Completed:          38 (90%)              │
+│ Failed:             4 (10%)               │
+│ Skipped (R2):       12                    │
+│                                          │
+│ LRC timing:                              │
+│   Average:           45.2s                │
+│   Median:            38.1s                │
+│   Min/Max:           12.3s / 180.5s       │
+│                                          │
+│ LRC source:                              │
+│   YouTube (existing): 8                   │
+│   ASR (generated):   30                   │
+│                                          │
+│ Failed songs:                            │
+│   - 敬拜之歌 1: download failed (3 retries)
+│   - 敬拜之歌 2: LRC failed (3 retries)
+│   - ...                                  │
+╰──────────────────────────────────────────╯
+```
+
+### LRC Source Tracking
+
+Stats need to distinguish "LRC already existed on R2" vs "LRC generated by ASR." This is derivable from batch processing:
+
+- If `lrc_exists()` returned a URL before any job was submitted → "YouTube (existing)" or "R2 pre-existing"
+- If `lrc_exists()` returned a URL after job submission → "ASR (generated)"
+
+No new DB column needed — tracked in-memory during the batch run.
+
+## `--stdin` Pipe Integration
+
+Enables flexible song selection:
+
+```bash
+# Resubmit all failed LRC jobs
+sow-admin audio list --lrc-status failed --format ids | sow-admin audio batch --stdin
+
+# Process specific songs
+echo -e "song1\nsong2\nsong3" | sow-admin audio batch --stdin
+
+# Combine with grep
+sow-admin audio list --format csv | grep "敬拜" | cut -d, -f1 | sow-admin audio batch --stdin
+```
+
+## Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| Song has no recording yet | Create recording (import step), then proceed |
+| Song has no YouTube URL | Skip with warning, mark as failed |
+| Download succeeds but upload to R2 fails | Retry download step (R2 upload is part of download step) |
+| LRC job submitted but Analysis Service crashes | Poll R2 — when service restarts and reprocesses, R2 check succeeds |
+| Multiple batch runs on same songs | R2 pre-check makes this idempotent — skips steps with existing R2 output |
+| Batch interrupted (Ctrl+C) | Print partial stats, mark in-progress jobs as `processing` (they'll be picked up by `--reconcile` or next batch run) |
+| `--skip-download` but audio not on R2 | Skip download step, LRC step will likely fail (no audio to transcribe) |
+
+## Relationship to `--reconcile`
+
+Batch mode and `--reconcile` are complementary:
+
+| Feature | `--reconcile` | `batch` |
+|---------|--------------|---------|
+| Purpose | Check if jobs are done | Process songs end-to-end |
+| Submits new jobs | No | Yes |
+| Updates DB | Yes (status only) | Yes (status + retries) |
+| Use case | Cron, manual status check | Bulk processing |
+| Typical trigger | Automated (cron) | Manual (admin action) |
+
+After a batch run, `--reconcile` can be used to pick up any completions that happened after the batch run ended.
+
+## Future Enhancements (Out of Scope)
+
+- **Parallel processing**: Process multiple songs concurrently with `ThreadPoolExecutor`
+- **Analysis step**: Add `analyze` step to the pipeline (requires Docker + ML dependencies)
+- **Resume interrupted batch**: Save batch state to file, allow resuming from last checkpoint
+- **Progress bar**: Rich progress bar for long-running batches
+- **Notification**: Send email/webhook when batch completes
+- **Failure details in DB**: Add `lrc_failed_at` / `lrc_failure_reason` columns for persistent failure tracking (requires schema change — deferred)

--- a/specs/lrc-reconciliation-via-r2.md
+++ b/specs/lrc-reconciliation-via-r2.md
@@ -1,0 +1,248 @@
+# LRC Status Reconciliation via R2 Scan
+
+## Problem Summary
+
+When the Admin submits LRC jobs via `sow-admin audio lrc`, the local DB is set to `lrc_status="processing"`. The Analysis Service completes the job and uploads the LRC file to R2, but it **never writes to Turso**. The Admin CLI only discovers completion if:
+
+- `--wait` was used (single-song only, not batch)
+- `audio status --sync` is run (polls Analysis Service, but unreliable if the service restarts and loses job state)
+- `db sync` is run (only syncs local↔Turso, but nobody wrote the completion to Turso either)
+
+### Current Latency
+
+Admins see LRC status updates only when they manually run sync commands, which can be hours or days after job completion.
+
+### Desired Behavior
+
+Admins should see LRC status updates within a few minutes (at most 5 minutes) of job completion, even if the Analysis Service restarts.
+
+## Solution: Add `--reconcile` to `audio status`
+
+Instead of polling the Analysis Service (fragile), scan R2 directly for LRC file presence. R2 is the durable source of truth — if `{hash_prefix}/lyrics.lrc` exists, the job completed successfully. This approach is robust against Analysis Service restarts since R2 is persistent storage.
+
+### Key Design Decisions
+
+1. **R2 as source of truth**: LRC completion is determined by file presence in R2, not Analysis Service job state
+2. **DB-driven scan**: Iterate over DB recordings with incomplete status and check R2 for each (vs. listing all R2 files)
+3. **No auto-fail detection**: Leave `processing` entries alone if no LRC file found (job may still be running)
+4. **Never auto-sync**: Admin runs `db sync` separately after reconcile
+5. **No new containers**: Leverage existing Admin CLI infrastructure
+
+## File Changes
+
+| File | Change |
+|------|--------|
+| `src/stream_of_worship/admin/services/r2.py` | Add `lrc_exists(hash_prefix) -> Optional[str]` |
+| `src/stream_of_worship/admin/commands/audio.py` | Add `--reconcile` flag to `check_status()`, deprecate `--sync` |
+| `src/stream_of_worship/admin/db/client.py` | No changes needed (existing methods sufficient) |
+
+## Detailed Changes
+
+### 1. `src/stream_of_worship/admin/services/r2.py` — Add `lrc_exists()`
+
+Add a method following the existing pattern of `audio_exists()`:
+
+```python
+def lrc_exists(self, hash_prefix: str) -> Optional[str]:
+    """Check whether an LRC file exists in R2.
+
+    Args:
+        hash_prefix: 12-character hash prefix
+
+    Returns:
+        S3 URL of the LRC file if it exists, None otherwise
+    """
+    try:
+        s3_key = f"{hash_prefix}/lyrics.lrc"
+        self._client.head_object(Bucket=self.bucket, Key=s3_key)
+        return f"s3://{self.bucket}/{s3_key}"
+    except ClientError:
+        return None
+```
+
+**Location**: Insert after `audio_exists()` method (around line 137)
+
+### 2. `src/stream_of_worship/admin/commands/audio.py` — Add `--reconcile` to `check_status()`
+
+**New parameter** (add after `force_url` parameter, around line 1801):
+
+```python
+reconcile: bool = typer.Option(
+    False, "--reconcile", "-r",
+    help="Reconcile LRC status by scanning R2 for completed LRC files (robust against service restarts)"
+)
+```
+
+**Reconcile logic** (insert after `--force-status` handler and before "Mode A: Query specific job", around line 1850):
+
+```python
+# Handle --reconcile mode
+if reconcile:
+    # Initialize R2 client
+    try:
+        r2_client = R2Client(config.r2_bucket, config.r2_endpoint_url, config.r2_region)
+    except ValueError as e:
+        console.print(f"[red]R2 not configured: {e}[/red]")
+        raise typer.Exit(1)
+
+    # DB-driven: get all recordings with lrc_status != 'completed'
+    incomplete = db_client.list_recordings(lrc_status="incomplete")
+
+    if not incomplete:
+        console.print("[green]No recordings with incomplete LRC status.[/green]")
+        # Fall through to list pending recordings table
+    else:
+        console.print(f"[cyan]Scanning R2 for LRC files across {len(incomplete)} recording(s)...[/cyan]")
+        reconciled = 0
+        for rec in incomplete:
+            lrc_url = r2_client.lrc_exists(rec.hash_prefix)
+            if lrc_url:
+                db_client.update_recording_lrc(
+                    hash_prefix=rec.hash_prefix,
+                    r2_lrc_url=lrc_url,
+                )
+                reconciled += 1
+                console.print(f"  [green]✓[/green] {rec.song_id or rec.hash_prefix}: pending/processing → completed")
+
+        if reconciled > 0:
+            console.print(f"[green]Reconciled {reconciled} LRC status(es) from R2.[/green]")
+        else:
+            console.print("[dim]No completed LRC files found in R2 for pending recordings.[/dim]")
+        console.print("")
+    # Fall through to list pending recordings table
+```
+
+**Deprecate `--sync`**: Add warning at the start of `--sync` handling (around line 1920):
+
+```python
+# Mode B: Sync and list pending recordings
+# If --sync, query analysis service for all pending jobs and update local DB
+if sync:
+    console.print(
+        "[yellow]Warning: --sync is unreliable if the Analysis Service has restarted. "
+        "Consider using --reconcile instead, which scans R2 directly.[/yellow]"
+    )
+    # ... rest of --sync logic ...
+```
+
+**Update docstring** (around line 1804):
+
+```python
+"""Check analysis status.
+
+With JOB_ID: query the service for that job's status.
+Without: list all recordings with pending/processing/failed status.
+Use --reconcile to update LRC status by scanning R2 (robust against service restarts).
+Use --sync to poll the analysis service (unreliable if service restarted).
+Use --force-status when you need to manually override status.
+"""
+```
+
+### 3. No changes needed to `db/client.py`
+
+The existing methods are sufficient:
+- `list_recordings(lrc_status="incomplete")` returns recordings where `lrc_status IN ('pending', 'processing', 'failed')`
+- `update_recording_lrc(hash_prefix, r2_lrc_url)` sets `lrc_status='completed'` and auto-publishes
+
+## Automation / Cron Integration
+
+The `--reconcile` flag works seamlessly with cron:
+
+```cron
+# Reconcile LRC status every 3 minutes, then sync to Turso
+*/3 * * * * sow-admin audio status --reconcile > /tmp/sow-reconcile.log 2>&1 && sow-admin db sync >> /tmp/sow-reconcile.log 2>&1
+```
+
+This delivers **≤3 min latency** for LRC status visibility:
+
+1. Job completes and LRC uploaded to R2
+2. cron runs `audio status --reconcile at T+0-3m`, finds R2 files, updates local DB
+3. cron runs `db sync`, pushes updates to Turso cloud
+4. Other Admin replicas sync from Turso and see completed status
+
+## Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| LRC exists in R2, DB says `pending` | Updated to `completed` with correct `r2_lrc_url` |
+| LRC exists in R2, DB says `processing` | Updated to `completed` with correct `r2_lrc_url` |
+| LRC exists in R2, DB says `failed` | Updated to `completed` with correct `r2_lrc_url` |
+| No LRC in R2, DB says `processing` | Left unchanged (job may still be running) |
+| No LRC in R2, DB says `failed` | Left unchanged |
+| `r2_lrc_url` already set but `lrc_status != 'completed'` | Fixed to `completed` |
+| Recording not in DB but LRC in R2 | Ignored (DB-driven scan only checks known recordings) |
+
+## Performance Considerations
+
+- **R2 API calls**: Each incomplete recording triggers one `head_object` call
+- **Current use cases**: Admins typically have <100 recordings with incomplete LRC status
+- **Duration**: ~100ms per R2 API call on average (Cloudflare R2 has low latency)
+- **Total time for 100 recordings**: ~10 seconds (acceptable for cron)
+
+### Future Optimization (Out of Scope)
+
+For larger catalogs, use `concurrent.futures.ThreadPoolExecutor` to parallelize R2 checks:
+
+```python
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+with ThreadPoolExecutor(max_workers=10) as executor:
+    futures = {
+        executor.submit(r2_client.lrc_exists, rec.hash_prefix): rec
+        for rec in incomplete
+    }
+    for future in as_completed(futures):
+        rec = futures[future]
+        try:
+            lrc_url = future.result()
+            if lrc_url:
+                db_client.update_recording_lrc(rec.hash_prefix, lrc_url)
+                reconciled += 1
+                console.print(f"  [green]✓[/green] {rec.song_id or rec.hash_prefix}")
+        except Exception as e:
+            console.print(f"  [red]✗[/red] Failed to check {rec.hash_prefix}: {e}")
+```
+
+This would reduce ~100 recordings from 10s to 1-2s.
+
+## Testing
+
+### Manual Testing Steps
+
+1. Submit LRC job: `sow-admin audio lrc <song_id>`
+2. Verify DB shows `lrc_status="processing"`
+3. Wait for Analysis Service to complete (or manually upload LRC to R2 for testing)
+4. Run: `sow-admin audio status --reconcile`
+5. Verify DB shows `lrc_status="completed"` and `r2_lrc_url` set
+6. Run second reconciliation: should report "No completed LRC files found"
+
+### Unit Test Coverage
+
+Add tests for new `R2Client.lrc_exists()` method:
+
+```python
+def test_lrc_exists(monkeypatch):
+    client = R2Client("test-bucket", "https://r2.example.com")
+    
+    # Mock head_object to return successful response
+    def mock_head_object(Bucket, Key):
+        return True
+    monkeypatch.setattr(client._client, "head_object", mock_head_object)
+    
+    result = client.lrc_exists("abc123456789")
+    assert result == "s3://test-bucket/abc123456789/lyrics.lrc"
+```
+
+## Future Enhancements (Out of Scope)
+
+- **Analysis status reconciliation**: Could similarly check R2 for `analysis.json` / `stems/` to reconcile `analysis_status`
+- **`--reconcile-all`**: Scan all recordings (including completed) to backfill any missing LRC URLs
+- **`--reconcile` on `audio list`**: Auto-reconcile before listing could reduce surprise, but adds latency to every list command
+
+## References
+
+- Admin CLI LRC workflow: `src/stream_of_worship/admin/commands/audio.py` (lines 1456-1514)
+- Admin CLI status command: `src/stream_of_worship/admin/commands/audio.py` (lines 1786-2068)
+- R2Client implementation: `src/stream_of_worship/admin/services/r2.py`
+- Database client: `src/stream_of_worship/admin/db/client.py`
+- R2 file naming pattern: `{hash_prefix}/lyrics.lrc` (see `upload_lrc()` in R2Client)

--- a/specs/reconciliation-via-r2-v2.md
+++ b/specs/reconciliation-via-r2-v2.md
@@ -1,0 +1,429 @@
+# Status Reconciliation via R2 Scan (v2)
+
+## Problem Summary
+
+When the Admin submits jobs via `sow-admin audio lrc` or `sow-admin audio analyze`, the local DB is set to `processing`. The Analysis Service completes the job and uploads results to R2, but it **never writes to Turso**. The Admin CLI only discovers completion if:
+
+- `--wait` was used (single-song only, not batch)
+- `audio status --sync` is run (polls Analysis Service, but unreliable if the service restarts and loses job state)
+- `db sync` is run (only syncs local↔Turso, but nobody wrote the completion to Turso either)
+
+### Current Latency
+
+Admins see status updates only when they manually run sync commands, which can be hours or days after job completion.
+
+### Desired Behavior
+
+Admins should see status updates within a few minutes (at most 5 minutes) of job completion, even if the Analysis Service restarts.
+
+## Solution: Add `--reconcile` to `audio status`
+
+Instead of polling the Analysis Service (fragile), scan R2 directly for file presence. R2 is the durable source of truth:
+
+- `{hash_prefix}/lyrics.lrc` exists → LRC job completed successfully
+- `{hash_prefix}/analysis.json` exists → analysis job completed successfully
+
+This approach is robust against Analysis Service restarts since R2 is persistent storage.
+
+### Key Design Decisions
+
+1. **R2 as source of truth**: Completion is determined by file presence in R2, not Analysis Service job state
+2. **DB-driven scan**: Iterate over DB recordings with incomplete status and check R2 for each (vs. listing all R2 files)
+3. **Distinguish 404 from other R2 errors**: Non-404 errors (permission, credential, network) are logged and skipped — not silently treated as "file not found"
+4. **Reconcile both LRC and analysis**: Single `--reconcile` flag covers both job types
+5. **Analysis reconcile downloads + parses `analysis.json`**: Populates all structured fields (tempo, key, beats, etc.), not just status
+6. **No auto-fail detection**: Leave `processing` entries alone if no file found (job may still be running)
+7. **Never auto-sync**: Admin runs `db sync` separately after reconcile
+8. **No schema changes**: Existing DB methods and columns are sufficient
+9. **No new containers**: Leverage existing Admin CLI infrastructure
+
+## File Changes
+
+| File | Change |
+|------|--------|
+| `src/stream_of_worship/admin/services/r2.py` | Add `lrc_exists()`, `analysis_exists()`, `download_analysis_json()` |
+| `src/stream_of_worship/admin/commands/audio.py` | Add `--reconcile` flag to `check_status()` (LRC + analysis), narrow `--sync` deprecation warning |
+| `src/stream_of_worship/admin/db/client.py` | No changes needed |
+
+## Detailed Changes
+
+### 1. `src/stream_of_worship/admin/services/r2.py` — Add R2 check methods
+
+#### `lrc_exists(hash_prefix) -> Optional[str]`
+
+```python
+def lrc_exists(self, hash_prefix: str) -> Optional[str]:
+    """Check whether an LRC file exists in R2.
+
+    Args:
+        hash_prefix: 12-character hash prefix
+
+    Returns:
+        S3 URL of the LRC file if it exists, None if not found.
+
+    Raises:
+        ClientError: On non-404 errors (permission, credential, network).
+    """
+    s3_key = f"{hash_prefix}/lyrics.lrc"
+    try:
+        self._client.head_object(Bucket=self.bucket, Key=s3_key)
+        return f"s3://{self.bucket}/{s3_key}"
+    except ClientError as e:
+        error_code = e.response.get("Error", {}).get("Code", "")
+        if error_code in ("404", "NoSuchKey"):
+            return None
+        raise
+```
+
+**Critical difference from v1**: Only 404/NoSuchKey returns `None`. All other `ClientError` (permission denied, credential expired, network timeout) re-raise so the caller knows something went wrong.
+
+**Location**: Insert after `audio_exists()` method.
+
+#### `analysis_exists(hash_prefix) -> Optional[str]`
+
+```python
+def analysis_exists(self, hash_prefix: str) -> Optional[str]:
+    """Check whether an analysis.json file exists in R2.
+
+    Args:
+        hash_prefix: 12-character hash prefix
+
+    Returns:
+        S3 URL of the analysis.json if it exists, None if not found.
+
+    Raises:
+        ClientError: On non-404 errors (permission, credential, network).
+    """
+    s3_key = f"{hash_prefix}/analysis.json"
+    try:
+        self._client.head_object(Bucket=self.bucket, Key=s3_key)
+        return f"s3://{self.bucket}/{s3_key}"
+    except ClientError as e:
+        error_code = e.response.get("Error", {}).get("Code", "")
+        if error_code in ("404", "NoSuchKey"):
+            return None
+        raise
+```
+
+**Location**: Insert after `lrc_exists()` method.
+
+#### `download_analysis_json(hash_prefix) -> dict`
+
+```python
+def download_analysis_json(self, hash_prefix: str) -> dict:
+    """Download and parse analysis.json from R2.
+
+    Args:
+        hash_prefix: 12-character hash prefix
+
+    Returns:
+        Parsed analysis result dictionary with keys:
+        duration_seconds, tempo_bpm, musical_key, musical_mode,
+        key_confidence, loudness_db, beats, downbeats, sections,
+        embeddings_shape, stems_url
+
+    Raises:
+        ClientError: On any R2 error (including 404).
+        json.JSONDecodeError: If the file is not valid JSON.
+    """
+    s3_key = f"{hash_prefix}/analysis.json"
+    response = self._client.get_object(Bucket=self.bucket, Key=s3_key)
+    body = response["Body"].read().decode("utf-8")
+    return json.loads(body)
+```
+
+**Location**: Insert after `analysis_exists()` method.
+
+**Note**: This method does NOT catch errors — the caller handles them. If `analysis_exists()` returned a URL, then `download_analysis_json()` should succeed unless there's a race condition (file deleted between check and download).
+
+### 2. `src/stream_of_worship/admin/commands/audio.py` — Add `--reconcile` to `check_status()`
+
+**New parameter** (add after `force_url` parameter):
+
+```python
+reconcile: bool = typer.Option(
+    False, "--reconcile", "-r",
+    help="Reconcile LRC and analysis status by scanning R2 (robust against service restarts)"
+)
+```
+
+**Reconcile logic** (insert after `--force-status` handler and before "Mode A: Query specific job"):
+
+```python
+# Handle --reconcile mode
+if reconcile:
+    try:
+        r2_client = R2Client(config.r2_bucket, config.r2_endpoint_url, config.r2_region)
+    except ValueError as e:
+        console.print(f"[red]R2 not configured: {e}[/red]")
+        raise typer.Exit(1)
+
+    incomplete_lrc = db_client.list_recordings(lrc_status="incomplete")
+    incomplete_analysis = db_client.list_recordings(status="incomplete")
+
+    # Deduplicate: a recording may be incomplete on both
+    all_hashes = set()
+    reconcile_queue = []
+    for rec in incomplete_lrc:
+        if rec.hash_prefix not in all_hashes:
+            all_hashes.add(rec.hash_prefix)
+            reconcile_queue.append(rec)
+    for rec in incomplete_analysis:
+        if rec.hash_prefix not in all_hashes:
+            all_hashes.add(rec.hash_prefix)
+            reconcile_queue.append(rec)
+
+    if not reconcile_queue:
+        console.print("[green]No recordings with incomplete LRC or analysis status.[/green]")
+    else:
+        console.print(f"[cyan]Scanning R2 across {len(reconcile_queue)} recording(s)...[/cyan]")
+        reconciled_lrc = 0
+        reconciled_analysis = 0
+        error_count = 0
+
+        for rec in reconcile_queue:
+            # LRC reconciliation
+            if rec.lrc_status in ("pending", "processing", "failed"):
+                try:
+                    lrc_url = r2_client.lrc_exists(rec.hash_prefix)
+                    if lrc_url:
+                        db_client.update_recording_lrc(
+                            hash_prefix=rec.hash_prefix,
+                            r2_lrc_url=lrc_url,
+                        )
+                        reconciled_lrc += 1
+                        console.print(
+                            f"  [green]✓[/green] {rec.song_id or rec.hash_prefix}: "
+                            f"LRC {rec.lrc_status} → completed"
+                        )
+                except ClientError as e:
+                    error_count += 1
+                    console.print(
+                        f"  [red]✗[/red] {rec.hash_prefix}: R2 error checking LRC: {e}"
+                    )
+
+            # Analysis reconciliation
+            if rec.analysis_status in ("pending", "processing", "failed"):
+                try:
+                    analysis_url = r2_client.analysis_exists(rec.hash_prefix)
+                    if analysis_url:
+                        analysis_data = r2_client.download_analysis_json(rec.hash_prefix)
+                        db_client.update_recording_analysis(
+                            hash_prefix=rec.hash_prefix,
+                            duration_seconds=analysis_data.get("duration_seconds"),
+                            tempo_bpm=analysis_data.get("tempo_bpm"),
+                            musical_key=analysis_data.get("musical_key"),
+                            musical_mode=analysis_data.get("musical_mode"),
+                            key_confidence=analysis_data.get("key_confidence"),
+                            loudness_db=analysis_data.get("loudness_db"),
+                            beats=json.dumps(analysis_data["beats"]) if "beats" in analysis_data else None,
+                            downbeats=json.dumps(analysis_data["downbeats"]) if "downbeats" in analysis_data else None,
+                            sections=json.dumps(analysis_data["sections"]) if "sections" in analysis_data else None,
+                            embeddings_shape=json.dumps(analysis_data["embeddings_shape"]) if "embeddings_shape" in analysis_data else None,
+                            r2_stems_url=analysis_data.get("stems_url"),
+                        )
+                        reconciled_analysis += 1
+                        console.print(
+                            f"  [green]✓[/green] {rec.song_id or rec.hash_prefix}: "
+                            f"analysis {rec.analysis_status} → completed"
+                        )
+                except ClientError as e:
+                    error_count += 1
+                    console.print(
+                        f"  [red]✗[/red] {rec.hash_prefix}: R2 error checking analysis: {e}"
+                    )
+                except (json.JSONDecodeError, KeyError) as e:
+                    error_count += 1
+                    console.print(
+                        f"  [red]✗[/red] {rec.hash_prefix}: error parsing analysis.json: {e}"
+                    )
+
+        parts = []
+        if reconciled_lrc > 0:
+            parts.append(f"{reconciled_lrc} LRC")
+        if reconciled_analysis > 0:
+            parts.append(f"{reconciled_analysis} analysis")
+        if parts:
+            console.print(f"[green]Reconciled {' and '.join(parts)} status(es) from R2.[/green]")
+        else:
+            console.print("[dim]No completed files found in R2 for pending recordings.[/dim]")
+        if error_count > 0:
+            console.print(f"[yellow]{error_count} R2 error(s) encountered (see above).[/yellow]")
+        console.print("")
+    # Fall through to list pending recordings table
+```
+
+**Deprecate `--sync`**: Add warning at the start of `--sync` handling:
+
+```python
+if sync:
+    console.print(
+        "[yellow]Warning: --sync is unreliable if the Analysis Service has restarted. "
+        "For LRC and analysis status, consider using --reconcile instead, "
+        "which scans R2 directly.[/yellow]"
+    )
+```
+
+**Update docstring**:
+
+```python
+"""Check analysis status.
+
+With JOB_ID: query the service for that job's status.
+Without: list all recordings with pending/processing/failed status.
+Use --reconcile to update LRC and analysis status by scanning R2 (robust against service restarts).
+Use --sync to poll the analysis service (unreliable if service restarted).
+Use --force-status when you need to manually override status.
+"""
+```
+
+### 3. No changes needed to `db/client.py`
+
+Existing methods are sufficient:
+- `list_recordings(lrc_status="incomplete")` → recordings where `lrc_status IN ('pending', 'processing', 'failed')`
+- `list_recordings(status="incomplete")` → recordings where `analysis_status IN ('pending', 'processing', 'failed')`
+- `update_recording_lrc(hash_prefix, r2_lrc_url)` → sets `lrc_status='completed'`, auto-publishes if `visibility_status IS NULL`
+- `update_recording_analysis(hash_prefix, ...)` → sets `analysis_status='completed'` + all structured fields
+
+## Automation / Cron Integration
+
+```cron
+# Reconcile status every 3 minutes, then sync to Turso
+# Use ';' (not '&&') so db sync always runs even if reconcile has partial R2 errors
+*/3 * * * * sow-admin audio status --reconcile > /tmp/sow-reconcile.log 2>&1 ; sow-admin db sync >> /tmp/sow-reconcile.log 2>&1
+```
+
+This delivers **≤3 min latency** for status visibility:
+
+1. Job completes and files uploaded to R2
+2. cron runs `audio status --reconcile` at T+0-3m, finds R2 files, updates local DB
+3. cron runs `db sync`, pushes updates to Turso cloud
+4. Other Admin replicas sync from Turso and see completed status
+
+**Why `;` instead of `&&`**: If reconcile encounters non-404 R2 errors for some recordings, it still exits 0 (errors are logged but don't halt the command). However, using `;` ensures `db sync` always runs, pushing the successfully reconciled recordings to Turso even if some R2 checks failed.
+
+## Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| LRC exists in R2, DB says `pending` | Updated to `completed` with `r2_lrc_url` |
+| LRC exists in R2, DB says `processing` | Updated to `completed` with `r2_lrc_url` |
+| LRC exists in R2, DB says `failed` | Updated to `completed` with `r2_lrc_url` (admin may have set failed for bad content, but file exists) |
+| analysis.json exists in R2, DB says `pending`/`processing`/`failed` | Downloaded, parsed, all fields populated, `analysis_status='completed'` |
+| No file in R2, DB says `processing` | Left unchanged (job may still be running) |
+| No file in R2, DB says `failed` | Left unchanged |
+| R2 permission/credential error on one recording | Logged, that recording skipped, others continue |
+| analysis.json is malformed | Logged as error, that recording skipped, others continue |
+| `r2_lrc_url` already set but `lrc_status != 'completed'` | Fixed to `completed` via `update_recording_lrc()` |
+| Recording not in DB but files in R2 | Ignored (DB-driven scan only checks known recordings) |
+| `update_recording_lrc()` auto-publishes | If `visibility_status IS NULL`, set to `published` (existing behavior) |
+
+## Error Handling: 404 vs Other ClientError
+
+This is the key operational improvement over v1. The original spec caught ALL `ClientError` and returned `None`, making permission errors indistinguishable from "file not found."
+
+| Error Type | HTTP Code | Behavior |
+|------------|-----------|----------|
+| NoSuchKey / Not Found | 404 | Return `None` (file genuinely missing) |
+| Access Denied | 403 | Re-raise (credential issue — admin must fix) |
+| Network timeout | N/A | Re-raise (transient — retry later) |
+| Internal R2 error | 500 | Re-raise (Cloudflare issue — retry later) |
+
+**In `--reconcile` mode**: Non-404 errors are caught at the command level, logged, and the loop continues. The command still exits 0 so `db sync` runs afterward.
+
+## Performance Considerations
+
+- **R2 API calls**: Each incomplete recording triggers 1-2 `head_object` calls (one for LRC, one for analysis) plus a `get_object` for analysis download if found
+- **Current use cases**: Admins typically have <100 recordings with incomplete status
+- **Duration**: ~100ms per R2 `head_object`, ~200ms for `get_object` + parse
+- **Total time for 100 recordings**: ~15-20 seconds (acceptable for cron)
+
+### Future Optimization (Out of Scope)
+
+Use `concurrent.futures.ThreadPoolExecutor` to parallelize R2 checks (reduce 100 recordings from ~15s to ~2s).
+
+## Testing
+
+### Manual Testing Steps
+
+1. Submit LRC job: `sow-admin audio lrc <song_id>`
+2. Verify DB shows `lrc_status="processing"`
+3. Wait for Analysis Service to complete (or manually upload LRC to R2 for testing)
+4. Run: `sow-admin audio status --reconcile`
+5. Verify DB shows `lrc_status="completed"` and `r2_lrc_url` set
+6. Run second reconciliation: should report no new files found
+
+### Analysis Reconcile Testing
+
+1. Submit analysis job: `sow-admin audio analyze <song_id>`
+2. Verify DB shows `analysis_status="processing"`
+3. Wait for completion or manually upload `analysis.json` to R2
+4. Run: `sow-admin audio status --reconcile`
+5. Verify DB shows `analysis_status="completed"` and all fields populated (tempo, key, etc.)
+6. Compare fields against what Analysis Service reported
+
+### Error Handling Testing
+
+1. Temporarily set invalid R2 credentials
+2. Run: `sow-admin audio status --reconcile`
+3. Should see error messages, not silent `None` returns
+4. Restore credentials and verify reconcile works again
+
+### Unit Test Coverage
+
+```python
+def test_lrc_exists_found(monkeypatch):
+    client = R2Client("test-bucket", "https://r2.example.com")
+    monkeypatch.setattr(client._client, "head_object", lambda **kw: {})
+    assert client.lrc_exists("abc123456789") == "s3://test-bucket/abc123456789/lyrics.lrc"
+
+def test_lrc_exists_not_found(monkeypatch):
+    from botocore.exceptions import ClientError
+    client = R2Client("test-bucket", "https://r2.example.com")
+    error_response = {"Error": {"Code": "404"}}
+    def mock_head(**kw):
+        raise ClientError(error_response, "HeadObject")
+    monkeypatch.setattr(client._client, "head_object", mock_head)
+    assert client.lrc_exists("abc123456789") is None
+
+def test_lrc_exists_permission_denied(monkeypatch):
+    from botocore.exceptions import ClientError
+    client = R2Client("test-bucket", "https://r2.example.com")
+    error_response = {"Error": {"Code": "403"}}
+    def mock_head(**kw):
+        raise ClientError(error_response, "HeadObject")
+    monkeypatch.setattr(client._client, "head_object", mock_head)
+    with pytest.raises(ClientError):
+        client.lrc_exists("abc123456789")
+
+def test_analysis_exists_and_download(monkeypatch):
+    client = R2Client("test-bucket", "https://r2.example.com")
+    analysis = {"tempo_bpm": 120.0, "musical_key": "C", "musical_mode": "major"}
+    monkeypatch.setattr(client._client, "head_object", lambda **kw: {})
+    monkeypatch.setattr(
+        client._client, "get_object",
+        lambda **kw: {"Body": io.BytesIO(json.dumps(analysis).encode())},
+    )
+    assert client.analysis_exists("abc123456789") is not None
+    data = client.download_analysis_json("abc123456789")
+    assert data["tempo_bpm"] == 120.0
+```
+
+## Differences from v1 (`lrc-reconciliation-via-r2.md`)
+
+| Aspect | v1 | v2 |
+|--------|----|----|
+| Scope | LRC only | LRC + analysis |
+| `ClientError` handling | Catch all → `None` | Distinguish 404 only; re-raise others |
+| Analysis reconcile | Out of scope | Download + parse `analysis.json`, populate all DB fields |
+| Cron chaining | `&&` | `;` (db sync always runs) |
+| `--sync` deprecation | Generic warning | Narrowed: "for LRC and analysis status, consider --reconcile" |
+| Schema changes | None | None (unchanged) |
+
+## References
+
+- Admin CLI status command: `src/stream_of_worship/admin/commands/audio.py` (lines 1786-2068)
+- R2Client implementation: `src/stream_of_worship/admin/services/r2.py`
+- Database client: `src/stream_of_worship/admin/db/client.py`
+- Analysis Service R2 uploads: `services/analysis/src/sow_analysis/storage/r2.py`
+- R2 file naming: `{hash_prefix}/lyrics.lrc`, `{hash_prefix}/analysis.json`

--- a/src/stream_of_worship/admin/commands/audio.py
+++ b/src/stream_of_worship/admin/commands/audio.py
@@ -3025,14 +3025,26 @@ def batch(
     album: Optional[str] = typer.Option(None, "--album", help="Filter by album name (exact match)"),
     song: Optional[str] = typer.Option(None, "--song", help="Filter by song name (partial match)"),
     lrc_status: Optional[str] = typer.Option(None, "--lrc-status", help="Filter by LRC status"),
-    download_status: Optional[str] = typer.Option(None, "--download-status", help="Filter by download status"),
-    analysis_status: Optional[str] = typer.Option(None, "--analysis-status", help="Filter by analysis status"),
+    download_status: Optional[str] = typer.Option(
+        None, "--download-status", help="Filter by download status"
+    ),
+    analysis_status: Optional[str] = typer.Option(
+        None, "--analysis-status", help="Filter by analysis status"
+    ),
     stdin: bool = typer.Option(False, "--stdin", help="Read song IDs from stdin (pipe-friendly)"),
     limit: Optional[int] = typer.Option(None, "--limit", help="Maximum number of songs to process"),
-    skip_download: bool = typer.Option(False, "--skip-download", help="Skip download step (assume audio already on R2)"),
+    skip_download: bool = typer.Option(
+        False, "--skip-download", help="Skip download step (assume audio already on R2)"
+    ),
     skip_lrc: bool = typer.Option(False, "--skip-lrc", help="Skip LRC step"),
-    stale_after: int = typer.Option(120, "--stale-after", help="Minutes after which a 'processing' song is treated as lost (default: 120)"),
-    dry_run: bool = typer.Option(False, "--dry-run", help="Show what would be processed without executing"),
+    stale_after: int = typer.Option(
+        120,
+        "--stale-after",
+        help="Minutes after which a 'processing' song is treated as lost (default: 120)",
+    ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Show what would be processed without executing"
+    ),
     format: str = typer.Option("rich", "--format", help="Output format (rich, json)"),
     config_path: Optional[Path] = typer.Option(None, "--config", "-c", help="Path to config file"),
 ) -> None:
@@ -3087,7 +3099,9 @@ def batch(
     db_client = DatabaseClient(config.db_path)
 
     # Resolve song IDs to process
-    song_ids = _resolve_song_ids(db_client, album, song, lrc_status, download_status, analysis_status, stdin, limit)
+    song_ids = _resolve_song_ids(
+        db_client, album, song, lrc_status, download_status, analysis_status, stdin, limit
+    )
     if not song_ids:
         console.print("[yellow]No songs found matching the criteria.[/yellow]")
         raise typer.Exit(0)
@@ -3164,32 +3178,25 @@ def _resolve_song_ids(
     # Otherwise, query database with filters
     song_ids = set()
 
-    # Get all recordings with matching status filters
-    recordings = db_client.list_recordings(
+    # Use JOIN query to avoid N+1 lookups for song data
+    rows = db_client.list_recordings_with_songs(
         status=analysis_status,
         lrc_status=lrc_status,
-        limit=None,  # Apply limit after filtering
+        limit=None,
     )
 
-    # Additional filtering for download_status (not in list_recordings)
-    if download_status:
-        recordings = [r for r in recordings if r.download_status == download_status]
-
-    for recording in recordings:
+    for recording, song_title, album_name, album_series in rows:
         if not recording.song_id:
             continue
 
-        # Filter by album if specified
-        if album:
-            song = db_client.get_song(recording.song_id)
-            if not song or song.album_name != album:
-                continue
+        if download_status and recording.download_status != download_status:
+            continue
 
-        # Filter by song name if specified
-        if song:
-            song_obj = db_client.get_song(recording.song_id)
-            if not song_obj or song.lower() not in song_obj.title.lower():
-                continue
+        if album and album_name != album:
+            continue
+
+        if song and (not song_title or song.lower() not in song_title.lower()):
+            continue
 
         song_ids.add(recording.song_id)
 
@@ -3325,7 +3332,6 @@ def _process_batch(
         Dict with results for each song
     """
     results = {}
-    start_time = time.time()
 
     # Phase 1: Download (if needed)
     if not skip_download:
@@ -3368,7 +3374,8 @@ def _process_batch(
         console.print("[cyan]Phase 2: Submitting LRC jobs[/cyan]")
 
         songs_needing_lrc = [
-            sid for sid in song_ids
+            sid
+            for sid in song_ids
             if results.get(sid, {}).get("download") != "failed"
             and results.get(sid, {}).get("lrc") != "completed"
         ]
@@ -3398,12 +3405,18 @@ def _process_batch(
             if recording.lrc_status == "processing" and recording.lrc_job_id:
                 from datetime import datetime, timezone, timedelta
 
-                updated_at = datetime.fromisoformat(recording.updated_at) if recording.updated_at else None
+                updated_at = (
+                    datetime.fromisoformat(recording.updated_at) if recording.updated_at else None
+                )
                 if updated_at:
+                    if updated_at.tzinfo is None:
+                        updated_at = updated_at.replace(tzinfo=timezone.utc)
                     staleness = datetime.now(timezone.utc) - updated_at
                     if staleness < timedelta(minutes=stale_after_minutes):
                         active_jobs[song_id] = recording.lrc_job_id
-                        console.print(f"  [yellow]→ {song_id} (reusing existing job: {recording.lrc_job_id})[/yellow]")
+                        console.print(
+                            f"  [yellow]→ {song_id} (reusing existing job: {recording.lrc_job_id})[/yellow]"
+                        )
                         continue
 
             # Submit new job
@@ -3482,6 +3495,9 @@ def _poll_all_jobs(
     last_completion_time = time.time()
     stale_warning_seconds = stale_after_minutes * 60
     job_timing = {}  # song_id -> (start_time, elapsed)
+    batch_start_time = time.time()
+    resubmit_counts = {}  # song_id -> count of resubmissions
+    max_resubmits = 3
 
     # Record start times for all jobs
     for song_id, job_id in active_jobs.items():
@@ -3523,9 +3539,13 @@ def _poll_all_jobs(
                             # Get song for display
                             song = db_client.get_song(song_id)
                             song_name = song.title if song else song_id
-                            console.print(f"  [green]✓[/green] {song_name} — LRC completed ({elapsed:.1f}s)")
+                            console.print(
+                                f"  [green]✓[/green] {song_name} — LRC completed ({elapsed:.1f}s)"
+                            )
                         else:
-                            console.print(f"  [yellow]→ {song_id}: Job completed but LRC not on R2 yet, retrying...[/yellow]")
+                            console.print(
+                                f"  [yellow]→ {song_id}: Job completed but LRC not on R2 yet, retrying...[/yellow]"
+                            )
                             continue
 
                     elif job.status == "failed":
@@ -3540,7 +3560,9 @@ def _poll_all_jobs(
 
                         song = db_client.get_song(song_id)
                         song_name = song.title if song else song_id
-                        console.print(f"  [red]✗[/red] {song_name} — LRC failed: {job.error_message or 'Unknown error'}")
+                        console.print(
+                            f"  [red]✗[/red] {song_name} — LRC failed: {job.error_message or 'Unknown error'}"
+                        )
 
                 except AnalysisServiceError as e:
                     if e.status_code == 404:
@@ -3559,14 +3581,78 @@ def _poll_all_jobs(
 
                             song = db_client.get_song(song_id)
                             song_name = song.title if song else song_id
-                            console.print(f"  [green]✓[/green] {song_name} — LRC found on R2 (job was lost)")
+                            console.print(
+                                f"  [green]✓[/green] {song_name} — LRC found on R2 (job was lost)"
+                            )
                         else:
-                            console.print(f"  [yellow]→ {song_id}: Job lost (404), resubmitting...[/yellow]")
-                            # Could resubmit here, but for now we'll just mark as failed
-                            # because we need context to resubmit properly
-                            results[song_id]["lrc"] = "failed"
-                            results[song_id]["lrc_error"] = "Job lost (404) and not found on R2"
-                            del active_jobs[song_id]
+                            resubmit_count = resubmit_counts.get(song_id, 0)
+                            if resubmit_count >= max_resubmits:
+                                console.print(
+                                    f"  [red]✗ {song_id}: Job lost (404) after "
+                                    f"{max_resubmits} resubmits, marking as failed[/red]"
+                                )
+                                results[song_id]["lrc"] = "failed"
+                                results[song_id][
+                                    "lrc_error"
+                                ] = f"Job lost (404) and not found on R2 after {max_resubmits} resubmits"
+                                db_client.update_recording_status(
+                                    hash_prefix=recording.hash_prefix,
+                                    lrc_status="failed",
+                                )
+                                del active_jobs[song_id]
+                                any_completed_this_cycle = True
+                            else:
+                                console.print(
+                                    f"  [yellow]→ {song_id}: Job lost (404), "
+                                    f"resubmitting (attempt {resubmit_count + 1}/{max_resubmits})...[/yellow]"
+                                )
+                                try:
+                                    song = db_client.get_song(song_id)
+                                    if not song or not song.lyrics_raw:
+                                        results[song_id]["lrc"] = "failed"
+                                        results[song_id][
+                                            "lrc_error"
+                                        ] = "Job lost and no lyrics available for resubmit"
+                                        db_client.update_recording_status(
+                                            hash_prefix=recording.hash_prefix,
+                                            lrc_status="failed",
+                                        )
+                                        del active_jobs[song_id]
+                                        any_completed_this_cycle = True
+                                        continue
+
+                                    new_job = analysis_client.submit_lrc(
+                                        audio_url=recording.r2_audio_url,
+                                        content_hash=recording.content_hash,
+                                        lyrics_text=song.lyrics_raw,
+                                        whisper_model="large-v3",
+                                        language="zh",
+                                        use_vocals_stem=True,
+                                        force=False,
+                                        force_whisper=False,
+                                        youtube_url=recording.youtube_url or "",
+                                        use_qwen3=True,
+                                    )
+                                    db_client.update_recording_status(
+                                        hash_prefix=recording.hash_prefix,
+                                        lrc_status="processing",
+                                        lrc_job_id=new_job.job_id,
+                                    )
+                                    active_jobs[song_id] = new_job.job_id
+                                    resubmit_counts[song_id] = resubmit_count + 1
+                                    job_timing[song_id] = (time.time(), 0)
+                                except AnalysisServiceError as submit_err:
+                                    console.print(
+                                        f"  [red]✗ {song_id}: Resubmit failed: {submit_err}[/red]"
+                                    )
+                                    results[song_id]["lrc"] = "failed"
+                                    results[song_id]["lrc_error"] = f"Resubmit failed: {submit_err}"
+                                    db_client.update_recording_status(
+                                        hash_prefix=recording.hash_prefix,
+                                        lrc_status="failed",
+                                    )
+                                    del active_jobs[song_id]
+                                    any_completed_this_cycle = True
                     else:
                         console.print(f"  [yellow]→ Error polling {job_id}: {e}[/yellow]")
                 except Exception as e:
@@ -3593,7 +3679,8 @@ def _poll_all_jobs(
                 last_completion_time = time.time()
 
             # Print progress
-            _print_progress(active_jobs, results, start_time=job_timing[list(active_jobs.keys())[0]][0])
+            if active_jobs:
+                _print_progress(active_jobs, results, start_time=batch_start_time)
 
             if active_jobs:
                 time.sleep(poll_interval)
@@ -3729,6 +3816,7 @@ def _print_stats(
     """
     if format == "json":
         import json
+
         console.print(json.dumps(results, indent=2))
         return
 
@@ -3743,7 +3831,9 @@ def _print_stats(
     # LRC stats
     lrc_completed = sum(1 for r in results.values() if r.get("lrc") == "completed")
     lrc_failed = sum(1 for r in results.values() if r.get("lrc") == "failed")
-    lrc_skipped_existing = sum(1 for r in results.values() if r.get("lrc_source") == "r2_preexisting")
+    lrc_skipped_existing = sum(
+        1 for r in results.values() if r.get("lrc_source") == "r2_preexisting"
+    )
     lrc_skipped_download = sum(1 for r in results.values() if r.get("download") == "failed")
 
     # LRC timing stats (only for ASR-generated LRCs)
@@ -3781,21 +3871,25 @@ def _print_stats(
 
     if lrc_completed > 0 and lrc_skipped_existing < lrc_completed:
         asr_count = lrc_completed - lrc_skipped_existing
-        lines.extend([
-            f"│ {'':<30} {'':>18} │",
-            f"│ {'LRC source:':<30} {'':>18} │",
-            f"│ {'  R2 pre-existing:':<30} {lrc_skipped_existing:>18} │",
-            f"│ {'  ASR (generated):':<30} {asr_count:>18} │",
-        ])
+        lines.extend(
+            [
+                f"│ {'':<30} {'':>18} │",
+                f"│ {'LRC source:':<30} {'':>18} │",
+                f"│ {'  R2 pre-existing:':<30} {lrc_skipped_existing:>18} │",
+                f"│ {'  ASR (generated):':<30} {asr_count:>18} │",
+            ]
+        )
 
     if avg_lrc_time is not None:
-        lines.extend([
-            f"│ {'':<30} {'':>18} │",
-            f"│ {'LRC timing (ASR jobs only):':<30} {'':>18} │",
-            f"│ {'  Average:':<30} {avg_lrc_time:.1f}s{'':>12} │",
-            f"│ {'  Median:':<30} {med_lrc_time:.1f}s{'':>12} │",
-            f"│ {'  Min/Max:':<30} {min_lrc_time:.1f}s / {max_lrc_time:.1f}s   │",
-        ])
+        lines.extend(
+            [
+                f"│ {'':<30} {'':>18} │",
+                f"│ {'LRC timing (ASR jobs only):':<30} {'':>18} │",
+                f"│ {'  Average:':<30} {avg_lrc_time:.1f}s{'':>12} │",
+                f"│ {'  Median:':<30} {med_lrc_time:.1f}s{'':>12} │",
+                f"│ {'  Min/Max:':<30} {min_lrc_time:.1f}s / {max_lrc_time:.1f}s   │",
+            ]
+        )
 
     lines.append("╰" + "─" * 52 + "╯")
 
@@ -3803,9 +3897,7 @@ def _print_stats(
 
     # Print failed downloads
     failed_downloads = [
-        (song_id, r.get("error"))
-        for song_id, r in results.items()
-        if r.get("download") == "failed"
+        (song_id, r.get("error")) for song_id, r in results.items() if r.get("download") == "failed"
     ]
     if failed_downloads:
         console.print("\n[bold red]Failed downloads:[/bold red]")
@@ -3816,9 +3908,7 @@ def _print_stats(
 
     # Print failed LRCs
     failed_lrcs = [
-        (song_id, r.get("lrc_error"))
-        for song_id, r in results.items()
-        if r.get("lrc") == "failed"
+        (song_id, r.get("lrc_error")) for song_id, r in results.items() if r.get("lrc") == "failed"
     ]
     if failed_lrcs:
         console.print("\n[bold red]Failed LRC:[/bold red]")
@@ -3826,4 +3916,3 @@ def _print_stats(
             song = db_client.get_song(song_id)
             song_name = song.title if song else song_id
             console.print(f"  - {song_name}: {error}")
-

--- a/src/stream_of_worship/admin/commands/audio.py
+++ b/src/stream_of_worship/admin/commands/audio.py
@@ -11,7 +11,7 @@ import tempfile
 import termios
 import time
 import tty
-from datetime import datetime
+from datetime import datetime, timezone, timedelta
 from pathlib import Path
 from typing import Any, Optional
 
@@ -3018,3 +3018,812 @@ def playback_audio(
         console.print("[yellow]Playback stopped.[/yellow]")
     else:
         console.print("[green]Playback finished.[/green]")
+
+
+@app.command("batch")
+def batch(
+    album: Optional[str] = typer.Option(None, "--album", help="Filter by album name (exact match)"),
+    song: Optional[str] = typer.Option(None, "--song", help="Filter by song name (partial match)"),
+    lrc_status: Optional[str] = typer.Option(None, "--lrc-status", help="Filter by LRC status"),
+    download_status: Optional[str] = typer.Option(None, "--download-status", help="Filter by download status"),
+    analysis_status: Optional[str] = typer.Option(None, "--analysis-status", help="Filter by analysis status"),
+    stdin: bool = typer.Option(False, "--stdin", help="Read song IDs from stdin (pipe-friendly)"),
+    limit: Optional[int] = typer.Option(None, "--limit", help="Maximum number of songs to process"),
+    skip_download: bool = typer.Option(False, "--skip-download", help="Skip download step (assume audio already on R2)"),
+    skip_lrc: bool = typer.Option(False, "--skip-lrc", help="Skip LRC step"),
+    stale_after: int = typer.Option(120, "--stale-after", help="Minutes after which a 'processing' song is treated as lost (default: 120)"),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Show what would be processed without executing"),
+    format: str = typer.Option("rich", "--format", help="Output format (rich, json)"),
+    config_path: Optional[Path] = typer.Option(None, "--config", "-c", help="Path to config file"),
+) -> None:
+    """Batch process songs: download audio and generate LRC.
+
+    Processes multiple songs end-to-end: downloads audio (if needed),
+    submits LRC jobs, polls for completion, and prints summary stats.
+    Uses submit-all-then-poll with hybrid polling (service-first, R2-fallback).
+
+    Examples:
+        sow-admin audio batch --album "敬拜精选"
+        sow-admin audio list --lrc-status failed --format ids | sow-admin audio batch --stdin
+    """
+    # Validate format
+    if format not in ("rich", "json"):
+        console.print(f"[red]Invalid format: {format}. Must be 'rich' or 'json'[/red]")
+        raise typer.Exit(1)
+
+    # Validate status filters
+    valid_lrc_statuses = {"pending", "processing", "completed", "failed", "incomplete"}
+    if lrc_status and lrc_status not in valid_lrc_statuses:
+        console.print(
+            f"[red]Invalid LRC status: {lrc_status}. Must be one of: {', '.join(valid_lrc_statuses)}[/red]"
+        )
+        raise typer.Exit(1)
+
+    valid_download_statuses = {"pending", "processing", "completed", "failed"}
+    if download_status and download_status not in valid_download_statuses:
+        console.print(
+            f"[red]Invalid download status: {download_status}. Must be one of: {', '.join(valid_download_statuses)}[/red]"
+        )
+        raise typer.Exit(1)
+
+    valid_analysis_statuses = {"pending", "processing", "completed", "failed", "incomplete"}
+    if analysis_status and analysis_status not in valid_analysis_statuses:
+        console.print(
+            f"[red]Invalid analysis status: {analysis_status}. Must be one of: {', '.join(valid_analysis_statuses)}[/red]"
+        )
+        raise typer.Exit(1)
+
+    # Load config
+    try:
+        config = AdminConfig.load(config_path) if config_path else AdminConfig.load()
+    except FileNotFoundError:
+        console.print("[red]Config file not found. Run 'sow-admin db init' first.[/red]")
+        raise typer.Exit(1)
+
+    if not config.db_path.exists():
+        console.print(f"[red]Database not found at {config.db_path}[/red]")
+        raise typer.Exit(1)
+
+    db_client = DatabaseClient(config.db_path)
+
+    # Resolve song IDs to process
+    song_ids = _resolve_song_ids(db_client, album, song, lrc_status, download_status, analysis_status, stdin, limit)
+    if not song_ids:
+        console.print("[yellow]No songs found matching the criteria.[/yellow]")
+        raise typer.Exit(0)
+
+    if dry_run:
+        _print_dry_run(db_client, song_ids)
+        return
+
+    # Initialize R2 and Analysis clients
+    try:
+        r2_client = R2Client(
+            bucket=config.r2_bucket,
+            endpoint_url=config.r2_endpoint_url,
+            region=config.r2_region,
+        )
+    except ValueError as e:
+        console.print(f"[red]R2 configuration error: {e}[/red]")
+        raise typer.Exit(1)
+
+    try:
+        analysis_client = AnalysisClient(config.analysis_url)
+    except ValueError as e:
+        console.print(f"[red]Analysis service not configured: {e}[/red]")
+        raise typer.Exit(1)
+
+    # Process all songs
+    results = _process_batch(
+        db_client=db_client,
+        r2_client=r2_client,
+        analysis_client=analysis_client,
+        song_ids=song_ids,
+        skip_download=skip_download,
+        skip_lrc=skip_lrc,
+        stale_after_minutes=stale_after,
+        console=console,
+    )
+
+    # Print final stats
+    _print_stats(results, db_client, console, format)
+
+
+def _resolve_song_ids(
+    db_client: DatabaseClient,
+    album: Optional[str],
+    song: Optional[str],
+    lrc_status: Optional[str],
+    download_status: Optional[str],
+    analysis_status: Optional[str],
+    stdin: bool,
+    limit: Optional[int],
+) -> list[str]:
+    """Resolve song IDs based on filters.
+
+    Args:
+        db_client: Database client
+        album: Filter by album name (exact match)
+        song: Filter by song name (partial match, case-insensitive)
+        lrc_status: Filter by LRC status
+        download_status: Filter by download status
+        analysis_status: Filter by analysis status
+        stdin: Read song IDs from stdin
+        limit: Maximum number of songs to return
+
+    Returns:
+        List of song IDs to process
+    """
+    # If stdin, read from pipe
+    if stdin:
+        song_ids = _read_song_ids_from_stdin()
+        if limit:
+            song_ids = song_ids[:limit]
+        return song_ids
+
+    # Otherwise, query database with filters
+    song_ids = set()
+
+    # Get all recordings with matching status filters
+    recordings = db_client.list_recordings(
+        status=analysis_status,
+        lrc_status=lrc_status,
+        limit=None,  # Apply limit after filtering
+    )
+
+    # Additional filtering for download_status (not in list_recordings)
+    if download_status:
+        recordings = [r for r in recordings if r.download_status == download_status]
+
+    for recording in recordings:
+        if not recording.song_id:
+            continue
+
+        # Filter by album if specified
+        if album:
+            song = db_client.get_song(recording.song_id)
+            if not song or song.album_name != album:
+                continue
+
+        # Filter by song name if specified
+        if song:
+            song_obj = db_client.get_song(recording.song_id)
+            if not song_obj or song.lower() not in song_obj.title.lower():
+                continue
+
+        song_ids.add(recording.song_id)
+
+    result = list(song_ids)
+    if limit:
+        result = result[:limit]
+    return result
+
+
+def _print_dry_run(db_client: DatabaseClient, song_ids: list[str]) -> None:
+    """Print dry run information showing what would be processed.
+
+    Args:
+        db_client: Database client
+        song_ids: List of song IDs to show
+    """
+    console.print("[cyan]Dry run mode - would process the following songs:[/cyan]")
+    console.print()
+
+    for song_id in song_ids:
+        song = db_client.get_song(song_id)
+        recording = db_client.get_recording_by_song_id(song_id)
+
+        if song and recording:
+            console.print(f"  [cyan]•[/cyan] {song.title} ({recording.hash_prefix})")
+            console.print(f"    [dim]Album:[/dim] {song.album_name or '-'}")
+            console.print(f"    [dim]Download:[/dim] {recording.download_status}")
+            console.print(f"    [dim]LRC:[/dim] {recording.lrc_status}")
+        else:
+            console.print(f"  [yellow]•[/yellow] {song_id} (no recording found)")
+
+    console.print(f"\n[dim]Total: {len(song_ids)} song(s)[/dim]")
+
+
+def _download_if_needed(
+    song_id: str,
+    recording: Recording,
+    db_client: DatabaseClient,
+    r2_client: R2Client,
+    console: Console,
+) -> dict:
+    """Download audio if not on R2. Sets download_status in DB.
+
+    Args:
+        song_id: Song ID
+        recording: Recording object
+        db_client: Database client
+        r2_client: R2 client
+        console: Rich console
+
+    Returns:
+        Dict with download result: {'download': 'completed'|'skipped'|'failed', 'error': str}
+    """
+    hash_prefix = recording.hash_prefix
+
+    # Check R2 first
+    if r2_client.audio_exists(hash_prefix):
+        db_client.update_recording_download(hash_prefix, "completed")
+        return {"download": "skipped_r2"}
+
+    # Download audio
+    db_client.update_recording_download(hash_prefix, "processing")
+
+    try:
+        # Look up song for metadata
+        song = db_client.get_song(song_id)
+        if not song:
+            raise ValueError(f"Song not found: {song_id}")
+
+        # Initialize downloader
+        downloader = YouTubeDownloader()
+
+        # Build search query
+        query = downloader.build_search_query(
+            title=song.title,
+            composer=song.composer,
+            album_name=song.album_name,
+            suffix=OFFICIAL_LYRICS_SUFFIX,
+        )
+
+        # Download
+        console.print(f"[{song_id}] Downloading audio from YouTube...")
+        audio_path = downloader.download(query)
+
+        # Compute hash and upload to R2
+        content_hash = compute_file_hash(audio_path)
+        prefix = get_hash_prefix(content_hash)
+
+        r2_url = r2_client.upload_audio(audio_path, prefix)
+        console.print(f"[{song_id}] [green]→[/green] Uploaded to R2")
+
+        # Update recording with R2 URL
+        db_client.update_recording_status(
+            hash_prefix=hash_prefix,
+            r2_audio_url=r2_url,
+        )
+        db_client.update_recording_download(hash_prefix, "completed")
+
+        # Clean up temp file
+        audio_path.unlink(missing_ok=True)
+
+        return {"download": "completed"}
+
+    except Exception as e:
+        db_client.update_recording_download(hash_prefix, "failed")
+        console.print(f"[{song_id}] [red]✗[/red] Download failed: {e}")
+        return {"download": "failed", "error": str(e)}
+
+
+def _process_batch(
+    db_client: DatabaseClient,
+    r2_client: R2Client,
+    analysis_client: AnalysisClient,
+    song_ids: list[str],
+    skip_download: bool,
+    skip_lrc: bool,
+    stale_after_minutes: int,
+    console: Console,
+) -> dict:
+    """Process all songs in batch.
+
+    Args:
+        db_client: Database client
+        r2_client: R2 client
+        analysis_client: Analysis service client
+        song_ids: List of song IDs to process
+        skip_download: Skip download step
+        skip_lrc: Skip LRC step
+        stale_after_minutes: Staleness threshold for processing jobs
+        console: Rich console
+
+    Returns:
+        Dict with results for each song
+    """
+    results = {}
+    start_time = time.time()
+
+    # Phase 1: Download (if needed)
+    if not skip_download:
+        console.print("[cyan]Phase 1: Downloading audio[/cyan]")
+        downloaded_count = 0
+        skipped_count = 0
+        failed_count = 0
+
+        for i, song_id in enumerate(song_ids, 1):
+            console.print(f"[{i}/{len(song_ids)}] {song_id}...")
+
+            recording = db_client.get_recording_by_song_id(song_id)
+            if not recording:
+                console.print(f"  [red]✗ No recording found[/red]")
+                results[song_id] = {
+                    "download": "failed",
+                    "error": "No recording found",
+                }
+                failed_count += 1
+                continue
+
+            result = _download_if_needed(song_id, recording, db_client, r2_client, console)
+            results[song_id] = result
+
+            if result["download"] == "completed":
+                downloaded_count += 1
+            elif result["download"] == "skipped_r2":
+                skipped_count += 1
+            else:
+                failed_count += 1
+
+        console.print(f"  [green]Downloaded: {downloaded_count}[/green]")
+        console.print(f"  [dim]Skipped: {skipped_count}[/dim]")
+        console.print(f"  [red]Failed: {failed_count}[/red]")
+        console.print()
+
+    # Phase 2: Submit LRC jobs
+    active_jobs = {}  # song_id -> job_id
+    if not skip_lrc:
+        console.print("[cyan]Phase 2: Submitting LRC jobs[/cyan]")
+
+        songs_needing_lrc = [
+            sid for sid in song_ids
+            if results.get(sid, {}).get("download") != "failed"
+            and results.get(sid, {}).get("lrc") != "completed"
+        ]
+
+        for song_id in songs_needing_lrc:
+            recording = db_client.get_recording_by_song_id(song_id)
+            if not recording:
+                continue
+
+            # Get song for lyrics
+            song = db_client.get_song(song_id)
+            if not song or not song.lyrics_raw:
+                console.print(f"  [yellow]→ {song_id} (no lyrics, skipping)[/yellow]")
+                continue
+
+            # Check if R2 already has LRC
+            lrc_url = r2_client.lrc_exists(recording.hash_prefix)
+            if lrc_url:
+                db_client.update_recording_lrc(recording.hash_prefix, lrc_url)
+                results[song_id] = results.get(song_id, {})
+                results[song_id]["lrc"] = "completed"
+                results[song_id]["lrc_source"] = "r2_preexisting"
+                console.print(f"  [green]→ {song_id} (LRC already on R2, skipping)[/green]")
+                continue
+
+            # Check for existing processing job (not stale)
+            if recording.lrc_status == "processing" and recording.lrc_job_id:
+                from datetime import datetime, timezone, timedelta
+
+                updated_at = datetime.fromisoformat(recording.updated_at) if recording.updated_at else None
+                if updated_at:
+                    staleness = datetime.now(timezone.utc) - updated_at
+                    if staleness < timedelta(minutes=stale_after_minutes):
+                        active_jobs[song_id] = recording.lrc_job_id
+                        console.print(f"  [yellow]→ {song_id} (reusing existing job: {recording.lrc_job_id})[/yellow]")
+                        continue
+
+            # Submit new job
+            try:
+                youtube_url = recording.youtube_url or ""
+
+                job = analysis_client.submit_lrc(
+                    audio_url=recording.r2_audio_url,
+                    content_hash=recording.content_hash,
+                    lyrics_text=song.lyrics_raw,
+                    whisper_model="large-v3",
+                    language="zh",
+                    use_vocals_stem=True,
+                    force=False,
+                    force_whisper=False,
+                    youtube_url=youtube_url,
+                    use_qwen3=True,
+                )
+
+                db_client.update_recording_status(
+                    hash_prefix=recording.hash_prefix,
+                    lrc_status="processing",
+                    lrc_job_id=job.job_id,
+                )
+
+                active_jobs[song_id] = job.job_id
+                console.print(f"  [green]→ {song_id} (submitted: {job.job_id})[/green]")
+
+            except AnalysisServiceError as e:
+                console.print(f"  [red]✗ {song_id} failed to submit: {e}[/red]")
+                results[song_id] = results.get(song_id, {})
+                results[song_id]["lrc"] = "failed"
+                results[song_id]["lrc_error"] = str(e)
+
+        console.print(f"  Submitted: {len(active_jobs)} job(s)")
+        console.print()
+
+    # Phase 3: Poll all jobs
+    if active_jobs and not skip_lrc:
+        console.print("[cyan]Phase 3: Polling LRC jobs[/cyan]")
+        _poll_all_jobs(
+            active_jobs=active_jobs,
+            results=results,
+            db_client=db_client,
+            analysis_client=analysis_client,
+            r2_client=r2_client,
+            stale_after_minutes=stale_after_minutes,
+            console=console,
+        )
+
+    # Phase 4: Print stats (done by caller)
+    return results
+
+
+def _poll_all_jobs(
+    active_jobs: dict,
+    results: dict,
+    db_client: DatabaseClient,
+    analysis_client: AnalysisClient,
+    r2_client: R2Client,
+    stale_after_minutes: int,
+    console: Console,
+) -> None:
+    """Poll all active jobs until terminal state or Ctrl+C.
+
+    Args:
+        active_jobs: Dict of song_id -> job_id
+        results: Results dict to update
+        db_client: Database client
+        analysis_client: Analysis service client
+        r2_client: R2 client
+        stale_after_minutes: Staleness threshold
+        console: Rich console
+    """
+    poll_interval = 30.0
+    last_completion_time = time.time()
+    stale_warning_seconds = stale_after_minutes * 60
+    job_timing = {}  # song_id -> (start_time, elapsed)
+
+    # Record start times for all jobs
+    for song_id, job_id in active_jobs.items():
+        job_timing[song_id] = (time.time(), 0)
+
+    try:
+        while active_jobs:
+            any_completed_this_cycle = False
+
+            for song_id in list(active_jobs.keys()):
+                job_id = active_jobs[song_id]
+                try:
+                    job = analysis_client.get_job(job_id)
+
+                    if job.status == "completed":
+                        # R2 confirmation check
+                        recording = db_client.get_recording_by_song_id(song_id)
+                        lrc_url = _confirm_r2_lrc(r2_client, recording.hash_prefix, console)
+
+                        if lrc_url:
+                            db_client.update_recording_lrc(
+                                recording.hash_prefix,
+                                lrc_url,
+                            )
+                            results[song_id]["lrc"] = "completed"
+
+                            # Track timing
+                            start_time, _ = job_timing.get(song_id, (time.time(), 0))
+                            elapsed = time.time() - start_time
+                            job_timing[song_id] = (start_time, elapsed)
+
+                            # Store timing in results for stats
+                            results[song_id]["start_time"] = start_time
+                            results[song_id]["elapsed"] = elapsed
+
+                            del active_jobs[song_id]
+                            any_completed_this_cycle = True
+
+                            # Get song for display
+                            song = db_client.get_song(song_id)
+                            song_name = song.title if song else song_id
+                            console.print(f"  [green]✓[/green] {song_name} — LRC completed ({elapsed:.1f}s)")
+                        else:
+                            console.print(f"  [yellow]→ {song_id}: Job completed but LRC not on R2 yet, retrying...[/yellow]")
+                            continue
+
+                    elif job.status == "failed":
+                        db_client.update_recording_status(
+                            hash_prefix=recording.hash_prefix,
+                            lrc_status="failed",
+                        )
+                        results[song_id]["lrc"] = "failed"
+                        results[song_id]["lrc_error"] = job.error_message or "Unknown error"
+                        del active_jobs[song_id]
+                        any_completed_this_cycle = True
+
+                        song = db_client.get_song(song_id)
+                        song_name = song.title if song else song_id
+                        console.print(f"  [red]✗[/red] {song_name} — LRC failed: {job.error_message or 'Unknown error'}")
+
+                except AnalysisServiceError as e:
+                    if e.status_code == 404:
+                        # Job lost — check R2, resubmit if needed
+                        recording = db_client.get_recording_by_song_id(song_id)
+                        lrc_url = r2_client.lrc_exists(recording.hash_prefix)
+
+                        if lrc_url:
+                            db_client.update_recording_lrc(
+                                recording.hash_prefix,
+                                lrc_url,
+                            )
+                            results[song_id]["lrc"] = "completed"
+                            del active_jobs[song_id]
+                            any_completed_this_cycle = True
+
+                            song = db_client.get_song(song_id)
+                            song_name = song.title if song else song_id
+                            console.print(f"  [green]✓[/green] {song_name} — LRC found on R2 (job was lost)")
+                        else:
+                            console.print(f"  [yellow]→ {song_id}: Job lost (404), resubmitting...[/yellow]")
+                            # Could resubmit here, but for now we'll just mark as failed
+                            # because we need context to resubmit properly
+                            results[song_id]["lrc"] = "failed"
+                            results[song_id]["lrc_error"] = "Job lost (404) and not found on R2"
+                            del active_jobs[song_id]
+                    else:
+                        console.print(f"  [yellow]→ Error polling {job_id}: {e}[/yellow]")
+                except Exception as e:
+                    console.print(f"  [yellow]→ Error polling {job_id}: {e}[/yellow]")
+
+            if any_completed_this_cycle:
+                last_completion_time = time.time()
+
+            # Staleness warning
+            elapsed_since_completion = time.time() - last_completion_time
+            if elapsed_since_completion > stale_warning_seconds and active_jobs:
+                hours = int(elapsed_since_completion // 3600)
+                mins = int((elapsed_since_completion % 3600) // 60)
+                console.print()
+                console.print(
+                    f"[yellow]⚠ WARNING: No jobs completed in {hours}h {mins}m. "
+                    f"Analysis Service may be hung or restarting.[/yellow]"
+                )
+                console.print(
+                    "[yellow]Press Ctrl+C to stop and reconcile, "
+                    "or wait for service recovery.[/yellow]"
+                )
+                console.print()
+                last_completion_time = time.time()
+
+            # Print progress
+            _print_progress(active_jobs, results, start_time=job_timing[list(active_jobs.keys())[0]][0])
+
+            if active_jobs:
+                time.sleep(poll_interval)
+
+    except KeyboardInterrupt:
+        _reconcile_on_interrupt(active_jobs, results, db_client, r2_client, console)
+
+
+def _confirm_r2_lrc(
+    r2_client: R2Client,
+    hash_prefix: str,
+    console: Console,
+    max_retries: int = 3,
+    retry_delay: float = 5.0,
+) -> Optional[str]:
+    """Confirm LRC file exists on R2 after service reports completion.
+
+    Args:
+        r2_client: R2 client
+        hash_prefix: Recording hash prefix
+        console: Rich console
+        max_retries: Maximum number of retries
+        retry_delay: Delay between retries in seconds
+
+    Returns:
+        LRC URL if found, None if not confirmed
+    """
+    for attempt in range(max_retries):
+        lrc_url = r2_client.lrc_exists(hash_prefix)
+        if lrc_url:
+            return lrc_url
+        if attempt < max_retries - 1:
+            time.sleep(retry_delay)
+    return None
+
+
+def _reconcile_on_interrupt(
+    active_jobs: dict,
+    results: dict,
+    db_client: DatabaseClient,
+    r2_client: R2Client,
+    console: Console,
+) -> None:
+    """Reconcile status for in-progress jobs on Ctrl+C.
+
+    Args:
+        active_jobs: Dict of song_id -> job_id still in progress
+        results: Results dict to update
+        db_client: Database client
+        r2_client: R2 client
+        console: Rich console
+    """
+    console.print()
+    console.print("[yellow]Batch interrupted. Reconciling status...[/yellow]")
+
+    for song_id, job_id in active_jobs.items():
+        recording = db_client.get_recording_by_song_id(song_id)
+        if not recording:
+            continue
+
+        hash_prefix = recording.hash_prefix
+
+        # Check R2 for LRC
+        lrc_url = r2_client.lrc_exists(hash_prefix)
+        if lrc_url:
+            db_client.update_recording_lrc(hash_prefix, lrc_url)
+            results[song_id]["lrc"] = "completed"
+
+            song = db_client.get_song(song_id)
+            song_name = song.title if song else song_id
+            console.print(f"  [green]✓[/green] {song_name}: LRC found on R2 (completed)")
+        else:
+            db_client.update_recording_status(
+                hash_prefix=hash_prefix,
+                lrc_status="failed",
+            )
+            results[song_id]["lrc"] = "failed"
+            results[song_id]["lrc_error"] = "Batch interrupted, LRC not on R2"
+
+            song = db_client.get_song(song_id)
+            song_name = song.title if song else song_id
+            console.print(f"  [red]✗[/red] {song_name}: LRC not on R2 (marked failed)")
+
+    console.print()
+    console.print(
+        "[dim]Tip: Run 'sow-admin audio status --reconcile' later to catch "
+        "late completions after the service finishes processing.[/dim]"
+    )
+
+
+def _print_progress(
+    active_jobs: dict,
+    results: dict,
+    start_time: float,
+    console: Console,
+) -> None:
+    """Print polling progress.
+
+    Args:
+        active_jobs: Dict of song_id -> job_id still in progress
+        results: Results dict
+        start_time: Batch start time
+        console: Rich console
+    """
+    completed_count = sum(1 for r in results.values() if r.get("lrc") == "completed")
+    failed_count = sum(1 for r in results.values() if r.get("lrc") == "failed")
+    in_progress_count = len(active_jobs)
+
+    elapsed = time.time() - start_time
+    elapsed_mins = int(elapsed // 60)
+    elapsed_secs = int(elapsed % 60)
+
+    console.print(
+        f"⏳ Polling {len(active_jobs)} job(s)... "
+        f"{completed_count} completed, {failed_count} failed, {in_progress_count} in progress "
+        f"(elapsed: {elapsed_mins}m {elapsed_secs}s)"
+    )
+
+
+def _print_stats(
+    results: dict,
+    db_client: DatabaseClient,
+    console: Console,
+    format: str,
+) -> None:
+    """Print final batch statistics.
+
+    Args:
+        results: Results dict from batch processing
+        db_client: Database client for looking up song info
+        console: Rich console
+        format: Output format (rich or json)
+    """
+    if format == "json":
+        import json
+        console.print(json.dumps(results, indent=2))
+        return
+
+    # Rich format
+    total = len(results)
+
+    # Download stats
+    download_completed = sum(1 for r in results.values() if r.get("download") == "completed")
+    download_skipped = sum(1 for r in results.values() if r.get("download") == "skipped_r2")
+    download_failed = sum(1 for r in results.values() if r.get("download") == "failed")
+
+    # LRC stats
+    lrc_completed = sum(1 for r in results.values() if r.get("lrc") == "completed")
+    lrc_failed = sum(1 for r in results.values() if r.get("lrc") == "failed")
+    lrc_skipped_existing = sum(1 for r in results.values() if r.get("lrc_source") == "r2_preexisting")
+    lrc_skipped_download = sum(1 for r in results.values() if r.get("download") == "failed")
+
+    # LRC timing stats (only for ASR-generated LRCs)
+    lrc_timings = []
+    for song_id, t in results.items():
+        # Only track timings for jobs that were actually generated by ASR
+        if "elapsed" in t and t.get("lrc_source") != "r2_preexisting":
+            # Add to timings list
+            lrc_timings.append(t["elapsed"])
+
+    if lrc_timings:
+        avg_lrc_time = sum(lrc_timings) / len(lrc_timings)
+        med_lrc_time = sorted(lrc_timings)[len(lrc_timings) // 2]
+        min_lrc_time = min(lrc_timings)
+        max_lrc_time = max(lrc_timings)
+    else:
+        avg_lrc_time = med_lrc_time = min_lrc_time = max_lrc_time = None
+
+    # Build summary table
+    lines = [
+        f"╭─ {'Batch Summary':^50} ╮",
+        f"│ {'Songs processed:':<30} {total:>18} │",
+        f"│ {'':<30} {'':>18} │",
+        f"│ {'Downloads:':<30} {'':>18} │",
+        f"│ {'  Completed:':<30} {download_completed:>18} │",
+        f"│ {'  Skipped (R2):':<30} {download_skipped:>18} │",
+        f"│ {'  Failed:':<30} {download_failed:>18} │",
+        f"│ {'':<30} {'':>18} │",
+        f"│ {'LRC:':<30} {'':>18} │",
+        f"│ {'  Completed:':<30} {lrc_completed:>18} │",
+        f"│ {'  Failed:':<30} {lrc_failed:>18} │",
+        f"│ {'  Skipped (R2):':<30} {lrc_skipped_existing:>18} │",
+        f"│ {'  Skipped (dl failed):':<30} {lrc_skipped_download:>18} │",
+    ]
+
+    if lrc_completed > 0 and lrc_skipped_existing < lrc_completed:
+        asr_count = lrc_completed - lrc_skipped_existing
+        lines.extend([
+            f"│ {'':<30} {'':>18} │",
+            f"│ {'LRC source:':<30} {'':>18} │",
+            f"│ {'  R2 pre-existing:':<30} {lrc_skipped_existing:>18} │",
+            f"│ {'  ASR (generated):':<30} {asr_count:>18} │",
+        ])
+
+    if avg_lrc_time is not None:
+        lines.extend([
+            f"│ {'':<30} {'':>18} │",
+            f"│ {'LRC timing (ASR jobs only):':<30} {'':>18} │",
+            f"│ {'  Average:':<30} {avg_lrc_time:.1f}s{'':>12} │",
+            f"│ {'  Median:':<30} {med_lrc_time:.1f}s{'':>12} │",
+            f"│ {'  Min/Max:':<30} {min_lrc_time:.1f}s / {max_lrc_time:.1f}s   │",
+        ])
+
+    lines.append("╰" + "─" * 52 + "╯")
+
+    console.print("\n".join(lines))
+
+    # Print failed downloads
+    failed_downloads = [
+        (song_id, r.get("error"))
+        for song_id, r in results.items()
+        if r.get("download") == "failed"
+    ]
+    if failed_downloads:
+        console.print("\n[bold red]Failed downloads:[/bold red]")
+        for song_id, error in failed_downloads:
+            song = db_client.get_song(song_id)
+            song_name = song.title if song else song_id
+            console.print(f"  - {song_name}: {error}")
+
+    # Print failed LRCs
+    failed_lrcs = [
+        (song_id, r.get("lrc_error"))
+        for song_id, r in results.items()
+        if r.get("lrc") == "failed"
+    ]
+    if failed_lrcs:
+        console.print("\n[bold red]Failed LRC:[/bold red]")
+        for song_id, error in failed_lrcs:
+            song = db_client.get_song(song_id)
+            song_name = song.title if song else song_id
+            console.print(f"  - {song_name}: {error}")
+

--- a/src/stream_of_worship/admin/commands/audio.py
+++ b/src/stream_of_worship/admin/commands/audio.py
@@ -922,9 +922,11 @@ def delete_recording(
         f"[cyan]Song Title:[/cyan] {song_title}",
         f"[cyan]Hash Prefix:[/cyan] {recording.hash_prefix}",
         f"[cyan]Filename:[/cyan] {recording.original_filename}",
-        f"[cyan]Size:[/cyan] {_format_size_mb(recording.file_size_bytes)}"
-        if recording.file_size_bytes
-        else "[cyan]Size:[/cyan] -- MB",
+        (
+            f"[cyan]Size:[/cyan] {_format_size_mb(recording.file_size_bytes)}"
+            if recording.file_size_bytes
+            else "[cyan]Size:[/cyan] -- MB"
+        ),
     ]
 
     # List R2 resources
@@ -1437,9 +1439,9 @@ def analyze_recording(
                 beats=json.dumps(result.beats) if result.beats else None,
                 downbeats=json.dumps(result.downbeats) if result.downbeats else None,
                 sections=json.dumps(result.sections) if result.sections else None,
-                embeddings_shape=json.dumps(result.embeddings_shape)
-                if result.embeddings_shape
-                else None,
+                embeddings_shape=(
+                    json.dumps(result.embeddings_shape) if result.embeddings_shape else None
+                ),
                 r2_stems_url=result.stems_url,
             )
 
@@ -1799,14 +1801,21 @@ def check_status(
         "--force-url",
         help="URL to set when using --force-status (stems_url for analysis, lrc_url for lrc)",
     ),
+    reconcile: bool = typer.Option(
+        False,
+        "--reconcile",
+        "-r",
+        help="Reconcile LRC and analysis status by scanning R2 (robust against service restarts)",
+    ),
     config_path: Optional[Path] = typer.Option(None, "--config", "-c", help="Path to config file"),
 ) -> None:
     """Check analysis status.
 
     With JOB_ID: query the service for that job's status.
     Without: list all recordings with pending/processing/failed status.
-    Use --sync to update local database with latest statuses from service.
-    Use --force-status when Analysis Service has restarted and lost job state.
+    Use --reconcile to update LRC and analysis status by scanning R2 (robust against service restarts).
+    Use --sync to poll the analysis service (unreliable if service restarted).
+    Use --force-status when you need to manually override status.
     """
     # Standard config/db boilerplate
     try:
@@ -1847,6 +1856,128 @@ def check_status(
         else:
             console.print("[red]--force-status requires either a JOB_ID or --sync flag[/red]")
             raise typer.Exit(1)
+
+    # Handle --reconcile mode
+    if reconcile:
+        try:
+            r2_client = R2Client(config.r2_bucket, config.r2_endpoint_url, config.r2_region)
+        except ValueError as e:
+            console.print(f"[red]R2 not configured: {e}[/red]")
+            raise typer.Exit(1)
+
+        incomplete_lrc = db_client.list_recordings(lrc_status="incomplete")
+        incomplete_analysis = db_client.list_recordings(status="incomplete")
+
+        # Deduplicate: a recording may be incomplete on both
+        all_hashes = set()
+        reconcile_queue = []
+        for rec in incomplete_lrc:
+            if rec.hash_prefix not in all_hashes:
+                all_hashes.add(rec.hash_prefix)
+                reconcile_queue.append(rec)
+        for rec in incomplete_analysis:
+            if rec.hash_prefix not in all_hashes:
+                all_hashes.add(rec.hash_prefix)
+                reconcile_queue.append(rec)
+
+        if not reconcile_queue:
+            console.print("[green]No recordings with incomplete LRC or analysis status.[/green]")
+        else:
+            console.print(f"[cyan]Scanning R2 across {len(reconcile_queue)} recording(s)...[/cyan]")
+            reconciled_lrc = 0
+            reconciled_analysis = 0
+            error_count = 0
+
+            for rec in reconcile_queue:
+                # LRC reconciliation
+                if rec.lrc_status in ("pending", "processing", "failed"):
+                    try:
+                        lrc_url = r2_client.lrc_exists(rec.hash_prefix)
+                        if lrc_url:
+                            db_client.update_recording_lrc(
+                                hash_prefix=rec.hash_prefix,
+                                r2_lrc_url=lrc_url,
+                            )
+                            reconciled_lrc += 1
+                            console.print(
+                                f"  [green]✓[/green] {rec.song_id or rec.hash_prefix}: "
+                                f"LRC {rec.lrc_status} → completed"
+                            )
+                    except ClientError as e:
+                        error_count += 1
+                        console.print(
+                            f"  [red]✗[/red] {rec.hash_prefix}: R2 error checking LRC: {e}"
+                        )
+
+                # Analysis reconciliation
+                if rec.analysis_status in ("pending", "processing", "failed"):
+                    try:
+                        analysis_url = r2_client.analysis_exists(rec.hash_prefix)
+                        if analysis_url:
+                            analysis_data = r2_client.download_analysis_json(rec.hash_prefix)
+                            db_client.update_recording_analysis(
+                                hash_prefix=rec.hash_prefix,
+                                duration_seconds=analysis_data.get("duration_seconds"),
+                                tempo_bpm=analysis_data.get("tempo_bpm"),
+                                musical_key=analysis_data.get("musical_key"),
+                                musical_mode=analysis_data.get("musical_mode"),
+                                key_confidence=analysis_data.get("key_confidence"),
+                                loudness_db=analysis_data.get("loudness_db"),
+                                beats=(
+                                    json.dumps(analysis_data["beats"])
+                                    if "beats" in analysis_data
+                                    else None
+                                ),
+                                downbeats=(
+                                    json.dumps(analysis_data["downbeats"])
+                                    if "downbeats" in analysis_data
+                                    else None
+                                ),
+                                sections=(
+                                    json.dumps(analysis_data["sections"])
+                                    if "sections" in analysis_data
+                                    else None
+                                ),
+                                embeddings_shape=(
+                                    json.dumps(analysis_data["embeddings_shape"])
+                                    if "embeddings_shape" in analysis_data
+                                    else None
+                                ),
+                                r2_stems_url=analysis_data.get("stems_url"),
+                            )
+                            reconciled_analysis += 1
+                            console.print(
+                                f"  [green]✓[/green] {rec.song_id or rec.hash_prefix}: "
+                                f"analysis {rec.analysis_status} → completed"
+                            )
+                    except ClientError as e:
+                        error_count += 1
+                        console.print(
+                            f"  [red]✗[/red] {rec.hash_prefix}: R2 error checking analysis: {e}"
+                        )
+                    except (json.JSONDecodeError, KeyError) as e:
+                        error_count += 1
+                        console.print(
+                            f"  [red]✗[/red] {rec.hash_prefix}: error parsing analysis.json: {e}"
+                        )
+
+            parts = []
+            if reconciled_lrc > 0:
+                parts.append(f"{reconciled_lrc} LRC")
+            if reconciled_analysis > 0:
+                parts.append(f"{reconciled_analysis} analysis")
+            if parts:
+                console.print(
+                    f"[green]Reconciled {' and '.join(parts)} status(es) from R2.[/green]"
+                )
+            else:
+                console.print("[dim]No completed files found in R2 for pending recordings.[/dim]")
+            if error_count > 0:
+                console.print(
+                    f"[yellow]{error_count} R2 error(s) encountered (see above).[/yellow]"
+                )
+            console.print("")
+    # Fall through to list pending recordings table
 
     # Mode A: Query specific job
     if job_id:
@@ -1918,6 +2049,11 @@ def check_status(
     # Mode B: Sync and list pending recordings
     # If --sync, query analysis service for all pending jobs and update local DB
     if sync:
+        console.print(
+            "[yellow]Warning: --sync is unreliable if the Analysis Service has restarted. "
+            "For LRC and analysis status, consider using --reconcile instead, "
+            "which scans R2 directly.[/yellow]"
+        )
         try:
             client = AnalysisClient(config.analysis_url)
         except ValueError as e:
@@ -1957,26 +2093,34 @@ def check_status(
                         if job.status == "completed":
                             db_client.update_recording_analysis(
                                 hash_prefix=rec.hash_prefix,
-                                duration_seconds=job.result.duration_seconds
-                                if job.result
-                                else None,
+                                duration_seconds=(
+                                    job.result.duration_seconds if job.result else None
+                                ),
                                 tempo_bpm=job.result.tempo_bpm if job.result else None,
                                 musical_key=job.result.musical_key if job.result else None,
                                 musical_mode=job.result.musical_mode if job.result else None,
                                 key_confidence=job.result.key_confidence if job.result else None,
                                 loudness_db=job.result.loudness_db if job.result else None,
-                                beats=json.dumps(job.result.beats)
-                                if job.result and job.result.beats
-                                else None,
-                                downbeats=json.dumps(job.result.downbeats)
-                                if job.result and job.result.downbeats
-                                else None,
-                                sections=json.dumps(job.result.sections)
-                                if job.result and job.result.sections
-                                else None,
-                                embeddings_shape=json.dumps(job.result.embeddings_shape)
-                                if job.result and job.result.embeddings_shape
-                                else None,
+                                beats=(
+                                    json.dumps(job.result.beats)
+                                    if job.result and job.result.beats
+                                    else None
+                                ),
+                                downbeats=(
+                                    json.dumps(job.result.downbeats)
+                                    if job.result and job.result.downbeats
+                                    else None
+                                ),
+                                sections=(
+                                    json.dumps(job.result.sections)
+                                    if job.result and job.result.sections
+                                    else None
+                                ),
+                                embeddings_shape=(
+                                    json.dumps(job.result.embeddings_shape)
+                                    if job.result and job.result.embeddings_shape
+                                    else None
+                                ),
                                 r2_stems_url=job.result.stems_url if job.result else None,
                             )
                             synced_count += 1
@@ -2021,15 +2165,13 @@ def check_status(
 
     # List pending recordings
     cursor = db_client.connection.cursor()
-    cursor.execute(
-        """
+    cursor.execute("""
         SELECT r.*, s.title as song_title
         FROM recordings r
         LEFT JOIN songs s ON r.song_id = s.id
         WHERE r.analysis_status != 'completed' OR r.lrc_status != 'completed'
         ORDER BY r.imported_at DESC
-        """
-    )
+        """)
 
     rows = cursor.fetchall()
     if not rows:
@@ -2135,13 +2277,11 @@ def _force_sync_all_pending(
     """Force update all pending recordings."""
     # Get all non-completed recordings
     cursor = db_client.connection.cursor()
-    cursor.execute(
-        """
+    cursor.execute("""
         SELECT * FROM recordings
         WHERE analysis_status IN ('pending', 'processing', 'failed')
            OR lrc_status IN ('pending', 'processing', 'failed')
-        """
-    )
+        """)
     rows = cursor.fetchall()
 
     if not rows:

--- a/src/stream_of_worship/admin/db/client.py
+++ b/src/stream_of_worship/admin/db/client.py
@@ -621,8 +621,11 @@ class DatabaseClient:
             query += " AND deleted_at IS NULL"
 
         if status:
-            query += " AND analysis_status = ?"
-            params.append(status)
+            if status == "incomplete":
+                query += " AND analysis_status IN ('pending', 'processing', 'failed')"
+            else:
+                query += " AND analysis_status = ?"
+                params.append(status)
 
         if visibility:
             query += " AND visibility_status = ?"

--- a/src/stream_of_worship/admin/db/client.py
+++ b/src/stream_of_worship/admin/db/client.py
@@ -227,6 +227,12 @@ class DatabaseClient:
             except sqlite3.OperationalError:
                 pass
 
+            # Migration: add download_status column if it doesn't exist (idempotent)
+            try:
+                cursor.execute("ALTER TABLE recordings ADD COLUMN download_status TEXT DEFAULT 'pending'")
+            except sqlite3.OperationalError:
+                pass
+
             # Now create indexes (they can reference migrated columns)
             for statement in CREATE_INDEXES:
                 cursor.execute(statement)
@@ -518,8 +524,8 @@ class DatabaseClient:
                     musical_mode, key_confidence, loudness_db, beats,
                     downbeats, sections, embeddings_shape, analysis_status,
                     analysis_job_id, lrc_status, lrc_job_id, visibility_status,
-                    created_at, updated_at, youtube_url
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    download_status, created_at, updated_at, youtube_url
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     recording.content_hash,
@@ -546,6 +552,7 @@ class DatabaseClient:
                     recording.lrc_status,
                     recording.lrc_job_id,
                     recording.visibility_status,
+                    recording.download_status or "pending",
                     recording.created_at or datetime.now().isoformat(),
                     recording.updated_at or datetime.now().isoformat(),
                     recording.youtube_url,
@@ -681,6 +688,8 @@ class DatabaseClient:
         cursor = self.connection.cursor()
 
         # Build query with LEFT JOIN to songs table
+        # Build query with LEFT JOIN to songs table
+        # Note: r.* returns all recording columns including download_status (29 cols total)
         query = """
             SELECT r.*, s.title as song_title, s.album_name, s.album_series
             FROM recordings r
@@ -728,13 +737,9 @@ class DatabaseClient:
         results = []
         for row in cursor.fetchall():
             # Extract song data from row (last 3 columns)
+            # Row structure: [29 recording columns] + [song_title, album_name, album_series] = 32 columns total
             row_tuple = tuple(row)
-            song_title = row_tuple[-3]
-            album_name = row_tuple[-2]
-            album_series = row_tuple[-3]  # Actually -3 is song_title, let's be careful
-            # Re-extract: row has recording columns + song_title + album_name + album_series
-            # The Recording.from_row expects only recording columns
-            recording_cols = row_tuple[:-3]
+            recording_cols = row_tuple[:-3]  # First 29 columns are recording columns
             song_title = row_tuple[-3]
             album_name = row_tuple[-2]
             album_series_val = row_tuple[-1]
@@ -923,6 +928,39 @@ class DatabaseClient:
             """
 
             cursor.execute(sql, (r2_lrc_url, hash_prefix))
+
+    def update_recording_download(
+        self,
+        hash_prefix: str,
+        download_status: str,
+    ) -> None:
+        """Update download status for a recording.
+
+        Args:
+            hash_prefix: The hash prefix of the recording
+            download_status: New download status (pending|processing|completed|failed)
+
+        Raises:
+            ValueError: If download_status is not valid
+        """
+        valid_statuses = {"pending", "processing", "completed", "failed"}
+        if download_status not in valid_statuses:
+            raise ValueError(
+                f"Invalid download_status: {download_status}. "
+                f"Must be one of: {', '.join(valid_statuses)}"
+            )
+
+        with self.transaction() as conn:
+            cursor = conn.cursor()
+
+            sql = """
+                UPDATE recordings SET
+                    download_status = ?,
+                    updated_at = datetime('now')
+                WHERE hash_prefix = ?
+            """
+
+            cursor.execute(sql, (download_status, hash_prefix))
 
     def update_recording_visibility(
         self,

--- a/src/stream_of_worship/admin/db/models.py
+++ b/src/stream_of_worship/admin/db/models.py
@@ -186,6 +186,7 @@ class Recording:
     lrc_status: str = "pending"
     lrc_job_id: Optional[str] = None
     visibility_status: Optional[str] = None
+    download_status: str = "pending"
     created_at: Optional[str] = None
     updated_at: Optional[str] = None
     deleted_at: Optional[str] = None
@@ -206,33 +207,45 @@ class Recording:
             - 26 columns: with youtube_url at the end, no visibility_status
             - 27 columns: with visibility_status at the end (after youtube_url)
             - 28 columns: with deleted_at at the end
+            - 29 columns: with download_status at the end (after deleted_at)
         """
         row_len = len(row)
 
-        if row_len == 28:
+        if row_len >= 29:
             created_at = row[23]
             updated_at = row[24]
             youtube_url = row[25]
             visibility_status = row[26]
             deleted_at = row[27]
+            download_status = row[28]
+        elif row_len == 28:
+            created_at = row[23]
+            updated_at = row[24]
+            youtube_url = row[25]
+            visibility_status = row[26]
+            deleted_at = row[27]
+            download_status = None
         elif row_len == 27:
             created_at = row[23]
             updated_at = row[24]
             youtube_url = row[25]
             visibility_status = row[26]
             deleted_at = None
+            download_status = None
         elif row_len == 26:
             visibility_status = None
             created_at = row[23]
             updated_at = row[24]
             youtube_url = row[25]
             deleted_at = None
+            download_status = None
         else:
             visibility_status = None
             created_at = row[23] if row_len > 23 else None
             updated_at = row[24] if row_len > 24 else None
             youtube_url = None
             deleted_at = None
+            download_status = None
 
         return cls(
             content_hash=row[0],
@@ -260,6 +273,7 @@ class Recording:
             lrc_status=row[21],
             lrc_job_id=row[22],
             visibility_status=visibility_status,
+            download_status=download_status or "pending",
             created_at=created_at,
             updated_at=updated_at,
             deleted_at=deleted_at,
@@ -297,6 +311,7 @@ class Recording:
             "lrc_status": self.lrc_status,
             "lrc_job_id": self.lrc_job_id,
             "visibility_status": self.visibility_status,
+            "download_status": self.download_status,
             "created_at": self.created_at,
             "updated_at": self.updated_at,
             "deleted_at": self.deleted_at,

--- a/src/stream_of_worship/admin/db/schema.py
+++ b/src/stream_of_worship/admin/db/schema.py
@@ -195,11 +195,11 @@ RECORDING_COLUMNS_FOR_JOIN = """
     r.musical_mode, r.key_confidence, r.loudness_db, r.beats,
     r.downbeats, r.sections, r.embeddings_shape, r.analysis_status,
     r.analysis_job_id, r.lrc_status, r.lrc_job_id, r.youtube_url,
-    r.visibility_status, r.created_at, r.updated_at, r.deleted_at
+    r.visibility_status, r.download_status, r.created_at, r.updated_at, r.deleted_at
 """
 
 SONG_COLUMN_COUNT = 17
-RECORDING_COLUMN_COUNT = 28
+RECORDING_COLUMN_COUNT = 29
 
 # Default sync metadata values
 DEFAULT_SYNC_METADATA = {

--- a/src/stream_of_worship/admin/services/r2.py
+++ b/src/stream_of_worship/admin/services/r2.py
@@ -5,8 +5,10 @@ exposes an S3-compatible API.  Credentials are read from environment
 variables so they never appear in config files.
 """
 
+import json
 import os
 from pathlib import Path
+from typing import Optional
 
 import boto3
 from botocore.exceptions import ClientError
@@ -128,13 +130,19 @@ class R2Client:
 
         Returns:
             True if ``{hash_prefix}/audio.mp3`` exists in the bucket
+
+        Raises:
+            ClientError: On non-404 errors (permission, credential, network).
         """
+        s3_key = f"{hash_prefix}/audio.mp3"
         try:
-            s3_key = f"{hash_prefix}/audio.mp3"
             self._client.head_object(Bucket=self.bucket, Key=s3_key)
             return True
-        except ClientError:
-            return False
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "")
+            if error_code in ("404", "NoSuchKey"):
+                return False
+            raise
 
     def download_file(self, s3_key: str, dest_path: Path) -> Path:
         """Download a file from R2 by its S3 key.
@@ -158,12 +166,83 @@ class R2Client:
 
         Returns:
             True if the object exists in the bucket
+
+        Raises:
+            ClientError: On non-404 errors (permission, credential, network).
         """
         try:
             self._client.head_object(Bucket=self.bucket, Key=s3_key)
             return True
-        except ClientError:
-            return False
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "")
+            if error_code in ("404", "NoSuchKey"):
+                return False
+            raise
+
+    def lrc_exists(self, hash_prefix: str) -> Optional[str]:
+        """Check whether an LRC file exists in R2.
+
+        Args:
+            hash_prefix: 12-character hash prefix
+
+        Returns:
+            S3 URL of the LRC file if it exists, None if not found.
+
+        Raises:
+            ClientError: On non-404 errors (permission, credential, network).
+        """
+        s3_key = f"{hash_prefix}/lyrics.lrc"
+        try:
+            self._client.head_object(Bucket=self.bucket, Key=s3_key)
+            return f"s3://{self.bucket}/{s3_key}"
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "")
+            if error_code in ("404", "NoSuchKey"):
+                return None
+            raise
+
+    def analysis_exists(self, hash_prefix: str) -> Optional[str]:
+        """Check whether an analysis.json file exists in R2.
+
+        Args:
+            hash_prefix: 12-character hash prefix
+
+        Returns:
+            S3 URL of the analysis.json if it exists, None if not found.
+
+        Raises:
+            ClientError: On non-404 errors (permission, credential, network).
+        """
+        s3_key = f"{hash_prefix}/analysis.json"
+        try:
+            self._client.head_object(Bucket=self.bucket, Key=s3_key)
+            return f"s3://{self.bucket}/{s3_key}"
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "")
+            if error_code in ("404", "NoSuchKey"):
+                return None
+            raise
+
+    def download_analysis_json(self, hash_prefix: str) -> dict:
+        """Download and parse analysis.json from R2.
+
+        Args:
+            hash_prefix: 12-character hash prefix
+
+        Returns:
+            Parsed analysis result dictionary with keys:
+            duration_seconds, tempo_bpm, musical_key, musical_mode,
+            key_confidence, loudness_db, beats, downbeats, sections,
+            embeddings_shape, stems_url
+
+        Raises:
+            ClientError: On any R2 error (including 404).
+            json.JSONDecodeError: If the file is not valid JSON.
+        """
+        s3_key = f"{hash_prefix}/analysis.json"
+        response = self._client.get_object(Bucket=self.bucket, Key=s3_key)
+        body = response["Body"].read().decode("utf-8")
+        return json.loads(body)
 
     @staticmethod
     def parse_s3_url(s3_url: str) -> tuple[str, str]:

--- a/tests/admin/test_r2.py
+++ b/tests/admin/test_r2.py
@@ -1,5 +1,6 @@
 """Tests for R2 storage client."""
 
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -110,9 +111,7 @@ class TestDownloadAudio:
     """Tests for R2Client.download_audio."""
 
     @patch("stream_of_worship.admin.services.r2.boto3.client")
-    def test_download_calls_s3_with_correct_key(
-        self, mock_boto_client, r2_env, tmp_path
-    ):
+    def test_download_calls_s3_with_correct_key(self, mock_boto_client, r2_env, tmp_path):
         """download_file is called with the right parameters."""
         mock_s3 = MagicMock()
         mock_boto_client.return_value = mock_s3
@@ -271,3 +270,145 @@ class TestDeleteFile:
 
         with pytest.raises(ClientError):
             client.delete_file("abc123def456/audio.mp3")
+
+
+class TestLrcExists:
+    """Tests for R2Client.lrc_exists."""
+
+    @patch("stream_of_worship.admin.services.r2.boto3.client")
+    def test_lrc_exists_returns_url_when_found(self, mock_boto_client, r2_env):
+        """Returns S3 URL when LRC file exists."""
+        mock_s3 = MagicMock()
+        mock_boto_client.return_value = mock_s3
+
+        client = R2Client(bucket="sow-audio", endpoint_url="https://r2.example.com")
+        result = client.lrc_exists("abc123def456")
+
+        assert result == "s3://sow-audio/abc123def456/lyrics.lrc"
+        mock_s3.head_object.assert_called_once_with(
+            Bucket="sow-audio", Key="abc123def456/lyrics.lrc"
+        )
+
+    @patch("stream_of_worship.admin.services.r2.boto3.client")
+    def test_lrc_exists_returns_none_on_404(self, mock_boto_client, r2_env):
+        """Returns None when LRC file not found (404 error)."""
+        mock_s3 = MagicMock()
+        mock_s3.head_object.side_effect = ClientError(
+            {"Error": {"Code": "404", "Message": "Not Found"}},
+            "HeadObject",
+        )
+        mock_boto_client.return_value = mock_s3
+
+        client = R2Client(bucket="sow-audio", endpoint_url="https://r2.example.com")
+        result = client.lrc_exists("abc123def456")
+
+        assert result is None
+
+    @patch("stream_of_worship.admin.services.r2.boto3.client")
+    def test_lrc_exists_raises_on_permission_error(self, mock_boto_client, r2_env):
+        """Raises ClientError on non-404 errors (permission denied)."""
+        mock_s3 = MagicMock()
+        mock_s3.head_object.side_effect = ClientError(
+            {"Error": {"Code": "403", "Message": "Access Denied"}},
+            "HeadObject",
+        )
+        mock_boto_client.return_value = mock_s3
+
+        client = R2Client(bucket="sow-audio", endpoint_url="https://r2.example.com")
+
+        with pytest.raises(ClientError):
+            client.lrc_exists("abc123def456")
+
+
+class TestAnalysisExists:
+    """Tests for R2Client.analysis_exists."""
+
+    @patch("stream_of_worship.admin.services.r2.boto3.client")
+    def test_analysis_exists_returns_url_when_found(self, mock_boto_client, r2_env):
+        """Returns S3 URL when analysis.json exists."""
+        mock_s3 = MagicMock()
+        mock_boto_client.return_value = mock_s3
+
+        client = R2Client(bucket="sow-audio", endpoint_url="https://r2.example.com")
+        result = client.analysis_exists("abc123def456")
+
+        assert result == "s3://sow-audio/abc123def456/analysis.json"
+        mock_s3.head_object.assert_called_once_with(
+            Bucket="sow-audio", Key="abc123def456/analysis.json"
+        )
+
+    @patch("stream_of_worship.admin.services.r2.boto3.client")
+    def test_analysis_exists_returns_none_on_404(self, mock_boto_client, r2_env):
+        """Returns None when analysis.json not found (404 error)."""
+        mock_s3 = MagicMock()
+        mock_s3.head_object.side_effect = ClientError(
+            {"Error": {"Code": "NoSuchKey", "Message": "Not Found"}},
+            "HeadObject",
+        )
+        mock_boto_client.return_value = mock_s3
+
+        client = R2Client(bucket="sow-audio", endpoint_url="https://r2.example.com")
+        result = client.analysis_exists("abc123def456")
+
+        assert result is None
+
+    @patch("stream_of_worship.admin.services.r2.boto3.client")
+    def test_analysis_exists_raises_on_permission_error(self, mock_boto_client, r2_env):
+        """Raises ClientError on non-404 errors (permission denied)."""
+        from unittest.mock import MagicMock
+
+        mock_s3 = MagicMock()
+        mock_s3.head_object.side_effect = ClientError(
+            {"Error": {"Code": "403", "Message": "Access Denied"}},
+            "HeadObject",
+        )
+        mock_boto_client.return_value = mock_s3
+
+        client = R2Client(bucket="sow-audio", endpoint_url="https://r2.example.com")
+
+        with pytest.raises(ClientError):
+            client.analysis_exists("abc123def456")
+
+
+class TestDownloadAnalysisJson:
+    """Tests for R2Client.download_analysis_json."""
+
+    @patch("stream_of_worship.admin.services.r2.boto3.client")
+    def test_download_analysis_json_parses_and_returns_dict(self, mock_boto_client, r2_env):
+        """Downloads and parses analysis.json into dictionary."""
+        import io
+
+        mock_s3 = MagicMock()
+        analysis = {
+            "tempo_bpm": 120.0,
+            "musical_key": "C",
+            "musical_mode": "major",
+            "duration_seconds": 180.5,
+        }
+        mock_response = {"Body": io.BytesIO(json.dumps(analysis).encode())}
+        mock_s3.get_object.return_value = mock_response
+        mock_boto_client.return_value = mock_s3
+
+        client = R2Client(bucket="sow-audio", endpoint_url="https://r2.example.com")
+        result = client.download_analysis_json("abc123def456")
+
+        assert result["tempo_bpm"] == 120.0
+        assert result["musical_key"] == "C"
+        mock_s3.get_object.assert_called_once_with(
+            Bucket="sow-audio", Key="abc123def456/analysis.json"
+        )
+
+    @patch("stream_of_worship.admin.services.r2.boto3.client")
+    def test_download_analysis_json_raises_on_404(self, mock_boto_client, r2_env):
+        """Raises ClientError when file not found (including 404)."""
+        mock_s3 = MagicMock()
+        mock_s3.get_object.side_effect = ClientError(
+            {"Error": {"Code": "404", "Message": "Not Found"}},
+            "GetObject",
+        )
+        mock_boto_client.return_value = mock_s3
+
+        client = R2Client(bucket="sow-audio", endpoint_url="https://r2.example.com")
+
+        with pytest.raises(ClientError):
+            client.download_analysis_json("abc123def456")


### PR DESCRIPTION
## Summary

Implements two major features for the Admin CLI:
1. **Batch mode** - Submit-all-then-poll batch processing for end-to-end song management
2. **Status reconciliation** - R2-based status checking robust against service restarts

Also adds architectural reference documentation and comprehensive specifications for both features.

## Feature 1: Batch Mode

Implemented submit-all-then-poll batch processing with hybrid polling (service-first, R2-fallback).

### New Command

```bash
sow-admin audio batch [OPTIONS]
```

### Filter Options
- `--album TEXT` - Filter by album name (exact match)
- `--song TEXT` - Filter by song name (partial match)
- `--lrc-status TEXT` - Filter by LRC status
- `--download-status TEXT` - Filter by download status
- `--analysis-status TEXT` - Filter by analysis status
- `--stdin` - Read song IDs from stdin
- `--limit INT` - Maximum number of songs

### Processing Options
- `--skip-download` - Skip download step
- `--skip-lrc` - Skip LRC step
- `--stale-after INT` - Staleness timeout (default: 120 min)
- `--dry-run` - Show what would process without executing
- `--format TEXT` - Output format (rich|json)

### Key Design Decisions

1. **Submit-all-then-poll**: No per-song sequential wait. Submit all jobs, then poll all in a loop. Jobs queue on the service and are processed according to service concurrency limits.
2. **Hybrid polling**: Poll Analysis Service first (detects `failed` with reasons). Fall back to R2 poll on connection errors or 404 errors.
3. **Staleness timeout**: Jobs stuck in `lrc_status='processing'` for >2hr are treated as lost and resubmitted.
4. **R2 confirmation**: After service reports `completed`, verify R2 has the file (3 retries at 5s intervals).
5. **Ctrl+C reconciliation**: On interrupt, check R2 for each in-progress job. Mark completed if R2 has the file, failed otherwise.
6. **Resubmit on 404**: When a job is lost (404 from service) and not found on R2, resubmit with same params (capped at 3 attempts before marking as truly failed).

### Database Changes

| File | Change |
|------|--------|
| `src/stream_of_worship/admin/db/client.py` | Add `download_status` column migration, add `update_recording_download()` method |
| `src/stream_of_worship/admin/db/models.py` | Add `download_status` field to Recording model, update `from_row()` for 29 columns |
| `src/stream_of_worship/admin/db/schema.py` | Update `RECORDING_COLUMN_COUNT` from 28 to 29 |

### New Column: `download_status`

```sql
ALTER TABLE recordings ADD COLUMN download_status TEXT DEFAULT 'pending';
```

Values: `pending | processing | completed | failed`

## Feature 2: Status Reconciliation

Adds `--reconcile` flag to `audio status` command to detect completed jobs by scanning R2 directly instead of polling the Analysis Service. This provides robust status updates even if the service restarts and loses job state.

### Usage

```bash
sow-admin audio status --reconcile
sow-admin audio status --reconcile && sow-admin db sync
```

### Key Design Decisions

1. **R2 as source of truth**: Completion is determined by file presence in R2, not Analysis Service job state
2. **DB-driven scan**: Iterate over DB recordings with incomplete status and check R2 for each
3. **Distinguish 404 from other errors**: Non-404 errors (permission, credential, network) are logged and skipped
4. **Reconcile both LRC and analysis**: Single `--reconcile` flag covers both job types
5. **Analysis reconcile downloads + parses**: Populates all structured fields (tempo, key, beats, etc.)

### R2 Client Enhancements

| Method | Purpose |
|--------|---------|
| `lrc_exists(hash_prefix)` | Check if LRC file exists in R2, returns URL or None |
| `analysis_exists(hash_prefix)` | Check if analysis.json exists, returns URL or None |
| `download_analysis_json(hash_prefix)` | Download and parse analysis.json from R2 |

All methods now properly distinguish 404 errors (file not found) from other ClientError types (permission denied, credential expired, network timeout).

## Documentation

### Research Documentation (3 files)

- `docs/research-admin-cli-turso-sync.md` - Turso connection setup, sync mechanisms, Admin CLI flow
- `docs/research-analysis-service-lrc-completion-flow.md` - Two-tier architecture, how LRC results are written
- `docs/research-turso-r2-database-architecture.md` - Turso configuration, database schema, R2 storage

### Specification Documents (4 files)

- `specs/reconciliation-via-r2-v2.md` - Status reconciliation spec (v2)
- `specs/batch-mode-plan-v2.md` - Batch mode spec (v2)
- `specs/batch-mode-plan.md` - Batch mode spec (v1)
- `specs/lrc-reconciliation-via-r2.md` - LRC reconciliation spec (v1)

## Review Feedback Addressed

The following issues were identified during code review and fixed in `cc052d1`:

1. **TypeError from naive/aware datetime subtraction** (HIGH): `datetime.now(timezone.utc) - updated_at` raised `TypeError` because `updated_at` from `fromisoformat()` was timezone-naive. Fixed by adding `.replace(tzinfo=timezone.utc)` before subtraction.
2. **IndexError when all jobs complete in one cycle** (HIGH): `list(active_jobs.keys())[0]` crashed when `active_jobs` was empty. Fixed by guarding `_print_progress` call with `if active_jobs:` and using a `batch_start_time` instead of a per-job start time.
3. **N+1 query in `_resolve_song_ids`** (MEDIUM): Per-row `get_song()` calls replaced with `list_recordings_with_songs()` (LEFT JOIN) for efficient single-query filtering.
4. **Job loss (404) should resubmit, not fail** (MEDIUM): Aligned with spec — on 404 + no R2 file, the handler now re-fetches recording/song from DB, resubmits via `submit_lrc()`, and continues polling. Resubmissions are capped at 3 attempts per song.

## Usage Examples

### Batch Processing

```bash
# Process all songs in an album that need LRC
sow-admin audio batch --album "敬拜精选"

# Resubmit all failed LRC jobs
sow-admin audio list --lrc-status failed --format ids | sow-admin audio batch --stdin

# Process with custom staleness timeout
sow-admin audio batch --album "敬拜精选" --stale-after 60

# Dry run to preview
sow-admin audio batch --album "敬拜精选" --dry-run
```

### Status Reconciliation

```bash
# Manual status check after service restart
sow-admin audio status --reconcile

# Cron-friendly reconcile and sync
sow-admin audio status --reconcile && sow-admin db sync
```

## Testing

- Syntax validation: All modules compile
- Branch status: Clean, up to date with origin
- Ready for manual testing with real songs

## Files Changed

| File | Lines Changed |
|------|---------------|
| `src/stream_of_worship/admin/commands/audio.py` | +1102, -11 |
| `src/stream_of_worship/admin/db/client.py` | +61, -1 |
| `src/stream_of_worship/admin/db/models.py` | +17, -3 |
| `src/stream_of_worship/admin/db/schema.py` | +4, -0 |
| `src/stream_of_worship/admin/services/r2.py` | +89, -0 |
| `specs/batch-mode-plan-v2.md` | +655, -0 |
| `specs/reconciliation-via-r2-v2.md` | +429, -0 |
| `specs/batch-mode-plan.md` | +282, -0 |
| `specs/lrc-reconciliation-via-r2.md` | +248, -0 |
| `docs/research-admin-cli-turso-sync.md` | +125, -0 |
| `docs/research-analysis-service-lrc-completion-flow.md` | +108, -0 |
| `docs/research-turso-r2-database-architecture.md` | +130, -0 |
| `tests/admin/test_r2.py` | +147, -0 |

Total: 3344 insertions, 15 deletions