### PR TITLE
fix(scraper): handle malformed <br>...</br> pattern in lyrics cells

### DIFF
--- a/src/stream_of_worship/admin/services/scraper.py
+++ b/src/stream_of_worship/admin/services/scraper.py
@@ -307,18 +307,15 @@ class CatalogScraper:
 
     def _parse_lyrics_cell(self, cell) -> Dict:
         """Extract lyrics from table cell, preserving line breaks."""
-        # Handle malformed <br>...</br> pattern where html.parser treats
-        # non-self-closing <br> as an opening tag, nesting all content
-        # until the closing </br>. Insert newline before unwrapping to
-        # preserve line break, then unwrap to preserve nested content.
+        # Handle both malformed <br>...</br> pattern and standard <br/> tags.
+        # For malformed <br> with children, unwrap preserves nested content.
+        # For standard <br/>, replace with newline directly.
         for br in cell.find_all("br"):
-            if list(br.children):
+            if br.contents:
                 br.insert_before("\n")
                 br.unwrap()
-
-        # Replace remaining <br/> tags with newlines
-        for br in cell.find_all("br"):
-            br.replace_with("\n")
+            else:
+                br.replace_with("\n")
 
         # Get text with newlines preserved
         lyrics_raw = cell.get_text()

--- a/src/stream_of_worship/admin/services/scraper.py
+++ b/src/stream_of_worship/admin/services/scraper.py
@@ -307,7 +307,16 @@ class CatalogScraper:
 
     def _parse_lyrics_cell(self, cell) -> Dict:
         """Extract lyrics from table cell, preserving line breaks."""
-        # Replace <br/> tags with newlines
+        # Handle malformed <br>...</br> pattern where html.parser treats
+        # non-self-closing <br> as an opening tag, nesting all content
+        # until the closing </br>. Insert newline before unwrapping to
+        # preserve line break, then unwrap to preserve nested content.
+        for br in cell.find_all("br"):
+            if list(br.children):
+                br.insert_before("\n")
+                br.unwrap()
+
+        # Replace remaining <br/> tags with newlines
         for br in cell.find_all("br"):
             br.replace_with("\n")
 

--- a/tests/admin/test_scraper.py
+++ b/tests/admin/test_scraper.py
@@ -392,6 +392,25 @@ class TestCatalogScraperLyricsParsing:
         # Empty lines should be filtered out
         assert result["lyrics_lines"] == ["Line 1", "Line 2"]
 
+    def test_parse_lyrics_cell_malformed_br(self, scraper_no_db):
+        """Test parsing lyrics cell with malformed <br>...</br> pattern.
+
+        Some songs on sop.org have <br> (non-self-closing) followed by </br>
+        at the end, which html.parser treats as a nested element. This test
+        ensures the scraper correctly handles this case.
+        """
+        from bs4 import BeautifulSoup
+
+        # This is the actual HTML pattern from row 104 (大山可以挪開)
+        html = "<td>Line 1<br>Line 2<br/>Line 3<br/>Line 4</br></td>"
+        soup = BeautifulSoup(html, "html.parser")
+        cell = soup.find("td")
+
+        result = scraper_no_db._parse_lyrics_cell(cell)
+
+        # All lines should be preserved, not just Line 1
+        assert result["lyrics_lines"] == ["Line 1", "Line 2", "Line 3", "Line 4"]
+
 
 class TestCatalogScraperHelpers:
     """Tests for helper methods."""


### PR DESCRIPTION
## Summary

Fixes a bug where lyrics were truncated to a single line for 2 songs (rows 104 and 112) due to malformed HTML on sop.org.

## Problem

The sop.org HTML for 2 songs contains a malformed `<br>` tag pattern:

```html
<td>Line 1<br>Line 2<br/>Line 3<br/>Line 4</br></td>
```

Python's `html.parser` treats the first `<br>` (non-self-closing) as an **opening tag** and the `</br>` at the end as its **closing tag**, nesting all content between them as children of the first `<br>` element.

When the scraper's `_parse_lyrics_cell()` method replaced this `<br>` element with `"\n"`, it **destroyed all nested content** (the remaining lyrics lines), leaving only the text before the first `<br>`.

## Root Cause Analysis

1. `html.parser` parses `<br>` (non-self-closing) + `</br>` as a nested element
2. The first `<br>` element contains all subsequent `<br/>` tags and text as children
3. `br.replace_with("\n")` replaces the entire element including children with a single newline
4. Result: only the first line of lyrics is preserved

## Solution

Before unwrapping `<br>` elements that have children (the malformed pattern), insert a newline to preserve the line break:

```python
for br in cell.find_all("br"):
    if list(br.children):
        br.insert_before("\n")  # Preserve line break
        br.unwrap()              # Keep children, remove wrapper
```

This ensures:
- Text before the malformed `<br>` stays separated from text after
- All nested content (remaining lyrics lines) is preserved

## Affected Songs

Only 2 out of 690 songs had this issue:
- Row 104: 大山可以挪開［主的慈愛］ (1 → 10 lines)
- Row 112: I Believe［我相信］ (1 → 14 lines)

## Changes

- **scraper.py**: Added handling for malformed `<br>...</br>` pattern in `_parse_lyrics_cell()`
- **test_scraper.py**: Added test case `test_parse_lyrics_cell_malformed_br`

## Testing

- Verified fix with actual HTML from sop.org
- Re-scraped both affected songs in the database
- Confirmed lyrics now display correctly (10 and 14 lines respectively)