### PR TITLE
feat: add user identity to data model and TUI

### DIFF
--- a/src/stream_of_worship/admin/commands/db.py
+++ b/src/stream_of_worship/admin/commands/db.py
@@ -62,6 +62,15 @@ def init_db(
         "-f",
         help="Force re-initialization (runs schema statements again)",
     ),
+    wipe_songsets: bool = typer.Option(
+        False,
+        "--wipe-songsets",
+        help=(
+            "DROP songsets and songset_items (CASCADE) before applying the "
+            "schema. Required when upgrading a pre-multi-user DB to the new "
+            "schema with user_id NOT NULL."
+        ),
+    ),
     config_path: Path = typer.Option(
         None,
         "--config",
@@ -73,6 +82,9 @@ def init_db(
 
     Creates tables, indexes, and triggers if they don't exist.
     Use --force to re-run schema creation on an existing database.
+    Use --wipe-songsets to drop the existing songsets tables first (no
+    production data exists yet, and this is required to add the user_id
+    NOT NULL column on the songsets table).
     """
     try:
         config = AdminConfig.load(config_path) if config_path else AdminConfig.load()
@@ -92,12 +104,18 @@ def init_db(
     if force:
         console.print("[yellow]Force flag set — re-initializing schema...[/yellow]")
 
+    if wipe_songsets:
+        console.print(
+            "[yellow]--wipe-songsets: dropping songsets and songset_items "
+            "(CASCADE) before schema init...[/yellow]"
+        )
+
     console.print("Connecting to PostgreSQL...")
 
     try:
         client = _get_db_client(config)
         with client:
-            client.initialize_schema()
+            client.initialize_schema(wipe_songsets=wipe_songsets)
             console.print("[green]Postgres schema initialized successfully![/green]")
             # Display connection info without re-connecting
             _show_connection_info(config)

--- a/src/stream_of_worship/admin/commands/users.py
+++ b/src/stream_of_worship/admin/commands/users.py
@@ -1,0 +1,139 @@
+"""User management commands for sow-admin.
+
+Seed and inspect rows in the Better Auth ``"user"`` table. IDs are short
+sequential integers assigned by the DB.
+"""
+
+from pathlib import Path
+from typing import Optional
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from stream_of_worship.admin.config import AdminConfig
+from stream_of_worship.db.connection import ConnectionProvider
+from stream_of_worship.db.user_client import DuplicateEmailError, UserClient
+
+console = Console()
+app = typer.Typer(help="User management operations")
+
+
+def _get_user_client(config: AdminConfig) -> UserClient:
+    provider = ConnectionProvider(config.get_connection_url())
+    return UserClient(provider)
+
+
+def _load_config(config_path: Optional[Path]) -> AdminConfig:
+    try:
+        return AdminConfig.load(config_path) if config_path else AdminConfig.load()
+    except FileNotFoundError:
+        console.print("[red]Config file not found. Run 'sow-admin db init' first.[/red]")
+        raise typer.Exit(1)
+
+
+@app.command("add")
+def add_user(
+    email: str = typer.Argument(..., help="User email (must be unique)"),
+    display_name: Optional[str] = typer.Option(
+        None,
+        "--display-name",
+        "-n",
+        help="Display name (defaults to email local-part)",
+    ),
+    config_path: Optional[Path] = typer.Option(None, "--config", "-c"),
+) -> None:
+    """Create a new user."""
+    config = _load_config(config_path)
+    try:
+        client = _get_user_client(config)
+        with client:
+            user = client.create_user(email=email, name=display_name)
+    except DuplicateEmailError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1)
+    except Exception as exc:
+        console.print(f"[red]Failed to create user: {exc}[/red]")
+        raise typer.Exit(1)
+
+    table = Table(title="User created")
+    table.add_column("ID", style="cyan")
+    table.add_column("Name", style="green")
+    table.add_column("Email", style="green")
+    table.add_row(str(user.id), user.name, user.email)
+    console.print(table)
+
+
+@app.command("list")
+def list_users(
+    config_path: Optional[Path] = typer.Option(None, "--config", "-c"),
+) -> None:
+    """List all users."""
+    config = _load_config(config_path)
+    try:
+        client = _get_user_client(config)
+        with client:
+            users = client.list_users()
+    except Exception as exc:
+        console.print(f"[red]Failed to list users: {exc}[/red]")
+        raise typer.Exit(1)
+
+    if not users:
+        console.print(
+            "[yellow]No users yet.[/yellow] "
+            "Run [cyan]sow-admin users add <email>[/cyan] to create one."
+        )
+        return
+
+    table = Table(title=f"Users ({len(users)})")
+    table.add_column("ID", style="cyan", justify="right")
+    table.add_column("Name", style="green")
+    table.add_column("Email", style="green")
+    table.add_column("Created", style="dim")
+    for user in users:
+        table.add_row(str(user.id), user.name, user.email, user.created_at or "")
+    console.print(table)
+
+
+@app.command("delete")
+def delete_user(
+    user_id: int = typer.Argument(..., help="User ID to delete"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation"),
+    config_path: Optional[Path] = typer.Option(None, "--config", "-c"),
+) -> None:
+    """Delete a user (CASCADE deletes their songsets, settings, etc.)."""
+    config = _load_config(config_path)
+    try:
+        client = _get_user_client(config)
+        with client:
+            user = client.get_user(user_id)
+            if user is None:
+                console.print(f"[red]No user with id {user_id}[/red]")
+                raise typer.Exit(1)
+
+            if not yes:
+                console.print(
+                    f"About to delete [bold]{user.name}[/bold] "
+                    f"({user.email}, id={user.id}).\n"
+                    "[yellow]This will CASCADE delete their songsets, "
+                    "songset_items, user_settings, user_lrc_override, "
+                    "lyric_mark, songset_share rows, and Better Auth account/"
+                    "session rows.[/yellow]"
+                )
+                confirm = typer.confirm("Continue?", default=False)
+                if not confirm:
+                    console.print("[dim]Cancelled.[/dim]")
+                    raise typer.Exit(0)
+
+            deleted = client.delete_user(user_id)
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        console.print(f"[red]Failed to delete user: {exc}[/red]")
+        raise typer.Exit(1)
+
+    if deleted:
+        console.print(f"[green]Deleted user {user_id}[/green]")
+    else:
+        console.print(f"[red]No user with id {user_id}[/red]")
+        raise typer.Exit(1)

--- a/src/stream_of_worship/admin/db/client.py
+++ b/src/stream_of_worship/admin/db/client.py
@@ -16,12 +16,6 @@ import psycopg.errors
 from stream_of_worship.admin.db.models import DatabaseStats, Recording, Song
 from stream_of_worship.admin.db.schema import (
     ACTIVE_ROW_COUNT_QUERY,
-    CREATE_INDEXES,
-    CREATE_RECORDINGS_TABLE,
-    CREATE_RECORDINGS_UPDATE_TRIGGER,
-    CREATE_SONGS_TABLE,
-    CREATE_SONGS_UPDATE_TRIGGER,
-    CREATE_UPDATE_TIMESTAMP_FUNCTION,
     ROW_COUNT_QUERY,
 )
 from stream_of_worship.db.connection import ConnectionProvider
@@ -78,26 +72,33 @@ class DatabaseClient:
         except Exception:
             raise
 
-    def initialize_schema(self) -> None:
-        """Initialize the database schema.
+    def initialize_schema(self, wipe_songsets: bool = False) -> None:
+        """Initialize the full database schema (catalog + auth + app + per-user).
 
-        Creates all tables, indexes, and triggers if they don't exist.
+        Runs the unified ``ALL_SCHEMA_STATEMENTS`` list from
+        ``stream_of_worship.db.postgres_schema``. All statements are
+        ``CREATE ... IF NOT EXISTS`` or ``CREATE OR REPLACE``, so re-running
+        is safe.
+
+        Args:
+            wipe_songsets: If True, drops ``songset_items`` and ``songsets``
+                (CASCADE) before creating the new schema. Used during the
+                multi-user cutover to swap the songsets table for the new
+                NOT NULL ``user_id`` column without preserving old rows.
         """
+        # Lazy import to break the admin.db.__init__ ↔ postgres_schema cycle.
+        from stream_of_worship.db.postgres_schema import ALL_SCHEMA_STATEMENTS
+
         with self.transaction() as conn:
             cursor = conn.cursor()
 
-            # Create tables
-            cursor.execute(CREATE_SONGS_TABLE)
-            cursor.execute(CREATE_RECORDINGS_TABLE)
+            if wipe_songsets:
+                cursor.execute(
+                    "DROP TABLE IF EXISTS songset_items, songsets CASCADE;"
+                )
 
-            # Create indexes
-            for statement in CREATE_INDEXES:
+            for statement in ALL_SCHEMA_STATEMENTS:
                 cursor.execute(statement)
-
-            # Create trigger function and triggers
-            cursor.execute(CREATE_UPDATE_TIMESTAMP_FUNCTION)
-            cursor.execute(CREATE_SONGS_UPDATE_TRIGGER)
-            cursor.execute(CREATE_RECORDINGS_UPDATE_TRIGGER)
 
     def get_stats(self) -> DatabaseStats:
         """Get database statistics.

--- a/src/stream_of_worship/admin/main.py
+++ b/src/stream_of_worship/admin/main.py
@@ -12,6 +12,7 @@ from stream_of_worship.admin import __version__
 from stream_of_worship.admin.commands import audio as audio_commands
 from stream_of_worship.admin.commands import catalog as catalog_commands
 from stream_of_worship.admin.commands import db as db_commands
+from stream_of_worship.admin.commands import users as users_commands
 console = Console()
 
 # Create the main Typer app
@@ -23,6 +24,7 @@ app = typer.Typer(
 
 # Add subcommand groups
 app.add_typer(db_commands.app, name="db", help="Database operations")
+app.add_typer(users_commands.app, name="users", help="User management")
 app.add_typer(catalog_commands.app, name="catalog", help="Catalog operations")
 app.add_typer(audio_commands.app, name="audio", help="Audio recording operations")
 
@@ -53,6 +55,7 @@ def main(
     ## Commands
 
     * [bold cyan]db[/bold cyan] - Database operations (init, status, reset)
+    * [bold cyan]users[/bold cyan] - User management (add, list, delete)
     * [bold cyan]catalog[/bold cyan] - Catalog operations (scrape, list, search, show)
     * [bold cyan]audio[/bold cyan] - Audio operations (download, list, show)
 
@@ -61,10 +64,13 @@ def main(
     1. Initialize the database:
        [dim]$ sow-admin db init[/dim]
 
-    2. Check database status:
+    2. Add a user:
+       [dim]$ sow-admin users add alice@example.com[/dim]
+
+    3. Check database status:
        [dim]$ sow-admin db status[/dim]
 
-    3. Scrape song catalog:
+    4. Scrape song catalog:
        [dim]$ sow-admin catalog scrape --limit 10[/dim]
     """
     pass

--- a/src/stream_of_worship/app/app.py
+++ b/src/stream_of_worship/app/app.py
@@ -6,6 +6,8 @@ manage songsets, and export audio/video.
 
 from textual.app import App
 
+from typing import Optional
+
 from stream_of_worship.admin.services.r2 import R2Client
 from stream_of_worship.app.config import AppConfig
 from stream_of_worship.app.db.read_client import ReadOnlyClient
@@ -18,7 +20,9 @@ from stream_of_worship.app.services.export import ExportService
 from stream_of_worship.app.services.playback import PlaybackService
 from stream_of_worship.app.services.video_engine import VideoEngine
 from stream_of_worship.app.state import AppScreen, AppState
+from stream_of_worship.db.auth_models import User
 from stream_of_worship.db.connection import ConnectionProvider
+from stream_of_worship.db.user_client import UserClient
 
 logger = get_logger(__name__)
 
@@ -54,15 +58,19 @@ class SowApp(App):
         # Initialize state
         self.state = AppState()
 
-        # Shared connection provider for both clients
-        provider = ConnectionProvider(config.get_connection_url())
+        # Shared connection provider for all clients
+        self.provider = ConnectionProvider(config.get_connection_url())
 
         # ReadOnlyClient connects to the catalog tables (SELECT only via role)
-        self.read_client = ReadOnlyClient(provider)
+        self.read_client = ReadOnlyClient(self.provider)
 
-        # SongsetClient connects to the same database (songset CRUD via role)
-        self.songset_client = SongsetClient(provider)
-        self.songset_client.initialize_schema()
+        # UserClient is built up front so the LoginScreen can list users.
+        self.user_client = UserClient(self.provider)
+
+        # SongsetClient is per-user — built once the operator picks a user
+        # on the LOGIN screen via on_user_selected().
+        # Schema is owned by `sow-admin db init`; the TUI never issues DDL.
+        self.songset_client: Optional[SongsetClient] = None
 
         # Initialize services
         self.catalog = CatalogService(self.read_client)
@@ -96,7 +104,17 @@ class SowApp(App):
 
     def on_mount(self) -> None:
         """Handle app mount event."""
-        logger.info("App mounted, navigating to initial screen: SONGSET_LIST")
+        logger.info("App mounted, navigating to initial screen: LOGIN")
+        self.navigate_to(AppScreen.LOGIN)
+
+    def on_user_selected(self, user: User) -> None:
+        """Wire up the per-user ``SongsetClient`` and continue to the list.
+
+        Called by ``LoginScreen`` after the operator picks a user. From this
+        point on, every songset query is scoped to ``user.id``.
+        """
+        logger.info(f"User selected: id={user.id} email={user.email}")
+        self.songset_client = SongsetClient(self.provider, user.id)
         self.navigate_to(AppScreen.SONGSET_LIST)
 
     def action_reconnect_catalog(self) -> None:
@@ -121,7 +139,11 @@ class SowApp(App):
             New screen instance
         """
         logger.debug(f"Creating fresh screen instance: {screen.name}")
-        if screen == AppScreen.SONGSET_LIST:
+        if screen == AppScreen.LOGIN:
+            from stream_of_worship.app.screens.login import LoginScreen
+
+            return LoginScreen(self.state, self.user_client)
+        elif screen == AppScreen.SONGSET_LIST:
             from stream_of_worship.app.screens.songset_list import SongsetListScreen
 
             return SongsetListScreen(self.state, self.songset_client)
@@ -200,7 +222,8 @@ class SowApp(App):
             pass  # Don't fail on logging
 
         self.read_client.close()
-        self.songset_client.close()
+        if self.songset_client is not None:
+            self.songset_client.close()
         self.exit()
 
     def action_navigate_songsets(self) -> None:

--- a/src/stream_of_worship/app/db/models.py
+++ b/src/stream_of_worship/app/db/models.py
@@ -20,6 +20,7 @@ class Songset:
 
     Attributes:
         id: Unique songset ID (e.g., "songset_0001")
+        user_id: Owning user's ID (FK to "user"."id")
         name: Display name for the songset
         description: Optional description
         created_at: ISO timestamp when created
@@ -27,6 +28,7 @@ class Songset:
     """
 
     id: str
+    user_id: int
     name: str
     description: Optional[str] = None
     created_at: Optional[str] = None
@@ -37,17 +39,19 @@ class Songset:
         """Create a Songset from a database row tuple.
 
         Args:
-            row: Database row tuple with columns in schema order.
+            row: Database row tuple with columns in schema order
+                (id, user_id, name, description, created_at, updated_at).
 
         Returns:
             Songset instance.
         """
         return cls(
             id=row[0],
-            name=row[1],
-            description=row[2],
-            created_at=_to_str(row[3]),
-            updated_at=_to_str(row[4]),
+            user_id=row[1],
+            name=row[2],
+            description=row[3],
+            created_at=_to_str(row[4]),
+            updated_at=_to_str(row[5]),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -58,6 +62,7 @@ class Songset:
         """
         return {
             "id": self.id,
+            "user_id": self.user_id,
             "name": self.name,
             "description": self.description,
             "created_at": self.created_at,

--- a/src/stream_of_worship/app/db/schema.py
+++ b/src/stream_of_worship/app/db/schema.py
@@ -7,9 +7,13 @@ These tables live in the same Neon Postgres database as the admin catalog tables
 from stream_of_worship.admin.db.schema import CREATE_UPDATE_TIMESTAMP_FUNCTION
 
 # SQL to create the songsets table (user-created playlists)
+# user_id is BIGINT (matching "user"."id" identity column) and NOT NULL so
+# every songset has an owner. ON DELETE CASCADE removes a user's songsets
+# (and their items, via the FK on songset_items) when the user is deleted.
 CREATE_SONGSETS_TABLE = """
 CREATE TABLE IF NOT EXISTS songsets (
     id TEXT PRIMARY KEY,
+    user_id BIGINT NOT NULL REFERENCES "user"("id") ON DELETE CASCADE,
     name TEXT NOT NULL,
     description TEXT,
     created_at timestamptz DEFAULT NOW(),
@@ -41,6 +45,10 @@ CREATE TABLE IF NOT EXISTS songset_items (
 
 # Indexes for efficient lookups
 CREATE_APP_INDEXES = [
+    """
+    CREATE INDEX IF NOT EXISTS idx_songsets_user_id
+    ON songsets(user_id);
+    """,
     """
     CREATE INDEX IF NOT EXISTS idx_songset_items_songset_id
     ON songset_items(songset_id);

--- a/src/stream_of_worship/app/db/songset_client.py
+++ b/src/stream_of_worship/app/db/songset_client.py
@@ -11,10 +11,7 @@ from typing import Any, Callable, Generator, Optional
 import psycopg
 
 from stream_of_worship.app.db.models import Songset, SongsetItem
-from stream_of_worship.app.db.schema import (
-    ALL_APP_SCHEMA_STATEMENTS,
-    SONGSET_ITEMS_QUERY,
-)
+from stream_of_worship.app.db.schema import SONGSET_ITEMS_QUERY
 from stream_of_worship.db.connection import ConnectionProvider
 
 
@@ -27,23 +24,39 @@ class MissingReferenceError(Exception):
         self.reference_id = reference_id
 
 
-class SongsetClient:
-    """Client for songset CRUD operations.
+class NotOwnerError(Exception):
+    """Raised when a mutation targets a songset not owned by the current user."""
 
-    This client manages the app-specific ``songsets`` and ``songset_items``
-    tables via a ``ConnectionProvider``.
+    def __init__(self, songset_id: str, user_id: int):
+        super().__init__(
+            f"Songset {songset_id!r} is not owned by user {user_id}"
+        )
+        self.songset_id = songset_id
+        self.user_id = user_id
+
+
+class SongsetClient:
+    """Client for songset CRUD operations, scoped to a single user.
+
+    All reads and writes are filtered by ``user_id``: ``list_songsets`` /
+    ``get_songset`` return only this user's rows; ``create_songset`` writes
+    ``user_id`` automatically; mutations on items raise ``NotOwnerError`` if
+    the songset belongs to someone else.
 
     Attributes:
         connection_provider: ``ConnectionProvider`` instance.
+        user_id: Owning user ID; baked into every query.
     """
 
-    def __init__(self, connection_provider: ConnectionProvider):
-        """Initialize the songset client.
+    def __init__(self, connection_provider: ConnectionProvider, user_id: int):
+        """Initialize the songset client for a specific user.
 
         Args:
             connection_provider: ``ConnectionProvider`` wrapping the DSN.
+            user_id: ID of the user whose songsets this client operates on.
         """
         self.connection_provider = connection_provider
+        self.user_id = user_id
 
     @property
     def connection(self) -> psycopg.Connection:
@@ -74,19 +87,29 @@ class SongsetClient:
         except Exception:
             raise
 
-    def initialize_schema(self) -> None:
-        """Initialize the app-specific database schema.
+    # ------------------------------------------------------------------
+    # Ownership helpers
+    # ------------------------------------------------------------------
 
-        Creates songsets and songset_items tables if they don't exist.
-        """
-        with self.transaction() as conn:
-            cursor = conn.cursor()
-            for statement in ALL_APP_SCHEMA_STATEMENTS:
-                cursor.execute(statement)
+    def _owns_songset(self, songset_id: str) -> bool:
+        """Return True iff this client's user owns the given songset."""
+        cursor = self.connection.cursor()
+        cursor.execute(
+            "SELECT 1 FROM songsets WHERE id = %s AND user_id = %s",
+            (songset_id, self.user_id),
+        )
+        return cursor.fetchone() is not None
+
+    def _assert_owner(self, songset_id: str) -> None:
+        """Raise ``NotOwnerError`` if this client's user doesn't own the songset."""
+        if not self._owns_songset(songset_id):
+            raise NotOwnerError(songset_id, self.user_id)
 
     # ------------------------------------------------------------------
     # Songset operations
     # ------------------------------------------------------------------
+
+    _SONGSET_COLUMNS = "id, user_id, name, description, created_at, updated_at"
 
     def create_songset(
         self,
@@ -94,7 +117,7 @@ class SongsetClient:
         description: Optional[str] = None,
         id: Optional[str] = None,
     ) -> Songset:
-        """Create a new songset.
+        """Create a new songset owned by this client's user.
 
         Args:
             name: Display name for the songset.
@@ -106,6 +129,7 @@ class SongsetClient:
         """
         songset = Songset(
             id=id or Songset.generate_id(),
+            user_id=self.user_id,
             name=name,
             description=description,
             created_at=datetime.now().isoformat(),
@@ -116,11 +140,12 @@ class SongsetClient:
             cursor = conn.cursor()
             cursor.execute(
                 """
-                INSERT INTO songsets (id, name, description, created_at, updated_at)
-                VALUES (%s, %s, %s, %s, %s)
+                INSERT INTO songsets (id, user_id, name, description, created_at, updated_at)
+                VALUES (%s, %s, %s, %s, %s, %s)
                 """,
                 (
                     songset.id,
+                    songset.user_id,
                     songset.name,
                     songset.description,
                     songset.created_at,
@@ -131,16 +156,20 @@ class SongsetClient:
         return songset
 
     def get_songset(self, songset_id: str) -> Optional[Songset]:
-        """Get a songset by ID.
+        """Get a songset by ID, scoped to the current user.
 
         Args:
             songset_id: The songset ID.
 
         Returns:
-            ``Songset`` or ``None`` if not found.
+            ``Songset`` or ``None`` if not found or not owned by this user.
         """
         cursor = self.connection.cursor()
-        cursor.execute("SELECT * FROM songsets WHERE id = %s", (songset_id,))
+        cursor.execute(
+            f"SELECT {self._SONGSET_COLUMNS} FROM songsets "
+            "WHERE id = %s AND user_id = %s",
+            (songset_id, self.user_id),
+        )
         row = cursor.fetchone()
 
         if row:
@@ -148,7 +177,7 @@ class SongsetClient:
         return None
 
     def list_songsets(self, limit: Optional[int] = None) -> list[Songset]:
-        """List all songsets.
+        """List songsets owned by this client's user.
 
         Args:
             limit: Maximum number of results.
@@ -158,22 +187,24 @@ class SongsetClient:
         """
         cursor = self.connection.cursor()
 
-        query = "SELECT * FROM songsets ORDER BY updated_at DESC"
+        query = (
+            f"SELECT {self._SONGSET_COLUMNS} FROM songsets "
+            "WHERE user_id = %s ORDER BY updated_at DESC"
+        )
+        params: list = [self.user_id]
 
         if limit:
-            query += f" LIMIT {limit}"
+            query += " LIMIT %s"
+            params.append(int(limit))
 
-        cursor.execute(query)
+        cursor.execute(query, params)
 
-        results = []
-        for row in cursor.fetchall():
-            results.append(Songset.from_row(tuple(row)))
-        return results
+        return [Songset.from_row(tuple(row)) for row in cursor.fetchall()]
 
     def update_songset(
         self, songset_id: str, name: Optional[str] = None, description: Optional[str] = None
     ) -> bool:
-        """Update a songset's name and/or description.
+        """Update a songset's name and/or description, scoped to current user.
 
         Args:
             songset_id: The songset ID.
@@ -181,7 +212,7 @@ class SongsetClient:
             description: New description (optional).
 
         Returns:
-            True if updated, False if not found.
+            True if updated, False if not found or not owned by this user.
         """
         with self.transaction() as conn:
             cursor = conn.cursor()
@@ -200,29 +231,32 @@ class SongsetClient:
             if not updates:
                 return False
 
-            params.append(songset_id)
+            params.extend([songset_id, self.user_id])
 
             sql = f"""
                 UPDATE songsets
                 SET {', '.join(updates)}, updated_at = NOW()
-                WHERE id = %s
+                WHERE id = %s AND user_id = %s
             """
 
             cursor.execute(sql, params)
             return cursor.rowcount > 0
 
     def delete_songset(self, songset_id: str) -> bool:
-        """Delete a songset and all its items (CASCADE).
+        """Delete a songset and all its items (CASCADE), scoped to current user.
 
         Args:
             songset_id: The songset ID.
 
         Returns:
-            True if deleted, False if not found.
+            True if deleted, False if not found or not owned by this user.
         """
         with self.transaction() as conn:
             cursor = conn.cursor()
-            cursor.execute("DELETE FROM songsets WHERE id = %s", (songset_id,))
+            cursor.execute(
+                "DELETE FROM songsets WHERE id = %s AND user_id = %s",
+                (songset_id, self.user_id),
+            )
             return cursor.rowcount > 0
 
     def validate_recording_exists(
@@ -294,6 +328,8 @@ class SongsetClient:
         if recording_hash_prefix:
             self.validate_recording_exists(recording_hash_prefix, get_recording)
 
+        self._assert_owner(songset_id)
+
         with self.transaction() as conn:
             cursor = conn.cursor()
 
@@ -352,6 +388,9 @@ class SongsetClient:
     def get_items(self, songset_id: str, detailed: bool = False) -> list[SongsetItem]:
         """Get all items in a songset.
 
+        Returns an empty list if the songset isn't owned by this client's user
+        (rather than raising) so the TUI's read paths stay quiet.
+
         Args:
             songset_id: The songset ID.
             detailed: Deprecated - kept for compatibility, always returns basic items.
@@ -359,6 +398,8 @@ class SongsetClient:
         Returns:
             List of ``SongsetItem`` ordered by position.
         """
+        if not self._owns_songset(songset_id):
+            return []
         cursor = self.connection.cursor()
         cursor.execute(SONGSET_ITEMS_QUERY, (songset_id,))
         return [SongsetItem.from_row(tuple(row), detailed=False) for row in cursor.fetchall()]
@@ -400,9 +441,21 @@ class SongsetClient:
 
         Returns:
             True if updated, False if not found.
+
+        Raises:
+            NotOwnerError: If the item's songset is not owned by this user.
         """
         with self.transaction() as conn:
             cursor = conn.cursor()
+
+            cursor.execute(
+                "SELECT songset_id FROM songset_items WHERE id = %s",
+                (item_id,),
+            )
+            row = cursor.fetchone()
+            if not row:
+                return False
+            self._assert_owner(row[0])
 
             updates = []
             params: list = []
@@ -465,6 +518,9 @@ class SongsetClient:
 
         Returns:
             True if removed, False if not found.
+
+        Raises:
+            NotOwnerError: If the item's songset is not owned by this user.
         """
         with self.transaction() as conn:
             cursor = conn.cursor()
@@ -479,6 +535,7 @@ class SongsetClient:
                 return False
 
             songset_id, position = row
+            self._assert_owner(songset_id)
 
             cursor.execute("DELETE FROM songset_items WHERE id = %s", (item_id,))
 
@@ -507,6 +564,9 @@ class SongsetClient:
 
         Returns:
             True if moved, False if not found.
+
+        Raises:
+            NotOwnerError: If the item's songset is not owned by this user.
         """
         with self.transaction() as conn:
             cursor = conn.cursor()
@@ -521,6 +581,7 @@ class SongsetClient:
                 return False
 
             songset_id, old_position = row
+            self._assert_owner(songset_id)
 
             if old_position == new_position:
                 return True
@@ -559,12 +620,16 @@ class SongsetClient:
     def get_item_count(self, songset_id: str) -> int:
         """Get the number of items in a songset.
 
+        Returns 0 if the songset isn't owned by this client's user.
+
         Args:
             songset_id: The songset ID.
 
         Returns:
             Item count.
         """
+        if not self._owns_songset(songset_id):
+            return 0
         cursor = self.connection.cursor()
         cursor.execute(
             "SELECT COUNT(*) FROM songset_items WHERE songset_id = %s",

--- a/src/stream_of_worship/app/db/songset_client.py
+++ b/src/stream_of_worship/app/db/songset_client.py
@@ -93,12 +93,12 @@ class SongsetClient:
 
     def _owns_songset(self, songset_id: str) -> bool:
         """Return True iff this client's user owns the given songset."""
-        cursor = self.connection.cursor()
-        cursor.execute(
-            "SELECT 1 FROM songsets WHERE id = %s AND user_id = %s",
-            (songset_id, self.user_id),
-        )
-        return cursor.fetchone() is not None
+        with self.connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT 1 FROM songsets WHERE id = %s AND user_id = %s",
+                (songset_id, self.user_id),
+            )
+            return cursor.fetchone() is not None
 
     def _assert_owner(self, songset_id: str) -> None:
         """Raise ``NotOwnerError`` if this client's user doesn't own the songset."""
@@ -449,13 +449,20 @@ class SongsetClient:
             cursor = conn.cursor()
 
             cursor.execute(
-                "SELECT songset_id FROM songset_items WHERE id = %s",
+                """
+                SELECT i.songset_id, s.user_id
+                FROM songset_items i
+                JOIN songsets s ON i.songset_id = s.id
+                WHERE i.id = %s
+                """,
                 (item_id,),
             )
             row = cursor.fetchone()
             if not row:
                 return False
-            self._assert_owner(row[0])
+            songset_id, owner_id = row
+            if owner_id != self.user_id:
+                raise NotOwnerError(songset_id, self.user_id)
 
             updates = []
             params: list = []
@@ -526,7 +533,12 @@ class SongsetClient:
             cursor = conn.cursor()
 
             cursor.execute(
-                "SELECT songset_id, position FROM songset_items WHERE id = %s",
+                """
+                SELECT i.songset_id, i.position, s.user_id
+                FROM songset_items i
+                JOIN songsets s ON i.songset_id = s.id
+                WHERE i.id = %s
+                """,
                 (item_id,),
             )
             row = cursor.fetchone()
@@ -534,8 +546,9 @@ class SongsetClient:
             if not row:
                 return False
 
-            songset_id, position = row
-            self._assert_owner(songset_id)
+            songset_id, position, owner_id = row
+            if owner_id != self.user_id:
+                raise NotOwnerError(songset_id, self.user_id)
 
             cursor.execute("DELETE FROM songset_items WHERE id = %s", (item_id,))
 
@@ -572,7 +585,12 @@ class SongsetClient:
             cursor = conn.cursor()
 
             cursor.execute(
-                "SELECT songset_id, position FROM songset_items WHERE id = %s",
+                """
+                SELECT i.songset_id, i.position, s.user_id
+                FROM songset_items i
+                JOIN songsets s ON i.songset_id = s.id
+                WHERE i.id = %s
+                """,
                 (item_id,),
             )
             row = cursor.fetchone()
@@ -580,8 +598,9 @@ class SongsetClient:
             if not row:
                 return False
 
-            songset_id, old_position = row
-            self._assert_owner(songset_id)
+            songset_id, old_position, owner_id = row
+            if owner_id != self.user_id:
+                raise NotOwnerError(songset_id, self.user_id)
 
             if old_position == new_position:
                 return True

--- a/src/stream_of_worship/app/db/user_data_schema.py
+++ b/src/stream_of_worship/app/db/user_data_schema.py
@@ -1,0 +1,94 @@
+"""SQL schema for per-user app tables.
+
+Tables we own that are scoped to a user via FK to ``"user"."id"``:
+``user_settings``, ``user_lrc_override``, ``lyric_mark``, ``songset_share``.
+
+``songset_share`` is schema-only for now: the webapp will mint/revoke tokens
+and serve ``/share/[token]``. ``render_job_id`` is plain TEXT because the
+``render_jobs`` table does not exist yet; a FK will be added when it lands.
+"""
+
+CREATE_USER_SETTINGS_TABLE = """
+CREATE TABLE IF NOT EXISTS user_settings (
+    user_id            BIGINT PRIMARY KEY REFERENCES "user"("id") ON DELETE CASCADE,
+    offline_auto_cache BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+"""
+
+CREATE_USER_LRC_OVERRIDE_TABLE = """
+CREATE TABLE IF NOT EXISTS user_lrc_override (
+    id                     TEXT PRIMARY KEY,
+    user_id                BIGINT NOT NULL REFERENCES "user"("id") ON DELETE CASCADE,
+    recording_content_hash TEXT NOT NULL REFERENCES recordings(content_hash) ON DELETE CASCADE,
+    lrc_content            TEXT NOT NULL,
+    created_at             TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at             TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (user_id, recording_content_hash)
+);
+"""
+
+CREATE_LYRIC_MARK_TABLE = """
+CREATE TABLE IF NOT EXISTS lyric_mark (
+    id                     TEXT PRIMARY KEY,
+    user_id                BIGINT NOT NULL REFERENCES "user"("id") ON DELETE CASCADE,
+    recording_content_hash TEXT NOT NULL REFERENCES recordings(content_hash) ON DELETE CASCADE,
+    timestamp_seconds      DOUBLE PRECISION NOT NULL,
+    created_at             TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (user_id, recording_content_hash, timestamp_seconds)
+);
+"""
+
+# render_job_id is intentionally TEXT (not a FK) — the render_jobs table
+# does not exist yet. Add the FK in a follow-up when render_jobs lands.
+CREATE_SONGSET_SHARE_TABLE = """
+CREATE TABLE IF NOT EXISTS songset_share (
+    token              TEXT PRIMARY KEY,
+    songset_id         TEXT NOT NULL REFERENCES songsets(id) ON DELETE CASCADE,
+    render_job_id      TEXT NOT NULL,
+    created_by_user_id BIGINT NOT NULL REFERENCES "user"("id") ON DELETE CASCADE,
+    allow_download     BOOLEAN NOT NULL DEFAULT FALSE,
+    expires_at         TIMESTAMPTZ,
+    revoked_at         TIMESTAMPTZ,
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+"""
+
+CREATE_USER_DATA_INDEXES = [
+    "CREATE INDEX IF NOT EXISTS idx_user_lrc_override_user ON user_lrc_override(user_id);",
+    "CREATE INDEX IF NOT EXISTS idx_user_lrc_override_recording "
+    "ON user_lrc_override(recording_content_hash);",
+    "CREATE INDEX IF NOT EXISTS idx_lyric_mark_user ON lyric_mark(user_id);",
+    "CREATE INDEX IF NOT EXISTS idx_lyric_mark_recording "
+    "ON lyric_mark(recording_content_hash);",
+    "CREATE INDEX IF NOT EXISTS idx_songset_share_songset ON songset_share(songset_id);",
+    "CREATE INDEX IF NOT EXISTS idx_songset_share_creator "
+    "ON songset_share(created_by_user_id);",
+]
+
+CREATE_USER_SETTINGS_UPDATE_TRIGGER = """
+DROP TRIGGER IF EXISTS trg_user_settings_updated_at ON user_settings;
+CREATE TRIGGER trg_user_settings_updated_at
+    BEFORE UPDATE ON user_settings
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+"""
+
+CREATE_USER_LRC_OVERRIDE_UPDATE_TRIGGER = """
+DROP TRIGGER IF EXISTS trg_user_lrc_override_updated_at ON user_lrc_override;
+CREATE TRIGGER trg_user_lrc_override_updated_at
+    BEFORE UPDATE ON user_lrc_override
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+"""
+
+ALL_USER_DATA_SCHEMA_STATEMENTS = [
+    CREATE_USER_SETTINGS_TABLE,
+    CREATE_USER_LRC_OVERRIDE_TABLE,
+    CREATE_LYRIC_MARK_TABLE,
+    CREATE_SONGSET_SHARE_TABLE,
+    *CREATE_USER_DATA_INDEXES,
+    CREATE_USER_SETTINGS_UPDATE_TRIGGER,
+    CREATE_USER_LRC_OVERRIDE_UPDATE_TRIGGER,
+]

--- a/src/stream_of_worship/app/screens/login.py
+++ b/src/stream_of_worship/app/screens/login.py
@@ -1,0 +1,93 @@
+"""Login (pick-a-user) screen.
+
+Shows the list of users from the ``"user"`` table and lets the operator
+choose one. There's no password — the TUI runs on a trusted machine and
+identity is just a name attached to a user_id for data scoping.
+
+If no users exist, the screen instead shows a hint to run
+``sow-admin users add <email>`` first.
+"""
+
+from textual.app import ComposeResult
+from textual.containers import Vertical
+from textual.screen import Screen
+from textual.widgets import DataTable, Footer, Header, Label
+
+from stream_of_worship.app.logging_config import get_logger
+from stream_of_worship.app.state import AppState
+from stream_of_worship.db.auth_models import User
+from stream_of_worship.db.user_client import UserClient
+
+logger = get_logger(__name__)
+
+
+class LoginScreen(Screen):
+    """Pick-a-user screen, shown at TUI startup."""
+
+    BINDINGS = [
+        ("q", "quit", "Quit"),
+    ]
+
+    def __init__(self, state: AppState, user_client: UserClient):
+        """Initialize the login screen.
+
+        Args:
+            state: Application state.
+            user_client: Client for the Better Auth ``"user"`` table.
+        """
+        super().__init__()
+        self.state = state
+        self.user_client = user_client
+        self.users: list[User] = []
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        with Vertical():
+            yield Label("[bold]Pick a user[/bold]", id="title")
+            yield Label(
+                "Select the account to continue (Enter to confirm, q to quit)",
+                id="subtitle",
+            )
+            table = DataTable(id="user_table")
+            table.add_columns("ID", "Name", "Email")
+            yield table
+            yield Label("", id="empty_message")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        logger.info("LoginScreen mounted")
+        self.users = self.user_client.list_users()
+
+        table = self.query_one("#user_table", DataTable)
+        empty_label = self.query_one("#empty_message", Label)
+
+        if not self.users:
+            logger.warning("No users found — TUI cannot proceed past login")
+            empty_label.update(
+                "[red]No users found.[/red]\n"
+                "Run [cyan]sow-admin users add <email>[/cyan] then relaunch."
+            )
+            return
+
+        for user in self.users:
+            table.add_row(str(user.id), user.name, user.email, key=str(user.id))
+
+        if table.cursor_row is None and len(self.users) > 0:
+            table.cursor_row = 0
+        table.focus()
+
+    def on_data_table_row_selected(self, event: DataTable.RowSelected) -> None:
+        user_id_str = event.row_key.value
+        user = next((u for u in self.users if str(u.id) == user_id_str), None)
+        if user is None:
+            logger.warning(f"Unknown user row selected: {user_id_str}")
+            return
+        logger.info(f"User selected: id={user.id} email={user.email}")
+        self.state.set_current_user(user)
+        # Delegate to the app to wire up the user-scoped SongsetClient and
+        # navigate to the songset list.
+        self.app.on_user_selected(user)
+
+    def action_quit(self) -> None:
+        logger.info("Action: quit (from login)")
+        self.app.action_quit()

--- a/src/stream_of_worship/app/state.py
+++ b/src/stream_of_worship/app/state.py
@@ -10,11 +10,13 @@ from typing import Callable, Optional
 
 from stream_of_worship.app.db.models import Songset, SongsetItem
 from stream_of_worship.app.services.catalog import SongWithRecording
+from stream_of_worship.db.auth_models import User
 
 
 class AppScreen(Enum):
     """Available screens in the app."""
 
+    LOGIN = auto()
     SONGSET_LIST = auto()
     BROWSE = auto()
     SONGSET_EDITOR = auto()
@@ -43,8 +45,11 @@ class AppState:
     """
 
     # Navigation
-    current_screen: AppScreen = AppScreen.SONGSET_LIST
+    current_screen: AppScreen = AppScreen.LOGIN
     previous_screen: Optional[AppScreen] = None
+
+    # Authenticated user (set on the LOGIN screen, cleared on quit)
+    current_user: Optional[User] = None
 
     # Songset management
     selected_songset: Optional[Songset] = None
@@ -121,6 +126,15 @@ class AppState:
             self._notify("current_screen", self.current_screen)
             return True
         return False
+
+    def set_current_user(self, user: Optional[User]) -> None:
+        """Set the authenticated user (or None to clear).
+
+        Args:
+            user: User who just logged in, or None on logout.
+        """
+        self.current_user = user
+        self._notify("current_user", user)
 
     def select_songset(self, songset: Optional[Songset]) -> None:
         """Select a songset.

--- a/src/stream_of_worship/db/auth_models.py
+++ b/src/stream_of_worship/db/auth_models.py
@@ -1,0 +1,68 @@
+"""Data models for Better Auth identity entities.
+
+Shared between admin (``sow-admin users``) and app (TUI login screen). The
+``User`` dataclass maps the Better Auth ``"user"`` table's camelCase columns
+to Python snake_case fields. IDs are sequential integers assigned by the
+database (``BIGINT GENERATED ALWAYS AS IDENTITY``).
+"""
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from stream_of_worship.db.helpers import to_str
+
+
+@dataclass
+class User:
+    """A user identity (Better Auth ``"user"`` table row).
+
+    Attributes:
+        id: DB-assigned sequential integer ID.
+        name: Display name.
+        email: Login email (unique).
+        email_verified: Whether the email has been verified.
+        image: Optional avatar URL.
+        created_at: ISO timestamp when created.
+        updated_at: ISO timestamp when last updated.
+    """
+
+    id: int
+    name: str
+    email: str
+    email_verified: bool = False
+    image: Optional[str] = None
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+
+    @classmethod
+    def from_row(cls, row: tuple) -> "User":
+        """Create a User from a ``"user"`` table row.
+
+        Args:
+            row: Row tuple in column order:
+                (id, name, email, emailVerified, image, createdAt, updatedAt).
+
+        Returns:
+            User instance.
+        """
+        return cls(
+            id=row[0],
+            name=row[1],
+            email=row[2],
+            email_verified=bool(row[3]),
+            image=row[4],
+            created_at=to_str(row[5]),
+            updated_at=to_str(row[6]),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert User to a snake_case dictionary."""
+        return {
+            "id": self.id,
+            "name": self.name,
+            "email": self.email,
+            "email_verified": self.email_verified,
+            "image": self.image,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+        }

--- a/src/stream_of_worship/db/auth_schema.py
+++ b/src/stream_of_worship/db/auth_schema.py
@@ -1,0 +1,127 @@
+"""SQL schema for Better Auth core tables.
+
+Defines the canonical Better Auth schema shape (user, account, session,
+verification) so the future Next.js webapp can plug in Better Auth without
+schema migrations. Identifiers are camelCase quoted to match Better Auth's
+default schema; columns use `BIGINT GENERATED ALWAYS AS IDENTITY` so user
+IDs are short, sequential integers (e.g. "User 12"). The webapp must set
+``advanced.database.useNumberId: true`` in its Better Auth config to match.
+"""
+
+CREATE_USER_TABLE = """
+CREATE TABLE IF NOT EXISTS "user" (
+    "id"            BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    "name"          TEXT NOT NULL,
+    "email"         TEXT NOT NULL UNIQUE,
+    "emailVerified" BOOLEAN NOT NULL DEFAULT FALSE,
+    "image"         TEXT,
+    "createdAt"     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    "updatedAt"     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+"""
+
+CREATE_ACCOUNT_TABLE = """
+CREATE TABLE IF NOT EXISTS "account" (
+    "id"                    BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    "userId"                BIGINT NOT NULL REFERENCES "user"("id") ON DELETE CASCADE,
+    "accountId"             TEXT NOT NULL,
+    "providerId"            TEXT NOT NULL,
+    "accessToken"           TEXT,
+    "refreshToken"          TEXT,
+    "idToken"               TEXT,
+    "accessTokenExpiresAt"  TIMESTAMPTZ,
+    "refreshTokenExpiresAt" TIMESTAMPTZ,
+    "scope"                 TEXT,
+    "password"              TEXT,
+    "createdAt"             TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    "updatedAt"             TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE ("providerId", "accountId")
+);
+"""
+
+CREATE_SESSION_TABLE = """
+CREATE TABLE IF NOT EXISTS "session" (
+    "id"        BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    "userId"    BIGINT NOT NULL REFERENCES "user"("id") ON DELETE CASCADE,
+    "token"     TEXT NOT NULL UNIQUE,
+    "expiresAt" TIMESTAMPTZ NOT NULL,
+    "ipAddress" TEXT,
+    "userAgent" TEXT,
+    "createdAt" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    "updatedAt" TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+"""
+
+CREATE_VERIFICATION_TABLE = """
+CREATE TABLE IF NOT EXISTS "verification" (
+    "id"         BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    "identifier" TEXT NOT NULL,
+    "value"      TEXT NOT NULL,
+    "expiresAt"  TIMESTAMPTZ NOT NULL,
+    "createdAt"  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    "updatedAt"  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+"""
+
+CREATE_AUTH_INDEXES = [
+    'CREATE INDEX IF NOT EXISTS idx_account_user_id ON "account"("userId");',
+    'CREATE INDEX IF NOT EXISTS idx_session_user_id ON "session"("userId");',
+    'CREATE INDEX IF NOT EXISTS idx_session_token   ON "session"("token");',
+    'CREATE INDEX IF NOT EXISTS idx_verification_identifier ON "verification"("identifier");',
+]
+
+# Trigger function for camelCase "updatedAt" columns.
+CREATE_UPDATEDAT_TIMESTAMP_FUNCTION = """
+CREATE OR REPLACE FUNCTION update_updatedat_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW."updatedAt" = NOW();
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+"""
+
+CREATE_USER_UPDATEDAT_TRIGGER = """
+DROP TRIGGER IF EXISTS trg_user_updatedat ON "user";
+CREATE TRIGGER trg_user_updatedat
+    BEFORE UPDATE ON "user"
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updatedat_column();
+"""
+
+CREATE_ACCOUNT_UPDATEDAT_TRIGGER = """
+DROP TRIGGER IF EXISTS trg_account_updatedat ON "account";
+CREATE TRIGGER trg_account_updatedat
+    BEFORE UPDATE ON "account"
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updatedat_column();
+"""
+
+CREATE_SESSION_UPDATEDAT_TRIGGER = """
+DROP TRIGGER IF EXISTS trg_session_updatedat ON "session";
+CREATE TRIGGER trg_session_updatedat
+    BEFORE UPDATE ON "session"
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updatedat_column();
+"""
+
+CREATE_VERIFICATION_UPDATEDAT_TRIGGER = """
+DROP TRIGGER IF EXISTS trg_verification_updatedat ON "verification";
+CREATE TRIGGER trg_verification_updatedat
+    BEFORE UPDATE ON "verification"
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updatedat_column();
+"""
+
+ALL_AUTH_SCHEMA_STATEMENTS = [
+    CREATE_USER_TABLE,
+    CREATE_ACCOUNT_TABLE,
+    CREATE_SESSION_TABLE,
+    CREATE_VERIFICATION_TABLE,
+    *CREATE_AUTH_INDEXES,
+    CREATE_UPDATEDAT_TIMESTAMP_FUNCTION,
+    CREATE_USER_UPDATEDAT_TRIGGER,
+    CREATE_ACCOUNT_UPDATEDAT_TRIGGER,
+    CREATE_SESSION_UPDATEDAT_TRIGGER,
+    CREATE_VERIFICATION_UPDATEDAT_TRIGGER,
+]

--- a/src/stream_of_worship/db/postgres_schema.py
+++ b/src/stream_of_worship/db/postgres_schema.py
@@ -1,12 +1,12 @@
 """Unified PostgreSQL schema for Stream of Worship.
 
-Combines catalog (songs, recordings) and application (songsets, songset_items)
-schema definitions into a single source file.  Useful when you need to create
-or validate the entire database at once (e.g. ``sow-admin db init`` or test
-fixtures).
+Combines catalog (songs, recordings), auth (user, account, session,
+verification), app (songsets, songset_items), and per-user app tables
+(user_settings, user_lrc_override, lyric_mark, songset_share) into a
+single ordered DDL list. Used by ``sow-admin db init``.
 
-This module re-exports constants from the canonical per-component schema
-modules so that there is only one place where DDL lives.
+This module re-exports constants from the per-component schema modules so
+DDL has exactly one source of truth.
 """
 
 from stream_of_worship.admin.db.schema import (
@@ -18,11 +18,11 @@ from stream_of_worship.admin.db.schema import (
     CREATE_SONGS_TABLE,
     CREATE_SONGS_UPDATE_TRIGGER,
     CREATE_UPDATE_TIMESTAMP_FUNCTION,
-    RECORDING_COLUMNS_FOR_JOIN,
     RECORDING_COLUMN_COUNT,
+    RECORDING_COLUMNS_FOR_JOIN,
     ROW_COUNT_QUERY,
-    SONG_COLUMNS_FOR_JOIN,
     SONG_COLUMN_COUNT,
+    SONG_COLUMNS_FOR_JOIN,
     TABLE_STATS_QUERY,
 )
 from stream_of_worship.app.db.schema import (
@@ -34,22 +34,37 @@ from stream_of_worship.app.db.schema import (
     SONGSET_ITEMS_FULL_QUERY,
     SONGSET_ITEMS_QUERY,
 )
+from stream_of_worship.app.db.user_data_schema import (
+    ALL_USER_DATA_SCHEMA_STATEMENTS,
+)
+from stream_of_worship.db.auth_schema import (
+    ALL_AUTH_SCHEMA_STATEMENTS,
+)
 
-# Ordered list of *all* DDL statements needed to bring up a fresh Postgres DB.
-# Run this through a psycopg cursor / connection in order.
+# Ordered DDL to bring up a fresh Postgres DB.
+#
+# Order matters:
+#   1. Catalog (songs, recordings) — no FKs out to other groups.
+#   2. Auth (user, account, ...)   — songsets.user_id FKs into "user".
+#   3. App (songsets, items)       — songset_share FKs into songsets.
+#   4. Per-user app tables         — FK into both "user" and songsets/recordings.
 ALL_SCHEMA_STATEMENTS = [
-    # --- admin / catalog ---
+    # --- 1. admin / catalog ---
     CREATE_SONGS_TABLE,
     CREATE_RECORDINGS_TABLE,
     *CREATE_INDEXES,
     CREATE_UPDATE_TIMESTAMP_FUNCTION,
     CREATE_SONGS_UPDATE_TRIGGER,
     CREATE_RECORDINGS_UPDATE_TRIGGER,
-    # --- app / songsets ---
+    # --- 2. auth (Better Auth core) ---
+    *ALL_AUTH_SCHEMA_STATEMENTS,
+    # --- 3. app / songsets ---
     CREATE_SONGSETS_TABLE,
     CREATE_SONGSET_ITEMS_TABLE,
     *CREATE_APP_INDEXES,
     CREATE_SONGSETS_UPDATE_TRIGGER,
+    # --- 4. per-user app tables ---
+    *ALL_USER_DATA_SCHEMA_STATEMENTS,
 ]
 
 __all__ = [
@@ -76,6 +91,9 @@ __all__ = [
     "CREATE_SONGSET_ITEMS_TABLE",
     "CREATE_SONGSETS_TABLE",
     "CREATE_SONGSETS_UPDATE_TRIGGER",
+    # Re-exports from auth + per-user data schema
+    "ALL_AUTH_SCHEMA_STATEMENTS",
+    "ALL_USER_DATA_SCHEMA_STATEMENTS",
     # Unified list
     "ALL_SCHEMA_STATEMENTS",
 ]

--- a/src/stream_of_worship/db/user_client.py
+++ b/src/stream_of_worship/db/user_client.py
@@ -107,9 +107,11 @@ class UserClient:
         """List all users, ordered by ID ascending (creation order)."""
         cursor = self.connection.cursor()
         query = f'SELECT {_USER_COLUMNS} FROM "user" ORDER BY "id" ASC'
+        params: list = []
         if limit:
-            query += f" LIMIT {int(limit)}"
-        cursor.execute(query)
+            query += " LIMIT %s"
+            params.append(int(limit))
+        cursor.execute(query, params)
         return [User.from_row(tuple(row)) for row in cursor.fetchall()]
 
     def delete_user(self, user_id: int) -> bool:

--- a/src/stream_of_worship/db/user_client.py
+++ b/src/stream_of_worship/db/user_client.py
@@ -1,0 +1,125 @@
+"""Read-write database client for the Better Auth ``"user"`` table.
+
+Used by the admin CLI to seed users (``sow-admin users add``) and by the
+TUI to render the pick-a-user login screen. The other three Better Auth
+tables (``account``, ``session``, ``verification``) are owned by the future
+Next.js webapp and are not exposed through this client.
+"""
+
+from contextlib import contextmanager
+from typing import Generator, Optional
+
+import psycopg
+
+from stream_of_worship.db.auth_models import User
+from stream_of_worship.db.connection import ConnectionProvider
+
+
+class DuplicateEmailError(Exception):
+    """Raised when create_user is called with an email that already exists."""
+
+    def __init__(self, email: str):
+        super().__init__(f"User with email '{email}' already exists")
+        self.email = email
+
+
+_USER_COLUMNS = '"id", "name", "email", "emailVerified", "image", "createdAt", "updatedAt"'
+
+
+class UserClient:
+    """CRUD client for the Better Auth ``"user"`` table.
+
+    Attributes:
+        connection_provider: ``ConnectionProvider`` instance.
+    """
+
+    def __init__(self, connection_provider: ConnectionProvider):
+        self.connection_provider = connection_provider
+
+    @property
+    def connection(self) -> psycopg.Connection:
+        return self.connection_provider.get_connection()
+
+    def close(self) -> None:
+        self.connection_provider.close()
+
+    def __enter__(self) -> "UserClient":
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.close()
+
+    @contextmanager
+    def transaction(self) -> Generator[psycopg.Connection, None, None]:
+        conn = self.connection
+        with conn.transaction():
+            yield conn
+
+    def create_user(self, email: str, name: Optional[str] = None) -> User:
+        """Create a new user and return the row, with the DB-assigned ID.
+
+        Args:
+            email: Login email (must be unique).
+            name: Display name; defaults to the local-part of the email.
+
+        Returns:
+            The created ``User``.
+
+        Raises:
+            DuplicateEmailError: If a user with this email already exists.
+        """
+        display_name = name if name else email.split("@", 1)[0]
+        try:
+            with self.transaction() as conn:
+                cursor = conn.cursor()
+                cursor.execute(
+                    f"""
+                    INSERT INTO "user" ("name", "email")
+                    VALUES (%s, %s)
+                    RETURNING {_USER_COLUMNS}
+                    """,
+                    (display_name, email),
+                )
+                row = cursor.fetchone()
+        except psycopg.errors.UniqueViolation as exc:
+            raise DuplicateEmailError(email) from exc
+        return User.from_row(tuple(row))
+
+    def get_user(self, user_id: int) -> Optional[User]:
+        """Fetch a user by ID, or None if not found."""
+        cursor = self.connection.cursor()
+        cursor.execute(
+            f'SELECT {_USER_COLUMNS} FROM "user" WHERE "id" = %s', (user_id,)
+        )
+        row = cursor.fetchone()
+        return User.from_row(tuple(row)) if row else None
+
+    def get_user_by_email(self, email: str) -> Optional[User]:
+        """Fetch a user by email, or None if not found."""
+        cursor = self.connection.cursor()
+        cursor.execute(
+            f'SELECT {_USER_COLUMNS} FROM "user" WHERE "email" = %s', (email,)
+        )
+        row = cursor.fetchone()
+        return User.from_row(tuple(row)) if row else None
+
+    def list_users(self, limit: Optional[int] = None) -> list[User]:
+        """List all users, ordered by ID ascending (creation order)."""
+        cursor = self.connection.cursor()
+        query = f'SELECT {_USER_COLUMNS} FROM "user" ORDER BY "id" ASC'
+        if limit:
+            query += f" LIMIT {int(limit)}"
+        cursor.execute(query)
+        return [User.from_row(tuple(row)) for row in cursor.fetchall()]
+
+    def delete_user(self, user_id: int) -> bool:
+        """Delete a user. Returns True if a row was deleted.
+
+        Cascades to ``songsets`` (and their items), ``user_settings``,
+        ``user_lrc_override``, ``lyric_mark``, ``songset_share``,
+        ``account``, and ``session`` via FK ON DELETE CASCADE.
+        """
+        with self.transaction() as conn:
+            cursor = conn.cursor()
+            cursor.execute('DELETE FROM "user" WHERE "id" = %s', (user_id,))
+            return cursor.rowcount > 0

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -39,8 +39,18 @@ def sample_mp3_file(tmp_path):
 
 @pytest.fixture
 def sample_songset_row():
-    """Sample database row for Songset.from_row()."""
-    return ("songset_20240101120000", "Test Songset", "A test description", "2024-01-01T12:00:00", "2024-01-01T12:00:00")
+    """Sample database row for Songset.from_row().
+
+    Column order: id, user_id, name, description, created_at, updated_at.
+    """
+    return (
+        "songset_20240101120000",
+        1,
+        "Test Songset",
+        "A test description",
+        "2024-01-01T12:00:00",
+        "2024-01-01T12:00:00",
+    )
 
 
 @pytest.fixture

--- a/tests/app/db/test_models.py
+++ b/tests/app/db/test_models.py
@@ -18,6 +18,7 @@ class TestSongset:
         songset = Songset.from_row(sample_songset_row)
 
         assert songset.id == "songset_20240101120000"
+        assert songset.user_id == 1
         assert songset.name == "Test Songset"
         assert songset.description == "A test description"
         assert songset.created_at == "2024-01-01T12:00:00"
@@ -25,10 +26,18 @@ class TestSongset:
 
     def test_songset_from_row_full(self):
         """Verify from_row() with all fields including None."""
-        row = ("songset_0001", "Name", None, "2024-01-01T00:00:00", "2024-01-01T00:00:00")
+        row = (
+            "songset_0001",
+            42,
+            "Name",
+            None,
+            "2024-01-01T00:00:00",
+            "2024-01-01T00:00:00",
+        )
         songset = Songset.from_row(row)
 
         assert songset.id == "songset_0001"
+        assert songset.user_id == 42
         assert songset.name == "Name"
         assert songset.description is None
 
@@ -38,6 +47,7 @@ class TestSongset:
         d = songset.to_dict()
 
         assert d["id"] == "songset_20240101120000"
+        assert d["user_id"] == 1
         assert d["name"] == "Test Songset"
         assert d["description"] == "A test description"
         assert d["created_at"] == "2024-01-01T12:00:00"
@@ -52,6 +62,7 @@ class TestSongset:
         songset2 = Songset.from_row(values)
 
         assert songset2.id == songset.id
+        assert songset2.user_id == songset.user_id
         assert songset2.name == songset.name
         assert songset2.description == songset.description
 

--- a/tests/app/db/test_songset_client.py
+++ b/tests/app/db/test_songset_client.py
@@ -9,8 +9,11 @@ from stream_of_worship.db.postgres_schema import ALL_SCHEMA_STATEMENTS
 
 
 @pytest.fixture(scope="function")
-def songset_client(postgres_url):
-    """Create a SongsetClient connected to a fresh Postgres schema."""
+def songset_client(postgres_url, seed_user):
+    """Create a SongsetClient connected to a fresh Postgres schema.
+
+    Seeds a default user and scopes the client to it.
+    """
     provider = ConnectionProvider(postgres_url)
     conn = provider.get_connection()
 
@@ -19,7 +22,8 @@ def songset_client(postgres_url):
         for stmt in ALL_SCHEMA_STATEMENTS:
             cur.execute(stmt)
 
-    client = SongsetClient(provider)
+    user_id = seed_user(provider, email="songset-client-test@example.com")
+    client = SongsetClient(provider, user_id=user_id)
     yield client
 
     # Cleanup (use fresh connection in case provider was closed by a test)
@@ -27,11 +31,20 @@ def songset_client(postgres_url):
         cleanup_provider = ConnectionProvider(postgres_url)
         with cleanup_provider.get_connection().cursor() as cur:
             cur.execute("""
+                DROP TABLE IF EXISTS songset_share CASCADE;
+                DROP TABLE IF EXISTS lyric_mark CASCADE;
+                DROP TABLE IF EXISTS user_lrc_override CASCADE;
+                DROP TABLE IF EXISTS user_settings CASCADE;
                 DROP TABLE IF EXISTS songset_items CASCADE;
                 DROP TABLE IF EXISTS songsets CASCADE;
                 DROP TABLE IF EXISTS recordings CASCADE;
                 DROP TABLE IF EXISTS songs CASCADE;
+                DROP TABLE IF EXISTS "session" CASCADE;
+                DROP TABLE IF EXISTS "account" CASCADE;
+                DROP TABLE IF EXISTS "verification" CASCADE;
+                DROP TABLE IF EXISTS "user" CASCADE;
                 DROP FUNCTION IF EXISTS update_updated_at_column CASCADE;
+                DROP FUNCTION IF EXISTS update_updatedat_column CASCADE;
             """)
         cleanup_provider.close()
     except Exception:

--- a/tests/app/db/test_songset_client_user_isolation.py
+++ b/tests/app/db/test_songset_client_user_isolation.py
@@ -1,0 +1,130 @@
+"""User-isolation tests for SongsetClient.
+
+The critical regression: a SongsetClient bound to user A must never read,
+mutate, or delete a songset belonging to user B.
+"""
+
+import pytest
+
+from stream_of_worship.app.db.songset_client import NotOwnerError, SongsetClient
+from stream_of_worship.db.connection import ConnectionProvider
+from stream_of_worship.db.postgres_schema import ALL_SCHEMA_STATEMENTS
+
+
+@pytest.fixture(scope="function")
+def two_user_clients(postgres_url, seed_user):
+    """Set up schema, two users (alice and bob), and a client for each."""
+    provider = ConnectionProvider(postgres_url)
+    conn = provider.get_connection()
+
+    with conn.cursor() as cur:
+        for stmt in ALL_SCHEMA_STATEMENTS:
+            cur.execute(stmt)
+
+    alice_id = seed_user(provider, email="alice-iso@example.com", name="Alice")
+    bob_id = seed_user(provider, email="bob-iso@example.com", name="Bob")
+
+    alice = SongsetClient(provider, user_id=alice_id)
+    bob = SongsetClient(provider, user_id=bob_id)
+
+    yield alice, bob
+
+    try:
+        cleanup_provider = ConnectionProvider(postgres_url)
+        with cleanup_provider.get_connection().cursor() as cur:
+            cur.execute(
+                """
+                DROP TABLE IF EXISTS songset_share, lyric_mark,
+                    user_lrc_override, user_settings,
+                    songset_items, songsets,
+                    recordings, songs,
+                    "session", "account", "verification", "user" CASCADE;
+                DROP FUNCTION IF EXISTS update_updated_at_column CASCADE;
+                DROP FUNCTION IF EXISTS update_updatedat_column CASCADE;
+                """
+            )
+        cleanup_provider.close()
+    except Exception:
+        pass
+
+
+@pytest.mark.integration
+class TestSongsetUserIsolation:
+    def test_list_only_returns_own_songsets(self, two_user_clients):
+        alice, bob = two_user_clients
+        alice.create_songset("Alice Sunday")
+        alice.create_songset("Alice Evening")
+        bob.create_songset("Bob Sunday")
+
+        alice_sets = alice.list_songsets()
+        bob_sets = bob.list_songsets()
+
+        assert {s.name for s in alice_sets} == {"Alice Sunday", "Alice Evening"}
+        assert {s.name for s in bob_sets} == {"Bob Sunday"}
+
+    def test_get_other_users_songset_returns_none(self, two_user_clients):
+        alice, bob = two_user_clients
+        alice_songset = alice.create_songset("Alice's Set")
+        # Bob tries to fetch it
+        assert bob.get_songset(alice_songset.id) is None
+        # Alice can still fetch her own
+        assert alice.get_songset(alice_songset.id) is not None
+
+    def test_delete_other_users_songset_returns_false(self, two_user_clients):
+        alice, bob = two_user_clients
+        alice_songset = alice.create_songset("Alice's Set")
+        # Bob tries to delete it
+        assert bob.delete_songset(alice_songset.id) is False
+        # Songset still exists for Alice
+        assert alice.get_songset(alice_songset.id) is not None
+
+    def test_update_other_users_songset_returns_false(self, two_user_clients):
+        alice, bob = two_user_clients
+        alice_songset = alice.create_songset("Alice's Set")
+        assert bob.update_songset(alice_songset.id, name="HACKED") is False
+        # Verify Alice's name is intact
+        fresh = alice.get_songset(alice_songset.id)
+        assert fresh.name == "Alice's Set"
+
+    def test_add_item_to_other_users_songset_raises(self, two_user_clients):
+        alice, bob = two_user_clients
+        alice_songset = alice.create_songset("Alice's Set")
+        with pytest.raises(NotOwnerError):
+            bob.add_item(songset_id=alice_songset.id, song_id="song_x")
+
+    def test_get_items_of_other_users_songset_returns_empty(self, two_user_clients):
+        alice, bob = two_user_clients
+        alice_songset = alice.create_songset("Alice's Set")
+        alice.add_item(songset_id=alice_songset.id, song_id="song_1")
+        alice.add_item(songset_id=alice_songset.id, song_id="song_2")
+
+        # Bob sees nothing
+        assert bob.get_items(alice_songset.id) == []
+        assert bob.get_item_count(alice_songset.id) == 0
+        # Alice still sees both
+        assert len(alice.get_items(alice_songset.id)) == 2
+
+    def test_update_other_users_item_raises(self, two_user_clients):
+        alice, bob = two_user_clients
+        alice_songset = alice.create_songset("Alice's Set")
+        item = alice.add_item(songset_id=alice_songset.id, song_id="song_1")
+
+        with pytest.raises(NotOwnerError):
+            bob.update_item(item.id, gap_beats=4.0)
+
+    def test_remove_other_users_item_raises(self, two_user_clients):
+        alice, bob = two_user_clients
+        alice_songset = alice.create_songset("Alice's Set")
+        item = alice.add_item(songset_id=alice_songset.id, song_id="song_1")
+
+        with pytest.raises(NotOwnerError):
+            bob.remove_item(item.id)
+        # Alice's item still there
+        assert len(alice.get_items(alice_songset.id)) == 1
+
+    def test_create_songset_writes_clients_user_id(self, two_user_clients):
+        alice, _ = two_user_clients
+        s = alice.create_songset("Alice's Set")
+        # Round-trip via DB: user_id matches client's user_id
+        fresh = alice.get_songset(s.id)
+        assert fresh.user_id == alice.user_id

--- a/tests/app/screens/test_login.py
+++ b/tests/app/screens/test_login.py
@@ -1,0 +1,107 @@
+"""Tests for LoginScreen (pick-a-user) using Textual's pilot API."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from textual.app import App
+from textual.widgets import DataTable, Label
+
+from stream_of_worship.app.screens.login import LoginScreen
+from stream_of_worship.app.state import AppState
+from stream_of_worship.db.auth_models import User
+
+
+class _HarnessApp(App):
+    """Minimal Textual App that hosts the LoginScreen for testing.
+
+    Captures ``on_user_selected`` invocations so tests can assert that the
+    screen correctly delegates after a row is chosen.
+    """
+
+    def __init__(self, state: AppState, user_client):
+        super().__init__()
+        self._state = state
+        self._user_client = user_client
+        self.selected_user: User | None = None
+
+    def on_mount(self) -> None:
+        self.push_screen(LoginScreen(self._state, self._user_client))
+
+    def on_user_selected(self, user: User) -> None:
+        self.selected_user = user
+
+
+def _user(uid: int, name: str, email: str) -> User:
+    return User(id=uid, name=name, email=email)
+
+
+@pytest.mark.asyncio
+async def test_login_lists_users_and_focuses_table():
+    state = AppState()
+    user_client = MagicMock()
+    user_client.list_users.return_value = [
+        _user(1, "Alice", "alice@example.com"),
+        _user(2, "Bob", "bob@example.com"),
+    ]
+
+    app = _HarnessApp(state, user_client)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        table = app.screen.query_one("#user_table", DataTable)
+        # Two rows, one per user
+        assert len(list(table.rows.keys())) == 2
+        # Verifies on_mount called list_users()
+        user_client.list_users.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_login_empty_state_when_no_users():
+    state = AppState()
+    user_client = MagicMock()
+    user_client.list_users.return_value = []
+
+    app = _HarnessApp(state, user_client)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        table = app.screen.query_one("#user_table", DataTable)
+        assert len(list(table.rows.keys())) == 0
+        empty = app.screen.query_one("#empty_message", Label)
+        # ``Static`` widgets store their renderable on a name-mangled private,
+        # but the rendered content is accessible via the visual representation.
+        # The empty-state message must mention the admin CLI command so the
+        # operator knows how to recover.
+        assert "sow-admin users add" in str(empty.visual)
+
+
+@pytest.mark.asyncio
+async def test_login_row_selection_sets_user_and_delegates():
+    state = AppState()
+    alice = _user(1, "Alice", "alice@example.com")
+    bob = _user(2, "Bob", "bob@example.com")
+    user_client = MagicMock()
+    user_client.list_users.return_value = [alice, bob]
+
+    app = _HarnessApp(state, user_client)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        table = app.screen.query_one("#user_table", DataTable)
+        # Focus the table, move cursor to row 1 (Bob), and post a RowSelected
+        # event the same way Textual would after Enter on a focused DataTable.
+        table.focus()
+        table.move_cursor(row=1)
+        await pilot.pause()
+        # Fire the row-selected message directly (avoids relying on the
+        # specific key binding for Enter in this Textual version).
+        from textual.widgets.data_table import RowKey
+        message = DataTable.RowSelected(
+            table,
+            cursor_row=1,
+            row_key=RowKey(str(bob.id)),
+        )
+        app.screen.post_message(message)
+        await pilot.pause()
+
+    assert state.current_user is not None
+    assert state.current_user.id == bob.id
+    assert app.selected_user is not None
+    assert app.selected_user.id == bob.id

--- a/tests/app/services/test_export.py
+++ b/tests/app/services/test_export.py
@@ -62,6 +62,7 @@ def sample_songset():
     """Sample songset for testing."""
     return Songset(
         id="songset_0001",
+        user_id=1,
         name="Test Songset",
         description="A test songset",
         created_at="2024-01-01T00:00:00",
@@ -350,6 +351,7 @@ class TestFilenameSanitization:
         """Verify special chars replaced with underscore."""
         songset = Songset(
             id="songset_0001",
+            user_id=1,
             name="Test/Songset: With*Special?Chars",
             created_at="2024-01-01T00:00:00",
             updated_at="2024-01-01T00:00:00",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,3 +34,28 @@ def postgres_url():
         # psycopg doesn't understand the +psycopg2 dialect prefix
         url = url.replace("postgresql+psycopg2://", "postgresql://")
         yield url
+
+
+@pytest.fixture
+def seed_user():
+    """Return a callable that inserts a user into the ``"user"`` table.
+
+    Usage::
+
+        def test_something(postgres_url, seed_user):
+            from stream_of_worship.db.connection import ConnectionProvider
+            provider = ConnectionProvider(postgres_url)
+            user_id = seed_user(provider, email="alice@example.com", name="Alice")
+            # ... use user_id to scope SongsetClient, etc.
+
+    Assumes the schema has already been initialized for ``provider``.
+    """
+
+    def _seed(provider, email: str = "test@example.com", name: str = "Test User") -> int:
+        from stream_of_worship.db.user_client import UserClient
+
+        with UserClient(provider) as client:
+            user = client.create_user(email=email, name=name)
+            return user.id
+
+    return _seed

--- a/tests/db/test_full_schema_init.py
+++ b/tests/db/test_full_schema_init.py
@@ -1,0 +1,122 @@
+"""Test that ALL_SCHEMA_STATEMENTS produces the full expected schema."""
+
+import pytest
+
+from stream_of_worship.db.connection import ConnectionProvider
+from stream_of_worship.db.postgres_schema import ALL_SCHEMA_STATEMENTS
+
+
+EXPECTED_TABLES = {
+    # catalog
+    "songs",
+    "recordings",
+    # auth (Better Auth core)
+    "user",
+    "account",
+    "session",
+    "verification",
+    # app
+    "songsets",
+    "songset_items",
+    # per-user app
+    "user_settings",
+    "user_lrc_override",
+    "lyric_mark",
+    "songset_share",
+}
+
+
+@pytest.mark.integration
+class TestFullSchemaInit:
+    def test_all_tables_created(self, postgres_url):
+        """Running ALL_SCHEMA_STATEMENTS creates every expected table."""
+        provider = ConnectionProvider(postgres_url)
+        conn = provider.get_connection()
+
+        with conn.cursor() as cur:
+            for stmt in ALL_SCHEMA_STATEMENTS:
+                cur.execute(stmt)
+
+            cur.execute(
+                """
+                SELECT table_name FROM information_schema.tables
+                WHERE table_schema = 'public'
+                """
+            )
+            actual = {row[0] for row in cur.fetchall()}
+
+        missing = EXPECTED_TABLES - actual
+        assert not missing, f"Missing tables: {sorted(missing)}"
+
+        # Cleanup
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                DROP TABLE IF EXISTS songset_share, lyric_mark,
+                    user_lrc_override, user_settings,
+                    songset_items, songsets,
+                    recordings, songs,
+                    "session", "account", "verification", "user" CASCADE;
+                DROP FUNCTION IF EXISTS update_updated_at_column CASCADE;
+                DROP FUNCTION IF EXISTS update_updatedat_column CASCADE;
+                """
+            )
+
+    def test_critical_foreign_keys(self, postgres_url):
+        """Verify the FKs that enforce multi-user isolation are in place."""
+        provider = ConnectionProvider(postgres_url)
+        conn = provider.get_connection()
+
+        with conn.cursor() as cur:
+            for stmt in ALL_SCHEMA_STATEMENTS:
+                cur.execute(stmt)
+
+            cur.execute(
+                """
+                SELECT
+                    tc.table_name AS from_table,
+                    kcu.column_name AS from_column,
+                    ccu.table_name AS to_table,
+                    ccu.column_name AS to_column
+                FROM information_schema.table_constraints tc
+                JOIN information_schema.key_column_usage kcu
+                  ON tc.constraint_name = kcu.constraint_name
+                 AND tc.table_schema = kcu.table_schema
+                JOIN information_schema.constraint_column_usage ccu
+                  ON ccu.constraint_name = tc.constraint_name
+                 AND ccu.table_schema = tc.table_schema
+                WHERE tc.constraint_type = 'FOREIGN KEY'
+                  AND tc.table_schema = 'public'
+                """
+            )
+            fks = {
+                (r[0], r[1], r[2], r[3]) for r in cur.fetchall()
+            }
+
+        # FKs that MUST exist for multi-user isolation to work.
+        required = [
+            ("songsets", "user_id", "user", "id"),
+            ("user_lrc_override", "user_id", "user", "id"),
+            ("user_lrc_override", "recording_content_hash",
+             "recordings", "content_hash"),
+            ("lyric_mark", "user_id", "user", "id"),
+            ("songset_share", "songset_id", "songsets", "id"),
+            ("songset_share", "created_by_user_id", "user", "id"),
+        ]
+
+        for fk in required:
+            assert fk in fks, f"Missing FK: {fk}"
+
+        # Cleanup
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                DROP TABLE IF EXISTS songset_share, lyric_mark,
+                    user_lrc_override, user_settings,
+                    songset_items, songsets,
+                    recordings, songs,
+                    "session", "account", "verification", "user" CASCADE;
+                DROP FUNCTION IF EXISTS update_updated_at_column CASCADE;
+                DROP FUNCTION IF EXISTS update_updatedat_column CASCADE;
+                """
+            )

--- a/tests/db/test_model_coercion.py
+++ b/tests/db/test_model_coercion.py
@@ -150,8 +150,9 @@ class TestSongsetFromRowCoercion:
         """Test Songset.from_row with datetime objects."""
         created = datetime(2024, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
         updated = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
-        row = ("set_1", "My Set", "desc", created, updated)
+        row = ("set_1", 7, "My Set", "desc", created, updated)
         songset = Songset.from_row(row)
+        assert songset.user_id == 7
         assert songset.created_at == "2024-01-15T10:00:00+00:00"
         assert songset.updated_at == "2024-01-15T12:00:00+00:00"
 

--- a/tests/db/test_postgres_clients.py
+++ b/tests/db/test_postgres_clients.py
@@ -15,8 +15,11 @@ from stream_of_worship.db.postgres_schema import ALL_SCHEMA_STATEMENTS
 
 
 @pytest.fixture(scope="function")
-def db_clients(postgres_url):
-    """Create schema and return connected clients.
+def db_clients(postgres_url, seed_user):
+    """Create schema, seed a default user, and return connected clients.
+
+    The ``SongsetClient`` returned is scoped to the seeded user so existing
+    test bodies don't have to thread ``user_id`` through every call.
 
     Returns:
         Tuple of (DatabaseClient, ReadOnlyClient, SongsetClient, connection).
@@ -29,9 +32,12 @@ def db_clients(postgres_url):
         for stmt in ALL_SCHEMA_STATEMENTS:
             cur.execute(stmt)
 
+    # Songsets now require a user_id FK; seed a default user for the test.
+    default_user_id = seed_user(provider, email="default@test", name="Default")
+
     admin_client = DatabaseClient(provider)
     read_client = ReadOnlyClient(provider)
-    songset_client = SongsetClient(provider)
+    songset_client = SongsetClient(provider, user_id=default_user_id)
 
     yield admin_client, read_client, songset_client, conn
 
@@ -40,11 +46,20 @@ def db_clients(postgres_url):
         cleanup_provider = ConnectionProvider(postgres_url)
         with cleanup_provider.get_connection().cursor() as cur:
             cur.execute("""
+                DROP TABLE IF EXISTS songset_share CASCADE;
+                DROP TABLE IF EXISTS lyric_mark CASCADE;
+                DROP TABLE IF EXISTS user_lrc_override CASCADE;
+                DROP TABLE IF EXISTS user_settings CASCADE;
                 DROP TABLE IF EXISTS songset_items CASCADE;
                 DROP TABLE IF EXISTS songsets CASCADE;
                 DROP TABLE IF EXISTS recordings CASCADE;
                 DROP TABLE IF EXISTS songs CASCADE;
+                DROP TABLE IF EXISTS "session" CASCADE;
+                DROP TABLE IF EXISTS "account" CASCADE;
+                DROP TABLE IF EXISTS "verification" CASCADE;
+                DROP TABLE IF EXISTS "user" CASCADE;
                 DROP FUNCTION IF EXISTS update_updated_at_column CASCADE;
+                DROP FUNCTION IF EXISTS update_updatedat_column CASCADE;
             """)
         cleanup_provider.close()
     except Exception:

--- a/tests/db/test_role_permissions.py
+++ b/tests/db/test_role_permissions.py
@@ -42,9 +42,17 @@ def restricted_connection(postgres_url):
         # Read-only on catalog
         cur.execute("GRANT SELECT ON songs TO sow_app_test;")
         cur.execute("GRANT SELECT ON recordings TO sow_app_test;")
+        # Read-only on auth user table (for TUI pick-a-user); no writes on
+        # account/session/verification (webapp Better Auth role owns those).
+        cur.execute('GRANT SELECT ON "user" TO sow_app_test;')
         # Full CRUD on songsets
         cur.execute("GRANT ALL ON songsets TO sow_app_test;")
         cur.execute("GRANT ALL ON songset_items TO sow_app_test;")
+        # Full CRUD on per-user app tables
+        cur.execute("GRANT ALL ON user_settings TO sow_app_test;")
+        cur.execute("GRANT ALL ON user_lrc_override TO sow_app_test;")
+        cur.execute("GRANT ALL ON lyric_mark TO sow_app_test;")
+        cur.execute("GRANT ALL ON songset_share TO sow_app_test;")
         # Allow sequence usage for songset inserts
         cur.execute("GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO sow_app_test;")
     conn.autocommit = False
@@ -109,18 +117,34 @@ class TestRolePermissions:
 
         restricted_conn.close()
 
+    def _seed_user(self, admin_conn) -> int:
+        """Insert a user via the admin connection and return its id (idempotent)."""
+        with admin_conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO "user" ("name", "email") VALUES (%s, %s)
+                ON CONFLICT ("email") DO UPDATE SET "name" = EXCLUDED."name"
+                RETURNING "id"
+                """,
+                ("Role Test User", "role-test@example.com"),
+            )
+            user_id = cur.fetchone()[0]
+            admin_conn.commit()
+        return user_id
+
     def test_app_role_can_crud_songsets(self, restricted_connection):
         """App role should be able to create, read, update, delete songsets."""
-        _, restricted_url = restricted_connection
+        admin_conn, restricted_url = restricted_connection
         import psycopg
 
+        user_id = self._seed_user(admin_conn)
         restricted_conn = psycopg.connect(restricted_url)
 
         # Create songset
         with restricted_conn.cursor() as cur:
             cur.execute(
-                "INSERT INTO songsets (id, name) VALUES (%s, %s)",
-                ("set_1", "Test Set"),
+                "INSERT INTO songsets (id, user_id, name) VALUES (%s, %s, %s)",
+                ("set_1", user_id, "Test Set"),
             )
             restricted_conn.commit()
 
@@ -149,16 +173,17 @@ class TestRolePermissions:
 
     def test_app_role_can_crud_songset_items(self, restricted_connection):
         """App role should be able to manage songset_items."""
-        _, restricted_url = restricted_connection
+        admin_conn, restricted_url = restricted_connection
         import psycopg
 
+        user_id = self._seed_user(admin_conn)
         restricted_conn = psycopg.connect(restricted_url)
 
         # Create songset first
         with restricted_conn.cursor() as cur:
             cur.execute(
-                "INSERT INTO songsets (id, name) VALUES (%s, %s)",
-                ("set_1", "Test Set"),
+                "INSERT INTO songsets (id, user_id, name) VALUES (%s, %s, %s)",
+                ("set_1", user_id, "Test Set"),
             )
             restricted_conn.commit()
 
@@ -188,6 +213,63 @@ class TestRolePermissions:
         # Delete
         with restricted_conn.cursor() as cur:
             cur.execute("DELETE FROM songset_items WHERE id = %s", ("item_1",))
+            restricted_conn.commit()
+
+        restricted_conn.close()
+
+    def test_app_role_can_select_user(self, restricted_connection):
+        """App role should be able to read from the user table (for TUI picker)."""
+        admin_conn, restricted_url = restricted_connection
+        import psycopg
+
+        self._seed_user(admin_conn)
+        restricted_conn = psycopg.connect(restricted_url)
+
+        with restricted_conn.cursor() as cur:
+            cur.execute('SELECT "name" FROM "user" WHERE "email" = %s',
+                        ("role-test@example.com",))
+            row = cur.fetchone()
+            assert row is not None
+            assert row[0] == "Role Test User"
+
+        restricted_conn.close()
+
+    def test_app_role_cannot_insert_into_user(self, restricted_connection):
+        """App role must NOT be able to create users; that's admin/webapp only."""
+        _, restricted_url = restricted_connection
+        import psycopg
+
+        restricted_conn = psycopg.connect(restricted_url)
+
+        with pytest.raises(Exception):
+            with restricted_conn.cursor() as cur:
+                cur.execute(
+                    'INSERT INTO "user" ("name", "email") VALUES (%s, %s)',
+                    ("Sneaky", "sneak@example.com"),
+                )
+                restricted_conn.commit()
+
+        restricted_conn.close()
+
+    def test_app_role_can_crud_user_settings(self, restricted_connection):
+        """App role should be able to CRUD per-user app tables."""
+        admin_conn, restricted_url = restricted_connection
+        import psycopg
+
+        user_id = self._seed_user(admin_conn)
+        restricted_conn = psycopg.connect(restricted_url)
+
+        with restricted_conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO user_settings (user_id, offline_auto_cache) VALUES (%s, %s)",
+                (user_id, False),
+            )
+            cur.execute(
+                "SELECT offline_auto_cache FROM user_settings WHERE user_id = %s",
+                (user_id,),
+            )
+            assert cur.fetchone()[0] is False
+            cur.execute("DELETE FROM user_settings WHERE user_id = %s", (user_id,))
             restricted_conn.commit()
 
         restricted_conn.close()

--- a/tests/db/test_user_client.py
+++ b/tests/db/test_user_client.py
@@ -1,0 +1,105 @@
+"""Integration tests for UserClient against the Better Auth ``"user"`` table."""
+
+import pytest
+
+from stream_of_worship.db.connection import ConnectionProvider
+from stream_of_worship.db.postgres_schema import ALL_SCHEMA_STATEMENTS
+from stream_of_worship.db.user_client import DuplicateEmailError, UserClient
+
+
+@pytest.fixture(scope="function")
+def user_client(postgres_url):
+    """Create a UserClient with a fresh schema."""
+    provider = ConnectionProvider(postgres_url)
+    conn = provider.get_connection()
+
+    with conn.cursor() as cur:
+        for stmt in ALL_SCHEMA_STATEMENTS:
+            cur.execute(stmt)
+
+    client = UserClient(provider)
+    yield client
+
+    try:
+        cleanup_provider = ConnectionProvider(postgres_url)
+        with cleanup_provider.get_connection().cursor() as cur:
+            cur.execute(
+                """
+                DROP TABLE IF EXISTS songset_share, lyric_mark,
+                    user_lrc_override, user_settings,
+                    songset_items, songsets,
+                    recordings, songs,
+                    "session", "account", "verification", "user" CASCADE;
+                DROP FUNCTION IF EXISTS update_updated_at_column CASCADE;
+                DROP FUNCTION IF EXISTS update_updatedat_column CASCADE;
+                """
+            )
+        cleanup_provider.close()
+    except Exception:
+        pass
+
+
+@pytest.mark.integration
+class TestUserClient:
+    def test_create_user_returns_sequential_id(self, user_client):
+        u1 = user_client.create_user("alice@example.com", name="Alice")
+        u2 = user_client.create_user("bob@example.com", name="Bob")
+        assert isinstance(u1.id, int)
+        assert isinstance(u2.id, int)
+        assert u2.id == u1.id + 1
+        assert u1.name == "Alice"
+        assert u1.email == "alice@example.com"
+
+    def test_create_user_default_name_from_email(self, user_client):
+        u = user_client.create_user("carol@example.com")
+        assert u.name == "carol"
+
+    def test_duplicate_email_raises(self, user_client):
+        user_client.create_user("dupe@example.com", name="First")
+        with pytest.raises(DuplicateEmailError):
+            user_client.create_user("dupe@example.com", name="Second")
+
+    def test_get_user_returns_user(self, user_client):
+        created = user_client.create_user("alice@example.com", name="Alice")
+        fetched = user_client.get_user(created.id)
+        assert fetched is not None
+        assert fetched.id == created.id
+        assert fetched.email == "alice@example.com"
+
+    def test_get_user_unknown_returns_none(self, user_client):
+        assert user_client.get_user(999999) is None
+
+    def test_get_user_by_email(self, user_client):
+        user_client.create_user("alice@example.com", name="Alice")
+        fetched = user_client.get_user_by_email("alice@example.com")
+        assert fetched is not None
+        assert fetched.name == "Alice"
+        assert user_client.get_user_by_email("nobody@example.com") is None
+
+    def test_list_users_creation_order(self, user_client):
+        user_client.create_user("a@example.com", name="A")
+        user_client.create_user("b@example.com", name="B")
+        user_client.create_user("c@example.com", name="C")
+        users = user_client.list_users()
+        assert [u.name for u in users] == ["A", "B", "C"]
+
+    def test_delete_user_returns_false_for_unknown(self, user_client):
+        assert user_client.delete_user(999999) is False
+
+    def test_delete_user_cascades_to_songsets(self, user_client, postgres_url):
+        """Deleting a user must remove their songsets via CASCADE."""
+        from stream_of_worship.app.db.songset_client import SongsetClient
+
+        user = user_client.create_user("alice@example.com", name="Alice")
+        songset_client = SongsetClient(
+            ConnectionProvider(postgres_url), user_id=user.id
+        )
+        songset_client.create_songset("Sunday")
+        songset_client.create_songset("Evening")
+
+        assert len(songset_client.list_songsets()) == 2
+
+        assert user_client.delete_user(user.id) is True
+        assert user_client.get_user(user.id) is None
+        # Songsets cascade-deleted: list returns empty for this (now-defunct) user_id
+        assert songset_client.list_songsets() == []


### PR DESCRIPTION
Songsets and the related per-user tables were globally shared, blocking
the planned phone-first webapp which assumes Better Auth-backed
ownership. This adds a Better Auth-compatible identity layer now so the
schema is ready when the Next.js app ships.

- New "user", "account", "session", "verification" tables (camelCase,
  BIGINT IDENTITY ids — the webapp will set `useNumberId: true`)
- New per-user tables: user_settings, user_lrc_override, lyric_mark,
  songset_share (schema only for the share table)
- songsets gains NOT NULL user_id FK with ON DELETE CASCADE
- SongsetClient is constructor-scoped to a user; reads filter by
  user_id, mutations on items raise NotOwnerError for foreign owners
- New UserClient and `sow-admin users add|list|delete` for seeding
- TUI gains a pick-a-user LoginScreen as the first navigated screen
- `sow-admin db init --wipe-songsets` for the one-shot cutover
- Tests for user isolation, schema build, and the login flow

https://claude.ai/code/session_01WW15qMiJBJwEEj639nVyqB