### PR TITLE
feat: add MVSEP queue-full exponential backoff and improve YouTube transcript error logging

### DIFF
--- a/services/analysis/src/sow_analysis/services/mvsep_client.py
+++ b/services/analysis/src/sow_analysis/services/mvsep_client.py
@@ -40,6 +40,15 @@ class MvsepTimeoutError(MvsepClientError):
     pass
 
 
+class MvsepQueueFullError(MvsepClientError):
+    """Exception raised when MVSEP queue is full (HTTP 400 with queue-full message).
+
+    This is a retriable error that signals the worker should wait longer before retrying.
+    """
+
+    pass
+
+
 class MvsepClient:
     """Async HTTP client for MVSEP Cloud API stem separation.
 
@@ -211,6 +220,10 @@ class MvsepClient:
             if status_code in (401, 403):
                 self._disabled = True
                 raise MvsepNonRetriableError(f"Authentication failed: {status_code}") from e
+            if status_code == 400:
+                error_text = e.response.text.lower()
+                if "queue" in error_text or "wait before adding" in error_text:
+                    raise MvsepQueueFullError(f"MVSEP queue full: {e.response.text}") from e
             raise MvsepClientError(f"HTTP error {status_code}: {e.response.text}") from e
         except httpx.TimeoutException as e:
             raise MvsepClientError("Request timed out") from e

--- a/services/analysis/src/sow_analysis/workers/stem_separation.py
+++ b/services/analysis/src/sow_analysis/workers/stem_separation.py
@@ -23,11 +23,15 @@ if TYPE_CHECKING:
     from ..services.mvsep_client import MvsepClient
 
 # Import exception at module level to avoid local imports in retry loops
-from ..services.mvsep_client import MvsepNonRetriableError
+from ..services.mvsep_client import MvsepNonRetriableError, MvsepQueueFullError
 
 logger = logging.getLogger(__name__)
 
 MVSEP_MAX_RETRIES = 3
+MVSEP_QUEUE_FULL_MAX_RETRIES = 4
+
+QUEUE_FULL_BACKOFF_SECONDS = [60, 120, 300]
+OTHER_ERROR_BACKOFF_SECONDS = [5, 10, 20]
 
 # Legacy stem name mappings for cache backward compatibility
 CACHE_STEM_LEGACY_NAMES = {
@@ -151,8 +155,11 @@ async def _separate_with_mvsep_fallback(
     # --- Stage 1: Vocal separation ---
     stage1_dir = output_dir / "mvsep_stage1"
     stage1_result = None
+    stage1_max_attempts = MVSEP_MAX_RETRIES
 
-    for attempt in range(1, MVSEP_MAX_RETRIES + 1):
+    for attempt in range(1, MVSEP_QUEUE_FULL_MAX_RETRIES + 1):
+        if attempt > stage1_max_attempts:
+            break
         if _time_remaining() <= 0:
             logger.warning("MVSEP total timeout exceeded, falling back to local")
             break
@@ -168,9 +175,22 @@ async def _separate_with_mvsep_fallback(
             if isinstance(e, MvsepNonRetriableError):
                 logger.error(f"MVSEP Stage 1 non-retriable error: {e}")
                 break
-            logger.warning(f"MVSEP Stage 1 attempt {attempt} failed: {e}")
-            if attempt >= MVSEP_MAX_RETRIES:
-                logger.error(f"MVSEP Stage 1 exhausted all {MVSEP_MAX_RETRIES} retries")
+            if isinstance(e, MvsepQueueFullError):
+                stage1_max_attempts = MVSEP_QUEUE_FULL_MAX_RETRIES
+                backoff_list = QUEUE_FULL_BACKOFF_SECONDS
+                backoff_label = "queue full"
+            else:
+                backoff_list = OTHER_ERROR_BACKOFF_SECONDS
+                backoff_label = "error"
+            logger.warning(f"MVSEP Stage 1 attempt {attempt} failed ({backoff_label}): {e}")
+            if attempt >= stage1_max_attempts:
+                logger.error(f"MVSEP Stage 1 exhausted all {stage1_max_attempts} retries")
+                break
+            backoff = backoff_list[attempt - 1] if attempt - 1 < len(backoff_list) else backoff_list[-1]
+            wait = min(backoff, _time_remaining())
+            if wait > 0:
+                logger.info(f"MVSEP Stage 1 waiting {wait:.0f}s before retry ({backoff_label})")
+                await asyncio.sleep(wait)
 
     if stage1_result is None:
         # Stage 1 MVSEP failed — fall back to full local pipeline
@@ -196,8 +216,11 @@ async def _separate_with_mvsep_fallback(
 
     stage2_dir = output_dir / "mvsep_stage2"
     stage2_result = None
+    stage2_max_attempts = MVSEP_MAX_RETRIES
 
-    for attempt in range(1, MVSEP_MAX_RETRIES + 1):
+    for attempt in range(1, MVSEP_QUEUE_FULL_MAX_RETRIES + 1):
+        if attempt > stage2_max_attempts:
+            break
         if _time_remaining() <= 0:
             logger.warning("MVSEP total timeout exceeded during Stage 2, using local fallback")
             break
@@ -213,9 +236,22 @@ async def _separate_with_mvsep_fallback(
             if isinstance(e, MvsepNonRetriableError):
                 logger.error(f"MVSEP Stage 2 non-retriable error: {e}")
                 break
-            logger.warning(f"MVSEP Stage 2 attempt {attempt} failed: {e}")
-            if attempt >= MVSEP_MAX_RETRIES:
-                logger.error(f"MVSEP Stage 2 exhausted all {MVSEP_MAX_RETRIES} retries")
+            if isinstance(e, MvsepQueueFullError):
+                stage2_max_attempts = MVSEP_QUEUE_FULL_MAX_RETRIES
+                backoff_list = QUEUE_FULL_BACKOFF_SECONDS
+                backoff_label = "queue full"
+            else:
+                backoff_list = OTHER_ERROR_BACKOFF_SECONDS
+                backoff_label = "error"
+            logger.warning(f"MVSEP Stage 2 attempt {attempt} failed ({backoff_label}): {e}")
+            if attempt >= stage2_max_attempts:
+                logger.error(f"MVSEP Stage 2 exhausted all {stage2_max_attempts} retries")
+                break
+            backoff = backoff_list[attempt - 1] if attempt - 1 < len(backoff_list) else backoff_list[-1]
+            wait = min(backoff, _time_remaining())
+            if wait > 0:
+                logger.info(f"MVSEP Stage 2 waiting {wait:.0f}s before retry ({backoff_label})")
+                await asyncio.sleep(wait)
 
     if stage2_result is None:
         # Stage 2 MVSEP failed — local Stage 2 only (cross-backend handoff)

--- a/services/analysis/src/sow_analysis/workers/youtube_transcript.py
+++ b/services/analysis/src/sow_analysis/workers/youtube_transcript.py
@@ -296,7 +296,7 @@ async def fetch_youtube_transcript(
             logger.info(f"Fetched {len(transcript)} transcript segments from YouTube")
             return transcript
     except Exception as e:
-        logger.info(f"Direct fetch failed for {video_id}, trying list fallback: {e}")
+        logger.error(f"Direct fetch failed for {video_id}, trying list fallback: {e}")
 
     # Phase 2: List available transcripts and pick the best one
     try:
@@ -312,6 +312,7 @@ async def fetch_youtube_transcript(
     except YouTubeTranscriptError:
         raise
     except Exception as e:
+        logger.error(f"List fallback also failed for {video_id}: {e}")
         raise YouTubeTranscriptError(
             f"Failed to fetch YouTube transcript for video {video_id}: {e}"
         ) from e

--- a/services/analysis/tests/test_mvsep_client.py
+++ b/services/analysis/tests/test_mvsep_client.py
@@ -53,6 +53,7 @@ from sow_analysis.services.mvsep_client import (
     MvsepClientError,
     MvsepNonRetriableError,
     MvsepTimeoutError,
+    MvsepQueueFullError,
 )
 
 
@@ -165,6 +166,54 @@ async def test_submit_403_raises_non_retriable(client):
             )
 
         assert client._disabled is True
+
+
+@pytest.mark.asyncio
+async def test_submit_400_queue_full_raises_queue_full_error(client):
+    """Test 400 with queue-full message raises MvsepQueueFullError (retriable with longer backoff)."""
+    error_response = MagicMock()
+    error_response.status_code = 400
+    error_response.text = '{"success":false,"errors":["You already have unprocessed file in queue. Please wait before adding new file!"]}'
+
+    with patch.object(client._client, "post", new_callable=AsyncMock) as mock_post:
+        mock_post.side_effect = httpx.HTTPStatusError(
+            "400 Bad Request",
+            request=MagicMock(),
+            response=error_response,
+        )
+
+        with pytest.raises(MvsepQueueFullError, match="queue full"):
+            await client._submit_job(
+                client._test_audio,
+                sep_type=48,
+                add_opt1=11,
+            )
+
+        assert client._disabled is False
+
+
+@pytest.mark.asyncio
+async def test_submit_400_other_raises_client_error(client):
+    """Test 400 without queue-full message raises MvsepClientError (retriable with normal backoff)."""
+    error_response = MagicMock()
+    error_response.status_code = 400
+    error_response.text = '{"success":false,"errors":["Invalid parameter"]}'
+
+    with patch.object(client._client, "post", new_callable=AsyncMock) as mock_post:
+        mock_post.side_effect = httpx.HTTPStatusError(
+            "400 Bad Request",
+            request=MagicMock(),
+            response=error_response,
+        )
+
+        with pytest.raises(MvsepClientError, match="HTTP error 400"):
+            await client._submit_job(
+                client._test_audio,
+                sep_type=48,
+                add_opt1=11,
+            )
+
+        assert client._disabled is False
 
 
 def test_is_available_disabled_after_non_retriable(client):

--- a/services/analysis/tests/test_mvsep_fallback.py
+++ b/services/analysis/tests/test_mvsep_fallback.py
@@ -13,7 +13,7 @@ import pytest_asyncio
 
 from sow_analysis.config import settings
 from sow_analysis.models import Job, JobResult, JobStatus, StemSeparationJobRequest, StemSeparationOptions
-from sow_analysis.services.mvsep_client import MvsepClient, MvsepClientError, MvsepNonRetriableError
+from sow_analysis.services.mvsep_client import MvsepClient, MvsepClientError, MvsepNonRetriableError, MvsepQueueFullError
 from sow_analysis.workers.stem_separation import (
     _separate_with_mvsep_fallback,
     process_stem_separation,
@@ -445,3 +445,93 @@ async def test_stage1_no_vocals_file_fallback(mock_job, mock_mvsep_client, mock_
 
 
 # Note: test_httpx_500_retriable is in test_mvsep_client.py where it belongs
+
+
+@pytest.mark.asyncio
+async def test_queue_full_backoff_timing(mock_job, mock_mvsep_client, mock_separator_wrapper):
+    """Test that queue-full errors trigger correct backoff delays."""
+    from unittest.mock import patch
+    import time
+
+    sleep_times = []
+
+    async def fake_sleep(seconds):
+        sleep_times.append(seconds)
+
+    mock_mvsep_client.separate_vocals.side_effect = [
+        MvsepQueueFullError("Queue full"),
+        MvsepQueueFullError("Queue full again"),
+        (Path("/tmp/mvsep_vocals.flac"), Path("/tmp/mvsep_instrumental.flac")),
+    ]
+
+    with patch("asyncio.sleep", side_effect=fake_sleep):
+        result = await _separate_with_mvsep_fallback(
+            input_path=Path("/tmp/input.mp3"),
+            output_dir=Path("/tmp/output"),
+            job=mock_job,
+            mvsep_client=mock_mvsep_client,
+            separator_wrapper=mock_separator_wrapper,
+        )
+
+    assert len(sleep_times) == 2
+    assert sleep_times[0] == 60
+    assert sleep_times[1] == 120
+    assert mock_mvsep_client.separate_vocals.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_other_error_backoff_timing(mock_job, mock_mvsep_client, mock_separator_wrapper):
+    """Test that non-queue-full errors use shorter backoff delays."""
+    from unittest.mock import patch
+
+    sleep_times = []
+
+    async def fake_sleep(seconds):
+        sleep_times.append(seconds)
+
+    mock_mvsep_client.separate_vocals.side_effect = [
+        MvsepClientError("Network error"),
+        MvsepClientError("Timeout"),
+        (Path("/tmp/mvsep_vocals.flac"), Path("/tmp/mvsep_instrumental.flac")),
+    ]
+
+    with patch("asyncio.sleep", side_effect=fake_sleep):
+        result = await _separate_with_mvsep_fallback(
+            input_path=Path("/tmp/input.mp3"),
+            output_dir=Path("/tmp/output"),
+            job=mock_job,
+            mvsep_client=mock_mvsep_client,
+            separator_wrapper=mock_separator_wrapper,
+        )
+
+    assert len(sleep_times) == 2
+    assert sleep_times[0] == 5
+    assert sleep_times[1] == 10
+    assert mock_mvsep_client.separate_vocals.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_queue_full_4_attempts_before_fallback(mock_job, mock_mvsep_client, mock_separator_wrapper):
+    """Test that queue-full errors get 4 attempts (vs 3 for other errors)."""
+    from unittest.mock import patch
+
+    sleep_times = []
+
+    async def fake_sleep(seconds):
+        sleep_times.append(seconds)
+
+    mock_mvsep_client.separate_vocals.side_effect = MvsepQueueFullError("Queue full")
+
+    with patch("asyncio.sleep", side_effect=fake_sleep):
+        result = await _separate_with_mvsep_fallback(
+            input_path=Path("/tmp/input.mp3"),
+            output_dir=Path("/tmp/output"),
+            job=mock_job,
+            mvsep_client=mock_mvsep_client,
+            separator_wrapper=mock_separator_wrapper,
+        )
+
+    assert mock_mvsep_client.separate_vocals.call_count == 4
+    assert len(sleep_times) == 3
+    assert sleep_times == [60, 120, 300]
+    mock_separator_wrapper.separate_stems.assert_called_once()


### PR DESCRIPTION
## Summary

This PR improves the resilience of the stem separation pipeline when MVSEP's queue is full, and enhances observability of YouTube transcript retrieval failures.

## Changes

### MVSEP Queue-Full Exponential Backoff (`3175b61`)

**Problem:** When MVSEP's queue is full, the service returns HTTP 400 with a "wait before adding new file" message. The existing retry logic treated this like any other error with short 5-10s backoffs, leading to rapid retry exhaustion.

**Solution:**
- Added `MvsepQueueFullError` exception to detect queue-full responses (HTTP 400 with "queue" or "wait before adding" in error text)
- Queue-full errors now get **4 retry attempts** (vs 3 for other errors) with **longer exponential backoff**: 60s → 120s → 300s
- Other errors (network, timeout) keep shorter backoff: 5s → 10s → 20s
- Applied to both Stage 1 (vocal separation) and Stage 2 (stem separation)

**Files:**
- `services/analysis/src/sow_analysis/services/mvsep_client.py` — new `MvsepQueueFullError` exception, detection logic
- `services/analysis/src/sow_analysis/workers/stem_separation.py` — backoff timing, retry count logic
- `services/analysis/tests/test_mvsep_client.py` — tests for queue-full detection
- `services/analysis/tests/test_mvsep_fallback.py` — tests for backoff timing and attempt counts

### YouTube Transcript Error Logging (`6f5ccfd`)

**Problem:** YouTube transcript retrieval failures were logged at `INFO` level, making them easy to miss in monitoring/alerting.

**Solution:**
- Upgraded direct-fetch failure log from `INFO` to `ERROR`
- Added `ERROR`-level log for list-fallback failure as well

**Files:**
- `services/analysis/src/sow_analysis/workers/youtube_transcript.py`

## Testing

- New unit tests for `MvsepQueueFullError` detection in `test_mvsep_client.py`
- New unit tests for backoff timing in `test_mvsep_fallback.py`:
  - `test_queue_full_backoff_timing` — verifies 60s, 120s backoff delays
  - `test_other_error_backoff_timing` — verifies 5s, 10s backoff delays
  - `test_queue_full_4_attempts_before_fallback` — verifies 4 attempts before local fallback

## Migration Notes

None — this is a resilience improvement with no API or config changes.