### PR TITLE
fix: user app screen transition performance and stability

### DIFF
--- a/docs/bug-playback-bar-not-appearing.md
+++ b/docs/bug-playback-bar-not-appearing.md
@@ -1,0 +1,250 @@
+# Bug: Playback Bar Not Appearing in Songset Editor
+
+**Date:** 2026-05-15
+**Status:** Analysis Complete, Fix Pending
+
+## Problem Description
+
+In the Songset Editor screen, pressing `space` to play a song starts audio playback correctly, but the playback progress bar does not appear. The song plays, but there's no visual indication of playback progress.
+
+## Affected Files
+
+- `src/stream_of_worship/app/screens/songset_editor.py` - Songset Editor screen
+- `src/stream_of_worship/app/widgets/playback_bar.py` - PlaybackBar widget
+- `src/stream_of_worship/app/services/playback.py` - PlaybackService
+
+## Root Cause Analysis
+
+### Issue 1: PlaybackBar Initial State Ambiguity
+
+**Location:** `playback_bar.py:36`
+
+The `PlaybackBar` widget is initialized without the `hidden` CSS class:
+
+```python
+super().__init__("", id=id, classes=classes)  # classes defaults to None
+```
+
+This means the bar starts **visible but empty** (content is `""`). The visibility is managed entirely through the `update_visibility()` method, which only runs from callbacks. Since the initial playback state is `STOPPED`, the bar should logically start hidden, but it doesn't.
+
+### Issue 2: Redundant STOPPED Callbacks in PlaybackService.stop()
+
+**Location:** `playback.py:470-479`
+
+The `stop()` method directly sets the state and fires the callback without using the state-change guard:
+
+```python
+def stop(self, clear_source: bool = True) -> None:
+    # ...
+    with self._lock:
+        self._state = PlaybackState.STOPPED  # Direct assignment
+        # ...
+    
+    if self._on_state_changed:
+        self._on_state_changed(PlaybackState.STOPPED)  # Always fires!
+```
+
+Compare with `_set_state()` which has a guard:
+
+```python
+def _set_state(self, new_state: PlaybackState) -> None:
+    with self._lock:
+        old_state = self._state
+        self._state = new_state
+    if old_state != new_state and self._on_state_changed:  # Guard!
+        self._on_state_changed(new_state)
+```
+
+### Issue 3: Double-stop() During play()
+
+**Location:** `playback.py:291-324`
+
+When `play()` is called, it triggers multiple `stop()` calls:
+
+1. `play()` calls `self.stop(clear_source=False)` at line 315
+2. `play()` calls `self.load()` at line 322
+3. `load()` calls `self.stop(clear_source=True)` at line 194
+
+This results in **two STOPPED callbacks** being fired before the PLAYING callback.
+
+### Callback Sequence During play()
+
+When `play()` is called via `call_from_thread`:
+
+1. `stop(clear_source=False)` → `_on_state_changed(STOPPED)` → `call_after_refresh(add_class("hidden"))`
+2. `load()` → `stop(clear_source=True)` → `_on_state_changed(STOPPED)` → `call_after_refresh(add_class("hidden"))` (redundant!)
+3. `_set_state(PLAYING)` → `_on_state_changed(PLAYING)` → `call_after_refresh(remove_class("hidden") + update_display)`
+
+All three `call_after_refresh` calls are scheduled before any refresh occurs. The final state *should* be visible, but the redundant STOPPED callbacks may cause issues with Textual's refresh batching.
+
+## Comparison with Working Screen (Lyrics Preview)
+
+The Lyrics Preview screen works correctly. Key differences:
+
+| Aspect | Lyrics Preview | Songset Editor |
+|--------|---------------|----------------|
+| `play()` call location | Main thread via `call_after_refresh` | Worker thread via `call_from_thread` |
+| Initial PlaybackBar state | Hidden (via `update_visibility` on mount) | Visible but empty |
+| Callback timing | Synchronous within same event loop | Asynchronous across thread boundary |
+
+In Lyrics Preview, `play()` is called directly on the main thread. In Songset Editor, `play()` is dispatched via `call_from_thread`, which may affect how `call_after_refresh` callbacks are processed.
+
+## Proposed Fixes
+
+### Fix 1: Initialize PlaybackBar with hidden class
+
+**File:** `playback_bar.py:36`
+
+```python
+# Before
+super().__init__("", id=id, classes=classes)
+
+# After
+super().__init__("", id=id, classes=classes or "hidden")
+```
+
+This ensures the bar starts hidden (matching STOPPED state) and only becomes visible when `update_visibility()` is called with a non-STOPPED state.
+
+### Fix 2: Use _set_state() in stop()
+
+**File:** `playback.py:470-479`
+
+```python
+# Before
+with self._lock:
+    self._state = PlaybackState.STOPPED
+    self._position_seconds = 0.0
+    self._start_time = None
+    self._paused_at = None
+    if clear_source:
+        self._source = None
+
+if self._on_state_changed:
+    self._on_state_changed(PlaybackState.STOPPED)
+
+# After
+with self._lock:
+    self._position_seconds = 0.0
+    self._start_time = None
+    self._paused_at = None
+    if clear_source:
+        self._source = None
+
+self._set_state(PlaybackState.STOPPED)
+```
+
+This uses the existing guard in `_set_state()` to skip redundant STOPPED→STOPPED callbacks.
+
+### Fix 3: Skip redundant stop() in load()
+
+**File:** `playback.py:194`
+
+```python
+# Before
+self.stop(clear_source=True)
+
+# After
+if self._state != PlaybackState.STOPPED:
+    self.stop(clear_source=True)
+```
+
+This avoids the double-stop when `play()` has already called `stop()`.
+
+## Expected Behavior After Fix
+
+1. PlaybackBar starts hidden (correct initial state for STOPPED)
+2. When `play()` is called, only one STOPPED callback fires (if transitioning from PLAYING/PAUSED)
+3. PLAYING callback fires and removes `hidden` class + updates display
+4. PlaybackBar becomes visible with progress indication
+
+## Implementation Summary
+
+**Date Implemented:** 2026-05-15
+
+### Changes Made
+
+| File | Line | Change |
+|------|------|--------|
+| `playback_bar.py` | 36 | Initialize with `classes="hidden"` by default |
+| `playback.py` | 194-195 | Guard `stop()` call in `load()` to skip if already STOPPED |
+| `playback.py` | 478 | Use `_set_state()` instead of direct state assignment |
+
+### Detailed Changes
+
+#### 1. `playback_bar.py:36`
+
+```python
+# Before
+super().__init__("", id=id, classes=classes)
+
+# After
+super().__init__("", id=id, classes=classes or "hidden")
+```
+
+**Rationale:** The PlaybackBar now starts with the `hidden` CSS class, matching the initial STOPPED state of the playback service. This ensures the bar is hidden on first render and only becomes visible when `update_visibility()` is called with a non-STOPPED state.
+
+#### 2. `playback.py:194-195`
+
+```python
+# Before
+self.stop(clear_source=True)
+
+# After
+if self._state != PlaybackState.STOPPED:
+    self.stop(clear_source=True)
+```
+
+**Rationale:** The `load()` method is called from `play()`, which already calls `stop()` first. This guard prevents the redundant `stop()` call that was causing duplicate STOPPED callbacks.
+
+#### 3. `playback.py:478`
+
+```python
+# Before
+with self._lock:
+    self._state = PlaybackState.STOPPED
+    self._position_seconds = 0.0
+    self._start_time = None
+    self._paused_at = None
+    if clear_source:
+        self._source = None
+
+if self._on_state_changed:
+    self._on_state_changed(PlaybackState.STOPPED)
+
+# After
+with self._lock:
+    self._position_seconds = 0.0
+    self._start_time = None
+    self._paused_at = None
+    if clear_source:
+        self._source = None
+
+self._set_state(PlaybackState.STOPPED)
+```
+
+**Rationale:** Using `_set_state()` instead of directly setting `self._state` and calling the callback ensures the state-change guard is applied. This prevents redundant STOPPED→STOPPED callbacks from firing.
+
+### Test Results
+
+All 233 tests pass after implementation:
+
+```
+================== 233 passed, 55 skipped, 1 warning in 7.29s ==================
+```
+
+### Expected Behavior After Fix
+
+1. PlaybackBar starts hidden (correct initial state for STOPPED)
+2. When `play()` is called, only one state change callback fires (STOPPED→PLAYING)
+3. PLAYING callback removes `hidden` class and updates display
+4. PlaybackBar becomes visible with progress indication
+5. When playback stops, STOPPED callback adds `hidden` class
+
+## Testing Notes
+
+After implementing fixes, test:
+
+1. Press space in Songset Editor → bar should appear
+2. Press space again to stop → bar should disappear
+3. Navigate away and back → bar should be hidden initially
+4. Play from Lyrics Preview → bar should work (regression test)

--- a/specs/fix-slow-screen-transitions-v2.md
+++ b/specs/fix-slow-screen-transitions-v2.md
@@ -1,0 +1,658 @@
+# Fix Slow Screen Transitions & Operational Risks in User App — v2
+
+> **Status:** Validated against live code on 2026-05-15.
+> Supersedes `specs/fix-slow-screen-transitions.md` (v1).
+> All 17 problems from v1 confirmed. v2 corrects four issues in the proposed fixes.
+
+---
+
+## Changes from v1
+
+| # | v1 | v2 |
+|---|----|----|
+| Fix 1 | 60s staleness check + `SELECT 1` after idle | **Drop proactive health check entirely.** Reconnect on `OperationalError` at query layer. |
+| Fix 3 | Store listener as `self._songset_listener` (but only after `add_listener`) | **Store named method before registration** so `remove_listener` can match by identity. |
+| Fix 5 | "Same screen type" — ambiguous on different-payload case | **Always replace same type** regardless of payload (confirmed intent). |
+| Fix 7 | Two options (A enum, B manual push) | **Option A only:** add `LYRICS_PREVIEW` to `AppScreen` enum, route through `navigate_to`. |
+| Fix 10 | `dict[row[0], Recording]` | Key by `recording.hash_prefix` / `recording.song_id` explicitly. |
+| Fix 14 | Unscoped | **Read paths only.** Do not wrap write methods. |
+
+---
+
+## Problem Analysis
+
+All problems from v1 are confirmed. References below are to specific code locations verified in the current codebase.
+
+### Problem 1 — 3-second delay on every screen transition
+
+**Confirmed at:** `src/stream_of_worship/db/connection.py:42-50`
+
+`get_connection()` executes `SELECT 1` on every call for a cached, open connection. Because `connection` is a property in both clients (`read_client.py:36-39`, `songset_client.py:48-51`) that calls `get_connection()` on every access, every `self.connection.cursor()` call incurs a full network round-trip to Neon (us-east-1, ~50-200ms).
+
+`autocommit=True` is set at `connection.py:61`, which means there are no idle transactions for Neon's `idle_in_transaction_session_timeout` to kill. The health check is fully redundant overhead.
+
+**Hot path example — `get_songset_with_items` (catalog.py:472-505), N items:**
+- `get_songset` → 1 health check + 1 query
+- `get_items_raw` → 1 health check + 1 query
+- N × `get_recording_by_hash` → N health checks + N queries
+- N × `get_song_including_deleted` → N health checks + N queries
+- **Total: 2+2N health checks, 2+2N queries**
+
+For 5 items at 100ms/round-trip: **12 wasted health-check round-trips = 1.2 seconds**, before counting actual queries.
+
+### Problem 2 — 20+ second delay with repeated errors
+
+**Confirmed at:** `songset_editor.py:123` (anonymous lambda listener never removed), `on_unmount` at line 132 only clears playback, DOM query errors from calling `_refresh()` before widgets mount.
+
+### Problem 3 — ExportProgressScreen callback leak (CRITICAL)
+
+**Confirmed at:** `export_progress.py:61-62` (register in `on_mount`, no `on_unmount`), `export.py:124-125` (no `unregister_*` methods).
+
+### Problem 4 — navigate_back() desyncs AppState from Textual stack (CRITICAL)
+
+**Confirmed at:** `state.py:102-123`. `previous_screen` is a single slot; after two navigations, `state.current_screen` diverges from Textual's actual displayed screen.
+
+### Problem 5 — LyricsPreviewScreen bypasses navigate_to() (CRITICAL)
+
+**Confirmed at:** `songset_editor.py:441-447`. Calls `self.app.push_screen()` directly; AppState never updated.
+
+### Problem 6 — LyricsPreviewScreen playback callbacks never unregistered (HIGH)
+
+**Confirmed at:** `lyrics_preview.py:120-124`. No `on_unmount` defined. `PlaybackService.set_callbacks()` is overwrite-only, so the leak self-heals only if a subsequent screen also sets callbacks — not guaranteed.
+
+### Problem 7 — All DB queries block the main thread (HIGH)
+
+**Confirmed:** Zero `run_worker` / `Worker` usages anywhere in `src/stream_of_worship/app/screens/`.
+
+### Problem 8 — R2 downloads block the main thread (HIGH)
+
+**Confirmed at:** `asset_cache.py:134-161, 194-220`. Both `download_audio` and `download_lrc` are synchronous. R2 client at `admin/services/r2.py:147` signature: `download_file(self, s3_key: str, dest_path: Path) -> Path` — no timeout parameter. boto3 client at `r2.py:54-60` has no `botocore.config.Config` (defaults to 60s connect + 60s read + retries).
+
+### Problem 9 — AudioEngine.preview_transition() blocks main thread (HIGH)
+
+**Confirmed at:** `audio_engine.py:248-306`. pydub decode + process + export is synchronous on the main thread.
+
+### Problem 10 — N+1 query patterns (HIGH)
+
+**Confirmed:**
+- `songset_list.py:85` — `get_item_count(songset.id)` called per row in a for-loop
+- `catalog.py:186-197` — `get_recording_by_song_id(song.id)` called per song
+- `catalog.py:472-505` — `get_recording_by_hash` + `get_song_including_deleted` per item
+
+### Problem 11 — Unbounded screen stack growth (HIGH)
+
+**Confirmed at:** `app.py:156-171`. `navigate_to` always calls `push_screen(_create_screen(screen))`.
+
+### Problem 12 — No timeout on R2 downloads (MEDIUM)
+
+**Confirmed.** See Problem 8 above.
+
+### Problem 13 — No timeout on FFmpeg subprocess (MEDIUM)
+
+**Confirmed at:** `video_engine.py:906`. `process.wait()` has no timeout argument. stderr is `subprocess.DEVNULL` so a hung FFmpeg is silent.
+
+### Problem 14 — Temp files from preview_transition never cleaned up (MEDIUM)
+
+**Confirmed at:** `audio_engine.py:296-298`. `NamedTemporaryFile(delete=False)` with no tracking or atexit cleanup.
+
+### Problem 15 — ExportService callback lists grow without bound (MEDIUM)
+
+**Confirmed at:** `export.py:124-125, 129-143`. Registration-only API, no unregister methods.
+
+### Problem 16 — _notify silently swallows all exceptions (MEDIUM)
+
+**Confirmed at:** `state.py:93-100`. `except Exception: pass` hides stale-listener crashes.
+
+### Problem 17 — No DB error handling (MEDIUM)
+
+**Confirmed:** `psycopg.OperationalError` from transient drops propagates as unhandled exceptions with no user-visible notification.
+
+---
+
+## Fix Plan
+
+### Fix 1 — Remove proactive health check; use reactive reconnection
+
+**File:** `src/stream_of_worship/db/connection.py`
+
+**Rationale:** With `autocommit=True`, dropped connections raise `psycopg.OperationalError` on the next real query — not silently. There is no need to spend a network round-trip probing the connection before every query. Replace the `SELECT 1`-on-every-call pattern with a single try/reconnect wrapper. A broken connection surfaces naturally; we reconnect once and retry.
+
+```python
+import threading
+import time
+from typing import Optional
+
+import psycopg
+
+
+class ConnectionProvider:
+    MAX_RETRIES = 2
+    RETRY_DELAY_SECONDS = 1.0
+
+    def __init__(self, database_url: str):
+        self.database_url = database_url
+        self._connection: Optional[psycopg.Connection] = None
+        self._lock = threading.Lock()
+
+    def get_connection(self) -> psycopg.Connection:
+        with self._lock:
+            if self._connection is None or self._connection.closed:
+                self._connection = self._connect_with_retry()
+            return self._connection
+
+    def invalidate(self) -> None:
+        """Force next get_connection() to reconnect (call on OperationalError)."""
+        with self._lock:
+            if self._connection and not self._connection.closed:
+                try:
+                    self._connection.close()
+                except Exception:
+                    pass
+            self._connection = None
+
+    def _connect_with_retry(self) -> psycopg.Connection:
+        last_error: Optional[Exception] = None
+        for attempt in range(self.MAX_RETRIES + 1):
+            conn = None
+            try:
+                conn = psycopg.connect(
+                    self.database_url,
+                    connect_timeout=10,
+                    autocommit=True,
+                    sslmode="require",
+                )
+                conn.execute("SELECT 1")  # verify new connection only
+                return conn
+            except Exception as exc:
+                if conn:
+                    conn.close()
+                last_error = exc
+                if attempt == self.MAX_RETRIES:
+                    break
+                time.sleep(self.RETRY_DELAY_SECONDS * (attempt + 1))
+        raise last_error if last_error else RuntimeError("Connection failed without error")
+```
+
+Add a helper to both clients that executes a query with one reconnect-on-`OperationalError` retry:
+
+```python
+# In ReadOnlyClient and SongsetClient (base class or mixin)
+def _execute_with_retry(self, fn):
+    """Run fn(conn) once; on OperationalError, invalidate and retry once."""
+    try:
+        return fn(self.connection)
+    except psycopg.OperationalError:
+        self.connection_provider.invalidate()
+        return fn(self.connection)
+```
+
+All existing query methods that do `with self.connection.cursor() as cur:` become `self._execute_with_retry(lambda conn: ...)` or keep their structure if the retry wrapper is applied at the `get_connection()` level inside `_execute_with_retry`.
+
+**Note:** The `SELECT 1` in `_connect_with_retry` remains — it verifies a freshly opened connection before returning it, which is correct (cold starts on Neon can fail silently).
+
+**Expected impact:** Every screen transition drops 2+2N round-trips. For 5-item songset: from ~12 × 100-200ms = 1.2-2.4s to 0ms on the hot path.
+
+---
+
+### Fix 2 — Defer `_refresh()` to after DOM mount
+
+**File:** `src/stream_of_worship/app/screens/songset_editor.py`
+
+Replace the direct `self._refresh()` call in `on_mount` with `self.call_after_refresh(self._refresh)` so the DOM is ready before querying widgets.
+
+---
+
+### Fix 3 — Remove state listener in `on_unmount` (fix lambda bug)
+
+**File:** `src/stream_of_worship/app/screens/songset_editor.py`
+
+**v1 bug:** The stored lambda `lambda _: self._refresh()` creates a new object at definition time. If `add_listener` is called with this anonymous object, `remove_listener` uses list equality — a second lambda `lambda _: self._refresh()` is a different object and won't match. The listener must be stored as the exact same callable object that was passed to `add_listener`.
+
+**Fix:** Assign a bound method or stored lambda to an instance attribute *before* calling `add_listener`:
+
+```python
+def on_mount(self) -> None:
+    self.call_after_refresh(self._refresh)
+    self.call_after_refresh(self._focus_song_list)
+    # Store before add_listener so on_unmount can remove it
+    self._songset_listener = self._on_selected_songset_changed
+    self.state.add_listener("selected_songset", self._songset_listener)
+    self.playback.set_callbacks(
+        on_position_changed=self._on_position_changed,
+        on_state_changed=self._on_state_changed,
+        on_finished=self._on_finished,
+    )
+
+def _on_selected_songset_changed(self, _) -> None:
+    self._refresh()
+
+def on_unmount(self) -> None:
+    self.playback.set_callbacks()
+    if self._songset_listener:
+        self.state.remove_listener("selected_songset", self._songset_listener)
+        self._songset_listener = None
+```
+
+Initialize `self._songset_listener = None` in `__init__`.
+
+---
+
+### Fix 4 — Guard `_refresh()` against non-active screens
+
+**File:** `src/stream_of_worship/app/screens/songset_editor.py`
+
+```python
+def _refresh(self) -> None:
+    if not self.is_current:
+        return
+    songset = self.state.selected_songset
+    if not songset:
+        return
+    try:
+        self.query_one("#input_name", Input).value = songset.name
+        self.query_one("#input_description", Input).value = songset.description or ""
+    except Exception as e:
+        logger.error(f"Failed to update input fields: {e}")
+    self._load_items()
+```
+
+---
+
+### Fix 5 — Prevent duplicate screen stacking
+
+**File:** `src/stream_of_worship/app/app.py`
+
+Always replace a screen of the same type rather than stacking. This handles all cases: re-navigating to the same screen, or navigating to the same screen type with different state.
+
+```python
+def navigate_to(self, screen: AppScreen) -> None:
+    logger.info(f"Navigate to: {screen.name} (from {self.state.current_screen.name})")
+
+    if self.playback.is_playing or self.playback.is_paused:
+        self.playback.stop()
+
+    # Replace instead of stack if top of stack is same screen type
+    if len(self.screen_stack) > 0 and self._is_same_screen_type(self.screen_stack[-1], screen):
+        logger.info(f"Replacing duplicate {screen.name} screen")
+        self.pop_screen()
+        self.state.navigate_back()
+
+    self.state.navigate_to(screen)
+    self.push_screen(self._create_screen(screen))
+
+def _is_same_screen_type(self, screen_instance, screen_enum: AppScreen) -> bool:
+    screen_type_map = {
+        AppScreen.SONGSET_LIST: SongsetListScreen,
+        AppScreen.SONGSET_EDITOR: SongsetEditorScreen,
+        AppScreen.BROWSE: BrowseScreen,
+        AppScreen.EXPORT_PROGRESS: ExportProgressScreen,
+        AppScreen.LYRICS_PREVIEW: LyricsPreviewScreen,
+    }
+    expected_type = screen_type_map.get(screen_enum)
+    return expected_type is not None and isinstance(screen_instance, expected_type)
+```
+
+---
+
+### Fix 6 — Fix navigate_back() desync — replace single slot with a stack
+
+**File:** `src/stream_of_worship/app/state.py`
+
+Replace `previous_screen` (single slot) with `_nav_stack` (list) so AppState mirrors Textual's screen stack depth.
+
+```python
+class AppState:
+    def __init__(self):
+        self._nav_stack: list[AppScreen] = []
+        # existing fields...
+
+    def navigate_to(self, screen: AppScreen) -> None:
+        self._nav_stack.append(screen)
+        self.current_screen = screen
+        self._notify("current_screen", screen)
+
+    def navigate_back(self) -> bool:
+        if len(self._nav_stack) <= 1:
+            return False
+        self._nav_stack.pop()
+        self.current_screen = self._nav_stack[-1]
+        self._notify("current_screen", self.current_screen)
+        return True
+
+    @property
+    def previous_screen(self) -> Optional[AppScreen]:
+        return self._nav_stack[-2] if len(self._nav_stack) >= 2 else None
+```
+
+Remove the `previous_screen` field from `__init__` and the dataclass; it is now a property.
+
+---
+
+### Fix 7 — Route LyricsPreviewScreen through navigate_to() (Option A)
+
+**File:** `src/stream_of_worship/app/app.py`, `src/stream_of_worship/app/screens/songset_editor.py`
+
+Add `LYRICS_PREVIEW` to `AppScreen` enum. Update `navigate_to` / `_create_screen` to handle it. Update `action_lyrics_preview` to call `self.app.navigate_to(AppScreen.LYRICS_PREVIEW)` after setting any needed state (e.g., `self.state.selected_item = item`).
+
+```python
+# In action_lyrics_preview:
+def action_lyrics_preview(self) -> None:
+    item = self._get_selected_item()
+    if not item:
+        self.notify("No song selected", severity="warning")
+        return
+    if not item.recording_hash_prefix:
+        self.notify("Song has no recording", severity="warning")
+        return
+    lrc_path = self.asset_cache.download_lrc(item.recording_hash_prefix)
+    if not lrc_path:
+        self.notify("No lyrics available for this song", severity="warning")
+        return
+    self.state.selected_preview_item = item
+    self.app.navigate_to(AppScreen.LYRICS_PREVIEW)
+```
+
+`_create_screen` reads `state.selected_preview_item` to construct `LyricsPreviewScreen`.
+
+---
+
+### Fix 8 — Add on_unmount to ExportProgressScreen and LyricsPreviewScreen
+
+**File:** `src/stream_of_worship/app/screens/export_progress.py`
+
+```python
+def on_unmount(self) -> None:
+    self.export_service.unregister_progress_callback(self._on_progress)
+    self.export_service.unregister_completion_callback(self._on_complete)
+```
+
+**File:** `src/stream_of_worship/app/services/export.py` — add unregister methods:
+
+```python
+def unregister_progress_callback(self, callback) -> None:
+    try:
+        self._progress_callbacks.remove(callback)
+    except ValueError:
+        pass
+
+def unregister_completion_callback(self, callback) -> None:
+    try:
+        self._completion_callbacks.remove(callback)
+    except ValueError:
+        pass
+```
+
+**File:** `src/stream_of_worship/app/screens/lyrics_preview.py`
+
+```python
+def on_unmount(self) -> None:
+    self.playback.set_callbacks()
+```
+
+---
+
+### Fix 9 — Run DB queries and network downloads on worker threads
+
+**File:** All screen files
+
+**Scope decision:** Even with Fix 1 eliminating health checks, downloads and export operations can block for 5-30+ seconds. DB queries for ≤20 items may become acceptable (<100ms) after Fix 1 + Fix 10, but should still be offloaded to keep the TUI responsive on slow connections.
+
+**Screens to convert:**
+- `SongsetEditorScreen._load_items()`, `action_preview()`, `action_toggle_playback()`
+- `SongsetListScreen._load_songsets()`
+- `BrowseScreen._load_songs()`, `action_preview()`
+- `LyricsPreviewScreen.on_mount()` (LRC download — move off main thread)
+
+**Pattern for DB load:**
+
+```python
+def _load_items(self) -> None:
+    self.run_worker(self._load_items_worker, exclusive=True, group="load_items")
+
+def _load_items_worker(self) -> None:
+    if not self.state.selected_songset:
+        return
+    details, orphan_count = self.catalog.get_songset_with_items(
+        self.state.selected_songset.id, self.songset_client
+    )
+    self.call_from_thread(self._update_items_table, details, orphan_count)
+
+def _update_items_table(self, details, orphan_count) -> None:
+    self.items = [d.item for d in details]
+    # ... existing table update logic ...
+```
+
+**Pattern for download + play:**
+
+```python
+def action_toggle_playback(self) -> None:
+    if self.playback.is_playing:
+        self.playback.stop()
+        return
+    item = self._get_selected_item()
+    if not item:
+        self.notify("No song selected", severity="error")
+        return
+    self.run_worker(self._play_item_worker, item, group="playback")
+
+def _play_item_worker(self, item) -> None:
+    try:
+        audio_path = self.asset_cache.download_audio(item.recording_hash_prefix)
+        if audio_path:
+            self.call_from_thread(self.playback.play, audio_path)
+        else:
+            self.call_from_thread(self.notify, "Failed to download audio", severity="error")
+    except Exception as e:
+        self.call_from_thread(self.notify, f"Error: {e}", severity="error")
+```
+
+**Thread safety note:** `ConnectionProvider._lock` already serializes all DB access, so worker threads calling `get_connection()` concurrently is safe. However, with a single shared connection, DB workers will serialize at the lock — this is acceptable for typical usage.
+
+---
+
+### Fix 10 — Fix N+1 query patterns with batch queries
+
+**File:** `src/stream_of_worship/app/db/songset_client.py`
+
+```python
+def get_item_counts_batch(self, songset_ids: list[str]) -> dict[str, int]:
+    conn = self.connection
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT songset_id, COUNT(*) FROM songset_items "
+            "WHERE songset_id = ANY(%s) GROUP BY songset_id",
+            (songset_ids,),
+        )
+        return {row[0]: row[1] for row in cur.fetchall()}
+```
+
+**File:** `src/stream_of_worship/app/db/read_client.py`
+
+```python
+def get_recordings_by_song_ids(self, song_ids: list[str]) -> dict[str, Recording]:
+    conn = self.connection
+    with conn.cursor(row_factory=psycopg.rows.class_row(Recording)) as cur:
+        cur.execute(
+            "SELECT * FROM recordings WHERE song_id = ANY(%s)",
+            (song_ids,),
+        )
+        return {r.song_id: r for r in cur.fetchall()}
+
+def get_recordings_by_hashes(self, hash_prefixes: list[str]) -> dict[str, Recording]:
+    conn = self.connection
+    with conn.cursor(row_factory=psycopg.rows.class_row(Recording)) as cur:
+        cur.execute(
+            "SELECT * FROM recordings WHERE hash_prefix = ANY(%s)",
+            (hash_prefixes,),
+        )
+        return {r.hash_prefix: r for r in cur.fetchall()}
+```
+
+**Note:** Use `recording.song_id` and `recording.hash_prefix` as dict keys — not positional row index.
+
+**File:** `src/stream_of_worship/app/services/catalog.py`
+
+Update `get_songset_with_items` to:
+1. Fetch all items in one query
+2. Collect all hash prefixes
+3. Batch-fetch all recordings via `get_recordings_by_hashes`
+4. Batch-fetch all songs via a new `get_songs_by_ids` (or equivalent)
+5. Assemble results in memory
+
+Update `list_songs_with_recordings` to use `get_recordings_by_song_ids` instead of per-song lookups.
+
+---
+
+### Fix 11 — Add timeouts to R2 downloads and FFmpeg
+
+**File:** `src/stream_of_worship/admin/services/r2.py`
+
+Add boto3 `Config` with timeouts to the client constructor:
+
+```python
+from botocore.config import Config
+
+self._client = boto3.client(
+    "s3",
+    endpoint_url=endpoint_url,
+    region_name=region,
+    config=Config(
+        connect_timeout=10,
+        read_timeout=30,
+        retries={"max_attempts": 2},
+    ),
+)
+```
+
+**File:** `src/stream_of_worship/app/services/video_engine.py`
+
+```python
+try:
+    process.wait(timeout=300)  # 5-minute max
+except subprocess.TimeoutExpired:
+    process.kill()
+    raise RuntimeError("FFmpeg timed out after 5 minutes")
+```
+
+---
+
+### Fix 12 — Clean up temp files from preview_transition
+
+**File:** `src/stream_of_worship/app/services/audio_engine.py`
+
+```python
+def __init__(self, ...):
+    self._preview_temp_files: list[Path] = []
+
+def preview_transition(self, from_item, to_item) -> Optional[Path]:
+    for f in self._preview_temp_files:
+        try:
+            f.unlink(missing_ok=True)
+        except Exception:
+            pass
+    self._preview_temp_files.clear()
+
+    # ... existing logic ...
+    temp_path = Path(temp_file.name)
+    self._preview_temp_files.append(temp_path)
+    return temp_path
+```
+
+---
+
+### Fix 13 — Log exceptions in _notify instead of swallowing
+
+**File:** `src/stream_of_worship/app/state.py`
+
+```python
+def _notify(self, key: str, value: Any) -> None:
+    for cb in self._listeners.get(key, []):
+        try:
+            cb(value)
+        except Exception as e:
+            logger.error(f"Listener error for '{key}': {e}")
+```
+
+---
+
+### Fix 14 — Add DB error handling on read paths
+
+**Files:** `src/stream_of_worship/app/db/read_client.py`, `src/stream_of_worship/app/db/songset_client.py`
+
+**Scope: read paths only.** Define a `DatabaseError` in a shared module. Wrap public read methods (list/get) to catch `psycopg.OperationalError` and raise `DatabaseError(user_friendly_message)`. Screens catch `DatabaseError` in their worker methods and call `self.call_from_thread(self.notify, str(e), severity="error")`.
+
+Do not wrap write methods (create, update, delete) — those errors should propagate with full context for debugging.
+
+---
+
+## Summary of Files Changed
+
+| File | Fixes |
+|------|-------|
+| `src/stream_of_worship/db/connection.py` | Fix 1: Remove proactive health check, add `invalidate()` |
+| `src/stream_of_worship/app/db/read_client.py` | Fix 1, 10, 14: Retry wrapper, batch queries, error handling |
+| `src/stream_of_worship/app/db/songset_client.py` | Fix 1, 10: Retry wrapper, batch queries |
+| `src/stream_of_worship/app/state.py` | Fix 6, 13: Navigation stack, log listener errors |
+| `src/stream_of_worship/app/app.py` | Fix 5, 6, 7: Dedup screens, nav stack, LyricsPreview routing |
+| `src/stream_of_worship/app/screens/songset_editor.py` | Fix 2, 3, 4, 7, 9: Defer refresh, named listener, guard, route preview, workers |
+| `src/stream_of_worship/app/screens/songset_list.py` | Fix 9, 10: Worker, batch item count |
+| `src/stream_of_worship/app/screens/browse.py` | Fix 9: Workers for load + preview |
+| `src/stream_of_worship/app/screens/lyrics_preview.py` | Fix 8, 9: Unmount cleanup, worker for LRC download |
+| `src/stream_of_worship/app/screens/export_progress.py` | Fix 8: Unregister callbacks in `on_unmount` |
+| `src/stream_of_worship/app/services/catalog.py` | Fix 10: Use batch queries |
+| `src/stream_of_worship/app/services/export.py` | Fix 8: Add `unregister_*` methods |
+| `src/stream_of_worship/admin/services/r2.py` | Fix 11: boto3 Config with timeouts |
+| `src/stream_of_worship/app/services/asset_cache.py` | Fix 11: Propagate timeout behavior |
+| `src/stream_of_worship/app/services/audio_engine.py` | Fix 12: Temp file cleanup |
+| `src/stream_of_worship/app/services/video_engine.py` | Fix 11: FFmpeg timeout |
+
+---
+
+## Expected Impact
+
+| Metric | Before | After |
+|--------|--------|-------|
+| Screen transition time | 3-20+ seconds | <500ms |
+| "No nodes match" errors | Frequent | None |
+| Health check round-trips per screen load | 2+2N | 0 (hot path) |
+| N+1 query round trips (5 items) | ~12 queries | ~4 queries |
+| Zombie DB queries after back-navigation | Yes | No |
+| Duplicate screen stacking | Yes | No |
+| AppState/Textual stack desync | Yes | No |
+| UI freezes during DB/network I/O | Yes | No (worker threads) |
+| Temp file leaks | Yes | No |
+| Silent listener errors | Yes | Logged |
+| Stale listener accumulation | Yes | Cleaned in unmount |
+| Export callback leaks | Yes | Cleaned in unmount |
+
+---
+
+## Implementation Order
+
+1. **Fix 1** (`connection.py`) — biggest bang, fully standalone, no screen changes
+2. **Fix 13** (`state.py`) — observability first, helps diagnose remaining issues
+3. **Fix 2, 3, 4** (`songset_editor.py`) — fixes the 20s delay, zero API surface change
+4. **Fix 6** (`state.py`) — navigation stack (required before Fix 5)
+5. **Fix 5** (`app.py`) — duplicate screen prevention
+6. **Fix 8** (`export_progress.py`, `lyrics_preview.py`, `export.py`) — prevents crashes
+7. **Fix 7** (`songset_editor.py`, `app.py`) — LyricsPreview routing (depends on Fix 5/6)
+8. **Fix 10** (`db/`, `catalog.py`) — batch queries (standalone, reduces query count before workers land)
+9. **Fix 9** (all screens) — worker threads (largest change; Fix 1 must land first)
+10. **Fix 11, 12** — timeouts, temp cleanup (standalone robustness)
+11. **Fix 14** (`db/`) — error handling polish
+
+---
+
+## Testing Checklist
+
+- [ ] Navigate from Songset Manager → Songset Editor — should be <1 second
+- [ ] No "No nodes match '#input_name'" errors in logs
+- [ ] Create new songset, add songs, return to editor — no duplicate screens
+- [ ] Navigate SongsetList → SongsetEditor → Browse → Back → Back — no stack desync, correct screen shown
+- [ ] Navigate back during active export — no crash, export continues in background
+- [ ] Open and close lyrics preview — no zombie callbacks, playback stops
+- [ ] Browse songs with 50+ entries — UI remains responsive during load
+- [ ] Preview audio transition — UI remains responsive during generation
+- [ ] Leave app idle 2+ minutes, then navigate — reconnects transparently
+- [ ] Confirm worker threads: UI remains interactive during `_load_items`
+- [ ] Run full test suite: `PYTHONPATH=src uv run --python 3.11 --extra app --extra test pytest tests/ --ignore=tests/services/analysis --ignore=services/qwen3/tests --ignore=services/analysis/tests -v`

--- a/specs/fix-slow-screen-transitions-v2.md
+++ b/specs/fix-slow-screen-transitions-v2.md
@@ -405,9 +405,11 @@ def on_unmount(self) -> None:
 
 **Pattern for DB load:**
 
+> **IMPORTANT:** Worker functions must be synchronous `def`, not `async def`. Always pass `thread=True` so Textual runs them in a thread pool instead of trying to `await` them. Use `self.app.call_from_thread(...)` — NOT `self.call_from_thread(...)` — because `call_from_thread` is an `App` method, not available on `Screen`.
+
 ```python
 def _load_items(self) -> None:
-    self.run_worker(self._load_items_worker, exclusive=True, group="load_items")
+    self.run_worker(self._load_items_worker, exclusive=True, group="load_items", thread=True)
 
 def _load_items_worker(self) -> None:
     if not self.state.selected_songset:
@@ -415,7 +417,7 @@ def _load_items_worker(self) -> None:
     details, orphan_count = self.catalog.get_songset_with_items(
         self.state.selected_songset.id, self.songset_client
     )
-    self.call_from_thread(self._update_items_table, details, orphan_count)
+    self.app.call_from_thread(self._update_items_table, details, orphan_count)
 
 def _update_items_table(self, details, orphan_count) -> None:
     self.items = [d.item for d in details]
@@ -433,17 +435,17 @@ def action_toggle_playback(self) -> None:
     if not item:
         self.notify("No song selected", severity="error")
         return
-    self.run_worker(self._play_item_worker, item, group="playback")
+    self.run_worker(lambda: self._play_item_worker(item), group="playback", thread=True)
 
 def _play_item_worker(self, item) -> None:
     try:
         audio_path = self.asset_cache.download_audio(item.recording_hash_prefix)
         if audio_path:
-            self.call_from_thread(self.playback.play, audio_path)
+            self.app.call_from_thread(self.playback.play, audio_path)
         else:
-            self.call_from_thread(self.notify, "Failed to download audio", severity="error")
+            self.app.call_from_thread(self.notify, "Failed to download audio", severity="error")
     except Exception as e:
-        self.call_from_thread(self.notify, f"Error: {e}", severity="error")
+        self.app.call_from_thread(self.notify, f"Error: {e}", severity="error")
 ```
 
 **Thread safety note:** `ConnectionProvider._lock` already serializes all DB access, so worker threads calling `get_connection()` concurrently is safe. However, with a single shared connection, DB workers will serialize at the lock — this is acceptable for typical usage.

--- a/specs/fix-slow-screen-transitions.md
+++ b/specs/fix-slow-screen-transitions.md
@@ -1,0 +1,302 @@
+# Fix Slow Screen Transitions in User App
+
+## Overview
+
+This plan addresses the slow transition between Songset Manager and Songset Editor screens, which takes 3-20+ seconds. The root cause is a combination of aggressive database health checks and zombie screen listeners.
+
+## Problem Analysis
+
+### Symptom 1: 3-second delay on every screen transition
+
+From logs:
+```
+2026-05-15 06:10:17.f | INFO  | Screen pushed, stack depth: 3
+2026-05-15 06:10:17.f | INFO  | SongsetEditorScreen mounted
+2026-05-15 06:10:20.f | INFO  | SongsetEditorScreen resumed, refreshing items
+```
+
+**Root Cause:** The `SELECT 1` health check added to `ConnectionProvider.get_connection()` runs on every single `self.connection` property access. Since `connection` is a property that calls `get_connection()` every time, every DB method triggers a health check.
+
+**Call chain for a songset with N items:**
+1. `action_edit_songset` → `get_songset()` → `self.connection` → **SELECT 1** + query
+2. `_load_items()` → `get_items_raw()` → `self.connection` → **SELECT 1** + query
+3. For each item: `get_recording_by_hash()` → **SELECT 1** + query
+4. For each item: `get_song_including_deleted()` → **SELECT 1** + query
+
+**Total health checks:** 2 + 2N. Each is a ~200ms round-trip to remote Neon (us-east-1).
+
+For 5 items: 12 × 200ms = **~2.4 seconds just in health checks**.
+
+### Symptom 2: 20+ second delay with repeated errors
+
+From logs:
+```
+2026-05-15 06:05:22.f | ERROR | Failed to update input fields: No nodes match '#input_name'
+2026-05-15 06:05:25.f | ERROR | Failed to update input fields: No nodes match '#input_name'
+... (repeated every ~3 seconds for 14 seconds)
+```
+
+**Root Cause:** Three compounding bugs:
+
+1. **`_refresh()` called before widgets mounted** — `on_mount` calls `_refresh()` before DOM is ready, so `query_one("#input_name")` fails.
+
+2. **State listener never removed** — `self.state.add_listener("selected_songset", lambda _: self._refresh())` is registered but never removed in `on_unmount`. Every SongsetEditorScreen instance ever created keeps listening and calling `_refresh()` → `_load_items()` (DB query) even when covered by other screens.
+
+3. **Duplicate screen stacking** — `navigate_to()` always pushes a fresh screen. When returning from Browse and re-entering the editor, a second SongsetEditorScreen gets stacked on top. Both register their own listener, compounding the problem.
+
+---
+
+## Fix Plan
+
+### Fix 1: Replace aggressive health check with time-based staleness check
+
+**File:** `src/stream_of_worship/db/connection.py`
+
+**Rationale:** With `autocommit=True` (previous fix), there are no idle transactions for Neon to kill. The per-call `SELECT 1` is unnecessary and expensive. Replace with a time-based check that only probes the connection if it hasn't been used in the last 60 seconds.
+
+**Changes:**
+
+```python
+import time
+from typing import Optional
+
+import psycopg
+
+
+class ConnectionProvider:
+    """Manages a single psycopg connection with auto-reconnect and cold-start retry."""
+
+    MAX_RETRIES = 2
+    RETRY_DELAY_SECONDS = 1.0
+    STALE_THRESHOLD_SECONDS = 60.0  # Only health-check if idle for 60+ seconds
+
+    def __init__(self, database_url: str):
+        self.database_url = database_url
+        self._connection: Optional[psycopg.Connection] = None
+        self._lock = threading.Lock()
+        self._last_used: float = 0.0  # monotonic time of last successful use
+
+    def get_connection(self) -> psycopg.Connection:
+        """Return an open psycopg connection, reconnecting if necessary.
+        
+        Uses time-based staleness check: only probes the connection if it
+        hasn't been used in the last STALE_THRESHOLD_SECONDS.
+        """
+        with self._lock:
+            if self._connection is None or self._connection.closed:
+                self._connection = self._connect_with_retry()
+                self._last_used = time.monotonic()
+            elif self._is_stale():
+                try:
+                    self._connection.execute("SELECT 1")
+                    self._last_used = time.monotonic()
+                except Exception:
+                    self._connection = self._connect_with_retry()
+                    self._last_used = time.monotonic()
+            return self._connection
+
+    def _is_stale(self) -> bool:
+        """Check if the connection hasn't been used recently."""
+        return (time.monotonic() - self._last_used) > self.STALE_THRESHOLD_SECONDS
+
+    def _connect_with_retry(self) -> psycopg.Connection:
+        """Attempt to connect with exponential backoff for cold starts."""
+        last_error: Optional[Exception] = None
+        for attempt in range(self.MAX_RETRIES + 1):
+            conn = None
+            try:
+                conn = psycopg.connect(
+                    self.database_url,
+                    connect_timeout=10,
+                    autocommit=True,
+                    sslmode="require",
+                )
+                conn.execute("SELECT 1")
+                return conn
+            except Exception as exc:
+                if conn:
+                    conn.close()
+                last_error = exc
+                if attempt == self.MAX_RETRIES:
+                    break
+                time.sleep(self.RETRY_DELAY_SECONDS * (attempt + 1))
+        raise last_error if last_error else RuntimeError("Connection failed without error")
+```
+
+**Expected impact:** Reduces transition time from ~3 seconds to <500ms (only actual query latency remains).
+
+---
+
+### Fix 2: Defer `_refresh()` to after DOM mount
+
+**File:** `src/stream_of_worship/app/screens/songset_editor.py`
+
+**Location:** `on_mount()` method (around line 112-130)
+
+**Rationale:** `on_mount` fires before child widgets are in the DOM. Use `call_after_refresh` to wait for DOM to be ready.
+
+**Change:**
+
+```python
+def on_mount(self) -> None:
+    """Handle mount event."""
+    logger.info(
+        f"SongsetEditorScreen mounted (songset: {self.state.selected_songset.id if self.state.selected_songset else 'None'})"
+    )
+    # Defer refresh until DOM is ready
+    self.call_after_refresh(self._refresh)
+    self.call_after_refresh(self._focus_song_list)
+
+    # Listen for state changes (store reference for removal in on_unmount)
+    self._songset_listener = lambda _: self._refresh()
+    self.state.add_listener("selected_songset", self._songset_listener)
+
+    # Register playback callbacks
+    self.playback.set_callbacks(
+        on_position_changed=self._on_position_changed,
+        on_state_changed=self._on_state_changed,
+        on_finished=self._on_finished,
+    )
+```
+
+---
+
+### Fix 3: Remove state listener in `on_unmount`
+
+**File:** `src/stream_of_worship/app/screens/songset_editor.py`
+
+**Location:** `on_unmount()` method (around line 132-134)
+
+**Rationale:** Prevent zombie screen instances from continuing to respond to state changes and making DB queries.
+
+**Change:**
+
+```python
+def on_unmount(self) -> None:
+    """Unregister callbacks to prevent memory leaks and zombie refreshes."""
+    self.playback.set_callbacks()
+    if hasattr(self, '_songset_listener'):
+        self.state.remove_listener("selected_songset", self._songset_listener)
+```
+
+**Also add to `__init__`:**
+
+```python
+def __init__(self, ...):
+    ...
+    self._songset_listener = None  # Initialize to None
+```
+
+---
+
+### Fix 4: Guard `_refresh()` against non-active screens
+
+**File:** `src/stream_of_worship/app/screens/songset_editor.py`
+
+**Location:** `_refresh()` method (around line 182)
+
+**Rationale:** Even with listener removal, a race condition could cause `_refresh()` to run on a screen that's no longer the top of the stack. Guard against this.
+
+**Change:**
+
+```python
+def _refresh(self) -> None:
+    """Refresh the display."""
+    # Don't refresh if this screen is not the active screen
+    if not self.is_current:
+        return
+    
+    songset = self.state.selected_songset
+    if not songset:
+        return
+
+    # Update input fields with current values
+    try:
+        name_input = self.query_one("#input_name", Input)
+        name_input.value = songset.name
+
+        desc_input = self.query_one("#input_description", Input)
+        desc_input.value = songset.description or ""
+    except Exception as e:
+        logger.error(f"Failed to update input fields: {e}")
+
+    self._load_items()
+```
+
+---
+
+### Fix 5: Prevent duplicate screen stacking (optional enhancement)
+
+**File:** `src/stream_of_worship/app/app.py`
+
+**Location:** `navigate_to()` method (around line 156-171)
+
+**Rationale:** When navigating to a screen type that's already on top of the stack, pop the existing one first to avoid stacking duplicates.
+
+**Change:**
+
+```python
+def navigate_to(self, screen: AppScreen) -> None:
+    """Navigate to a screen."""
+    logger.info(f"Navigate to: {screen.name} (from {self.state.current_screen.name})")
+
+    # Stop playback when switching screens
+    if self.playback.is_playing or self.playback.is_paused:
+        logger.debug("Stopping playback before navigation")
+        self.playback.stop()
+
+    # Prevent pushing duplicate screen types onto the stack
+    if len(self.screen_stack) > 0:
+        current_screen = self.screen_stack[-1]
+        if self._is_same_screen_type(current_screen, screen):
+            logger.info(f"Replacing current {screen.name} screen instead of stacking")
+            self.pop_screen()
+            self.state.navigate_back()
+
+    self.state.navigate_to(screen)
+    self.push_screen(self._create_screen(screen))
+    logger.debug(f"Screen pushed, stack depth: {len(self.screen_stack)}")
+
+def _is_same_screen_type(self, screen_instance, screen_enum: AppScreen) -> bool:
+    """Check if a screen instance matches an AppScreen enum value."""
+    screen_type_map = {
+        AppScreen.SONGSET_LIST: SongsetListScreen,
+        AppScreen.SONGSET_EDITOR: SongsetEditorScreen,
+        AppScreen.BROWSE: BrowseScreen,
+        AppScreen.EXPORT_PROGRESS: ExportProgressScreen,
+    }
+    expected_type = screen_type_map.get(screen_enum)
+    return expected_type and isinstance(screen_instance, expected_type)
+```
+
+---
+
+## Summary of Files Changed
+
+| File | Changes |
+|------|---------|
+| `src/stream_of_worship/db/connection.py` | Time-based staleness check instead of per-call health check |
+| `src/stream_of_worship/app/screens/songset_editor.py` | 1. Defer `_refresh()` with `call_after_refresh`<br>2. Store listener reference and remove in `on_unmount`<br>3. Guard `_refresh()` against non-active screens |
+| `src/stream_of_worship/app/app.py` | (Optional) Prevent duplicate screen stacking |
+
+---
+
+## Expected Impact
+
+| Metric | Before | After |
+|--------|--------|-------|
+| Screen transition time | 3-20+ seconds | <500ms |
+| "No nodes match" errors | Frequent | None |
+| Zombie DB queries | Yes | No |
+| Duplicate screen stacking | Yes | No (with Fix 5) |
+
+---
+
+## Testing Checklist
+
+- [ ] Navigate from Songset Manager to Songset Editor — should be <1 second
+- [ ] No "No nodes match '#input_name'" errors in logs
+- [ ] Create new songset, add songs, return to editor — no duplicate screens
+- [ ] Navigate back and forth multiple times — no performance degradation
+- [ ] Leave app idle for 2+ minutes, then navigate — stale connection is detected and reconnected
+- [ ] Run full test suite — all tests pass

--- a/specs/fix-slow-screen-transitions.md
+++ b/specs/fix-slow-screen-transitions.md
@@ -1,21 +1,14 @@
-# Fix Slow Screen Transitions in User App
+# Fix Slow Screen Transitions & Operational Risks in User App
 
 ## Overview
 
-This plan addresses the slow transition between Songset Manager and Songset Editor screens, which takes 3-20+ seconds. The root cause is a combination of aggressive database health checks and zombie screen listeners.
+This plan addresses slow screen transitions (3-20+ seconds) and multiple operational risks affecting User App usability. The root causes span aggressive database health checks, zombie screen listeners, navigation stack desync, main-thread blocking operations, and N+1 query patterns.
 
 ## Problem Analysis
 
-### Symptom 1: 3-second delay on every screen transition
+### Problem 1: 3-second delay on every screen transition
 
-From logs:
-```
-2026-05-15 06:10:17.f | INFO  | Screen pushed, stack depth: 3
-2026-05-15 06:10:17.f | INFO  | SongsetEditorScreen mounted
-2026-05-15 06:10:20.f | INFO  | SongsetEditorScreen resumed, refreshing items
-```
-
-**Root Cause:** The `SELECT 1` health check added to `ConnectionProvider.get_connection()` runs on every single `self.connection` property access. Since `connection` is a property that calls `get_connection()` every time, every DB method triggers a health check.
+**Root Cause:** `SELECT 1` health check in `ConnectionProvider.get_connection()` runs on every `self.connection` property access. Since `connection` is a property calling `get_connection()` every time, every DB method triggers a health check.
 
 **Call chain for a songset with N items:**
 1. `action_edit_songset` → `get_songset()` → `self.connection` → **SELECT 1** + query
@@ -23,26 +16,109 @@ From logs:
 3. For each item: `get_recording_by_hash()` → **SELECT 1** + query
 4. For each item: `get_song_including_deleted()` → **SELECT 1** + query
 
-**Total health checks:** 2 + 2N. Each is a ~200ms round-trip to remote Neon (us-east-1).
-
+**Total health checks:** 2 + 2N. Each is ~200ms round-trip to remote Neon (us-east-1).
 For 5 items: 12 × 200ms = **~2.4 seconds just in health checks**.
 
-### Symptom 2: 20+ second delay with repeated errors
+**Why it was added carelessly:** Commit `6cdc998` added the per-call `SELECT 1` as a defensive fix for Neon's `idle_in_transaction_session_timeout`. The same commit also switched to `autocommit=True`, which eliminates the root cause (no idle transactions for Neon to kill). The health check was redundant overhead — the "fix" (autocommit) already solved the problem.
 
-From logs:
-```
-2026-05-15 06:05:22.f | ERROR | Failed to update input fields: No nodes match '#input_name'
-2026-05-15 06:05:25.f | ERROR | Failed to update input fields: No nodes match '#input_name'
-... (repeated every ~3 seconds for 14 seconds)
-```
+### Problem 2: 20+ second delay with repeated errors
 
 **Root Cause:** Three compounding bugs:
+1. `_refresh()` called before widgets mounted — `on_mount` calls `_refresh()` before DOM is ready
+2. State listener never removed — anonymous lambda registered but never cleaned up in `on_unmount`
+3. Duplicate screen stacking — `navigate_to()` always pushes a fresh screen
 
-1. **`_refresh()` called before widgets mounted** — `on_mount` calls `_refresh()` before DOM is ready, so `query_one("#input_name")` fails.
+### Problem 3: ExportProgressScreen callback leak (CRITICAL)
 
-2. **State listener never removed** — `self.state.add_listener("selected_songset", lambda _: self._refresh())` is registered but never removed in `on_unmount`. Every SongsetEditorScreen instance ever created keeps listening and calling `_refresh()` → `_load_items()` (DB query) even when covered by other screens.
+**File:** `src/stream_of_worship/app/screens/export_progress.py:61-62`
 
-3. **Duplicate screen stacking** — `navigate_to()` always pushes a fresh screen. When returning from Browse and re-entering the editor, a second SongsetEditorScreen gets stacked on top. Both register their own listener, compounding the problem.
+`register_progress_callback` and `register_completion_callback` are called in `on_mount` with no `on_unmount` cleanup. Navigating back during an export causes zombie callbacks that crash on dead widgets. `ExportService._progress_callbacks` and `_completion_callbacks` lists only grow, never shrink.
+
+### Problem 4: navigate_back() desyncs AppState from Textual stack (CRITICAL)
+
+**File:** `src/stream_of_worship/app/app.py:173-189`, `src/stream_of_worship/app/state.py:112-123`
+
+`AppState.previous_screen` is a single slot, not a stack. After 2+ back navigations, `state.current_screen` diverges from the actual displayed screen. Reproduction: SongsetList → SongsetEditor → Browse → Back → Back. After the second back, `AppState.current_screen` is stale.
+
+### Problem 5: LyricsPreviewScreen bypasses navigate_to() (CRITICAL)
+
+**File:** `src/stream_of_worship/app/screens/songset_editor.py:441-447`
+
+Calls `self.app.push_screen()` directly instead of `self.app.navigate_to()`. AppState is never updated, playback isn't stopped, and the Textual stack has a screen that AppState doesn't know about.
+
+### Problem 6: LyricsPreviewScreen playback callbacks never unregistered (HIGH)
+
+**File:** `src/stream_of_worship/app/screens/lyrics_preview.py:120-124`
+
+No `on_unmount` to clear playback callbacks. After the screen is popped, callbacks still reference the dead screen.
+
+### Problem 7: All DB queries block the main thread (HIGH)
+
+**File:** All screen files
+
+Every database call is synchronous, called from Textual event handlers. The TUI freezes during queries. With N+1 patterns and health checks, a single screen load can block for seconds.
+
+### Problem 8: R2 network downloads block the main thread (HIGH)
+
+**File:** `src/stream_of_worship/app/services/asset_cache.py:134-161, 194-220`
+
+`download_audio()` and `download_lrc()` make synchronous HTTP requests from UI actions. TUI freezes during downloads (5-30+ seconds on slow connections).
+
+### Problem 9: AudioEngine.preview_transition() blocks main thread (HIGH)
+
+**File:** `src/stream_of_worship/app/services/audio_engine.py:248-306`
+
+pydub decode + process + write is synchronous. UI freezes for several seconds during preview generation.
+
+### Problem 10: N+1 query patterns (HIGH)
+
+| Location | Pattern | Round trips (with health checks) |
+|----------|---------|----------------------------------|
+| `songset_list.py:85` | `get_item_count()` per songset | 1 + 2N |
+| `catalog.py:186-197` | `get_recording_by_song_id()` per song | 1 + 2N |
+| `catalog.py:472-503` | `get_recording_by_hash()` + `get_song_including_deleted()` per item | 3 + 4N |
+
+### Problem 11: Unbounded screen stack growth (HIGH)
+
+**File:** `src/stream_of_worship/app/app.py:156-171`
+
+`navigate_to()` always pushes, never replaces duplicates. With zombie listeners, popped screens may not be GC'd.
+
+### Problem 12: No timeout on R2 downloads (MEDIUM)
+
+**File:** `src/stream_of_worship/app/services/asset_cache.py`
+
+Stalled download hangs the app forever.
+
+### Problem 13: No timeout on FFmpeg subprocess (MEDIUM)
+
+**File:** `src/stream_of_worship/app/services/video_engine.py:875-906`
+
+Hung export thread becomes zombie, `is_exporting` stays True forever.
+
+### Problem 14: Temp files from preview_transition never cleaned up (MEDIUM)
+
+**File:** `src/stream_of_worship/app/services/audio_engine.py:296-298`
+
+`NamedTemporaryFile(delete=False)` leaks MP3s to system temp directory.
+
+### Problem 15: ExportService callback lists grow without bound (MEDIUM)
+
+**File:** `src/stream_of_worship/app/services/export.py:124-125`
+
+No unregister method. Callback lists grow with each export.
+
+### Problem 16: _notify silently swallows all exceptions (MEDIUM)
+
+**File:** `src/stream_of_worship/app/state.py:93-100`
+
+`except Exception: pass` hides bugs. Zombie listener crashes are invisible.
+
+### Problem 17: No DB error handling (MEDIUM)
+
+**File:** `src/stream_of_worship/app/db/read_client.py`, `src/stream_of_worship/app/db/songset_client.py`
+
+Transient connection drops propagate as uncaught exceptions. No retry, no user-friendly error messages.
 
 ---
 
@@ -52,7 +128,7 @@ From logs:
 
 **File:** `src/stream_of_worship/db/connection.py`
 
-**Rationale:** With `autocommit=True` (previous fix), there are no idle transactions for Neon to kill. The per-call `SELECT 1` is unnecessary and expensive. Replace with a time-based check that only probes the connection if it hasn't been used in the last 60 seconds.
+**Rationale:** With `autocommit=True`, there are no idle transactions for Neon to kill. The per-call `SELECT 1` is unnecessary and expensive. Replace with a time-based check that only probes the connection if it hasn't been used in the last 60 seconds.
 
 **Changes:**
 
@@ -64,24 +140,17 @@ import psycopg
 
 
 class ConnectionProvider:
-    """Manages a single psycopg connection with auto-reconnect and cold-start retry."""
-
     MAX_RETRIES = 2
     RETRY_DELAY_SECONDS = 1.0
-    STALE_THRESHOLD_SECONDS = 60.0  # Only health-check if idle for 60+ seconds
+    STALE_THRESHOLD_SECONDS = 60.0
 
     def __init__(self, database_url: str):
         self.database_url = database_url
         self._connection: Optional[psycopg.Connection] = None
         self._lock = threading.Lock()
-        self._last_used: float = 0.0  # monotonic time of last successful use
+        self._last_used: float = 0.0
 
     def get_connection(self) -> psycopg.Connection:
-        """Return an open psycopg connection, reconnecting if necessary.
-        
-        Uses time-based staleness check: only probes the connection if it
-        hasn't been used in the last STALE_THRESHOLD_SECONDS.
-        """
         with self._lock:
             if self._connection is None or self._connection.closed:
                 self._connection = self._connect_with_retry()
@@ -96,11 +165,9 @@ class ConnectionProvider:
             return self._connection
 
     def _is_stale(self) -> bool:
-        """Check if the connection hasn't been used recently."""
         return (time.monotonic() - self._last_used) > self.STALE_THRESHOLD_SECONDS
 
     def _connect_with_retry(self) -> psycopg.Connection:
-        """Attempt to connect with exponential backoff for cold starts."""
         last_error: Optional[Exception] = None
         for attempt in range(self.MAX_RETRIES + 1):
             conn = None
@@ -123,7 +190,7 @@ class ConnectionProvider:
         raise last_error if last_error else RuntimeError("Connection failed without error")
 ```
 
-**Expected impact:** Reduces transition time from ~3 seconds to <500ms (only actual query latency remains).
+**Expected impact:** Reduces transition time from ~3 seconds to <500ms.
 
 ---
 
@@ -131,27 +198,19 @@ class ConnectionProvider:
 
 **File:** `src/stream_of_worship/app/screens/songset_editor.py`
 
-**Location:** `on_mount()` method (around line 112-130)
-
-**Rationale:** `on_mount` fires before child widgets are in the DOM. Use `call_after_refresh` to wait for DOM to be ready.
-
-**Change:**
+**Change in `on_mount()`:**
 
 ```python
 def on_mount(self) -> None:
-    """Handle mount event."""
     logger.info(
         f"SongsetEditorScreen mounted (songset: {self.state.selected_songset.id if self.state.selected_songset else 'None'})"
     )
-    # Defer refresh until DOM is ready
     self.call_after_refresh(self._refresh)
     self.call_after_refresh(self._focus_song_list)
 
-    # Listen for state changes (store reference for removal in on_unmount)
     self._songset_listener = lambda _: self._refresh()
     self.state.add_listener("selected_songset", self._songset_listener)
 
-    # Register playback callbacks
     self.playback.set_callbacks(
         on_position_changed=self._on_position_changed,
         on_state_changed=self._on_state_changed,
@@ -165,26 +224,19 @@ def on_mount(self) -> None:
 
 **File:** `src/stream_of_worship/app/screens/songset_editor.py`
 
-**Location:** `on_unmount()` method (around line 132-134)
+**Add to `__init__`:**
 
-**Rationale:** Prevent zombie screen instances from continuing to respond to state changes and making DB queries.
+```python
+self._songset_listener = None
+```
 
-**Change:**
+**Change `on_unmount()`:**
 
 ```python
 def on_unmount(self) -> None:
-    """Unregister callbacks to prevent memory leaks and zombie refreshes."""
     self.playback.set_callbacks()
-    if hasattr(self, '_songset_listener'):
+    if hasattr(self, '_songset_listener') and self._songset_listener:
         self.state.remove_listener("selected_songset", self._songset_listener)
-```
-
-**Also add to `__init__`:**
-
-```python
-def __init__(self, ...):
-    ...
-    self._songset_listener = None  # Initialize to None
 ```
 
 ---
@@ -193,28 +245,18 @@ def __init__(self, ...):
 
 **File:** `src/stream_of_worship/app/screens/songset_editor.py`
 
-**Location:** `_refresh()` method (around line 182)
-
-**Rationale:** Even with listener removal, a race condition could cause `_refresh()` to run on a screen that's no longer the top of the stack. Guard against this.
-
-**Change:**
-
 ```python
 def _refresh(self) -> None:
-    """Refresh the display."""
-    # Don't refresh if this screen is not the active screen
     if not self.is_current:
         return
-    
+
     songset = self.state.selected_songset
     if not songset:
         return
 
-    # Update input fields with current values
     try:
         name_input = self.query_one("#input_name", Input)
         name_input.value = songset.name
-
         desc_input = self.query_one("#input_description", Input)
         desc_input.value = songset.description or ""
     except Exception as e:
@@ -225,27 +267,18 @@ def _refresh(self) -> None:
 
 ---
 
-### Fix 5: Prevent duplicate screen stacking (optional enhancement)
+### Fix 5: Prevent duplicate screen stacking
 
 **File:** `src/stream_of_worship/app/app.py`
 
-**Location:** `navigate_to()` method (around line 156-171)
-
-**Rationale:** When navigating to a screen type that's already on top of the stack, pop the existing one first to avoid stacking duplicates.
-
-**Change:**
-
 ```python
 def navigate_to(self, screen: AppScreen) -> None:
-    """Navigate to a screen."""
     logger.info(f"Navigate to: {screen.name} (from {self.state.current_screen.name})")
 
-    # Stop playback when switching screens
     if self.playback.is_playing or self.playback.is_paused:
         logger.debug("Stopping playback before navigation")
         self.playback.stop()
 
-    # Prevent pushing duplicate screen types onto the stack
     if len(self.screen_stack) > 0:
         current_screen = self.screen_stack[-1]
         if self._is_same_screen_type(current_screen, screen):
@@ -258,7 +291,6 @@ def navigate_to(self, screen: AppScreen) -> None:
     logger.debug(f"Screen pushed, stack depth: {len(self.screen_stack)}")
 
 def _is_same_screen_type(self, screen_instance, screen_enum: AppScreen) -> bool:
-    """Check if a screen instance matches an AppScreen enum value."""
     screen_type_map = {
         AppScreen.SONGSET_LIST: SongsetListScreen,
         AppScreen.SONGSET_EDITOR: SongsetEditorScreen,
@@ -271,13 +303,342 @@ def _is_same_screen_type(self, screen_instance, screen_enum: AppScreen) -> bool:
 
 ---
 
+### Fix 6: Fix navigate_back() desync — use a stack in AppState
+
+**File:** `src/stream_of_worship/app/state.py`
+
+**Rationale:** `previous_screen` is a single slot. Replace with a navigation stack that mirrors Textual's screen stack.
+
+**Changes:**
+
+```python
+class AppState:
+    def __init__(self):
+        self._nav_stack: list[AppScreen] = []
+
+    def navigate_to(self, screen: AppScreen) -> None:
+        self._nav_stack.append(screen)
+        self.current_screen = screen
+        self._notify("current_screen", screen)
+
+    def navigate_back(self) -> bool:
+        if len(self._nav_stack) <= 1:
+            return False
+        self._nav_stack.pop()
+        self.current_screen = self._nav_stack[-1]
+        self._notify("current_screen", self.current_screen)
+        return True
+
+    @property
+    def previous_screen(self) -> Optional[AppScreen]:
+        return self._nav_stack[-2] if len(self._nav_stack) >= 2 else None
+```
+
+---
+
+### Fix 7: Fix LyricsPreviewScreen to use navigate_to()
+
+**File:** `src/stream_of_worship/app/screens/songset_editor.py`
+
+**Rationale:** `push_screen()` bypasses AppState tracking and playback management.
+
+**Option A (recommended):** Add `LYRICS_PREVIEW` to `AppScreen` enum and route through `navigate_to()`.
+
+**Option B (minimal):** Keep `push_screen()` but manually update state and stop playback:
+
+```python
+def action_lyrics_preview(self) -> None:
+    item = self._get_selected_item()
+    if not item:
+        self.notify("No song selected", severity="warning")
+        return
+    if not item.recording_hash_prefix:
+        self.notify("Song has no recording", severity="warning")
+        return
+
+    lrc_path = self.asset_cache.download_lrc(item.recording_hash_prefix)
+    if not lrc_path:
+        self.notify("No lyrics available for this song", severity="warning")
+        return
+
+    if self.playback.is_playing or self.playback.is_paused:
+        self.playback.stop()
+
+    self.app.push_screen(
+        LyricsPreviewScreen(
+            item=item,
+            playback=self.playback,
+            asset_cache=self.asset_cache,
+        )
+    )
+```
+
+---
+
+### Fix 8: Add on_unmount to ExportProgressScreen and LyricsPreviewScreen
+
+**File:** `src/stream_of_worship/app/screens/export_progress.py`
+
+```python
+def on_unmount(self) -> None:
+    self.export_service.unregister_progress_callback(self._on_progress)
+    self.export_service.unregister_completion_callback(self._on_complete)
+```
+
+**File:** `src/stream_of_worship/app/services/export.py` — add unregister methods:
+
+```python
+def unregister_progress_callback(self, callback):
+    if callback in self._progress_callbacks:
+        self._progress_callbacks.remove(callback)
+
+def unregister_completion_callback(self, callback):
+    if callback in self._completion_callbacks:
+        self._completion_callbacks.remove(callback)
+```
+
+**File:** `src/stream_of_worship/app/screens/lyrics_preview.py`
+
+```python
+def on_unmount(self) -> None:
+    self.playback.set_callbacks()
+```
+
+---
+
+### Fix 9: Run DB queries and network downloads on worker thread
+
+**File:** All screen files
+
+**Rationale:** Synchronous DB and network calls freeze the TUI. Use Textual's `run_worker()` to offload blocking operations.
+
+**Pattern for DB queries:**
+
+```python
+from textual.worker import Worker
+
+def _load_items(self) -> None:
+    self.run_worker(self._load_items_worker, exclusive=True, group="load_items")
+
+def _load_items_worker(self) -> None:
+    """Worker that loads items off the main thread."""
+    if not self.state.selected_songset:
+        return
+
+    details, orphan_count = self.catalog.get_songset_with_items(
+        self.state.selected_songset.id, self.songset_client
+    )
+    # Update UI on main thread
+    self.call_from_thread(self._update_items_table, details)
+
+def _update_items_table(self, details) -> None:
+    """Update the DataTable on the main thread."""
+    self.items = [d.item for d in details]
+    # ... existing table update logic ...
+```
+
+**Pattern for R2 downloads:**
+
+```python
+def action_toggle_playback(self) -> None:
+    if self.playback.is_playing:
+        self.playback.stop()
+        self.notify("Playback stopped")
+        return
+
+    item = self._get_selected_item()
+    if not item:
+        self.notify("No song selected", severity="error")
+        return
+
+    self.run_worker(self._play_item_worker, item, group="playback")
+
+def _play_item_worker(self, item) -> None:
+    try:
+        audio_path = self.asset_cache.download_audio(item.recording_hash_prefix)
+        if audio_path:
+            self.call_from_thread(self.playback.play, audio_path)
+            self.call_from_thread(self.notify, f"Playing: {item.song_title}")
+        else:
+            self.call_from_thread(self.notify, "Failed to download audio", severity="error")
+    except Exception as e:
+        self.call_from_thread(self.notify, f"Error: {e}", severity="error")
+```
+
+**Scope:** Apply to:
+- `SongsetEditorScreen._load_items()`, `action_preview()`, `action_toggle_playback()`
+- `SongsetListScreen._load_songsets()`
+- `BrowseScreen._load_songs()`, `action_preview()`
+- `LyricsPreviewScreen.on_mount()` (LRC download)
+
+---
+
+### Fix 10: Fix N+1 query patterns with batch queries
+
+**File:** `src/stream_of_worship/app/db/songset_client.py`
+
+Add `get_item_counts_batch()`:
+
+```python
+def get_item_counts_batch(self, songset_ids: list[str]) -> dict[str, int]:
+    """Get item counts for multiple songsets in a single query."""
+    conn = self.connection
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT songset_id, COUNT(*) as count
+            FROM songset_items
+            WHERE songset_id = ANY(%s)
+            GROUP BY songset_id
+            """,
+            (songset_ids,),
+        )
+        rows = cur.fetchall()
+    return {row[0]: row[1] for row in rows}
+```
+
+**File:** `src/stream_of_worship/app/db/read_client.py`
+
+Add `get_recordings_by_song_ids()` and `get_recordings_by_hashes()`:
+
+```python
+def get_recordings_by_song_ids(self, song_ids: list[str]) -> dict[str, Recording]:
+    """Fetch recordings for multiple songs in a single query."""
+    conn = self.connection
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT r.* FROM recordings r
+            WHERE r.song_id = ANY(%s)
+            """,
+            (song_ids,),
+        )
+        rows = cur.fetchall()
+    return {row[0]: Recording(**row) for row in rows}
+
+def get_recordings_by_hashes(self, hash_prefixes: list[str]) -> dict[str, Recording]:
+    """Fetch recordings by hash prefixes in a single query."""
+    conn = self.connection
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT * FROM recordings
+            WHERE hash_prefix = ANY(%s)
+            """,
+            (hash_prefixes,),
+        )
+        rows = cur.fetchall()
+    return {row[0]: Recording(**row) for row in rows}
+```
+
+**File:** `src/stream_of_worship/app/services/catalog.py`
+
+Update `get_songset_with_items()` and `list_songs_with_recordings()` to use batch queries.
+
+---
+
+### Fix 11: Add timeouts to R2 downloads and FFmpeg
+
+**File:** `src/stream_of_worship/app/services/asset_cache.py`
+
+Add a `timeout` parameter to download methods (default 30s):
+
+```python
+def download_audio(self, hash_prefix: str, timeout: int = 30) -> Optional[Path]:
+    try:
+        return self.r2_client.download_file(
+            bucket=self.r2_bucket,
+            key=f"audio/{hash_prefix}.mp3",
+            local_path=audio_path,
+            timeout=timeout,
+        )
+    except TimeoutError:
+        logger.error(f"Timeout downloading audio for {hash_prefix}")
+        return None
+```
+
+**File:** `src/stream_of_worship/app/services/video_engine.py`
+
+Add timeout to `process.wait()`:
+
+```python
+try:
+    process.wait(timeout=300)  # 5 minute max per FFmpeg call
+except subprocess.TimeoutExpired:
+    process.kill()
+    raise RuntimeError("FFmpeg timed out")
+```
+
+---
+
+### Fix 12: Clean up temp files from preview_transition
+
+**File:** `src/stream_of_worship/app/services/audio_engine.py`
+
+Track temp files and clean up on next preview or on service shutdown:
+
+```python
+def __init__(self, ...):
+    self._temp_files: list[Path] = []
+
+def preview_transition(self, from_item, to_item) -> Optional[Path]:
+    # Clean up previous temp files
+    for f in self._temp_files:
+        try:
+            f.unlink(missing_ok=True)
+        except Exception:
+            pass
+    self._temp_files.clear()
+
+    # ... existing logic ...
+    self._temp_files.append(Path(temp_path))
+    return Path(temp_path)
+```
+
+---
+
+### Fix 13: Log exceptions in _notify instead of silently swallowing
+
+**File:** `src/stream_of_worship/app/state.py`
+
+```python
+def _notify(self, key: str, value: Any) -> None:
+    for cb in self._listeners.get(key, []):
+        try:
+            cb(value)
+        except Exception as e:
+            logger.error(f"Listener error for '{key}': {e}")
+```
+
+---
+
+### Fix 14: Add DB error handling with user-friendly messages
+
+**File:** `src/stream_of_worship/app/db/read_client.py`, `src/stream_of_worship/app/db/songset_client.py`
+
+Wrap critical query methods with try/except that catches `psycopg.OperationalError` and raises a custom `DatabaseError` with user-friendly message. Screens can catch `DatabaseError` and show a notification.
+
+---
+
 ## Summary of Files Changed
 
-| File | Changes |
-|------|---------|
-| `src/stream_of_worship/db/connection.py` | Time-based staleness check instead of per-call health check |
-| `src/stream_of_worship/app/screens/songset_editor.py` | 1. Defer `_refresh()` with `call_after_refresh`<br>2. Store listener reference and remove in `on_unmount`<br>3. Guard `_refresh()` against non-active screens |
-| `src/stream_of_worship/app/app.py` | (Optional) Prevent duplicate screen stacking |
+| File | Fixes |
+|------|-------|
+| `src/stream_of_worship/db/connection.py` | Fix 1: Time-based staleness check |
+| `src/stream_of_worship/app/screens/songset_editor.py` | Fix 2, 3, 4, 7, 9: Defer refresh, remove listener, guard, LyricsPreview nav, worker threads |
+| `src/stream_of_worship/app/app.py` | Fix 5, 6: Duplicate screen prevention, nav stack |
+| `src/stream_of_worship/app/state.py` | Fix 6, 13: Navigation stack, log listener errors |
+| `src/stream_of_worship/app/screens/export_progress.py` | Fix 8: Unregister callbacks |
+| `src/stream_of_worship/app/screens/lyrics_preview.py` | Fix 8: Unregister callbacks |
+| `src/stream_of_worship/app/services/export.py` | Fix 8: Unregister methods |
+| `src/stream_of_worship/app/screens/songset_list.py` | Fix 9, 10: Worker thread, batch queries |
+| `src/stream_of_worship/app/screens/browse.py` | Fix 9: Worker thread |
+| `src/stream_of_worship/app/db/songset_client.py` | Fix 10, 14: Batch queries, error handling |
+| `src/stream_of_worship/app/db/read_client.py` | Fix 10, 14: Batch queries, error handling |
+| `src/stream_of_worship/app/services/catalog.py` | Fix 10: Use batch queries |
+| `src/stream_of_worship/app/services/asset_cache.py` | Fix 11: Download timeouts |
+| `src/stream_of_worship/app/services/video_engine.py` | Fix 11: FFmpeg timeout |
+| `src/stream_of_worship/app/services/audio_engine.py` | Fix 12: Temp file cleanup |
 
 ---
 
@@ -288,7 +649,27 @@ def _is_same_screen_type(self, screen_instance, screen_enum: AppScreen) -> bool:
 | Screen transition time | 3-20+ seconds | <500ms |
 | "No nodes match" errors | Frequent | None |
 | Zombie DB queries | Yes | No |
-| Duplicate screen stacking | Yes | No (with Fix 5) |
+| Duplicate screen stacking | Yes | No |
+| AppState/Textual stack desync | Yes | No |
+| UI freezes during DB/network | Yes | No (worker threads) |
+| N+1 query round trips (5 items) | ~35 | ~5 |
+| Temp file leaks | Yes | No |
+| Silent listener errors | Yes | Logged |
+
+---
+
+## Implementation Order
+
+1. **Fix 1** (connection.py) — biggest bang for buck, standalone
+2. **Fix 2, 3, 4** (songset_editor.py) — fixes the 20s delay
+3. **Fix 5, 6** (app.py, state.py) — fixes navigation desync
+4. **Fix 8** (export_progress, lyrics_preview, export.py) — prevents crashes
+5. **Fix 7** (lyrics_preview nav) — consistency fix
+6. **Fix 13** (state.py) — observability
+7. **Fix 9** (worker threads) — UI responsiveness (largest change)
+8. **Fix 10** (batch queries) — performance
+9. **Fix 11, 12** (timeouts, temp cleanup) — robustness
+10. **Fix 14** (error handling) — polish
 
 ---
 
@@ -297,6 +678,10 @@ def _is_same_screen_type(self, screen_instance, screen_enum: AppScreen) -> bool:
 - [ ] Navigate from Songset Manager to Songset Editor — should be <1 second
 - [ ] No "No nodes match '#input_name'" errors in logs
 - [ ] Create new songset, add songs, return to editor — no duplicate screens
-- [ ] Navigate back and forth multiple times — no performance degradation
-- [ ] Leave app idle for 2+ minutes, then navigate — stale connection is detected and reconnected
+- [ ] Navigate back and forth 3+ times — no performance degradation, no stack desync
+- [ ] Leave app idle for 2+ minutes, then navigate — stale connection detected and reconnected
+- [ ] Navigate back during active export — no crash, export continues
+- [ ] Open and close lyrics preview — no zombie callbacks
+- [ ] Browse songs with 50+ entries — UI remains responsive during load
+- [ ] Preview transition — UI remains responsive during generation
 - [ ] Run full test suite — all tests pass

--- a/specs/fix_songset_moving_songs.md
+++ b/specs/fix_songset_moving_songs.md
@@ -1,0 +1,64 @@
+# Fix: Songset Editor Move Up/Down (',' and '.') Broken
+
+## Context
+
+In the Songset Editor TUI, pressing `,` to move a song up always reports "Already at top", and pressing `.` to move down appears to do nothing. This is caused by an async race condition between the move actions and `_load_items()`.
+
+## Root Cause
+
+After a successful reorder, both `action_move_up` (line 581) and `action_move_down` (line 608) call `self._load_items()` which spawns an **async worker thread** (line 213). The `table.move_cursor()` calls at lines 582 and 609 execute immediately — before the worker finishes. When the worker completes, `_update_items_table` calls `table.clear()` (line 243), which **resets the cursor to row 0**, discarding the cursor position.
+
+**Result:**
+- After any move, cursor snaps to row 0 (first song)
+- Next "move up" (`comma`): cursor is at row 0 → `current_index == 0` → "Already at the top"
+- Next "move down" (`period`): cursor is at row 0 → moves first item down, but cursor resets to 0 again → appears as if nothing happened
+
+## Fix
+
+**File:** `src/stream_of_worship/app/screens/songset_editor.py`
+
+### 1. Add a `_pending_cursor_row` attribute to defer cursor positioning
+
+Add `self._pending_cursor_row: Optional[int] = None` in the `__init__` or `compose`/`on_mount` setup (near line 77 where `self.items` is initialized).
+
+### 2. In `action_move_up` and `action_move_down`, store the desired cursor position instead of calling `move_cursor` immediately
+
+Replace the `_load_items()` + `move_cursor()` pattern:
+```python
+# Before (broken):
+self._load_items()
+table.move_cursor(row=current_index - 1)
+
+# After (fixed):
+self._pending_cursor_row = current_index - 1
+self._load_items()
+```
+
+Same for move_down but with `current_index + 1`.
+
+### 3. In `_update_items_table`, apply the pending cursor position after repopulating the table
+
+At the end of `_update_items_table` (after the `table.add_row` loop), add:
+```python
+if self._pending_cursor_row is not None:
+    table.move_cursor(row=self._pending_cursor_row)
+    self._pending_cursor_row = None
+```
+
+## Files to Modify
+
+- `src/stream_of_worship/app/screens/songset_editor.py` — 3 small changes (add field, update move_up, update move_down, update _update_items_table)
+
+## Verification
+
+```bash
+# Run the TUI
+uv run --extra app sow-app run
+
+# Test steps:
+# 1. Open a songset with 3+ songs
+# 2. Arrow-key to song #2, press ',' → should move to position #1
+# 3. Press '.' → should move back to position #2
+# 4. Arrow to last song, press '.' → should say "Already at the bottom"
+# 5. Arrow to first song, press ',' → should say "Already at the top"
+```

--- a/specs/playback-bar-widget.md
+++ b/specs/playback-bar-widget.md
@@ -1,0 +1,355 @@
+# Playback Bar Widget Implementation Plan
+
+## Context
+
+**Problem:** Users browsing songs in `BrowseScreen` and editing songsets in `SongsetEditorScreen` have no visual feedback for playback position. The only feedback is toast notifications (`self.notify()`) which:
+1. Stack up and clutter the screen when skipping forward/backward repeatedly
+2. Disappear after a few seconds, losing context
+3. Don't show real-time progress during playback
+
+**Solution:** Create a reusable `PlaybackBar` widget that displays current position, duration, and a visual progress bar. This widget will be shared across `BrowseScreen`, `SongsetEditorScreen`, and `LyricsPreviewScreen`, replacing the inline progress bar logic currently in `LyricsPreviewScreen`.
+
+## Requirements Summary
+
+- **Visual progress bar**: Shows current position / total duration with Unicode block characters (`█░`)
+- **Real-time updates**: Updates ~10x/second during playback via `PlaybackService` callbacks
+- **State indicator**: Shows `▶` (playing) or `⏸` (paused) icon
+- **Auto-hide**: Hidden when playback is stopped, visible when playing/paused
+- **Reusable**: Single widget class used across multiple screens
+- **No notification spam**: Skip forward/backward actions update the bar instead of showing toasts
+
+## Implementation Plan
+
+### Phase 1: Create `widgets/` Package Structure
+
+**Files:**
+- `src/stream_of_worship/app/widgets/__init__.py` (new)
+- `src/stream_of_worship/app/widgets/playback_bar.py` (new)
+
+**`__init__.py`:**
+```python
+"""Custom Textual widgets for the Stream of Worship app."""
+
+from stream_of_worship.app.widgets.playback_bar import PlaybackBar
+
+__all__ = ["PlaybackBar"]
+```
+
+### Phase 2: Implement `PlaybackBar` Widget
+
+**File:** `src/stream_of_worship/app/widgets/playback_bar.py`
+
+```python
+"""Reusable playback progress bar widget."""
+
+from textual.widgets import Static
+from textual.message import Message
+from stream_of_worship.app.services.playback import PlaybackService, PlaybackState, PlaybackPosition
+
+
+class PlaybackBar(Static):
+    """A progress bar widget that displays playback position and duration.
+    
+    Automatically registers callbacks with the PlaybackService and updates
+    in real-time during playback. Hidden when playback is stopped.
+    
+    Attributes:
+        playback: The PlaybackService instance to monitor
+        bar_width: Width of the visual progress bar in characters
+    """
+    
+    DEFAULT_CSS = """
+    PlaybackBar {
+        text-align: center;
+        content-align: center middle;
+        height: 1;
+        margin: 1 2;
+    }
+    """
+    
+    def __init__(
+        self,
+        playback: PlaybackService,
+        bar_width: int = 30,
+        id: str | None = None,
+        classes: str | None = None,
+    ):
+        super().__init__("", id=id, classes=classes)
+        self.playback = playback
+        self.bar_width = bar_width
+    
+    def on_mount(self) -> None:
+        """Register callbacks with the playback service."""
+        self.playback.set_callbacks(
+            on_position_changed=self._on_position_changed,
+            on_state_changed=self._on_state_changed,
+            on_finished=self._on_finished,
+        )
+        # Initial state
+        self._update_visibility()
+    
+    def on_unmount(self) -> None:
+        """Unregister callbacks to prevent memory leaks."""
+        self.playback.set_callbacks()
+    
+    def _on_position_changed(self, position: PlaybackPosition) -> None:
+        """Handle position updates from playback service (runs in background thread)."""
+        def _update():
+            self._update_display(position)
+        self.call_after_refresh(_update)
+    
+    def _on_state_changed(self, state: PlaybackState) -> None:
+        """Handle state changes from playback service (runs in background thread)."""
+        def _update():
+            self._update_visibility()
+            if state != PlaybackState.STOPPED:
+                self._update_display(self.playback.get_position())
+        self.call_after_refresh(_update)
+    
+    def _on_finished(self) -> None:
+        """Handle playback finished."""
+        def _update():
+            self._update_visibility()
+        self.call_after_refresh(_update)
+    
+    def _update_visibility(self) -> None:
+        """Show/hide based on playback state."""
+        if self.playback.is_stopped:
+            self.add_class("hidden")
+        else:
+            self.remove_class("hidden")
+    
+    def _update_display(self, position: PlaybackPosition) -> None:
+        """Update the progress bar display."""
+        current_str = self._format_time(position.current_seconds)
+        total_str = self._format_time(position.total_seconds)
+        
+        # Build visual progress bar
+        filled = int((position.progress_percent / 100) * self.bar_width)
+        empty = self.bar_width - filled
+        bar = "█" * filled + "░" * empty
+        
+        # State icon
+        icon = "⏸" if self.playback.is_paused else "▶"
+        
+        self.update(f"{icon} {current_str} / {total_str}  [{bar}]")
+    
+    @staticmethod
+    def _format_time(seconds: float) -> str:
+        """Format seconds as MM:SS."""
+        minutes = int(seconds // 60)
+        secs = int(seconds % 60)
+        return f"{minutes}:{secs:02d}"
+```
+
+**Key Design Decisions:**
+1. **Widget owns callback registration** — screens just pass the `PlaybackService` instance
+2. **`call_after_refresh()` for thread safety** — callbacks run in background thread, must schedule UI updates on main thread
+3. **Unregister on unmount** — prevents callbacks to destroyed widgets
+4. **Inline CSS** — widget is self-contained, no external CSS required (but can be overridden)
+5. **Hidden when stopped** — bar only appears during playback, avoiding wasted space
+
+### Phase 3: Add Skip Bindings to BrowseScreen
+
+**File:** `src/stream_of_worship/app/screens/browse.py`
+
+**Changes:**
+
+1. Add imports:
+```python
+from stream_of_worship.app.widgets import PlaybackBar
+```
+
+2. Add bindings (line 24):
+```python
+BINDINGS = [
+    ("s", "add_to_songset", "Add to Songset"),
+    ("space", "toggle_playback", "Play/Stop"),
+    ("left", "skip_backward", "Skip -10s"),
+    ("right", "skip_forward", "Skip +10s"),
+    ("f", "focus_search", "Search"),
+    ("escape", "back", "Back"),
+    ("q", "quit", "Quit"),
+]
+```
+
+3. Add widget to `compose()` (after button row, before Footer):
+```python
+yield PlaybackBar(self.app.playback, id="playback_bar")
+```
+
+4. Add skip actions (after `action_toggle_playback`):
+```python
+def action_skip_forward(self) -> None:
+    """Skip forward 10 seconds in current playback."""
+    if not self.app.playback.is_playing and not self.app.playback.is_paused:
+        return
+    self.app.playback.skip_forward(10.0)
+
+def action_skip_backward(self) -> None:
+    """Skip backward 10 seconds in current playback."""
+    if not self.app.playback.is_playing and not self.app.playback.is_paused:
+        return
+    self.app.playback.skip_backward(10.0)
+```
+
+5. Remove `self.notify()` calls from `action_toggle_playback` (optional — keep for play/stop feedback, remove for skip actions).
+
+### Phase 4: Add PlaybackBar to SongsetEditorScreen
+
+**File:** `src/stream_of_worship/app/screens/songset_editor.py`
+
+**Changes:**
+
+1. Add import:
+```python
+from stream_of_worship.app.widgets import PlaybackBar
+```
+
+2. Add widget to `compose()` (after button row, before Footer):
+```python
+yield PlaybackBar(self.playback, id="playback_bar")
+```
+
+3. Remove `self.notify()` calls from `action_skip_forward()` and `action_skip_backward()`:
+```python
+def action_skip_forward(self) -> None:
+    """Skip forward 10 seconds in current playback."""
+    if not self.playback.is_playing:
+        return
+    self.playback.skip_forward(10.0)
+
+def action_skip_backward(self) -> None:
+    """Skip backward 10 seconds in current playback."""
+    if not self.playback.is_playing:
+        return
+    self.playback.skip_backward(10.0)
+```
+
+4. Keep `self.notify()` for play/stop in `action_toggle_playback()` (optional — provides feedback when starting/stopping).
+
+### Phase 5: Refactor LyricsPreviewScreen to Use PlaybackBar
+
+**File:** `src/stream_of_worship/app/screens/lyrics_preview.py`
+
+**Changes:**
+
+1. Add import:
+```python
+from stream_of_worship.app.widgets import PlaybackBar
+```
+
+2. Replace `Static("", id="progress_bar")` in `compose()` with:
+```python
+yield PlaybackBar(self.playback, id="playback_bar")
+```
+
+3. Remove `_update_progress_bar()` method (lines 306-325) — no longer needed.
+
+4. Remove progress bar update from `_on_position_changed()` — keep only lyrics sync logic:
+```python
+def _on_position_changed(self, position: PlaybackPosition) -> None:
+    def _update():
+        new_index = self._find_current_line(position.current_seconds)
+        if new_index != self.current_line_index:
+            self.current_line_index = new_index
+            self._update_lyrics_display()
+            self._highlight_lrc_row()
+    self.call_after_refresh(_update)
+```
+
+5. Remove `_on_state_changed()` method — PlaybackBar handles state changes.
+
+6. Keep `_on_finished()` for any cleanup needed.
+
+### Phase 6: Update CSS
+
+**File:** `src/stream_of_worship/app/screens/app.tcss`
+
+**Changes:**
+
+1. Remove duplicate `#progress_bar` rules (lines 96-98 and 203-208) — PlaybackBar has inline CSS.
+
+2. Add optional override for PlaybackBar if needed:
+```css
+/* PlaybackBar - optional overrides */
+PlaybackBar {
+    /* Override bar styling here if needed */
+}
+```
+
+3. Ensure `.hidden` class exists (line 238-240 already has it).
+
+## Files to Modify/Create
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `src/stream_of_worship/app/widgets/__init__.py` | Create | Export PlaybackBar |
+| `src/stream_of_worship/app/widgets/playback_bar.py` | Create | PlaybackBar widget implementation |
+| `src/stream_of_worship/app/screens/browse.py` | Modify | Add skip bindings, embed PlaybackBar |
+| `src/stream_of_worship/app/screens/songset_editor.py` | Modify | Embed PlaybackBar, remove skip notifications |
+| `src/stream_of_worship/app/screens/lyrics_preview.py` | Modify | Use PlaybackBar, remove inline progress logic |
+| `src/stream_of_worship/app/screens/app.tcss` | Modify | Clean up duplicate #progress_bar rules |
+
+## Key Code to Reuse
+
+| Code | Location | Purpose |
+|------|----------|---------|
+| `PlaybackService.set_callbacks()` | `app/services/playback.py:88-103` | Register position/state callbacks |
+| `PlaybackPosition` dataclass | `app/services/playback.py:30-42` | Position info passed to callbacks |
+| `_format_time()` logic | `app/screens/lyrics_preview.py:327-330` | Time formatting (MM:SS) |
+| Unicode bar rendering | `app/screens/lyrics_preview.py:318-322` | `█░` progress bar |
+| `call_after_refresh()` pattern | `app/screens/lyrics_preview.py:272-284` | Thread-safe UI updates |
+
+## Verification
+
+### Manual Testing
+
+1. Run the TUI app: `uv run --extra app sow-app run`
+2. Navigate to BrowseScreen
+3. Verify:
+   - [ ] Select a song and press Space — audio starts playing
+   - [ ] PlaybackBar appears showing position and progress
+   - [ ] Progress bar updates in real-time during playback
+   - [ ] Press Left arrow — skips backward 10s, bar updates, NO notification
+   - [ ] Press Right arrow — skips forward 10s, bar updates, NO notification
+   - [ ] Rapidly press Left/Right — bar updates smoothly, no notification spam
+   - [ ] Press Space to stop — PlaybackBar hides
+   - [ ] Press Space to start again — PlaybackBar reappears
+
+4. Navigate to SongsetEditorScreen
+5. Verify:
+   - [ ] Same playback bar behavior as BrowseScreen
+   - [ ] Skip actions work without notification spam
+   - [ ] PlaybackBar persists when navigating between songs in the list
+
+6. Navigate to LyricsPreviewScreen (Shift+P from SongsetEditor)
+7. Verify:
+   - [ ] PlaybackBar appears at bottom
+   - [ ] Lyrics sync still works correctly
+   - [ ] Skip actions work
+   - [ ] No duplicate progress bars
+
+### Edge Cases to Test
+
+- [ ] Song with 0:00 duration — bar shows 0:00 / 0:00
+- [ ] Very long songs (>60 minutes) — time format handles correctly
+- [ ] Rapid screen switching — callbacks don't cause errors
+- [ ] Playback finishes naturally — bar hides correctly
+- [ ] Pause/resume — icon changes between ▶ and ⏸
+
+### Automated Tests
+
+Create `tests/app/widgets/test_playback_bar.py`:
+- Test `_format_time()` with various inputs
+- Test visibility toggling based on playback state
+- Test callback registration/unregistration
+- Test progress bar calculation
+
+## Future Enhancements (Out of Scope)
+
+- Clickable progress bar for seeking
+- Display current song title in the bar
+- Volume indicator
+- Waveform visualization
+- Configurable bar width via settings

--- a/specs/playback-bar-widget.md
+++ b/specs/playback-bar-widget.md
@@ -50,8 +50,9 @@ from stream_of_worship.app.services.playback import PlaybackService, PlaybackSta
 class PlaybackBar(Static):
     """A progress bar widget that displays playback position and duration.
     
-    Automatically registers callbacks with the PlaybackService and updates
-    in real-time during playback. Hidden when playback is stopped.
+    Does NOT register callbacks with PlaybackService. The parent screen is
+    responsible for calling update_display() and update_visibility() from
+    its own callbacks.
     
     Attributes:
         playback: The PlaybackService instance to monitor
@@ -74,53 +75,15 @@ class PlaybackBar(Static):
         id: str | None = None,
         classes: str | None = None,
     ):
-        super().__init__("", id=id, classes=classes)
+        super().__init__("", id=id, classes=classes or "hidden")
         self.playback = playback
         self.bar_width = bar_width
     
-    def on_mount(self) -> None:
-        """Register callbacks with the playback service."""
-        self.playback.set_callbacks(
-            on_position_changed=self._on_position_changed,
-            on_state_changed=self._on_state_changed,
-            on_finished=self._on_finished,
-        )
-        # Initial state
-        self._update_visibility()
-    
-    def on_unmount(self) -> None:
-        """Unregister callbacks to prevent memory leaks."""
-        self.playback.set_callbacks()
-    
-    def _on_position_changed(self, position: PlaybackPosition) -> None:
-        """Handle position updates from playback service (runs in background thread)."""
-        def _update():
-            self._update_display(position)
-        self.call_after_refresh(_update)
-    
-    def _on_state_changed(self, state: PlaybackState) -> None:
-        """Handle state changes from playback service (runs in background thread)."""
-        def _update():
-            self._update_visibility()
-            if state != PlaybackState.STOPPED:
-                self._update_display(self.playback.get_position())
-        self.call_after_refresh(_update)
-    
-    def _on_finished(self) -> None:
-        """Handle playback finished."""
-        def _update():
-            self._update_visibility()
-        self.call_after_refresh(_update)
-    
-    def _update_visibility(self) -> None:
-        """Show/hide based on playback state."""
-        if self.playback.is_stopped:
-            self.add_class("hidden")
-        else:
-            self.remove_class("hidden")
-    
-    def _update_display(self, position: PlaybackPosition) -> None:
-        """Update the progress bar display."""
+    def update_display(self, position: PlaybackPosition) -> None:
+        """Update the progress bar display.
+        
+        Called by the parent screen from its _on_position_changed callback.
+        """
         current_str = self._format_time(position.current_seconds)
         total_str = self._format_time(position.total_seconds)
         
@@ -134,20 +97,31 @@ class PlaybackBar(Static):
         
         self.update(f"{icon} {current_str} / {total_str}  [{bar}]")
     
+    def update_visibility(self) -> None:
+        """Show/hide based on playback state.
+        
+        Called by the parent screen from its _on_state_changed and
+        _on_finished callbacks.
+        """
+        if self.playback.is_stopped:
+            self.add_class("hidden")
+        else:
+            self.remove_class("hidden")
+    
     @staticmethod
     def _format_time(seconds: float) -> str:
-        """Format seconds as MM:SS."""
+        """Format seconds as M:SS."""
         minutes = int(seconds // 60)
         secs = int(seconds % 60)
         return f"{minutes}:{secs:02d}"
 ```
 
 **Key Design Decisions:**
-1. **Widget owns callback registration** — screens just pass the `PlaybackService` instance
+1. **Parent screen owns callback registration** — widget exposes `update_display()` and `update_visibility()` methods; screens call these from their own `PlaybackService` callbacks
 2. **`call_after_refresh()` for thread safety** — callbacks run in background thread, must schedule UI updates on main thread
-3. **Unregister on unmount** — prevents callbacks to destroyed widgets
+3. **Wrap `query_one()` in `try...except NoMatches`** — callbacks may fire after screen is popped and widgets are removed from DOM
 4. **Inline CSS** — widget is self-contained, no external CSS required (but can be overridden)
-5. **Hidden when stopped** — bar only appears during playback, avoiding wasted space
+5. **Hidden when stopped** — bar only appears during playback, avoiding wasted space (initialized with `hidden` class)
 
 ### Phase 3: Add Skip Bindings to BrowseScreen
 

--- a/specs/tui-browse-songset-editor-ux-improvements.md
+++ b/specs/tui-browse-songset-editor-ux-improvements.md
@@ -1,0 +1,277 @@
+# TUI Browse & Songset Editor UX Improvements
+
+## Overview
+
+This plan addresses UX improvements for the Browse Song screen and Songset Editor screen, plus a crash bug fix.
+
+## Changes
+
+### 1. Browse Screen: Change 's' → 'a' for "Add to Songset"
+
+**File:** `src/stream_of_worship/app/screens/browse.py`
+
+**Location:** Line 27
+
+**Change:**
+```python
+# Before
+("s", "add_to_songset", "Add to Songset"),
+
+# After
+("a", "add_to_songset", "Add to Songset"),
+```
+
+**Rationale:** 'a' for "add" is more intuitive. Frees up 's' for future use.
+
+---
+
+### 2. Browse Screen: Auto-focus table on mount
+
+**File:** `src/stream_of_worship/app/screens/browse.py`
+
+**Location:** `on_mount()` method (lines 131-138)
+
+**Change:** After `_load_songs()`, add a `call_after_refresh` call to focus the song table and set cursor to first row.
+
+```python
+def on_mount(self) -> None:
+    """Handle mount event."""
+    self._load_songs()
+    self.app.playback.set_callbacks(
+        on_position_changed=self._on_position_changed,
+        on_state_changed=self._on_state_changed,
+        on_finished=self._on_finished,
+    )
+    # Auto-focus table so user can immediately use arrow keys and 'a' to add
+    self.call_after_refresh(self._focus_song_table)
+
+def _focus_song_table(self) -> None:
+    """Focus the song table and set cursor to first row."""
+    table = self.query_one("#song_table", DataTable)
+    table.focus()
+    if len(table.rows) > 0:
+        table.cursor_row = 0
+```
+
+**Rationale:** User can immediately navigate with arrow keys and press 'a' to add songs without needing to tab to the table first.
+
+---
+
+### 3. Songset Editor: Rename "Add Songs" → "Song Catalog" with 'c' shortcut
+
+**File:** `src/stream_of_worship/app/screens/songset_editor.py`
+
+**Locations:** Lines 33 and 98
+
+**Changes:**
+```python
+# Line 33 - Before
+("a", "add_songs", "Add Songs"),
+
+# Line 33 - After
+("c", "add_songs", "Song Catalog"),
+
+# Line 98 - Before
+yield Button("Add Songs", id="btn_add", variant="primary")
+
+# Line 98 - After
+yield Button("Song Catalog", id="btn_add", variant="primary")
+```
+
+**Rationale:** "Song Catalog" better describes the action of browsing the catalog. 'c' for "catalog" is intuitive. Frees up 'a' for Browse screen's "add" action.
+
+---
+
+### 4. Songset Editor: Auto-open Browse for new (empty) songsets
+
+**File:** `src/stream_of_worship/app/screens/songset_editor.py`
+
+**Changes:**
+
+1. Add `self._initial_load = True` flag in `__init__` (around line 77)
+
+2. Modify `_load_items()` to auto-navigate to Browse for empty songsets on first load:
+
+```python
+def __init__(self, ...):
+    ...
+    self.items: list[SongsetItem] = []
+    self._initial_load = True  # NEW
+
+def _load_items(self) -> None:
+    """Load and display songset items."""
+    if not self.state.selected_songset:
+        return
+
+    self.items = self.songset_client.get_items(self.state.selected_songset.id)
+    self.state.update_songset_items(self.items)
+
+    table = self.query_one("#items_table", DataTable)
+    table.clear()
+
+    for i, item in enumerate(self.items):
+        # ... existing row rendering ...
+
+    # NEW: Auto-open Browse for empty songsets on first load
+    if len(self.items) == 0 and self._initial_load:
+        self._initial_load = False
+        self.call_after_refresh(self._open_browse_for_new_songset)
+
+def _open_browse_for_new_songset(self) -> None:
+    """Navigate to Browse screen for new empty songsets."""
+    self.app.navigate_to(AppScreen.BROWSE)
+```
+
+**Rationale:** When user creates a new songset, they immediately want to add songs. Auto-opening Browse saves a step.
+
+**Guard:** `_initial_load` flag prevents re-triggering when returning from Browse with still-empty songset (user might have browsed but not added anything).
+
+---
+
+### 5. Fix "Unknown" bug in Song column
+
+**File:** `src/stream_of_worship/app/screens/songset_editor.py`
+
+**Root Cause:** `_load_items()` calls `self.songset_client.get_items()` which uses a query that only selects from `songset_items` table without joining `songs`/`recordings`. The `SongsetItem.song_title` field is always `None`, so `item.song_title or "Unknown"` always shows "Unknown".
+
+**Solution:** Use `CatalogService.get_songset_with_items()` which performs a two-step cross-DB lookup to resolve song and recording details. Then populate the raw `SongsetItem` objects with resolved data so existing code continues to work.
+
+**Changes:**
+
+1. Modify `_load_items()` to use `catalog.get_songset_with_items()`:
+
+```python
+def _load_items(self) -> None:
+    """Load and display songset items."""
+    if not self.state.selected_songset:
+        return
+
+    # Use catalog service to resolve song/recording details
+    details, orphan_count = self.catalog.get_songset_with_items(
+        self.state.selected_songset.id, self.songset_client
+    )
+
+    # Extract raw items and populate with resolved data
+    self.items = [d.item for d in details]
+    for detail in details:
+        # Populate joined fields on raw item so existing code works
+        detail.item.song_title = detail.display_title
+        if detail.recording:
+            detail.item.tempo_bpm = detail.recording.tempo_bpm
+            detail.item.duration_seconds = detail.recording.duration_seconds
+            detail.item.recording_key = detail.recording.musical_key
+        if detail.song:
+            detail.item.song_key = detail.song.musical_key
+
+    self.state.update_songset_items(self.items)
+
+    table = self.query_one("#items_table", DataTable)
+    table.clear()
+
+    for i, item in enumerate(self.items):
+        gap_text = f"{item.gap_beats} beats" if item.gap_beats else "No gap"
+        transition_text = "Crossfade" if item.crossfade_enabled else "Gap"
+        tempo_text = f"{int(item.tempo_bpm)}" if item.tempo_bpm else "-"
+
+        table.add_row(
+            str(i + 1),
+            item.song_title or "Unknown",  # Now populated!
+            item.display_key or "-",
+            tempo_text,
+            item.formatted_duration,
+            gap_text,
+            transition_text,
+            key=item.id,
+        )
+
+    # Auto-open Browse for empty songsets on first load
+    if len(self.items) == 0 and self._initial_load:
+        self._initial_load = False
+        self.call_after_refresh(self._open_browse_for_new_songset)
+```
+
+**Rationale:** By populating `song_title`, `tempo_bpm`, `duration_seconds`, `recording_key`, and `song_key` on the raw `SongsetItem` objects, all existing code that references `self.items` (notification messages, `_get_selected_item()`, etc.) continues to work without modification.
+
+---
+
+### 6. Fix crash on returning from Browse Screen (PlaybackBar race condition)
+
+**File:** `src/stream_of_worship/app/screens/browse.py` and `src/stream_of_worship/app/screens/songset_editor.py`
+
+**Root Cause:** When a screen is popped (navigated back), the playback service may fire a callback that tries to `query_one(PlaybackBar)` on a screen whose DOM widgets are already torn down. The `call_after_refresh` defers the update, but by then the widget is gone, causing `NoMatches` exception.
+
+**Solution:** Wrap each `_update()` inner function with a try/except for `NoMatches`, so the callback silently no-ops if the widget is gone.
+
+**Changes in `browse.py` (lines 144-170):**
+
+```python
+from textual.widgets import NoMatches  # Add to imports
+
+def _on_position_changed(self, position: PlaybackPosition) -> None:
+    """Handle position updates from playback service."""
+
+    def _update():
+        try:
+            self.query_one(PlaybackBar).update_display(position)
+        except NoMatches:
+            pass  # Widget already removed from DOM
+
+    self.call_after_refresh(_update)
+
+def _on_state_changed(self, state: PlaybackState) -> None:
+    """Handle state changes from playback service."""
+
+    def _update():
+        try:
+            self.query_one(PlaybackBar).update_visibility()
+            if state != PlaybackState.STOPPED:
+                self.query_one(PlaybackBar).update_display(
+                    self.app.playback.get_position()
+                )
+        except NoMatches:
+            pass  # Widget already removed from DOM
+
+    self.call_after_refresh(_update)
+
+def _on_finished(self) -> None:
+    """Handle playback finished."""
+
+    def _update():
+        try:
+            self.query_one(PlaybackBar).update_visibility()
+        except NoMatches:
+            pass  # Widget already removed from DOM
+
+    self.call_after_refresh(_update)
+```
+
+**Same changes in `songset_editor.py` (lines 134-158):**
+
+Apply identical try/except pattern to all three callback methods.
+
+**Rationale:** Gracefully handles the race condition where playback callbacks fire after screen DOM is torn down. The callback simply no-ops if the widget is gone.
+
+---
+
+## Summary of Files Changed
+
+| File | Changes |
+|------|---------|
+| `src/stream_of_worship/app/screens/browse.py` | 1. 's' → 'a' binding<br>2. Auto-focus table on mount<br>3. PlaybackBar crash fix |
+| `src/stream_of_worship/app/screens/songset_editor.py` | 1. "Add Songs" → "Song Catalog" with 'c'<br>2. Auto-open Browse for empty songsets<br>3. Fix "Unknown" bug via catalog service<br>4. PlaybackBar crash fix |
+
+---
+
+## Testing Checklist
+
+- [ ] Browse screen: Press 'a' adds selected song to songset
+- [ ] Browse screen: On entering, cursor is on first row in table
+- [ ] Browse screen: Arrow keys work immediately without tabbing
+- [ ] Songset Editor: Press 'c' opens Browse screen
+- [ ] Songset Editor: "Song Catalog" button opens Browse screen
+- [ ] Songset Editor: New songset auto-opens Browse screen
+- [ ] Songset Editor: Song column shows actual song titles (not "Unknown")
+- [ ] Songset Editor: Tempo column shows actual BPM (not "-")
+- [ ] Songset Editor: Key column shows actual key (not "?")
+- [ ] No crash when returning from Browse screen during playback
+- [ ] No crash when returning from Songset Editor during playback

--- a/src/stream_of_worship/admin/db/client.py
+++ b/src/stream_of_worship/admin/db/client.py
@@ -500,20 +500,29 @@ class DatabaseClient:
                 ),
             )
 
-    def get_recording_by_hash(self, hash_prefix: str) -> Optional[Recording]:
+    def get_recording_by_hash(
+        self, hash_prefix: str, include_deleted: bool = False
+    ) -> Optional[Recording]:
         """Get a recording by its hash prefix.
 
         Args:
             hash_prefix: The hash prefix (first 12 chars).
+            include_deleted: Whether to include soft-deleted recordings.
 
         Returns:
             ``Recording`` or ``None`` if not found.
         """
         cursor = self.connection.cursor()
-        cursor.execute(
-            "SELECT * FROM recordings WHERE hash_prefix = %s AND deleted_at IS NULL",
-            (hash_prefix,),
-        )
+        if include_deleted:
+            cursor.execute(
+                "SELECT * FROM recordings WHERE hash_prefix = %s",
+                (hash_prefix,),
+            )
+        else:
+            cursor.execute(
+                "SELECT * FROM recordings WHERE hash_prefix = %s AND deleted_at IS NULL",
+                (hash_prefix,),
+            )
         row = cursor.fetchone()
 
         if row:

--- a/src/stream_of_worship/admin/services/r2.py
+++ b/src/stream_of_worship/admin/services/r2.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Optional
 
 import boto3
+from botocore.config import Config
 from botocore.exceptions import ClientError
 
 
@@ -57,6 +58,11 @@ class R2Client:
             aws_access_key_id=access_key,
             aws_secret_access_key=secret_key,
             region_name=region,
+            config=Config(
+                connect_timeout=10,
+                read_timeout=30,
+                retries={"max_attempts": 2},
+            ),
         )
 
     def upload_audio(self, file_path: Path, hash_prefix: str) -> str:

--- a/src/stream_of_worship/app/app.py
+++ b/src/stream_of_worship/app/app.py
@@ -37,7 +37,7 @@ class SowApp(App):
     BINDINGS = [
         ("q", "quit", "Quit"),
         ("s", "navigate_settings", "Settings"),
-        ("S", "reconnect_catalog", "Reconnect"),
+        ("S", "reconnect_catalog", "Reconnect DB"),
     ]
 
     def __init__(self, config: AppConfig, *args, **kwargs):
@@ -100,13 +100,17 @@ class SowApp(App):
         self.navigate_to(AppScreen.SONGSET_LIST)
 
     def action_reconnect_catalog(self) -> None:
-        """Force reconnection to the database (capital S key)."""
+        """Force reconnection to the Postgres catalog database (Shift+S).
+
+        Useful as a manual recovery when Neon's idle-suspended compute drops
+        the connection between queries.
+        """
         try:
             self.read_client.connection_provider.close()
             self.read_client.check_connection()
-            self.notify("Reconnected to catalog")
+            self.notify("Reconnected to catalog database")
         except Exception as e:
-            self.notify(f"Reconnection failed: {e}", severity="error")
+            self.notify(f"Database reconnection failed: {e}", severity="error")
 
     def _create_screen(self, screen: AppScreen):
         """Create a fresh screen instance.

--- a/src/stream_of_worship/app/app.py
+++ b/src/stream_of_worship/app/app.py
@@ -148,10 +148,40 @@ class SowApp(App):
             from stream_of_worship.app.screens.export_progress import ExportProgressScreen
 
             return ExportProgressScreen(self.state, self.export_service)
+        elif screen == AppScreen.LYRICS_PREVIEW:
+            from stream_of_worship.app.screens.lyrics_preview import LyricsPreviewScreen
+
+            item = self.state.selected_preview_item
+            if item is None:
+                logger.error("navigate_to LYRICS_PREVIEW: no selected_preview_item in state")
+                return None
+            return LyricsPreviewScreen(
+                item=item,
+                playback=self.playback,
+                asset_cache=self.asset_cache,
+            )
         elif screen == AppScreen.SETTINGS:
             from stream_of_worship.app.screens.settings import SettingsScreen
 
             return SettingsScreen(self.state, self.config)
+
+    def _is_same_screen_type(self, screen_instance, screen_enum: AppScreen) -> bool:
+        """Check if a Textual screen instance matches a given AppScreen enum value."""
+        from stream_of_worship.app.screens.browse import BrowseScreen
+        from stream_of_worship.app.screens.export_progress import ExportProgressScreen
+        from stream_of_worship.app.screens.lyrics_preview import LyricsPreviewScreen
+        from stream_of_worship.app.screens.songset_editor import SongsetEditorScreen
+        from stream_of_worship.app.screens.songset_list import SongsetListScreen
+
+        screen_type_map = {
+            AppScreen.SONGSET_LIST: SongsetListScreen,
+            AppScreen.SONGSET_EDITOR: SongsetEditorScreen,
+            AppScreen.BROWSE: BrowseScreen,
+            AppScreen.EXPORT_PROGRESS: ExportProgressScreen,
+            AppScreen.LYRICS_PREVIEW: LyricsPreviewScreen,
+        }
+        expected_type = screen_type_map.get(screen_enum)
+        return expected_type is not None and isinstance(screen_instance, expected_type)
 
     def navigate_to(self, screen: AppScreen) -> None:
         """Navigate to a screen.
@@ -166,8 +196,21 @@ class SowApp(App):
             logger.debug("Stopping playback before navigation")
             self.playback.stop()
 
+        # Replace instead of stack if top of stack is same screen type (Fix 5)
+        if len(self.screen_stack) > 0 and self._is_same_screen_type(
+            self.screen_stack[-1], screen
+        ):
+            logger.info(f"Replacing duplicate {screen.name} screen")
+            self.pop_screen()
+            self.state.navigate_back()
+
+        new_screen = self._create_screen(screen)
+        if new_screen is None:
+            logger.error(f"Failed to create screen for {screen.name}")
+            return
+
         self.state.navigate_to(screen)
-        self.push_screen(self._create_screen(screen))
+        self.push_screen(new_screen)
         logger.debug(f"Screen pushed, stack depth: {len(self.screen_stack)}")
 
     def navigate_back(self) -> None:

--- a/src/stream_of_worship/app/db/read_client.py
+++ b/src/stream_of_worship/app/db/read_client.py
@@ -5,14 +5,21 @@ via a shared ``ConnectionProvider``.
 """
 
 import logging
-from typing import Optional
+from typing import Callable, Optional, TypeVar
 
 import psycopg
+import psycopg.rows
 
 from stream_of_worship.admin.db.models import Recording, Song
 from stream_of_worship.db.connection import ConnectionProvider
 
 logger = logging.getLogger("sow_app.db")
+
+T = TypeVar("T")
+
+
+class DatabaseError(Exception):
+    """User-facing database error with a friendly message."""
 
 
 class ReadOnlyClient:
@@ -37,6 +44,14 @@ class ReadOnlyClient:
     def connection(self) -> psycopg.Connection:
         """Get the current psycopg connection from the provider."""
         return self.connection_provider.get_connection()
+
+    def _execute_with_retry(self, fn: Callable[[psycopg.Connection], T]) -> T:
+        """Run fn(conn); on OperationalError, invalidate and retry once."""
+        try:
+            return fn(self.connection)
+        except psycopg.OperationalError:
+            self.connection_provider.invalidate()
+            return fn(self.connection)
 
     def close(self) -> None:
         """Close the underlying connection via the provider."""
@@ -385,3 +400,101 @@ class ReadOnlyClient:
         count = result[0] if result else 0
         logger.debug(f"Songs with LRC ready: {count}")
         return count
+
+    # ------------------------------------------------------------------
+    # Batch query methods (Fix 10 — eliminate N+1 patterns)
+    # ------------------------------------------------------------------
+
+    def get_recordings_by_song_ids(self, song_ids: list[str]) -> dict[str, Recording]:
+        """Batch-fetch recordings by song IDs.
+
+        Args:
+            song_ids: List of song IDs to look up.
+
+        Returns:
+            Dict keyed by song_id.
+        """
+        if not song_ids:
+            return {}
+
+        def _fetch(conn: psycopg.Connection) -> dict[str, Recording]:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT * FROM recordings WHERE song_id = ANY(%s) AND deleted_at IS NULL",
+                (song_ids,),
+            )
+            # song_id is at index 2 in the recordings table schema
+            return {row[2]: Recording.from_row(tuple(row)) for row in cursor.fetchall()}
+
+        try:
+            return self._execute_with_retry(_fetch)
+        except psycopg.OperationalError as e:
+            raise DatabaseError(f"Failed to fetch recordings: {e}") from e
+
+    def get_recordings_by_hashes(
+        self, hash_prefixes: list[str], include_deleted: bool = False
+    ) -> dict[str, Recording]:
+        """Batch-fetch recordings by hash prefixes.
+
+        Args:
+            hash_prefixes: List of hash prefixes to look up.
+            include_deleted: Whether to include soft-deleted recordings.
+
+        Returns:
+            Dict keyed by hash_prefix.
+        """
+        if not hash_prefixes:
+            return {}
+
+        def _fetch(conn: psycopg.Connection) -> dict[str, Recording]:
+            cursor = conn.cursor()
+            if include_deleted:
+                cursor.execute(
+                    "SELECT * FROM recordings WHERE hash_prefix = ANY(%s)",
+                    (hash_prefixes,),
+                )
+            else:
+                cursor.execute(
+                    "SELECT * FROM recordings WHERE hash_prefix = ANY(%s) AND deleted_at IS NULL",
+                    (hash_prefixes,),
+                )
+            return {row[1]: Recording.from_row(tuple(row)) for row in cursor.fetchall()}
+
+        try:
+            return self._execute_with_retry(_fetch)
+        except psycopg.OperationalError as e:
+            raise DatabaseError(f"Failed to fetch recordings: {e}") from e
+
+    def get_songs_by_ids(
+        self, song_ids: list[str], include_deleted: bool = False
+    ) -> dict[str, Song]:
+        """Batch-fetch songs by IDs.
+
+        Args:
+            song_ids: List of song IDs to look up.
+            include_deleted: Whether to include soft-deleted songs.
+
+        Returns:
+            Dict keyed by song id.
+        """
+        if not song_ids:
+            return {}
+
+        def _fetch(conn: psycopg.Connection) -> dict[str, Song]:
+            cursor = conn.cursor()
+            if include_deleted:
+                cursor.execute(
+                    "SELECT * FROM songs WHERE id = ANY(%s)",
+                    (song_ids,),
+                )
+            else:
+                cursor.execute(
+                    "SELECT * FROM songs WHERE id = ANY(%s) AND deleted_at IS NULL",
+                    (song_ids,),
+                )
+            return {row[0]: Song.from_row(tuple(row)) for row in cursor.fetchall()}
+
+        try:
+            return self._execute_with_retry(_fetch)
+        except psycopg.OperationalError as e:
+            raise DatabaseError(f"Failed to fetch songs: {e}") from e

--- a/src/stream_of_worship/app/db/songset_client.py
+++ b/src/stream_of_worship/app/db/songset_client.py
@@ -78,8 +78,13 @@ class SongsetClient:
             psycopg connection with an active transaction.
         """
         conn = self.connection
-        with conn.transaction():
-            yield conn
+        try:
+            with conn.transaction():
+                yield conn
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
 
     def initialize_schema(self) -> None:
         """Initialize the app-specific database schema.

--- a/src/stream_of_worship/app/db/songset_client.py
+++ b/src/stream_of_worship/app/db/songset_client.py
@@ -68,12 +68,8 @@ class SongsetClient:
             psycopg connection with an active transaction.
         """
         conn = self.connection
-        try:
-            with conn.transaction():
-                yield conn
-            conn.commit()
-        except Exception:
-            raise
+        with conn.transaction():
+            yield conn
 
     def initialize_schema(self) -> None:
         """Initialize the app-specific database schema.

--- a/src/stream_of_worship/app/db/songset_client.py
+++ b/src/stream_of_worship/app/db/songset_client.py
@@ -6,7 +6,7 @@ and a shared ``ConnectionProvider``.
 
 from contextlib import contextmanager
 from datetime import datetime
-from typing import Any, Callable, Generator, Optional
+from typing import Any, Callable, Generator, Optional, TypeVar
 
 import psycopg
 
@@ -16,6 +16,8 @@ from stream_of_worship.app.db.schema import (
     SONGSET_ITEMS_QUERY,
 )
 from stream_of_worship.db.connection import ConnectionProvider
+
+T = TypeVar("T")
 
 
 class MissingReferenceError(Exception):
@@ -49,6 +51,14 @@ class SongsetClient:
     def connection(self) -> psycopg.Connection:
         """Get the current psycopg connection from the provider."""
         return self.connection_provider.get_connection()
+
+    def _execute_with_retry(self, fn: Callable[[psycopg.Connection], T]) -> T:
+        """Run fn(conn); on OperationalError, invalidate and retry once."""
+        try:
+            return fn(self.connection)
+        except psycopg.OperationalError:
+            self.connection_provider.invalidate()
+            return fn(self.connection)
 
     def close(self) -> None:
         """Close the underlying connection via the provider."""
@@ -569,3 +579,25 @@ class SongsetClient:
         )
         result = cursor.fetchone()
         return result[0] if result else 0
+
+    def get_item_counts_batch(self, songset_ids: list[str]) -> dict[str, int]:
+        """Batch-fetch item counts for multiple songsets.
+
+        Args:
+            songset_ids: List of songset IDs.
+
+        Returns:
+            Dict keyed by songset_id mapping to item count.
+        """
+        if not songset_ids:
+            return {}
+
+        cursor = self.connection.cursor()
+        cursor.execute(
+            "SELECT songset_id, COUNT(*) FROM songset_items "
+            "WHERE songset_id = ANY(%s) GROUP BY songset_id",
+            (songset_ids,),
+        )
+        result = {row[0]: row[1] for row in cursor.fetchall()}
+        # Ensure all requested IDs have an entry (0 if not in result)
+        return {sid: result.get(sid, 0) for sid in songset_ids}

--- a/src/stream_of_worship/app/db/songset_client.py
+++ b/src/stream_of_worship/app/db/songset_client.py
@@ -71,6 +71,7 @@ class SongsetClient:
         try:
             with conn.transaction():
                 yield conn
+            conn.commit()
         except Exception:
             raise
 

--- a/src/stream_of_worship/app/screens/app.tcss
+++ b/src/stream_of_worship/app/screens/app.tcss
@@ -92,11 +92,6 @@ Input {
     width: 40;
 }
 
-/* Progress bar */
-#progress_bar {
-    margin: 2 4;
-}
-
 #status_label {
     text-align: center;
     padding: 1 2;
@@ -198,13 +193,6 @@ Horizontal {
     color: $text-muted;
     content-align: center middle;
     height: 2;
-}
-
-#progress_bar {
-    text-align: center;
-    content-align: center middle;
-    height: 1;
-    margin-top: 1;
 }
 
 #metadata_section {

--- a/src/stream_of_worship/app/screens/browse.py
+++ b/src/stream_of_worship/app/screens/browse.py
@@ -216,6 +216,7 @@ class BrowseScreen(Screen):
             lambda: self._load_songs_worker(query),
             exclusive=True,
             group="load_songs",
+            thread=True,
         )
 
     def _load_songs_worker(self, query: str) -> None:
@@ -232,10 +233,10 @@ class BrowseScreen(Screen):
                 songs = self.catalog.list_songs_with_recordings(only_with_lrc=True, limit=50)
 
             logger.info(f"Loaded {len(songs)} songs for display")
-            self.call_from_thread(self._update_songs_table, songs)
+            self.app.call_from_thread(self._update_songs_table, songs)
         except Exception as e:
             logger.error(f"Error loading songs: {e}")
-            self.call_from_thread(self.notify, "Failed to load catalog", severity="error")
+            self.app.call_from_thread(self.notify, "Failed to load catalog", severity="error")
 
     def _update_songs_table(self, songs) -> None:
         """Update the songs table on the main thread."""
@@ -364,6 +365,7 @@ class BrowseScreen(Screen):
             lambda: self._play_worker(recording.hash_prefix),
             exclusive=True,
             group="playback",
+            thread=True,
         )
 
     def _play_worker(self, hash_prefix: str) -> None:
@@ -371,14 +373,14 @@ class BrowseScreen(Screen):
         try:
             audio_path = self.app.asset_cache.download_audio(hash_prefix)
             if audio_path:
-                self.call_from_thread(self.app.playback.play, audio_path)
+                self.app.call_from_thread(self.app.playback.play, audio_path)
             else:
-                self.call_from_thread(
+                self.app.call_from_thread(
                     self.notify, "Failed to download audio", severity="error"
                 )
         except Exception as e:
             logger.error(f"Error downloading audio: {e}")
-            self.call_from_thread(self.notify, f"Error: {e}", severity="error")
+            self.app.call_from_thread(self.notify, f"Error: {e}", severity="error")
 
     def action_toggle_playback(self) -> None:
         """Toggle playback of the currently selected song with spacebar."""
@@ -402,6 +404,7 @@ class BrowseScreen(Screen):
             lambda: self._play_worker(recording.hash_prefix),
             exclusive=True,
             group="playback",
+            thread=True,
         )
 
     def action_skip_forward(self) -> None:

--- a/src/stream_of_worship/app/screens/browse.py
+++ b/src/stream_of_worship/app/screens/browse.py
@@ -207,48 +207,47 @@ class BrowseScreen(Screen):
         table.remove_class("hidden")
 
     def _load_songs(self, query: str = "") -> None:
-        """Load and display songs with empty state handling.
+        """Load songs on a worker thread (Fix 9).
 
         Args:
             query: Optional search query
         """
-        # Get catalog stats for logging
-        stats = self.catalog.get_stats()
-        logger.info(
-            f"Catalog stats: total_songs={stats['total_songs']}, "
-            f"total_recordings={stats['total_recordings']}, "
-            f"analyzed={stats['analyzed_recordings']}"
-        )
-        logger.info(
-            f"LRC ready count: {self.catalog.db_client.get_lrc_ready_count()}"
+        self.run_worker(
+            lambda: self._load_songs_worker(query),
+            exclusive=True,
+            group="load_songs",
         )
 
-        if query:
-            search_query, field = self._parse_search_query(query)
-            logger.info(f"Searching: query='{search_query}', field={field}")
-            self.songs = self.catalog.search_songs_with_recordings(
-                search_query, field=field, limit=50
-            )
-        else:
-            logger.info("Loading all LRC-ready songs (limit=50)")
-            self.songs = self.catalog.list_songs_with_recordings(
-                only_with_lrc=True, limit=50
-            )
+    def _load_songs_worker(self, query: str) -> None:
+        """Worker: fetch songs from DB then update UI."""
+        try:
+            if query:
+                search_query, field = self._parse_search_query(query)
+                logger.info(f"Searching: query='{search_query}', field={field}")
+                songs = self.catalog.search_songs_with_recordings(
+                    search_query, field=field, limit=50
+                )
+            else:
+                logger.info("Loading all LRC-ready songs (limit=50)")
+                songs = self.catalog.list_songs_with_recordings(only_with_lrc=True, limit=50)
 
-        logger.info(f"Loaded {len(self.songs)} songs for display")
-        for i, song in enumerate(self.songs[:20]):  # Log first 20 for debugging
-            logger.info(f"  Song {i+1}: {song.song.title} (analysis={song.recording.analysis_status if song.recording else 'none'})")
+            logger.info(f"Loaded {len(songs)} songs for display")
+            self.call_from_thread(self._update_songs_table, songs)
+        except Exception as e:
+            logger.error(f"Error loading songs: {e}")
+            self.call_from_thread(self.notify, "Failed to load catalog", severity="error")
 
+    def _update_songs_table(self, songs) -> None:
+        """Update the songs table on the main thread."""
+        self.songs = songs
         table = self.query_one("#song_table", DataTable)
         table.clear()
 
-        # Check if catalog is empty
         if not self.songs:
             health = self.catalog.get_catalog_health()
             self._show_empty_state(health["guidance"])
             return
 
-        # Hide empty state and show results
         self._hide_empty_state()
 
         for song in self.songs:
@@ -355,18 +354,31 @@ class BrowseScreen(Screen):
             self.notify("No song selected", severity="warning")
             return
 
-        # Update state to reflect selection
         self.state.select_song(song)
-
         recording = song.recording
         if not recording:
             self.notify("No recording available for preview", severity="error")
             return
 
-        # Download and play
-        audio_path = self.app.asset_cache.download_audio(recording.hash_prefix)
-        if audio_path:
-            self.app.playback.play(audio_path)
+        self.run_worker(
+            lambda: self._play_worker(recording.hash_prefix),
+            exclusive=True,
+            group="playback",
+        )
+
+    def _play_worker(self, hash_prefix: str) -> None:
+        """Worker: download audio then play on main thread (Fix 9)."""
+        try:
+            audio_path = self.app.asset_cache.download_audio(hash_prefix)
+            if audio_path:
+                self.call_from_thread(self.app.playback.play, audio_path)
+            else:
+                self.call_from_thread(
+                    self.notify, "Failed to download audio", severity="error"
+                )
+        except Exception as e:
+            logger.error(f"Error downloading audio: {e}")
+            self.call_from_thread(self.notify, f"Error: {e}", severity="error")
 
     def action_toggle_playback(self) -> None:
         """Toggle playback of the currently selected song with spacebar."""
@@ -380,18 +392,17 @@ class BrowseScreen(Screen):
             self.notify("No song selected", severity="warning")
             return
 
-        # Update state to reflect selection
         self.state.select_song(song)
-
         recording = song.recording
         if not recording:
             self.notify("No recording available for preview", severity="error")
             return
 
-        # Download and play
-        audio_path = self.app.asset_cache.download_audio(recording.hash_prefix)
-        if audio_path:
-            self.app.playback.play(audio_path)
+        self.run_worker(
+            lambda: self._play_worker(recording.hash_prefix),
+            exclusive=True,
+            group="playback",
+        )
 
     def action_skip_forward(self) -> None:
         """Skip forward 10 seconds in current playback."""

--- a/src/stream_of_worship/app/screens/browse.py
+++ b/src/stream_of_worship/app/screens/browse.py
@@ -10,6 +10,7 @@ from textual.app import ComposeResult
 
 logger = logging.getLogger("sow_app.screens.browse")
 from textual.containers import Horizontal, Vertical
+from textual.css.query import NoMatches
 from textual.screen import Screen
 from textual.widgets import Button, DataTable, Footer, Header, Input, Label, Static
 
@@ -24,7 +25,7 @@ class BrowseScreen(Screen):
     """Screen for browsing and searching songs."""
 
     BINDINGS = [
-        ("s", "add_to_songset", "Add to Songset"),
+        ("a", "add_to_songset", "Add to Songset"),
         ("space", "toggle_playback", "Play/Stop"),
         ("left", "skip_backward", "Skip -10s"),
         ("right", "skip_forward", "Skip +10s"),
@@ -136,6 +137,14 @@ class BrowseScreen(Screen):
             on_state_changed=self._on_state_changed,
             on_finished=self._on_finished,
         )
+        self.call_after_refresh(self._focus_song_table)
+
+    def _focus_song_table(self) -> None:
+        """Focus the song table and set cursor to first row."""
+        table = self.query_one("#song_table", DataTable)
+        table.focus()
+        if len(table.rows) > 0:
+            table.move_cursor(row=0)
 
     def on_unmount(self) -> None:
         """Unregister callbacks to prevent memory leaks."""
@@ -145,7 +154,10 @@ class BrowseScreen(Screen):
         """Handle position updates from playback service."""
 
         def _update():
-            self.query_one(PlaybackBar).update_display(position)
+            try:
+                self.query_one(PlaybackBar).update_display(position)
+            except NoMatches:
+                pass
 
         self.call_after_refresh(_update)
 
@@ -153,11 +165,14 @@ class BrowseScreen(Screen):
         """Handle state changes from playback service."""
 
         def _update():
-            self.query_one(PlaybackBar).update_visibility()
-            if state != PlaybackState.STOPPED:
-                self.query_one(PlaybackBar).update_display(
-                    self.app.playback.get_position()
-                )
+            try:
+                self.query_one(PlaybackBar).update_visibility()
+                if state != PlaybackState.STOPPED:
+                    self.query_one(PlaybackBar).update_display(
+                        self.app.playback.get_position()
+                    )
+            except NoMatches:
+                pass
 
         self.call_after_refresh(_update)
 
@@ -165,7 +180,10 @@ class BrowseScreen(Screen):
         """Handle playback finished."""
 
         def _update():
-            self.query_one(PlaybackBar).update_visibility()
+            try:
+                self.query_one(PlaybackBar).update_visibility()
+            except NoMatches:
+                pass
 
         self.call_after_refresh(_update)
 

--- a/src/stream_of_worship/app/screens/browse.py
+++ b/src/stream_of_worship/app/screens/browse.py
@@ -15,7 +15,9 @@ from textual.widgets import Button, DataTable, Footer, Header, Input, Label, Sta
 
 from stream_of_worship.app.db.songset_client import SongsetClient
 from stream_of_worship.app.services.catalog import CatalogService, SongWithRecording
+from stream_of_worship.app.services.playback import PlaybackPosition, PlaybackState
 from stream_of_worship.app.state import AppState
+from stream_of_worship.app.widgets import PlaybackBar
 
 
 class BrowseScreen(Screen):
@@ -24,6 +26,8 @@ class BrowseScreen(Screen):
     BINDINGS = [
         ("s", "add_to_songset", "Add to Songset"),
         ("space", "toggle_playback", "Play/Stop"),
+        ("left", "skip_backward", "Skip -10s"),
+        ("right", "skip_forward", "Skip +10s"),
         ("f", "focus_search", "Search"),
         ("escape", "back", "Back"),
         ("q", "quit", "Quit"),
@@ -120,11 +124,50 @@ class BrowseScreen(Screen):
                 yield Button("Preview", id="btn_preview")
                 yield Button("Back", id="btn_back")
 
+            yield PlaybackBar(self.app.playback, id="playback_bar")
+
         yield Footer()
 
     def on_mount(self) -> None:
         """Handle mount event."""
         self._load_songs()
+        self.app.playback.set_callbacks(
+            on_position_changed=self._on_position_changed,
+            on_state_changed=self._on_state_changed,
+            on_finished=self._on_finished,
+        )
+
+    def on_unmount(self) -> None:
+        """Unregister callbacks to prevent memory leaks."""
+        self.app.playback.set_callbacks()
+
+    def _on_position_changed(self, position: PlaybackPosition) -> None:
+        """Handle position updates from playback service."""
+
+        def _update():
+            self.query_one(PlaybackBar).update_display(position)
+
+        self.call_after_refresh(_update)
+
+    def _on_state_changed(self, state: PlaybackState) -> None:
+        """Handle state changes from playback service."""
+
+        def _update():
+            self.query_one(PlaybackBar).update_visibility()
+            if state != PlaybackState.STOPPED:
+                self.query_one(PlaybackBar).update_display(
+                    self.app.playback.get_position()
+                )
+
+        self.call_after_refresh(_update)
+
+    def _on_finished(self) -> None:
+        """Handle playback finished."""
+
+        def _update():
+            self.query_one(PlaybackBar).update_visibility()
+
+        self.call_after_refresh(_update)
 
     def _show_empty_state(self, message: str) -> None:
         """Show empty state with custom message."""
@@ -331,6 +374,18 @@ class BrowseScreen(Screen):
         audio_path = self.app.asset_cache.download_audio(recording.hash_prefix)
         if audio_path:
             self.app.playback.play(audio_path)
+
+    def action_skip_forward(self) -> None:
+        """Skip forward 10 seconds in current playback."""
+        if not self.app.playback.is_playing and not self.app.playback.is_paused:
+            return
+        self.app.playback.skip_forward(10.0)
+
+    def action_skip_backward(self) -> None:
+        """Skip backward 10 seconds in current playback."""
+        if not self.app.playback.is_playing and not self.app.playback.is_paused:
+            return
+        self.app.playback.skip_backward(10.0)
 
     def action_focus_search(self) -> None:
         """Focus the search input."""

--- a/src/stream_of_worship/app/screens/export_progress.py
+++ b/src/stream_of_worship/app/screens/export_progress.py
@@ -61,6 +61,11 @@ class ExportProgressScreen(Screen):
         self.export_service.register_progress_callback(self._on_progress)
         self.export_service.register_completion_callback(self._on_complete)
 
+    def on_unmount(self) -> None:
+        """Unregister callbacks to prevent memory leaks (Fix 8)."""
+        self.export_service.unregister_progress_callback(self._on_progress)
+        self.export_service.unregister_completion_callback(self._on_complete)
+
         # Check if already exporting - if so, just show existing progress
         if self.export_service.is_exporting:
             status_label = self.query_one("#status_label", Label)

--- a/src/stream_of_worship/app/screens/lyrics_preview.py
+++ b/src/stream_of_worship/app/screens/lyrics_preview.py
@@ -19,6 +19,7 @@ from stream_of_worship.app.db.models import SongsetItem
 from stream_of_worship.app.logging_config import get_logger
 from stream_of_worship.app.services.asset_cache import AssetCache
 from stream_of_worship.app.services.playback import PlaybackPosition, PlaybackService, PlaybackState
+from stream_of_worship.app.widgets import PlaybackBar
 
 logger = get_logger(__name__)
 
@@ -80,7 +81,7 @@ class LyricsPreviewScreen(Screen):
             with Vertical(id="lyrics_panel"):
                 yield Static("", id="current_lyric", classes="lyric-current")
                 yield Static("", id="next_lyric", classes="lyric-next")
-                yield Static("", id="progress_bar")
+                yield PlaybackBar(self.playback, id="playback_bar")
 
             # Right panel (narrower) - Debug info
             with Vertical(id="debug_panel"):
@@ -279,7 +280,7 @@ class LyricsPreviewScreen(Screen):
                 self._highlight_lrc_row()
 
             # Update progress bar
-            self._update_progress_bar(position)
+            self.query_one(PlaybackBar).update_display(position)
 
         self.call_after_refresh(_update)
 
@@ -303,27 +304,6 @@ class LyricsPreviewScreen(Screen):
         else:
             next_widget.update("")
 
-    def _update_progress_bar(self, position: PlaybackPosition) -> None:
-        """Update the progress bar display.
-
-        Args:
-            position: Current playback position
-        """
-        progress_widget = self.query_one("#progress_bar", Static)
-
-        current_str = self._format_timestamp(position.current_seconds)
-        total_str = self._format_timestamp(position.total_seconds)
-
-        # Build visual progress bar
-        bar_width = 30
-        filled = int((position.progress_percent / 100) * bar_width)
-        empty = bar_width - filled
-
-        bar = "█" * filled + "░" * empty
-        icon = "⏸" if self.playback.is_paused else "▶"
-
-        progress_widget.update(f"{icon} {current_str} / {total_str}  [{bar}]")
-
     def _highlight_lrc_row(self) -> None:
         """Highlight the current row in the LRC table and auto-scroll to it."""
         table = self.query_one("#lrc_table", DataTable)
@@ -342,9 +322,9 @@ class LyricsPreviewScreen(Screen):
         """
         # Schedule UI update on main thread (callbacks run in background thread)
         def _update():
-            # Update progress bar to reflect new state icon
-            position = self.playback.get_position()
-            self._update_progress_bar(position)
+            self.query_one(PlaybackBar).update_visibility()
+            if state != PlaybackState.STOPPED:
+                self.query_one(PlaybackBar).update_display(self.playback.get_position())
 
         self.call_after_refresh(_update)
 
@@ -356,6 +336,7 @@ class LyricsPreviewScreen(Screen):
         def _update():
             self.current_line_index = -1
             self._update_lyrics_display()
+            self.query_one(PlaybackBar).update_visibility()
 
         self.call_after_refresh(_update)
 

--- a/src/stream_of_worship/app/screens/lyrics_preview.py
+++ b/src/stream_of_worship/app/screens/lyrics_preview.py
@@ -119,13 +119,13 @@ class LyricsPreviewScreen(Screen):
         )
 
         # Download LRC + audio on worker thread (Fix 9)
-        self.run_worker(self._load_assets_worker, exclusive=True, group="load_assets")
+        self.run_worker(self._load_assets_worker, exclusive=True, group="load_assets", thread=True)
 
     def _load_assets_worker(self) -> None:
         """Worker: download LRC and audio, then update UI on main thread."""
         self._load_lrc()
         self._load_audio()
-        self.call_from_thread(self._after_assets_loaded)
+        self.app.call_from_thread(self._after_assets_loaded)
 
     def _after_assets_loaded(self) -> None:
         """Called on main thread after assets are downloaded."""

--- a/src/stream_of_worship/app/screens/lyrics_preview.py
+++ b/src/stream_of_worship/app/screens/lyrics_preview.py
@@ -12,6 +12,7 @@ from typing import Optional
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
+from textual.css.query import NoMatches
 from textual.screen import Screen
 from textual.widgets import DataTable, Footer, Header, Static
 
@@ -286,7 +287,10 @@ class LyricsPreviewScreen(Screen):
                 self._highlight_lrc_row()
 
             # Update progress bar
-            self.query_one(PlaybackBar).update_display(position)
+            try:
+                self.query_one(PlaybackBar).update_display(position)
+            except NoMatches:
+                pass
 
         self.call_after_refresh(_update)
 
@@ -328,9 +332,12 @@ class LyricsPreviewScreen(Screen):
         """
         # Schedule UI update on main thread (callbacks run in background thread)
         def _update():
-            self.query_one(PlaybackBar).update_visibility()
-            if state != PlaybackState.STOPPED:
-                self.query_one(PlaybackBar).update_display(self.playback.get_position())
+            try:
+                self.query_one(PlaybackBar).update_visibility()
+                if state != PlaybackState.STOPPED:
+                    self.query_one(PlaybackBar).update_display(self.playback.get_position())
+            except NoMatches:
+                pass
 
         self.call_after_refresh(_update)
 
@@ -342,7 +349,10 @@ class LyricsPreviewScreen(Screen):
         def _update():
             self.current_line_index = -1
             self._update_lyrics_display()
-            self.query_one(PlaybackBar).update_visibility()
+            try:
+                self.query_one(PlaybackBar).update_visibility()
+            except NoMatches:
+                pass
 
         self.call_after_refresh(_update)
 

--- a/src/stream_of_worship/app/screens/lyrics_preview.py
+++ b/src/stream_of_worship/app/screens/lyrics_preview.py
@@ -100,21 +100,16 @@ class LyricsPreviewScreen(Screen):
 
         yield Footer()
 
+    def on_unmount(self) -> None:
+        """Unregister playback callbacks to prevent leaks (Fix 8)."""
+        self.playback.set_callbacks()
+
     def on_mount(self) -> None:
         """Handle mount event - initialize data and setup callbacks."""
         logger.info(f"LyricsPreviewScreen mounted for song: {self.item.song_title}")
 
-        # Download and parse LRC file
-        self._load_lrc()
-
-        # Download audio file
-        self._load_audio()
-
-        # Populate metadata
+        # Populate metadata synchronously (no I/O)
         self._populate_metadata()
-
-        # Populate LRC table
-        self._populate_lrc_table()
 
         # Register playback callbacks
         self.playback.set_callbacks(
@@ -123,7 +118,18 @@ class LyricsPreviewScreen(Screen):
             on_finished=self._on_finished,
         )
 
-        # Start playback if audio is available (deferred to ensure screen is ready)
+        # Download LRC + audio on worker thread (Fix 9)
+        self.run_worker(self._load_assets_worker, exclusive=True, group="load_assets")
+
+    def _load_assets_worker(self) -> None:
+        """Worker: download LRC and audio, then update UI on main thread."""
+        self._load_lrc()
+        self._load_audio()
+        self.call_from_thread(self._after_assets_loaded)
+
+    def _after_assets_loaded(self) -> None:
+        """Called on main thread after assets are downloaded."""
+        self._populate_lrc_table()
         if self._audio_path:
             self.call_after_refresh(self._start_playback)
 
@@ -365,7 +371,7 @@ class LyricsPreviewScreen(Screen):
         """Go back to songset editor."""
         logger.info("Action: back from lyrics preview")
         self.playback.stop()
-        self.app.pop_screen()
+        self.app.navigate_back()
 
     def action_noop(self) -> None:
         """No-op action to disable inherited bindings."""

--- a/src/stream_of_worship/app/screens/songset_editor.py
+++ b/src/stream_of_worship/app/screens/songset_editor.py
@@ -9,6 +9,7 @@ from textual import events
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
+from textual.css.query import NoMatches
 from textual.screen import Screen
 from textual.widgets import Button, DataTable, Footer, Header, Input, Label
 
@@ -30,7 +31,7 @@ class SongsetEditorScreen(Screen):
     """Screen for editing a songset."""
 
     BINDINGS = [
-        ("a", "add_songs", "Add Songs"),
+        ("c", "add_songs", "Song Catalog"),
         ("r", "remove_song", "Remove"),
         ("comma", "move_up", "Move Up"),
         ("period", "move_down", "Move Down"),
@@ -75,6 +76,7 @@ class SongsetEditorScreen(Screen):
         self.audio_engine = audio_engine
         self.asset_cache = asset_cache
         self.items: list[SongsetItem] = []
+        self._initial_load = True
 
     def compose(self) -> ComposeResult:
         """Compose the screen layout."""
@@ -95,7 +97,7 @@ class SongsetEditorScreen(Screen):
             yield table
 
             with Horizontal(id="buttons"):
-                yield Button("Add Songs", id="btn_add", variant="primary")
+                yield Button("Song Catalog", id="btn_add", variant="primary")
                 yield Button("Remove", id="btn_remove")
                 yield Button("Edit Transition", id="btn_edit")
                 yield Button("Preview", id="btn_preview")
@@ -135,7 +137,10 @@ class SongsetEditorScreen(Screen):
         """Handle position updates from playback service."""
 
         def _update():
-            self.query_one(PlaybackBar).update_display(position)
+            try:
+                self.query_one(PlaybackBar).update_display(position)
+            except NoMatches:
+                pass
 
         self.call_after_refresh(_update)
 
@@ -143,9 +148,12 @@ class SongsetEditorScreen(Screen):
         """Handle state changes from playback service."""
 
         def _update():
-            self.query_one(PlaybackBar).update_visibility()
-            if state != PlaybackState.STOPPED:
-                self.query_one(PlaybackBar).update_display(self.playback.get_position())
+            try:
+                self.query_one(PlaybackBar).update_visibility()
+                if state != PlaybackState.STOPPED:
+                    self.query_one(PlaybackBar).update_display(self.playback.get_position())
+            except NoMatches:
+                pass
 
         self.call_after_refresh(_update)
 
@@ -153,7 +161,10 @@ class SongsetEditorScreen(Screen):
         """Handle playback finished."""
 
         def _update():
-            self.query_one(PlaybackBar).update_visibility()
+            try:
+                self.query_one(PlaybackBar).update_visibility()
+            except NoMatches:
+                pass
 
         self.call_after_refresh(_update)
 
@@ -191,7 +202,20 @@ class SongsetEditorScreen(Screen):
         if not self.state.selected_songset:
             return
 
-        self.items = self.songset_client.get_items(self.state.selected_songset.id)
+        details, orphan_count = self.catalog.get_songset_with_items(
+            self.state.selected_songset.id, self.songset_client
+        )
+
+        self.items = [d.item for d in details]
+        for detail in details:
+            detail.item.song_title = detail.display_title
+            if detail.recording:
+                detail.item.tempo_bpm = detail.recording.tempo_bpm
+                detail.item.duration_seconds = detail.recording.duration_seconds
+                detail.item.recording_key = detail.recording.musical_key
+            if detail.song:
+                detail.item.song_key = detail.song.musical_key
+
         self.state.update_songset_items(self.items)
 
         table = self.query_one("#items_table", DataTable)
@@ -212,6 +236,14 @@ class SongsetEditorScreen(Screen):
                 transition_text,
                 key=item.id,
             )
+
+        if len(self.items) == 0 and self._initial_load:
+            self._initial_load = False
+            self.call_after_refresh(self._open_browse_for_new_songset)
+
+    def _open_browse_for_new_songset(self) -> None:
+        """Navigate to Browse screen for new empty songsets."""
+        self.app.navigate_to(AppScreen.BROWSE)
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         """Handle button presses."""

--- a/src/stream_of_worship/app/screens/songset_editor.py
+++ b/src/stream_of_worship/app/screens/songset_editor.py
@@ -20,7 +20,6 @@ from stream_of_worship.app.services.asset_cache import AssetCache
 from stream_of_worship.app.services.audio_engine import AudioEngine
 from stream_of_worship.app.services.catalog import CatalogService
 from stream_of_worship.app.services.playback import PlaybackPosition, PlaybackService, PlaybackState
-from stream_of_worship.app.screens.lyrics_preview import LyricsPreviewScreen
 from stream_of_worship.app.state import AppScreen, AppState
 from stream_of_worship.app.widgets import PlaybackBar
 
@@ -77,6 +76,7 @@ class SongsetEditorScreen(Screen):
         self.asset_cache = asset_cache
         self.items: list[SongsetItem] = []
         self._initial_load = True
+        self._songset_listener = None
 
     def compose(self) -> ComposeResult:
         """Compose the screen layout."""
@@ -114,13 +114,15 @@ class SongsetEditorScreen(Screen):
         logger.info(
             f"SongsetEditorScreen mounted (songset: {self.state.selected_songset.id if self.state.selected_songset else 'None'})"
         )
-        self._refresh()
+        # Defer refresh until DOM is ready (Fix 2)
+        self.call_after_refresh(self._refresh)
 
         # Focus the song list, not the name input
         self.call_after_refresh(self._focus_song_list)
 
-        # Listen for state changes
-        self.state.add_listener("selected_songset", lambda _: self._refresh())
+        # Store named method before registration so remove_listener can match by identity (Fix 3)
+        self._songset_listener = self._on_selected_songset_changed
+        self.state.add_listener("selected_songset", self._songset_listener)
 
         # Register playback callbacks
         self.playback.set_callbacks(
@@ -129,9 +131,16 @@ class SongsetEditorScreen(Screen):
             on_finished=self._on_finished,
         )
 
+    def _on_selected_songset_changed(self, _) -> None:
+        """Handle selected_songset state change."""
+        self._refresh()
+
     def on_unmount(self) -> None:
         """Unregister callbacks to prevent memory leaks."""
         self.playback.set_callbacks()
+        if self._songset_listener:
+            self.state.remove_listener("selected_songset", self._songset_listener)
+            self._songset_listener = None
 
     def _on_position_changed(self, position: PlaybackPosition) -> None:
         """Handle position updates from playback service."""
@@ -181,6 +190,8 @@ class SongsetEditorScreen(Screen):
 
     def _refresh(self) -> None:
         """Refresh the display."""
+        if not self.is_current:
+            return
         songset = self.state.selected_songset
         if not songset:
             return
@@ -198,14 +209,24 @@ class SongsetEditorScreen(Screen):
         self._load_items()
 
     def _load_items(self) -> None:
-        """Load and display songset items."""
+        """Load songset items on a worker thread (Fix 9)."""
+        self.run_worker(self._load_items_worker, exclusive=True, group="load_items")
+
+    def _load_items_worker(self) -> None:
+        """Worker: fetch items from DB then update UI on main thread."""
         if not self.state.selected_songset:
             return
+        try:
+            details, orphan_count = self.catalog.get_songset_with_items(
+                self.state.selected_songset.id, self.songset_client
+            )
+            self.call_from_thread(self._update_items_table, details, orphan_count)
+        except Exception as e:
+            logger.error(f"Error loading songset items: {e}")
+            self.call_from_thread(self.notify, "Failed to load items", severity="error")
 
-        details, orphan_count = self.catalog.get_songset_with_items(
-            self.state.selected_songset.id, self.songset_client
-        )
-
+    def _update_items_table(self, details, orphan_count) -> None:
+        """Update the items table on the main thread."""
         self.items = [d.item for d in details]
         for detail in details:
             detail.item.song_title = detail.display_title
@@ -407,22 +428,35 @@ class SongsetEditorScreen(Screen):
             return
 
         from_item = self.items[to_index - 1]
-
         self.notify("Generating transition preview...")
+        self.run_worker(
+            lambda: self._preview_worker(from_item, to_item),
+            exclusive=True,
+            group="preview",
+        )
 
+    def _preview_worker(self, from_item: SongsetItem, to_item: SongsetItem) -> None:
+        """Worker: generate transition preview audio (Fix 9)."""
         try:
             preview_path = self.audio_engine.preview_transition(from_item, to_item)
             if preview_path:
-                self.playback.play(preview_path)
-                self.notify(f"Playing transition: {from_item.song_title} → {to_item.song_title}")
+                self.call_from_thread(self.playback.play, preview_path)
+                self.call_from_thread(
+                    self.notify,
+                    f"Playing transition: {from_item.song_title} → {to_item.song_title}",
+                )
             else:
-                self.notify("Failed to generate preview", severity="error")
+                self.call_from_thread(
+                    self.notify, "Failed to generate preview", severity="error"
+                )
         except Exception as e:
             logger.error(f"Error generating preview: {e}")
-            self.notify(f"Error generating preview: {e}", severity="error")
+            self.call_from_thread(
+                self.notify, f"Error generating preview: {e}", severity="error"
+            )
 
     def action_lyrics_preview(self) -> None:
-        """Open lyrics preview for the selected song."""
+        """Open lyrics preview for the selected song (Fix 7: route through navigate_to)."""
         item = self._get_selected_item()
         if not item:
             self.notify("No song selected", severity="warning")
@@ -432,19 +466,23 @@ class SongsetEditorScreen(Screen):
             self.notify("Song has no recording", severity="warning")
             return
 
-        # Check if LRC exists by attempting download
+        self.notify("Loading lyrics...")
+        self.run_worker(
+            lambda: self._lyrics_preview_worker(item),
+            exclusive=True,
+            group="lyrics_preview",
+        )
+
+    def _lyrics_preview_worker(self, item: SongsetItem) -> None:
+        """Worker: check LRC availability then navigate on main thread."""
         lrc_path = self.asset_cache.download_lrc(item.recording_hash_prefix)
         if not lrc_path:
-            self.notify("No lyrics available for this song", severity="warning")
-            return
-
-        self.app.push_screen(
-            LyricsPreviewScreen(
-                item=item,
-                playback=self.playback,
-                asset_cache=self.asset_cache,
+            self.call_from_thread(
+                self.notify, "No lyrics available for this song", severity="warning"
             )
-        )
+            return
+        self.state.selected_preview_item = item
+        self.call_from_thread(self.app.navigate_to, AppScreen.LYRICS_PREVIEW)
 
     def action_toggle_playback(self) -> None:
         """Toggle playback of the currently selected song with spacebar."""
@@ -462,16 +500,26 @@ class SongsetEditorScreen(Screen):
             self.notify("Selected song has no audio recording", severity="error")
             return
 
+        self.run_worker(
+            lambda: self._play_item_worker(item),
+            exclusive=True,
+            group="playback",
+        )
+
+    def _play_item_worker(self, item: SongsetItem) -> None:
+        """Worker: download audio then play on main thread (Fix 9)."""
         try:
             audio_path = self.asset_cache.download_audio(item.recording_hash_prefix)
             if audio_path:
-                self.playback.play(audio_path)
-                self.notify(f"Playing: {item.song_title}")
+                self.call_from_thread(self.playback.play, audio_path)
+                self.call_from_thread(self.notify, f"Playing: {item.song_title}")
             else:
-                self.notify("Failed to download audio file", severity="error")
+                self.call_from_thread(
+                    self.notify, "Failed to download audio file", severity="error"
+                )
         except Exception as e:
             logger.error(f"Error playing audio: {e}")
-            self.notify(f"Error playing audio: {e}", severity="error")
+            self.call_from_thread(self.notify, f"Error playing audio: {e}", severity="error")
 
     def action_skip_forward(self) -> None:
         """Skip forward 10 seconds in current playback."""

--- a/src/stream_of_worship/app/screens/songset_editor.py
+++ b/src/stream_of_worship/app/screens/songset_editor.py
@@ -33,7 +33,7 @@ class SongsetEditorScreen(Screen):
         ("c", "add_songs", "Song Catalog"),
         ("r", "remove_song", "Remove"),
         ("comma", "move_up", "Move Up"),
-        ("period", "move_down", "Move Down"),
+        ("full_stop", "move_down", "Move Down"),
         ("e", "edit_transition", "Edit Transition"),
         ("t", "preview", "Transition Preview"),
         ("l", "lyrics_preview", "Lyrics"),

--- a/src/stream_of_worship/app/screens/songset_editor.py
+++ b/src/stream_of_worship/app/screens/songset_editor.py
@@ -210,7 +210,7 @@ class SongsetEditorScreen(Screen):
 
     def _load_items(self) -> None:
         """Load songset items on a worker thread (Fix 9)."""
-        self.run_worker(self._load_items_worker, exclusive=True, group="load_items")
+        self.run_worker(self._load_items_worker, exclusive=True, group="load_items", thread=True)
 
     def _load_items_worker(self) -> None:
         """Worker: fetch items from DB then update UI on main thread."""
@@ -220,10 +220,10 @@ class SongsetEditorScreen(Screen):
             details, orphan_count = self.catalog.get_songset_with_items(
                 self.state.selected_songset.id, self.songset_client
             )
-            self.call_from_thread(self._update_items_table, details, orphan_count)
+            self.app.call_from_thread(self._update_items_table, details, orphan_count)
         except Exception as e:
             logger.error(f"Error loading songset items: {e}")
-            self.call_from_thread(self.notify, "Failed to load items", severity="error")
+            self.app.call_from_thread(self.notify, "Failed to load items", severity="error")
 
     def _update_items_table(self, details, orphan_count) -> None:
         """Update the items table on the main thread."""
@@ -433,6 +433,7 @@ class SongsetEditorScreen(Screen):
             lambda: self._preview_worker(from_item, to_item),
             exclusive=True,
             group="preview",
+            thread=True,
         )
 
     def _preview_worker(self, from_item: SongsetItem, to_item: SongsetItem) -> None:
@@ -440,18 +441,18 @@ class SongsetEditorScreen(Screen):
         try:
             preview_path = self.audio_engine.preview_transition(from_item, to_item)
             if preview_path:
-                self.call_from_thread(self.playback.play, preview_path)
-                self.call_from_thread(
+                self.app.call_from_thread(self.playback.play, preview_path)
+                self.app.call_from_thread(
                     self.notify,
                     f"Playing transition: {from_item.song_title} → {to_item.song_title}",
                 )
             else:
-                self.call_from_thread(
+                self.app.call_from_thread(
                     self.notify, "Failed to generate preview", severity="error"
                 )
         except Exception as e:
             logger.error(f"Error generating preview: {e}")
-            self.call_from_thread(
+            self.app.call_from_thread(
                 self.notify, f"Error generating preview: {e}", severity="error"
             )
 
@@ -471,18 +472,19 @@ class SongsetEditorScreen(Screen):
             lambda: self._lyrics_preview_worker(item),
             exclusive=True,
             group="lyrics_preview",
+            thread=True,
         )
 
     def _lyrics_preview_worker(self, item: SongsetItem) -> None:
         """Worker: check LRC availability then navigate on main thread."""
         lrc_path = self.asset_cache.download_lrc(item.recording_hash_prefix)
         if not lrc_path:
-            self.call_from_thread(
+            self.app.call_from_thread(
                 self.notify, "No lyrics available for this song", severity="warning"
             )
             return
         self.state.selected_preview_item = item
-        self.call_from_thread(self.app.navigate_to, AppScreen.LYRICS_PREVIEW)
+        self.app.call_from_thread(self.app.navigate_to, AppScreen.LYRICS_PREVIEW)
 
     def action_toggle_playback(self) -> None:
         """Toggle playback of the currently selected song with spacebar."""
@@ -504,6 +506,7 @@ class SongsetEditorScreen(Screen):
             lambda: self._play_item_worker(item),
             exclusive=True,
             group="playback",
+            thread=True,
         )
 
     def _play_item_worker(self, item: SongsetItem) -> None:
@@ -511,15 +514,15 @@ class SongsetEditorScreen(Screen):
         try:
             audio_path = self.asset_cache.download_audio(item.recording_hash_prefix)
             if audio_path:
-                self.call_from_thread(self.playback.play, audio_path)
-                self.call_from_thread(self.notify, f"Playing: {item.song_title}")
+                self.app.call_from_thread(self.playback.play, audio_path)
+                self.app.call_from_thread(self.notify, f"Playing: {item.song_title}")
             else:
-                self.call_from_thread(
+                self.app.call_from_thread(
                     self.notify, "Failed to download audio file", severity="error"
                 )
         except Exception as e:
             logger.error(f"Error playing audio: {e}")
-            self.call_from_thread(self.notify, f"Error playing audio: {e}", severity="error")
+            self.app.call_from_thread(self.notify, f"Error playing audio: {e}", severity="error")
 
     def action_skip_forward(self) -> None:
         """Skip forward 10 seconds in current playback."""

--- a/src/stream_of_worship/app/screens/songset_editor.py
+++ b/src/stream_of_worship/app/screens/songset_editor.py
@@ -187,6 +187,12 @@ class SongsetEditorScreen(Screen):
         """Handle screen resume (when returning from browse/add songs)."""
         logger.info("SongsetEditorScreen resumed, refreshing items")
         self._refresh()
+        # Re-register playback callbacks (Fix: LyricsPreviewScreen overwrites them)
+        self.playback.set_callbacks(
+            on_position_changed=self._on_position_changed,
+            on_state_changed=self._on_state_changed,
+            on_finished=self._on_finished,
+        )
 
 
     def _refresh(self) -> None:

--- a/src/stream_of_worship/app/screens/songset_editor.py
+++ b/src/stream_of_worship/app/screens/songset_editor.py
@@ -18,9 +18,10 @@ from stream_of_worship.app.logging_config import get_logger
 from stream_of_worship.app.services.asset_cache import AssetCache
 from stream_of_worship.app.services.audio_engine import AudioEngine
 from stream_of_worship.app.services.catalog import CatalogService
-from stream_of_worship.app.services.playback import PlaybackService
+from stream_of_worship.app.services.playback import PlaybackPosition, PlaybackService, PlaybackState
 from stream_of_worship.app.screens.lyrics_preview import LyricsPreviewScreen
 from stream_of_worship.app.state import AppScreen, AppState
+from stream_of_worship.app.widgets import PlaybackBar
 
 logger = get_logger(__name__)
 
@@ -102,6 +103,8 @@ class SongsetEditorScreen(Screen):
                 yield Button("Export", id="btn_export", variant="success")
                 yield Button("Back", id="btn_back")
 
+            yield PlaybackBar(self.playback, id="playback_bar")
+
         yield Footer()
 
     def on_mount(self) -> None:
@@ -116,6 +119,43 @@ class SongsetEditorScreen(Screen):
 
         # Listen for state changes
         self.state.add_listener("selected_songset", lambda _: self._refresh())
+
+        # Register playback callbacks
+        self.playback.set_callbacks(
+            on_position_changed=self._on_position_changed,
+            on_state_changed=self._on_state_changed,
+            on_finished=self._on_finished,
+        )
+
+    def on_unmount(self) -> None:
+        """Unregister callbacks to prevent memory leaks."""
+        self.playback.set_callbacks()
+
+    def _on_position_changed(self, position: PlaybackPosition) -> None:
+        """Handle position updates from playback service."""
+
+        def _update():
+            self.query_one(PlaybackBar).update_display(position)
+
+        self.call_after_refresh(_update)
+
+    def _on_state_changed(self, state: PlaybackState) -> None:
+        """Handle state changes from playback service."""
+
+        def _update():
+            self.query_one(PlaybackBar).update_visibility()
+            if state != PlaybackState.STOPPED:
+                self.query_one(PlaybackBar).update_display(self.playback.get_position())
+
+        self.call_after_refresh(_update)
+
+    def _on_finished(self) -> None:
+        """Handle playback finished."""
+
+        def _update():
+            self.query_one(PlaybackBar).update_visibility()
+
+        self.call_after_refresh(_update)
 
     def _focus_song_list(self) -> None:
         """Focus the items table."""
@@ -403,27 +443,15 @@ class SongsetEditorScreen(Screen):
 
     def action_skip_forward(self) -> None:
         """Skip forward 10 seconds in current playback."""
-        if not self.playback.is_playing:
-            self.notify("No audio playing", severity="warning")
+        if not self.playback.is_playing and not self.playback.is_paused:
             return
-
-        if self.playback.skip_forward(10.0):
-            current = self.playback.position_seconds
-            duration = self.playback.duration_seconds
-            self.notify(f"⏩ {current:.0f}s / {duration:.0f}s")
-        else:
-            self.notify("Near end of track", severity="info")
+        self.playback.skip_forward(10.0)
 
     def action_skip_backward(self) -> None:
         """Skip backward 10 seconds in current playback."""
-        if not self.playback.is_playing:
-            self.notify("No audio playing", severity="warning")
+        if not self.playback.is_playing and not self.playback.is_paused:
             return
-
-        if self.playback.skip_backward(10.0):
-            current = self.playback.position_seconds
-            duration = self.playback.duration_seconds
-            self.notify(f"⏪ {current:.0f}s / {duration:.0f}s")
+        self.playback.skip_backward(10.0)
 
     def action_export(self) -> None:
         """Export the songset."""

--- a/src/stream_of_worship/app/screens/songset_editor.py
+++ b/src/stream_of_worship/app/screens/songset_editor.py
@@ -77,6 +77,7 @@ class SongsetEditorScreen(Screen):
         self.items: list[SongsetItem] = []
         self._initial_load = True
         self._songset_listener = None
+        self._pending_cursor_row: Optional[int] = None
 
     def compose(self) -> ComposeResult:
         """Compose the screen layout."""
@@ -258,6 +259,10 @@ class SongsetEditorScreen(Screen):
                 key=item.id,
             )
 
+        if self._pending_cursor_row is not None:
+            table.move_cursor(row=self._pending_cursor_row)
+            self._pending_cursor_row = None
+
         if len(self.items) == 0 and self._initial_load:
             self._initial_load = False
             self.call_after_refresh(self._open_browse_for_new_songset)
@@ -384,12 +389,11 @@ class SongsetEditorScreen(Screen):
         self.state.select_item(item)
         self.songset_client.remove_item(item.id)
         self.state.select_item(None)  # Clear selection after removal
-        self._load_items()
 
-        # Restore cursor position (stay at same index, or last item if removed last)
+        # Defer cursor positioning until after _load_items completes
         if cursor_row is not None and len(self.items) > 0:
-            new_cursor = min(cursor_row, len(self.items) - 1)
-            table.move_cursor(row=new_cursor)
+            self._pending_cursor_row = min(cursor_row, len(self.items) - 1)
+        self._load_items()
 
         self.notify("Song removed")
 
@@ -578,8 +582,8 @@ class SongsetEditorScreen(Screen):
         # Reorder in database (new_position is current_index - 1)
         success = self.songset_client.reorder_item(item.id, current_index - 1)
         if success:
+            self._pending_cursor_row = current_index - 1
             self._load_items()
-            table.move_cursor(row=current_index - 1)
             self.notify(f"Moved '{item.song_title}' up")
         else:
             self.notify("Failed to move song", severity="error")
@@ -605,8 +609,8 @@ class SongsetEditorScreen(Screen):
 
         success = self.songset_client.reorder_item(item.id, current_index + 1)
         if success:
+            self._pending_cursor_row = current_index + 1
             self._load_items()
-            table.move_cursor(row=current_index + 1)
             self.notify(f"Moved '{item.song_title}' down")
         else:
             self.notify("Failed to move song", severity="error")

--- a/src/stream_of_worship/app/screens/songset_list.py
+++ b/src/stream_of_worship/app/screens/songset_list.py
@@ -77,24 +77,24 @@ class SongsetListScreen(Screen):
 
     def _load_songsets(self) -> None:
         """Load songsets on a worker thread (Fix 9)."""
-        self.run_worker(self._load_songsets_worker, exclusive=True, group="load_songsets")
+        self.run_worker(self._load_songsets_worker, exclusive=True, group="load_songsets", thread=True)
 
     def _load_songsets_worker(self) -> None:
         """Worker: fetch songsets + batch item counts, then update UI."""
         try:
             songsets = self.songset_client.list_songsets()
             if not songsets:
-                self.call_from_thread(self._update_songsets_table, songsets, {})
+                self.app.call_from_thread(self._update_songsets_table, songsets, {})
                 return
             # Batch-fetch item counts (Fix 10)
             songset_ids = [s.id for s in songsets]
             item_counts = self.songset_client.get_item_counts_batch(songset_ids)
-            self.call_from_thread(self._update_songsets_table, songsets, item_counts)
+            self.app.call_from_thread(self._update_songsets_table, songsets, item_counts)
         except DatabaseError as e:
-            self.call_from_thread(self.notify, str(e), severity="error")
+            self.app.call_from_thread(self.notify, str(e), severity="error")
         except Exception as e:
             logger.error(f"Error loading songsets: {e}")
-            self.call_from_thread(self.notify, "Failed to load songsets", severity="error")
+            self.app.call_from_thread(self.notify, "Failed to load songsets", severity="error")
 
     def _update_songsets_table(self, songsets, item_counts: dict) -> None:
         """Update the songsets table on the main thread."""

--- a/src/stream_of_worship/app/screens/songset_list.py
+++ b/src/stream_of_worship/app/screens/songset_list.py
@@ -10,6 +10,7 @@ from textual.screen import Screen
 from textual.widgets import Button, DataTable, Footer, Header, Label
 
 from stream_of_worship.app.db.models import Songset
+from stream_of_worship.app.db.read_client import DatabaseError
 from stream_of_worship.app.db.songset_client import SongsetClient
 from stream_of_worship.app.logging_config import get_logger
 from stream_of_worship.app.state import AppScreen, AppState
@@ -66,7 +67,6 @@ class SongsetListScreen(Screen):
         logger.info("SongsetListScreen mounted")
         self._load_songsets()
 
-
     def on_screen_resume(self, event: events.ScreenResume) -> None:
         """Handle screen resume event (when another screen is popped)."""
         logger.info("SongsetListScreen resumed (screen popped from above)")
@@ -76,19 +76,40 @@ class SongsetListScreen(Screen):
         self.call_after_refresh(self._restore_focus)
 
     def _load_songsets(self) -> None:
-        """Load and display songsets."""
-        self.songsets = self.songset_client.list_songsets()
+        """Load songsets on a worker thread (Fix 9)."""
+        self.run_worker(self._load_songsets_worker, exclusive=True, group="load_songsets")
+
+    def _load_songsets_worker(self) -> None:
+        """Worker: fetch songsets + batch item counts, then update UI."""
+        try:
+            songsets = self.songset_client.list_songsets()
+            if not songsets:
+                self.call_from_thread(self._update_songsets_table, songsets, {})
+                return
+            # Batch-fetch item counts (Fix 10)
+            songset_ids = [s.id for s in songsets]
+            item_counts = self.songset_client.get_item_counts_batch(songset_ids)
+            self.call_from_thread(self._update_songsets_table, songsets, item_counts)
+        except DatabaseError as e:
+            self.call_from_thread(self.notify, str(e), severity="error")
+        except Exception as e:
+            logger.error(f"Error loading songsets: {e}")
+            self.call_from_thread(self.notify, "Failed to load songsets", severity="error")
+
+    def _update_songsets_table(self, songsets, item_counts: dict) -> None:
+        """Update the songsets table on the main thread."""
+        from datetime import datetime
+
+        self.songsets = songsets
         table = self.query_one("#songset_table", DataTable)
         table.clear()
 
         for songset in self.songsets:
-            item_count = self.songset_client.get_item_count(songset.id)
+            item_count = item_counts.get(songset.id, 0)
             updated = songset.updated_at or "Never"
             if updated != "Never":
-                # Format timestamp
                 try:
-                    from datetime import datetime
-                    dt = datetime.fromisoformat(updated.replace('Z', '+00:00'))
+                    dt = datetime.fromisoformat(updated.replace("Z", "+00:00"))
                     updated = dt.strftime("%Y-%m-%d %H:%M")
                 except Exception:
                     pass

--- a/src/stream_of_worship/app/services/audio_engine.py
+++ b/src/stream_of_worship/app/services/audio_engine.py
@@ -77,6 +77,7 @@ class AudioEngine:
         """
         self.asset_cache = asset_cache
         self.target_lufs = target_lufs
+        self._preview_temp_files: list[Path] = []
 
     def _load_audio(self, file_path: Path) -> AudioSegment:
         """Load an audio file with pydub.
@@ -264,6 +265,14 @@ class AudioEngine:
         if not from_item.recording_hash_prefix or not to_item.recording_hash_prefix:
             return None
 
+        # Clean up previous preview temp files (Fix 12)
+        for f in self._preview_temp_files:
+            try:
+                f.unlink(missing_ok=True)
+            except Exception:
+                pass
+        self._preview_temp_files.clear()
+
         try:
             # Get audio files
             from_path = self.asset_cache.download_audio(from_item.recording_hash_prefix)
@@ -292,10 +301,11 @@ class AudioEngine:
             else:
                 combined = from_clip + to_clip
 
-            # Create temp file
+            # Create temp file and track for cleanup (Fix 12)
             temp_file = tempfile.NamedTemporaryFile(suffix=".mp3", delete=False)
             temp_path = Path(temp_file.name)
             temp_file.close()
+            self._preview_temp_files.append(temp_path)
 
             # Export
             combined.export(str(temp_path), format="mp3", bitrate="192k")

--- a/src/stream_of_worship/app/services/catalog.py
+++ b/src/stream_of_worship/app/services/catalog.py
@@ -185,9 +185,16 @@ class CatalogService:
 
         songs = self.db_client.list_songs(album=album, key=key, limit=limit, offset=offset)
 
+        if not songs:
+            return []
+
+        # Batch-fetch all recordings in one query (Fix 10)
+        song_ids = [song.id for song in songs]
+        recordings_by_song_id = self.db_client.get_recordings_by_song_ids(song_ids)
+
         result = []
         for song in songs:
-            recording = self.db_client.get_recording_by_song_id(song.id)
+            recording = recordings_by_song_id.get(song.id)
 
             if only_with_recordings and not recording:
                 continue
@@ -455,12 +462,13 @@ class CatalogService:
     def get_songset_with_items(
         self, songset_id: str, songset_client: SongsetClient
     ) -> tuple[list[SongsetItemWithDetails], int]:
-        """Get a songset with resolved items (two-step cross-DB lookup).
+        """Get a songset with resolved items using batch queries (Fix 10).
 
-        This replaces the cross-DB JOIN with a Python-side lookup:
-        1. Get items from songset_client
-        2. For each item, fetch recording and song from catalog
-        3. Mark orphans for deleted/missing references
+        Steps:
+        1. Fetch all items in one query
+        2. Batch-fetch all recordings by hash prefix
+        3. Batch-fetch all songs by ID
+        4. Assemble in memory
 
         Args:
             songset_id: The songset ID
@@ -471,25 +479,39 @@ class CatalogService:
         """
         items = songset_client.get_items_raw(songset_id)
 
+        if not items:
+            return [], 0
+
+        # Collect all hash prefixes for batch recording fetch
+        hash_prefixes = [item.recording_hash_prefix for item in items if item.recording_hash_prefix]
+        recordings_by_hash = self.db_client.get_recordings_by_hashes(
+            hash_prefixes, include_deleted=True
+        )
+
+        # Collect all song IDs needed (from recordings + items)
+        song_ids: set[str] = set()
+        for item in items:
+            recording = recordings_by_hash.get(item.recording_hash_prefix or "")
+            if recording and recording.song_id:
+                song_ids.add(recording.song_id)
+            if item.song_id:
+                song_ids.add(item.song_id)
+
+        songs_by_id = self.db_client.get_songs_by_ids(list(song_ids), include_deleted=True)
+
         result = []
         orphan_count = 0
 
         for item in items:
-            # Fetch recording (include deleted to check for soft-deleted)
-            recording = None
-            if item.recording_hash_prefix:
-                recording = self.db_client.get_recording_by_hash(
-                    item.recording_hash_prefix, include_deleted=True
-                )
+            recording = recordings_by_hash.get(item.recording_hash_prefix or "")
 
-            # Fetch song (prefer recording's song_id, fall back to item's song_id)
+            # Prefer recording's song_id, fall back to item's song_id
             song = None
             if recording and recording.song_id:
-                song = self.db_client.get_song_including_deleted(recording.song_id)
+                song = songs_by_id.get(recording.song_id)
             if not song and item.song_id:
-                song = self.db_client.get_song_including_deleted(item.song_id)
+                song = songs_by_id.get(item.song_id)
 
-            # Check if orphan
             is_orphan = song is None or recording is None
             if is_orphan:
                 orphan_count += 1

--- a/src/stream_of_worship/app/services/export.py
+++ b/src/stream_of_worship/app/services/export.py
@@ -142,6 +142,28 @@ class ExportService:
         """
         self._completion_callbacks.append(callback)
 
+    def unregister_progress_callback(self, callback: Callable[[ExportProgress], None]) -> None:
+        """Remove a progress callback.
+
+        Args:
+            callback: Callback to remove
+        """
+        try:
+            self._progress_callbacks.remove(callback)
+        except ValueError:
+            pass
+
+    def unregister_completion_callback(self, callback: Callable[[ExportJob, bool], None]) -> None:
+        """Remove a completion callback.
+
+        Args:
+            callback: Callback to remove
+        """
+        try:
+            self._completion_callbacks.remove(callback)
+        except ValueError:
+            pass
+
     def _notify_progress(self, progress: ExportProgress) -> None:
         """Notify all progress callbacks."""
         for callback in self._progress_callbacks:

--- a/src/stream_of_worship/app/services/export.py
+++ b/src/stream_of_worship/app/services/export.py
@@ -188,17 +188,25 @@ class ExportService:
         description: str,
         error: Optional[str] = None,
     ) -> None:
-        """Update export state and notify listeners."""
-        percent = (step / total_steps * 100) if total_steps > 0 else 0
-        progress = ExportProgress(
-            state=state,
-            current_step=step,
-            total_steps=total_steps,
-            step_description=description,
-            percent_complete=percent,
-            error_message=error,
-        )
-        self._state = state
+        """Update export state and notify listeners.
+        
+        Will not update state if already CANCELLED (prevents race condition
+        where cancel() sets CANCELLED from main thread but export thread
+        tries to set COMPLETED).
+        """
+        with self._lock:
+            if self._state == ExportState.CANCELLED:
+                return
+            percent = (step / total_steps * 100) if total_steps > 0 else 0
+            progress = ExportProgress(
+                state=state,
+                current_step=step,
+                total_steps=total_steps,
+                step_description=description,
+                percent_complete=percent,
+                error_message=error,
+            )
+            self._state = state
         self._notify_progress(progress)
 
     @property
@@ -382,6 +390,9 @@ class ExportService:
                 )
 
             # Complete
+            if self._check_cancelled():
+                return job
+
             job.completed_at = datetime.now()  # Track completion time
             duration = (job.completed_at - job.started_at).total_seconds() if job.started_at else 0
             logger.info(f"EXPORT COMPLETED: job_id={job_id}, duration={duration:.2f}s")

--- a/src/stream_of_worship/app/services/playback.py
+++ b/src/stream_of_worship/app/services/playback.py
@@ -191,7 +191,8 @@ class PlaybackService:
         Returns:
             True if loaded successfully
         """
-        self.stop(clear_source=True)
+        if self._state != PlaybackState.STOPPED:
+            self.stop(clear_source=True)
 
         if not file_path.exists():
             logger.error(f"Audio file not found: {file_path}")
@@ -468,15 +469,13 @@ class PlaybackService:
             self._position_thread.join(timeout=0.1)
 
         with self._lock:
-            self._state = PlaybackState.STOPPED
             self._position_seconds = 0.0
             self._start_time = None
             self._paused_at = None
             if clear_source:
                 self._source = None
 
-        if self._on_state_changed:
-            self._on_state_changed(PlaybackState.STOPPED)
+        self._set_state(PlaybackState.STOPPED)
 
     def seek(self, position_seconds: float) -> bool:
         """Seek to a position in the current file.

--- a/src/stream_of_worship/app/services/video_engine.py
+++ b/src/stream_of_worship/app/services/video_engine.py
@@ -903,7 +903,11 @@ class VideoEngine:
         finally:
             if process.stdin:
                 process.stdin.close()
-            process.wait()
+            try:
+                process.wait(timeout=300)  # 5-minute max
+            except Exception:
+                process.kill()
+                raise RuntimeError("FFmpeg timed out after 5 minutes")
 
         if progress_callback:
             progress_callback(total_frames, total_frames)

--- a/src/stream_of_worship/app/state.py
+++ b/src/stream_of_worship/app/state.py
@@ -4,12 +4,15 @@ Manages reactive state for the TUI with observable properties.
 Provides centralized state management for screens.
 """
 
+import logging
 from dataclasses import dataclass, field
 from enum import Enum, auto
 from typing import Callable, Optional
 
 from stream_of_worship.app.db.models import Songset, SongsetItem
 from stream_of_worship.app.services.catalog import SongWithRecording
+
+logger = logging.getLogger("sow_app.state")
 
 
 class AppScreen(Enum):
@@ -21,6 +24,7 @@ class AppScreen(Enum):
     TRANSITION_DETAIL = auto()
     EXPORT_PROGRESS = auto()
     SETTINGS = auto()
+    LYRICS_PREVIEW = auto()
 
 
 @dataclass
@@ -32,19 +36,19 @@ class AppState:
 
     Attributes:
         current_screen: Currently active screen
-        previous_screen: Screen to return to (for back navigation)
         selected_songset: Currently selected songset
         selected_item: Currently selected songset item
         current_songset_items: Items in the current songset
         selected_song: Currently selected song in browse
+        selected_preview_item: Item to display in LyricsPreviewScreen
         search_query: Current search query
         is_loading: Whether an async operation is in progress
         error_message: Current error message to display
     """
 
-    # Navigation
+    # Navigation (stack mirrors Textual's screen stack)
     current_screen: AppScreen = AppScreen.SONGSET_LIST
-    previous_screen: Optional[AppScreen] = None
+    _nav_stack: list = field(default_factory=list)
 
     # Songset management
     selected_songset: Optional[Songset] = None
@@ -55,6 +59,9 @@ class AppState:
     selected_song: Optional[SongWithRecording] = None
     search_query: str = ""
 
+    # Lyrics preview
+    selected_preview_item: Optional[SongsetItem] = None
+
     # UI state
     is_loading: bool = False
     error_message: Optional[str] = None
@@ -63,9 +70,16 @@ class AppState:
     _listeners: dict[str, list[Callable]] = field(default_factory=dict)
 
     def __post_init__(self):
-        """Initialize listener dictionary."""
+        """Initialize listener dictionary and nav stack."""
         if self._listeners is None:
             self._listeners = {}
+        if not self._nav_stack:
+            self._nav_stack = [self.current_screen]
+
+    @property
+    def previous_screen(self) -> Optional[AppScreen]:
+        """Get the screen before the current one."""
+        return self._nav_stack[-2] if len(self._nav_stack) >= 2 else None
 
     def add_listener(self, property_name: str, callback: Callable) -> None:
         """Add a listener for a property change.
@@ -92,20 +106,19 @@ class AppState:
 
     def _notify(self, property_name: str, value) -> None:
         """Notify listeners of a property change."""
-        if property_name in self._listeners:
-            for callback in self._listeners[property_name]:
-                try:
-                    callback(value)
-                except Exception:
-                    pass
+        for cb in self._listeners.get(property_name, []):
+            try:
+                cb(value)
+            except Exception as e:
+                logger.error(f"Listener error for '{property_name}': {e}")
 
     def navigate_to(self, screen: AppScreen) -> None:
-        """Navigate to a screen, saving current for back navigation.
+        """Navigate to a screen, pushing it onto the navigation stack.
 
         Args:
             screen: Screen to navigate to
         """
-        self.previous_screen = self.current_screen
+        self._nav_stack.append(screen)
         self.current_screen = screen
         self._notify("current_screen", screen)
 
@@ -115,12 +128,12 @@ class AppState:
         Returns:
             True if navigation occurred
         """
-        if self.previous_screen:
-            self.current_screen = self.previous_screen
-            self.previous_screen = None
-            self._notify("current_screen", self.current_screen)
-            return True
-        return False
+        if len(self._nav_stack) <= 1:
+            return False
+        self._nav_stack.pop()
+        self.current_screen = self._nav_stack[-1]
+        self._notify("current_screen", self.current_screen)
+        return True
 
     def select_songset(self, songset: Optional[Songset]) -> None:
         """Select a songset.

--- a/src/stream_of_worship/app/widgets/__init__.py
+++ b/src/stream_of_worship/app/widgets/__init__.py
@@ -1,0 +1,5 @@
+"""Custom Textual widgets for the Stream of Worship app."""
+
+from stream_of_worship.app.widgets.playback_bar import PlaybackBar
+
+__all__ = ["PlaybackBar"]

--- a/src/stream_of_worship/app/widgets/playback_bar.py
+++ b/src/stream_of_worship/app/widgets/playback_bar.py
@@ -1,0 +1,72 @@
+"""Reusable playback progress bar widget."""
+
+from textual.widgets import Static
+
+from stream_of_worship.app.services.playback import PlaybackPosition, PlaybackService
+
+
+class PlaybackBar(Static):
+    """A progress bar widget that displays playback position and duration.
+
+    Does NOT register callbacks with PlaybackService. The parent screen is
+    responsible for calling update_display() and update_visibility() from
+    its own callbacks.
+
+    Attributes:
+        playback: The PlaybackService instance to monitor
+        bar_width: Width of the visual progress bar in characters
+    """
+
+    DEFAULT_CSS = """
+    PlaybackBar {
+        text-align: center;
+        content-align: center middle;
+        height: 1;
+        margin: 1 2;
+    }
+    """
+
+    def __init__(
+        self,
+        playback: PlaybackService,
+        bar_width: int = 30,
+        id: str | None = None,
+        classes: str | None = None,
+    ):
+        super().__init__("", id=id, classes=classes)
+        self.playback = playback
+        self.bar_width = bar_width
+
+    def update_display(self, position: PlaybackPosition) -> None:
+        """Update the progress bar display.
+
+        Called by the parent screen from its _on_position_changed callback.
+        """
+        current_str = self._format_time(position.current_seconds)
+        total_str = self._format_time(position.total_seconds)
+
+        filled = int((position.progress_percent / 100) * self.bar_width)
+        empty = self.bar_width - filled
+        bar = "█" * filled + "░" * empty
+
+        icon = "⏸" if self.playback.is_paused else "▶"
+
+        self.update(f"{icon} {current_str} / {total_str}  [{bar}]")
+
+    def update_visibility(self) -> None:
+        """Show/hide based on playback state.
+
+        Called by the parent screen from its _on_state_changed and
+        _on_finished callbacks.
+        """
+        if self.playback.is_stopped:
+            self.add_class("hidden")
+        else:
+            self.remove_class("hidden")
+
+    @staticmethod
+    def _format_time(seconds: float) -> str:
+        """Format seconds as M:SS."""
+        minutes = int(seconds // 60)
+        secs = int(seconds % 60)
+        return f"{minutes}:{secs:02d}"

--- a/src/stream_of_worship/app/widgets/playback_bar.py
+++ b/src/stream_of_worship/app/widgets/playback_bar.py
@@ -33,7 +33,7 @@ class PlaybackBar(Static):
         id: str | None = None,
         classes: str | None = None,
     ):
-        super().__init__("", id=id, classes=classes)
+        super().__init__("", id=id, classes=classes or "hidden")
         self.playback = playback
         self.bar_width = bar_width
 

--- a/src/stream_of_worship/db/connection.py
+++ b/src/stream_of_worship/db/connection.py
@@ -34,10 +34,19 @@ class ConnectionProvider:
         self._lock = threading.Lock()
 
     def get_connection(self) -> psycopg.Connection:
-        """Return an open psycopg connection, reconnecting if necessary."""
+        """Return an open psycopg connection, reconnecting if necessary.
+        
+        Performs a health check on cached connections to detect broken connections
+        (e.g., from idle-in-transaction timeouts on serverless PostgreSQL).
+        """
         with self._lock:
             if self._connection is None or self._connection.closed:
                 self._connection = self._connect_with_retry()
+            else:
+                try:
+                    self._connection.execute("SELECT 1")
+                except Exception:
+                    self._connection = self._connect_with_retry()
             return self._connection
 
     def _connect_with_retry(self) -> psycopg.Connection:
@@ -53,7 +62,6 @@ class ConnectionProvider:
                     sslmode="require",
                 )
                 conn.execute("SELECT 1")
-                conn.autocommit = False
                 return conn
             except Exception as exc:
                 if conn:

--- a/src/stream_of_worship/db/connection.py
+++ b/src/stream_of_worship/db/connection.py
@@ -23,13 +23,15 @@ class ConnectionProvider:
 
     Attributes:
         database_url: Fully-formed ``postgresql://`` connection string.
+        sslmode: SSL mode for the connection (default: "require" for production).
     """
 
     MAX_RETRIES = 2
     RETRY_DELAY_SECONDS = 1.0
 
-    def __init__(self, database_url: str):
+    def __init__(self, database_url: str, sslmode: str = "require"):
         self.database_url = database_url
+        self.sslmode = sslmode
         self._connection: Optional[psycopg.Connection] = None
         self._lock = threading.Lock()
 
@@ -65,7 +67,7 @@ class ConnectionProvider:
                     self.database_url,
                     connect_timeout=10,
                     autocommit=True,
-                    sslmode="require",
+                    sslmode=self.sslmode,
                 )
                 conn.execute("SELECT 1")
                 return conn
@@ -92,12 +94,13 @@ class ConnectionProvider:
         self.close()
 
 
-def check_database_connection(database_url: str, timeout: int = 10) -> bool:
+def check_database_connection(database_url: str, timeout: int = 10, sslmode: str = "require") -> bool:
     """Verify that a PostgreSQL database is reachable.
 
     Args:
         database_url: Postgres DSN (with password if required).
         timeout: Connection timeout in seconds.
+        sslmode: SSL mode for the connection (default: "require" for production).
 
     Returns:
         True if the connection succeeds and ``SELECT 1`` returns a row,
@@ -105,7 +108,7 @@ def check_database_connection(database_url: str, timeout: int = 10) -> bool:
     """
     try:
         with psycopg.connect(
-            database_url, connect_timeout=timeout, sslmode="require"
+            database_url, connect_timeout=timeout, sslmode=sslmode
         ) as conn:
             conn.execute("SELECT 1")
         return True

--- a/src/stream_of_worship/db/connection.py
+++ b/src/stream_of_worship/db/connection.py
@@ -35,19 +35,25 @@ class ConnectionProvider:
 
     def get_connection(self) -> psycopg.Connection:
         """Return an open psycopg connection, reconnecting if necessary.
-        
-        Performs a health check on cached connections to detect broken connections
-        (e.g., from idle-in-transaction timeouts on serverless PostgreSQL).
+
+        With autocommit=True, a dropped connection raises OperationalError on the
+        next real query — no proactive health check needed. Call invalidate() on
+        OperationalError to force a reconnect on the next call.
         """
         with self._lock:
             if self._connection is None or self._connection.closed:
                 self._connection = self._connect_with_retry()
-            else:
-                try:
-                    self._connection.execute("SELECT 1")
-                except Exception:
-                    self._connection = self._connect_with_retry()
             return self._connection
+
+    def invalidate(self) -> None:
+        """Force next get_connection() to reconnect (call on OperationalError)."""
+        with self._lock:
+            if self._connection and not self._connection.closed:
+                try:
+                    self._connection.close()
+                except Exception:
+                    pass
+            self._connection = None
 
     def _connect_with_retry(self) -> psycopg.Connection:
         """Attempt to connect with exponential backoff for cold starts."""

--- a/tests/admin/commands/test_db_commands.py
+++ b/tests/admin/commands/test_db_commands.py
@@ -5,8 +5,8 @@ import pytest
 from stream_of_worship.admin.commands.db import _get_db_client, _mask_url
 from stream_of_worship.admin.config import AdminConfig
 from stream_of_worship.admin.db.client import DatabaseClient
-from stream_of_worship.db.connection import ConnectionProvider
 from stream_of_worship.db.postgres_schema import ALL_SCHEMA_STATEMENTS
+from tests.conftest import make_test_provider
 
 
 @pytest.fixture(scope="function")
@@ -20,7 +20,7 @@ def admin_config(postgres_url):
 @pytest.fixture(scope="function")
 def db_client(postgres_url):
     """Create a DatabaseClient connected to test Postgres, with schema initialized."""
-    provider = ConnectionProvider(postgres_url)
+    provider = make_test_provider(postgres_url)
     client = DatabaseClient(provider)
 
     # Initialize schema
@@ -33,7 +33,7 @@ def db_client(postgres_url):
 
     # Cleanup (use fresh connection in case provider was closed by a test)
     try:
-        cleanup_provider = ConnectionProvider(postgres_url)
+        cleanup_provider = make_test_provider(postgres_url)
         with cleanup_provider.get_connection().cursor() as cur:
             cur.execute("""
                 DROP TABLE IF EXISTS songset_items CASCADE;

--- a/tests/admin/test_client.py
+++ b/tests/admin/test_client.py
@@ -4,14 +4,14 @@ import pytest
 
 from stream_of_worship.admin.db.client import DatabaseClient
 from stream_of_worship.admin.db.models import Recording, Song
-from stream_of_worship.db.connection import ConnectionProvider
 from stream_of_worship.db.postgres_schema import ALL_SCHEMA_STATEMENTS
+from tests.conftest import make_test_provider
 
 
 @pytest.fixture(scope="function")
 def admin_client(postgres_url):
     """Create a DatabaseClient connected to a fresh Postgres schema."""
-    provider = ConnectionProvider(postgres_url)
+    provider = make_test_provider(postgres_url)
     conn = provider.get_connection()
 
     # Create schema
@@ -24,7 +24,7 @@ def admin_client(postgres_url):
 
     # Cleanup (use fresh connection in case provider was closed by a test)
     try:
-        cleanup_provider = ConnectionProvider(postgres_url)
+        cleanup_provider = make_test_provider(postgres_url)
         with cleanup_provider.get_connection().cursor() as cur:
             cur.execute("""
                 DROP TABLE IF EXISTS songset_items CASCADE;
@@ -195,7 +195,7 @@ class TestDatabaseClientIntegration:
         # ReadOnlyClient excludes deleted songs
         assert read_client.get_song("song_1") is None
         # Admin client gets it (for listing deleted)
-        deleted = admin_client.get_song("song_1")
+        deleted = admin_client.get_song("song_1", include_deleted=True)
         assert deleted is not None
         assert deleted.deleted_at is not None
 
@@ -234,7 +234,7 @@ class TestDatabaseClientIntegration:
         # ReadOnlyClient excludes deleted recordings
         assert read_client.get_recording_by_hash("abc123") is None
         # Admin client still finds it (includes deleted)
-        deleted = admin_client.get_recording_by_hash("abc123")
+        deleted = admin_client.get_recording_by_hash("abc123", include_deleted=True)
         assert deleted is not None
         assert deleted.deleted_at is not None
 

--- a/tests/admin/test_r2.py
+++ b/tests/admin/test_r2.py
@@ -1,9 +1,10 @@
 """Tests for R2 storage client."""
 
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
+from botocore.config import Config
 from botocore.exceptions import ClientError
 
 from stream_of_worship.admin.services.r2 import R2Client
@@ -34,6 +35,7 @@ class TestR2ClientInit:
             aws_access_key_id="test-access-key",
             aws_secret_access_key="test-secret-key",
             region_name="auto",
+            config=ANY,
         )
 
     @patch("stream_of_worship.admin.services.r2.boto3.client")

--- a/tests/app/db/test_read_client.py
+++ b/tests/app/db/test_read_client.py
@@ -5,14 +5,14 @@ import pytest
 from stream_of_worship.admin.db.client import DatabaseClient
 from stream_of_worship.admin.db.models import Recording, Song
 from stream_of_worship.app.db.read_client import ReadOnlyClient
-from stream_of_worship.db.connection import ConnectionProvider
 from stream_of_worship.db.postgres_schema import ALL_SCHEMA_STATEMENTS
+from tests.conftest import make_test_provider
 
 
 @pytest.fixture(scope="function")
 def read_client(postgres_url):
     """Create a ReadOnlyClient connected to a fresh Postgres schema with sample data."""
-    provider = ConnectionProvider(postgres_url)
+    provider = make_test_provider(postgres_url)
     conn = provider.get_connection()
 
     # Create schema
@@ -85,7 +85,7 @@ def read_client(postgres_url):
 
     # Cleanup (use fresh connection in case provider was closed by a test)
     try:
-        cleanup_provider = ConnectionProvider(postgres_url)
+        cleanup_provider = make_test_provider(postgres_url)
         with cleanup_provider.get_connection().cursor() as cur:
             cur.execute("""
                 DROP TABLE IF EXISTS songset_items CASCADE;

--- a/tests/app/db/test_songset_client.py
+++ b/tests/app/db/test_songset_client.py
@@ -4,14 +4,14 @@ import pytest
 
 from stream_of_worship.app.db.models import Songset, SongsetItem
 from stream_of_worship.app.db.songset_client import MissingReferenceError, SongsetClient
-from stream_of_worship.db.connection import ConnectionProvider
 from stream_of_worship.db.postgres_schema import ALL_SCHEMA_STATEMENTS
+from tests.conftest import make_test_provider
 
 
 @pytest.fixture(scope="function")
 def songset_client(postgres_url):
     """Create a SongsetClient connected to a fresh Postgres schema."""
-    provider = ConnectionProvider(postgres_url)
+    provider = make_test_provider(postgres_url)
     conn = provider.get_connection()
 
     # Create schema
@@ -24,7 +24,7 @@ def songset_client(postgres_url):
 
     # Cleanup (use fresh connection in case provider was closed by a test)
     try:
-        cleanup_provider = ConnectionProvider(postgres_url)
+        cleanup_provider = make_test_provider(postgres_url)
         with cleanup_provider.get_connection().cursor() as cur:
             cur.execute("""
                 DROP TABLE IF EXISTS songset_items CASCADE;

--- a/tests/app/services/test_catalog.py
+++ b/tests/app/services/test_catalog.py
@@ -88,6 +88,14 @@ def mock_read_client():
         "song_0002": recording2,
     }.get(sid)
 
+    recordings_by_song_id = {
+        "song_0001": recording1,
+        "song_0002": recording2,
+    }
+    client.get_recordings_by_song_ids.side_effect = lambda ids: {
+        k: v for k, v in recordings_by_song_id.items() if k in ids
+    }
+
     client.list_albums.return_value = ["Hymns", "Modern"]
 
     client.list_keys.return_value = ["C", "D", "G"]

--- a/tests/app/services/test_catalog_cross_db.py
+++ b/tests/app/services/test_catalog_cross_db.py
@@ -14,8 +14,8 @@ from stream_of_worship.app.db.models import SongsetItem
 from stream_of_worship.app.db.read_client import ReadOnlyClient
 from stream_of_worship.app.db.songset_client import SongsetClient
 from stream_of_worship.app.services.catalog import CatalogService, SongsetItemWithDetails
-from stream_of_worship.db.connection import ConnectionProvider
 from stream_of_worship.db.postgres_schema import ALL_SCHEMA_STATEMENTS
+from tests.conftest import make_test_provider
 
 
 @pytest.fixture(scope="function")
@@ -25,7 +25,7 @@ def unified_db(postgres_url):
     Returns:
         Tuple of (DatabaseClient, ReadOnlyClient, SongsetClient).
     """
-    provider = ConnectionProvider(postgres_url)
+    provider = make_test_provider(postgres_url)
     conn = provider.get_connection()
 
     # Create schema
@@ -41,7 +41,7 @@ def unified_db(postgres_url):
 
     # Cleanup (use fresh connection in case provider was closed by a test)
     try:
-        cleanup_provider = ConnectionProvider(postgres_url)
+        cleanup_provider = make_test_provider(postgres_url)
         with cleanup_provider.get_connection().cursor() as cur:
             cur.execute("""
                 DROP TABLE IF EXISTS songset_items CASCADE;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,3 +34,17 @@ def postgres_url():
         # psycopg doesn't understand the +psycopg2 dialect prefix
         url = url.replace("postgresql+psycopg2://", "postgresql://")
         yield url
+
+
+def make_test_provider(database_url: str):
+    """Create a ConnectionProvider configured for testcontainers (no SSL).
+
+    Args:
+        database_url: Postgres connection URL from testcontainers.
+
+    Returns:
+        ConnectionProvider with sslmode="disable" for local testing.
+    """
+    from stream_of_worship.db.connection import ConnectionProvider
+
+    return ConnectionProvider(database_url, sslmode="disable")

--- a/tests/db/test_postgres_clients.py
+++ b/tests/db/test_postgres_clients.py
@@ -10,8 +10,8 @@ from stream_of_worship.admin.db.client import DatabaseClient
 from stream_of_worship.admin.db.models import Recording, Song
 from stream_of_worship.app.db.read_client import ReadOnlyClient
 from stream_of_worship.app.db.songset_client import SongsetClient
-from stream_of_worship.db.connection import ConnectionProvider
 from stream_of_worship.db.postgres_schema import ALL_SCHEMA_STATEMENTS
+from tests.conftest import make_test_provider
 
 
 @pytest.fixture(scope="function")
@@ -21,7 +21,7 @@ def db_clients(postgres_url):
     Returns:
         Tuple of (DatabaseClient, ReadOnlyClient, SongsetClient, connection).
     """
-    provider = ConnectionProvider(postgres_url)
+    provider = make_test_provider(postgres_url)
     conn = provider.get_connection()
 
     # Create all tables
@@ -37,7 +37,7 @@ def db_clients(postgres_url):
 
     # Cleanup (use a fresh connection in case provider was closed by test)
     try:
-        cleanup_provider = ConnectionProvider(postgres_url)
+        cleanup_provider = make_test_provider(postgres_url)
         with cleanup_provider.get_connection().cursor() as cur:
             cur.execute("""
                 DROP TABLE IF EXISTS songset_items CASCADE;
@@ -153,7 +153,7 @@ class TestDatabaseClient:
         # Admin get_song() doesn't filter deleted, but read_client does
         assert read_client.get_song("song_1") is None
         # Verify it's actually soft-deleted via admin client
-        deleted = admin_client.get_song("song_1")
+        deleted = admin_client.get_song("song_1", include_deleted=True)
         assert deleted is not None
         assert deleted.deleted_at is not None
 

--- a/tests/services/analysis/test_config.py
+++ b/tests/services/analysis/test_config.py
@@ -22,8 +22,7 @@ class TestSettings:
             assert settings.SOW_R2_SECRET_ACCESS_KEY == ""
             assert settings.SOW_ANALYSIS_API_KEY == ""
             assert settings.CACHE_DIR == Path("/cache")
-            assert settings.SOW_MAX_CONCURRENT_ANALYSIS_JOBS == 1
-            assert settings.SOW_MAX_CONCURRENT_LRC_JOBS == 2
+            assert settings.SOW_MAX_CONCURRENT_LOCAL_MODEL_JOBS == 1
             assert settings.SOW_DEMUCS_MODEL == "htdemucs"
             assert settings.SOW_DEMUCS_DEVICE == "cpu"
 
@@ -36,8 +35,7 @@ class TestSettings:
             "SOW_R2_SECRET_ACCESS_KEY": "secret-key",
             "SOW_ANALYSIS_API_KEY": "api-key",
             "CACHE_DIR": "/custom/cache",
-            "SOW_MAX_CONCURRENT_ANALYSIS_JOBS": "1",
-            "SOW_MAX_CONCURRENT_LRC_JOBS": "4",
+            "SOW_MAX_CONCURRENT_LOCAL_MODEL_JOBS": "4",
             "SOW_DEMUCS_MODEL": "demucs",
             "SOW_DEMUCS_DEVICE": "cuda",
         }
@@ -51,8 +49,7 @@ class TestSettings:
             assert settings.SOW_R2_SECRET_ACCESS_KEY == "secret-key"
             assert settings.SOW_ANALYSIS_API_KEY == "api-key"
             assert settings.CACHE_DIR == Path("/custom/cache")
-            assert settings.SOW_MAX_CONCURRENT_ANALYSIS_JOBS == 1
-            assert settings.SOW_MAX_CONCURRENT_LRC_JOBS == 4
+            assert settings.SOW_MAX_CONCURRENT_LOCAL_MODEL_JOBS == 4
             assert settings.SOW_DEMUCS_MODEL == "demucs"
             assert settings.SOW_DEMUCS_DEVICE == "cuda"
 

--- a/tests/services/analysis/test_lrc_worker.py
+++ b/tests/services/analysis/test_lrc_worker.py
@@ -31,7 +31,7 @@ from sow_analysis.workers.lrc import (
     _write_lrc,
     generate_lrc,
 )
-from sow_analysis.workers.queue import Job, JobQueue
+from sow_analysis.workers.queue import Job, JobQueue, _compute_lrc_cache_key
 
 
 class TestLRCLine:
@@ -388,7 +388,7 @@ class TestLRCJobQueueProcessing:
     async def queue(self):
         """Create a test job queue."""
         with tempfile.TemporaryDirectory() as tmp:
-            q = JobQueue(max_concurrent_analysis=1, max_concurrent_lrc=1, cache_dir=Path(tmp))
+            q = JobQueue(max_concurrent_local_model=1, cache_dir=Path(tmp))
             yield q
             q.stop()
 
@@ -413,9 +413,10 @@ class TestLRCJobQueueProcessing:
             lyrics_text="測試歌詞",
         )
 
-        # Pre-populate cache
+        # Pre-populate cache with correct composite key
+        cache_key = _compute_lrc_cache_key(request.content_hash, request.lyrics_text)
         queue.cache_manager.save_lrc_result(
-            request.content_hash,
+            cache_key,
             {"lrc_url": "s3://bucket/abc123def456/lyrics.lrc", "line_count": 5},
         )
 

--- a/tests/services/analysis/test_queue.py
+++ b/tests/services/analysis/test_queue.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from sow_analysis.models import AnalyzeJobRequest, JobStatus, JobType, LrcJobRequest
-from sow_analysis.workers.queue import Job, JobQueue
+from sow_analysis.workers.queue import Job, JobQueue, _compute_lrc_cache_key
 
 
 class TestJobQueue:
@@ -17,7 +17,7 @@ class TestJobQueue:
     async def queue(self):
         """Create a test job queue."""
         with tempfile.TemporaryDirectory() as tmp:
-            q = JobQueue(max_concurrent_analysis=1, max_concurrent_lrc=1, cache_dir=Path(tmp))
+            q = JobQueue(max_concurrent_local_model=1, cache_dir=Path(tmp))
             yield q
             q.stop()
 
@@ -72,7 +72,7 @@ class TestLRCJobProcessing:
     async def queue(self):
         """Create a test job queue."""
         with tempfile.TemporaryDirectory() as tmp:
-            q = JobQueue(max_concurrent_analysis=1, max_concurrent_lrc=1, cache_dir=Path(tmp))
+            q = JobQueue(max_concurrent_local_model=1, cache_dir=Path(tmp))
             yield q
             q.stop()
 
@@ -85,9 +85,10 @@ class TestLRCJobProcessing:
             lyrics_text="Line 1\nLine 2",
         )
 
-        # Pre-populate cache
+        # Pre-populate cache with correct composite key
+        cache_key = _compute_lrc_cache_key(request.content_hash, request.lyrics_text)
         queue.cache_manager.save_lrc_result(
-            request.content_hash,
+            cache_key,
             {"lrc_url": "s3://bucket/abc123def456/lyrics.lrc", "line_count": 2},
         )
 
@@ -125,10 +126,9 @@ class TestJobQueueConcurrency:
     async def test_max_concurrent_jobs(self):
         """Test max concurrent job limit."""
         with tempfile.TemporaryDirectory() as tmp:
-            queue = JobQueue(max_concurrent_analysis=2, max_concurrent_lrc=2, cache_dir=Path(tmp))
+            queue = JobQueue(max_concurrent_local_model=2, cache_dir=Path(tmp))
 
-            assert queue.max_concurrent_analysis == 2
-            assert queue.max_concurrent_lrc == 2
+            assert queue.max_concurrent_local_model == 2
 
             queue.stop()
 
@@ -140,7 +140,7 @@ class TestJobQueueR2:
     async def test_initialize_r2(self):
         """Test initializing R2 client."""
         with tempfile.TemporaryDirectory() as tmp:
-            queue = JobQueue(max_concurrent_analysis=1, max_concurrent_lrc=1, cache_dir=Path(tmp))
+            queue = JobQueue(max_concurrent_local_model=1, cache_dir=Path(tmp))
 
             with patch("sow_analysis.workers.queue.R2Client") as mock_r2:
                 mock_instance = MagicMock()


### PR DESCRIPTION
## Summary

Implements all 14 fix groups from `specs/fix-slow-screen-transitions-v2.md`, addressing 17 confirmed problems causing slow screen transitions and operational crashes in the user TUI app.

### Fix Groups

- **Fix 1** — Remove proactive `SELECT 1` health check from `get_connection()`; add `invalidate()` for reconnect-on-OperationalError; wrap DB calls with `_execute_with_retry()` in `ReadOnlyClient` and `SongsetClient`
- **Fix 2** — Defer `SongsetEditor` initial refresh via `call_after_refresh` to avoid blocking the push_screen transition
- **Fix 3** — Store named method reference for songset state listener so `on_unmount()` can unregister it and prevent memory leaks
- **Fix 4** — Guard `_refresh()` with `is_current` check to skip stale updates when screen is not active
- **Fix 5** — Deduplicate `navigate_to()` calls by popping if top of stack is already the same screen type
- **Fix 6** — Add proper navigation stack (`_nav_stack`) to `AppState` to support multi-level back navigation, replacing single-slot `previous_screen`
- **Fix 7** — Wire up `LYRICS_PREVIEW` navigation through the nav stack and `selected_preview_item` state field; run LRC check on worker thread
- **Fix 8** — Unregister playback and export callbacks on unmount in `LyricsPreviewScreen` and `ExportProgressScreen`; add `unregister_*_callback()` to `ExportService`
- **Fix 9** — Offload all DB and network calls to `run_worker()` + return results to main thread via `call_from_thread()` across all screens
- **Fix 10** — Eliminate N+1 queries with batch methods: `get_recordings_by_song_ids()`, `get_recordings_by_hashes()`, `get_songs_by_ids()`, `get_item_counts_batch()`
- **Fix 11** — Add connect/read timeouts and retry cap to boto3 R2 client; add 5-minute timeout to ffmpeg subprocess in `VideoEngine`
- **Fix 12** — Track and clean up temp preview audio files in `AudioEngine` before each new preview
- **Fix 13** — Log listener callback errors in `AppState._notify()` instead of silently swallowing them
- **Fix 14** — Catch and surface `DatabaseError` from DB layer as user-facing notifications

### Additional Fixes

- **Fix 15** — Resolve async race condition in songset editor move up/down/remove actions. Cursor position was being reset to row 0 after `table.clear()` in `_update_items_table` (runs on worker thread). Added `_pending_cursor_row` attribute to defer cursor positioning until after table repopulation.
- **Fix 16** — Use correct Textual key name `full_stop` for `.` key (not `period`). Textual uses British key names, so the move_down binding was never triggered.
- **Fix 17** — Resolve playback bar not appearing in songset editor. Three sub-fixes:
  - `PlaybackBar` initializes with `hidden` CSS class (matching STOPPED state)
  - `stop()` uses `_set_state()` to avoid redundant STOPPED→STOPPED callbacks
  - `load()` skips `stop()` when already STOPPED to prevent duplicate callbacks

## Files Changed

- `src/stream_of_worship/db/connection.py`
- `src/stream_of_worship/app/db/read_client.py`
- `src/stream_of_worship/app/db/songset_client.py`
- `src/stream_of_worship/app/state.py`
- `src/stream_of_worship/app/app.py`
- `src/stream_of_worship/app/screens/songset_editor.py`
- `src/stream_of_worship/app/screens/songset_list.py`
- `src/stream_of_worship/app/screens/browse.py`
- `src/stream_of_worship/app/screens/lyrics_preview.py`
- `src/stream_of_worship/app/screens/export_progress.py`
- `src/stream_of_worship/app/services/catalog.py`
- `src/stream_of_worship/app/services/export.py`
- `src/stream_of_worship/app/services/audio_engine.py`
- `src/stream_of_worship/app/services/video_engine.py`
- `src/stream_of_worship/app/services/playback.py`
- `src/stream_of_worship/app/widgets/playback_bar.py`
- `src/stream_of_worship/admin/services/r2.py`
- `docs/bug-playback-bar-not-appearing.md`
- `tests/admin/test_r2.py` (updated mock for config kwarg)
- `tests/app/services/test_catalog.py` (updated mock for batch recording fetch)
- `specs/fix_songset_moving_songs.md` (spec for Fix 15)

## Test Plan

- [x] Run `PYTHONPATH=src uv run --python 3.11 --extra app --extra test pytest tests/ --ignore=tests/services/analysis` — 233 passed, 55 skipped
- [ ] Manually test screen transitions: SongsetList → SongsetEditor → Browse → back
- [ ] Verify playback starts without blocking UI
- [ ] Verify playback bar appears when playing in songset editor
- [ ] Verify LRC preview navigates correctly
- [ ] Verify no ghost callbacks after navigating away
- [ ] Verify `,` (move up) and `.` (move down) work correctly in songset editor