### PR TITLE
fix: use centralized .env at /opt/sow/.env for analysis service

### DIFF
--- a/services/analysis/README.md
+++ b/services/analysis/README.md
@@ -30,7 +30,13 @@ This service is designed to run as a long-lived container with async job process
 
 ## Environment Variables
 
-Create a `.env` file in this directory with the following variables:
+The active `.env` file is loaded from the centralized location `/opt/sow/.env` (not from this directory). A `.env.example` file is provided in this directory as a template — copy and configure it:
+
+```bash
+cp services/analysis/.env.example /opt/sow/.env
+```
+
+The following variables are required:
 
 ### Required
 
@@ -261,7 +267,7 @@ print(f'Models downloaded to: {model_dir}')
 After downloading, set the environment variable:
 
 ```bash
-# Add to your .env file
+# Add to /opt/sow/.env
 export SOW_AUDIO_SEPARATOR_MODEL_ROOT="$HOME/.cache/audio-separator"
 ```
 
@@ -299,7 +305,7 @@ ls ~/.cache/huggingface/hub/models--Qwen--Qwen3-ForcedAligner-0.6B/snapshots/
 
 ### Configure Environment
 
-Add to your `.env` file:
+Add to `/opt/sow/.env`:
 
 ```bash
 SOW_QWEN3_MODEL_ROOT="/home/user/.cache/huggingface/hub/models--Qwen--Qwen3-ForcedAligner-0.6B"

--- a/services/analysis/start-dev.sh
+++ b/services/analysis/start-dev.sh
@@ -94,7 +94,7 @@ export SOW_AUDIO_SEPARATOR_MODEL_ROOT="$MODEL_DIR"
 if [[ ! -f "/opt/sow/.env" ]]; then
     echo -e "${YELLOW}Warning: .env file not found at /opt/sow/.env${NC}"
     echo -e "Copy from .env.example and configure your environment variables:"
-    echo -e "  cp /opt/sow/.env.example /opt/sow/.env"
+    echo -e "  cp $SCRIPT_DIR/.env.example /opt/sow/.env"
     echo ""
     read -p "Continue anyway? [y/N] " -n 1 -r
     echo

--- a/services/analysis/start-dev.sh
+++ b/services/analysis/start-dev.sh
@@ -91,10 +91,10 @@ fi
 export SOW_AUDIO_SEPARATOR_MODEL_ROOT="$MODEL_DIR"
 
 # Check if .env file exists
-if [[ ! -f "$SCRIPT_DIR/.env" ]]; then
-    echo -e "${YELLOW}Warning: .env file not found at $SCRIPT_DIR/.env${NC}"
+if [[ ! -f "/opt/sow/.env" ]]; then
+    echo -e "${YELLOW}Warning: .env file not found at /opt/sow/.env${NC}"
     echo -e "Copy from .env.example and configure your environment variables:"
-    echo -e "  cp $SCRIPT_DIR/.env.example $SCRIPT_DIR/.env"
+    echo -e "  cp /opt/sow/.env.example /opt/sow/.env"
     echo ""
     read -p "Continue anyway? [y/N] " -n 1 -r
     echo
@@ -116,4 +116,4 @@ echo "  API will be available at: http://localhost:8000"
 echo ""
 
 cd "$SCRIPT_DIR"
-docker compose up analysis-dev "$@"
+docker compose --env-file /opt/sow/.env up analysis-dev "$@"

--- a/services/analysis/start-dev.sh
+++ b/services/analysis/start-dev.sh
@@ -116,4 +116,8 @@ echo "  API will be available at: http://localhost:8000"
 echo ""
 
 cd "$SCRIPT_DIR"
-docker compose --env-file /opt/sow/.env up analysis-dev "$@"
+if [[ -f "/opt/sow/.env" ]]; then
+    docker compose --env-file /opt/sow/.env up analysis-dev "$@"
+else
+    docker compose up analysis-dev "$@"
+fi


### PR DESCRIPTION
## Summary

Updates the analysis service startup script to use a centralized `.env` file at `/opt/sow/.env` instead of a local `.env` file.

## Changes

- `services/analysis/start-dev.sh`:
  - Updated `.env` file location check to verify `/opt/sow/.env` instead of `$SCRIPT_DIR/.env`
  - Added `--env-file /opt/sow/.env` to `docker compose` command
  - Updated warning messages to reference the centralized location

## Testing

- Verify script loads environment variables from `/opt/sow/.env`
- Ensure docker compose starts correctly with centralized configuration