### PR TITLE
feat(webapp): add download audio/video to songset KAB menus

### DIFF
--- a/services/render-worker/src/sow_render_worker/db.py
+++ b/services/render-worker/src/sow_render_worker/db.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 from dataclasses import dataclass
@@ -48,6 +49,7 @@ class RenderJob:
     font_size_preset: str = "M"
     include_title_card: bool = False
     title_card_duration_seconds: Optional[float] = None
+    title_card_lines: Optional[list[str]] = None
     mp3_r2_key: Optional[str] = None
     mp4_r2_key: Optional[str] = None
     chapters_r2_key: Optional[str] = None
@@ -79,6 +81,16 @@ def get_phase_index(phase: str) -> int:
 
 
 def _row_to_render_job(row: dict[str, Any]) -> RenderJob:
+    title_card_lines_raw = row.get("title_card_lines")
+    title_card_lines = None
+    if title_card_lines_raw:
+        try:
+            parsed = json.loads(title_card_lines_raw)
+            title_card_lines = parsed if parsed else None
+        except json.JSONDecodeError:
+            logger.warning("Failed to parse title_card_lines JSON: %s", title_card_lines_raw)
+            title_card_lines = None
+
     return RenderJob(
         id=row["id"],
         songset_id=row["songset_id"],
@@ -101,6 +113,7 @@ def _row_to_render_job(row: dict[str, Any]) -> RenderJob:
         font_size_preset=row.get("font_size_preset") or "M",
         include_title_card=row.get("include_title_card", False),
         title_card_duration_seconds=row.get("title_card_duration_seconds"),
+        title_card_lines=title_card_lines,
         mp3_r2_key=row.get("mp3_r2_key"),
         mp4_r2_key=row.get("mp4_r2_key"),
         chapters_r2_key=row.get("chapters_r2_key"),

--- a/services/render-worker/src/sow_render_worker/frame_renderer.py
+++ b/services/render-worker/src/sow_render_worker/frame_renderer.py
@@ -48,8 +48,7 @@ class SegmentInfo:
 class TitleCardConfig:
     enabled: bool
     duration_seconds: float
-    songset_name: str
-    song_count: int
+    lines: tuple[str, ...]
     total_duration_seconds: float
 
 
@@ -424,31 +423,65 @@ class FrameRenderer:
 
         text_r, text_g, text_b = self.template.text_color
 
-        title_card_font_size_target = self.base_font_size * 2
-        margin = self.get_margin(draw, title_card_font_size_target)
-        title_card_font_size = self.fit_text(
-            draw, config.songset_name, title_card_font_size_target, width - margin * 2
-        )
-        font = self._get_font(title_card_font_size)
-        draw.text(
-            (width // 2, int(height * 0.4)),
-            config.songset_name,
-            fill=(text_r, text_g, text_b),
-            font=font,
-            anchor="mm",
-        )
+        if not config.lines:
+            return img
 
-        base_font = self._get_font(self.base_font_size)
-        duration_minutes = math.floor(config.total_duration_seconds / 60)
-        duration_seconds = math.floor(config.total_duration_seconds % 60)
-        duration_text = f"{duration_minutes}:{duration_seconds:02d}"
-        subtitle = f"{config.song_count} 首歌曲 · {duration_text}"
-        draw.text(
-            (width // 2, int(height * 0.55)),
-            subtitle,
-            fill=(text_r, text_g, text_b),
-            font=base_font,
-            anchor="mm",
-        )
+        margin = 40
+        min_body_font_size = 16
+        line_spacing_factor = 1.2
+        heading_gap_factor = 1.5
+
+        heading_font_size_target = self.base_font_size * 2
+        body_font_size_target = heading_font_size_target - 20
+
+        heading_font_size = heading_font_size_target
+        body_font_size = body_font_size_target
+
+        while True:
+            heading_font = self._get_font(heading_font_size)
+            body_font = self._get_font(body_font_size)
+
+            total_height = 0
+            for i, line in enumerate(config.lines):
+                font = heading_font if i == 0 else body_font
+                bbox = draw.textbbox((0, 0), line, font=font)
+                line_height = bbox[3] - bbox[1]
+                total_height += line_height
+                if i == 0 and len(config.lines) > 1:
+                    total_height += int(body_font_size * heading_gap_factor)
+                elif i > 0:
+                    total_height += int(body_font_size * line_spacing_factor)
+
+            if total_height <= height - margin * 2 or body_font_size <= min_body_font_size:
+                break
+
+            heading_font_size -= 2
+            body_font_size = max(min_body_font_size, heading_font_size - 20)
+
+        heading_font = self._get_font(heading_font_size)
+        body_font = self._get_font(body_font_size)
+
+        y_start = (height - total_height) // 2
+        current_y = y_start
+
+        for i, line in enumerate(config.lines):
+            font = heading_font if i == 0 else body_font
+            target_size = heading_font_size if i == 0 else body_font_size
+            fitted_size = self.fit_text(draw, line, target_size, width - margin * 2)
+            font = self._get_font(fitted_size)
+            draw.text(
+                (width // 2, current_y),
+                line,
+                fill=(text_r, text_g, text_b),
+                font=font,
+                anchor="mt",
+            )
+            bbox = draw.textbbox((0, 0), line, font=font)
+            line_height = bbox[3] - bbox[1]
+            current_y += line_height
+            if i == 0 and len(config.lines) > 1:
+                current_y += int(body_font_size * heading_gap_factor)
+            elif i > 0:
+                current_y += int(body_font_size * line_spacing_factor)
 
         return img

--- a/services/render-worker/src/sow_render_worker/pipeline.py
+++ b/services/render-worker/src/sow_render_worker/pipeline.py
@@ -99,8 +99,18 @@ def get_render_ratio(
 def fetch_songset_items(
     conn: psycopg2.extensions.connection,
     songset_id: str,
-) -> list[SongsetItem]:
+) -> tuple[str, list[SongsetItem]]:
+    """
+    Returns: (songset_name, list of SongsetItem)
+    """
     with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(
+            "SELECT name FROM songsets WHERE id = %s",
+            (songset_id,),
+        )
+        songset_row = cur.fetchone()
+        songset_name = songset_row["name"] if songset_row else "Worship Set"
+
         cur.execute(
             "SELECT "
             "  si.id, "
@@ -125,7 +135,7 @@ def fetch_songset_items(
         )
         rows = cur.fetchall()
 
-    return [
+    items = [
         SongsetItem(
             id=row["id"],
             songset_id=row["songset_id"],
@@ -143,6 +153,8 @@ def fetch_songset_items(
         )
         for row in rows
     ]
+
+    return songset_name, items
 
 
 class PipelineCancelledError(Exception):
@@ -254,7 +266,7 @@ def execute_render_pipeline(
 
         check_cancelled()
 
-        items = fetch_songset_items(conn, job.songset_id)
+        songset_name, items = fetch_songset_items(conn, job.songset_id)
         if not items:
             raise ValueError("Songset has no items")
 
@@ -344,6 +356,7 @@ def execute_render_pipeline(
 
         video_output_path: str | None = None
         if job.video_enabled:
+            title_card_lines = job.title_card_lines if job.title_card_lines else None
             video_engine = VideoEngine(
                 asset_fetcher,
                 template=job.template,
@@ -351,6 +364,8 @@ def execute_render_pipeline(
                 resolution=job.resolution,
                 include_title_card=job.include_title_card,
                 title_card_duration_seconds=job.title_card_duration_seconds or 5.0,
+                title_card_lines=title_card_lines,
+                songset_name=songset_name,
             )
 
             video_output_path = str(Path(temp_dir) / "output.mp4")

--- a/services/render-worker/src/sow_render_worker/video_engine.py
+++ b/services/render-worker/src/sow_render_worker/video_engine.py
@@ -70,6 +70,8 @@ class VideoEngine:
         fps: int = 24,
         include_title_card: bool = True,
         title_card_duration_seconds: float = 5.0,
+        title_card_lines: list[str] | None = None,
+        songset_name: str = "",
         ffmpeg_path: str | None = None,
         ffprobe_path: str | None = None,
     ):
@@ -80,6 +82,8 @@ class VideoEngine:
         self.fps = fps
         self.include_title_card = include_title_card
         self.title_card_duration_seconds = max(5.0, min(title_card_duration_seconds, 30.0))
+        self.title_card_lines = title_card_lines
+        self.songset_name = songset_name
         self.ffmpeg_path = ffmpeg_path or self._find_ffmpeg()
         self.ffprobe_path = ffprobe_path or "ffprobe"
 
@@ -201,13 +205,17 @@ class VideoEngine:
 
         title_card_config: TitleCardConfig | None = None
         if self.include_title_card:
+            if self.title_card_lines:
+                title_lines = tuple(self.title_card_lines)
+            else:
+                song_titles = [seg.item.song_title for seg in segments if seg.item.song_title]
+                display_name = self.songset_name or "Worship Set"
+                title_lines = tuple([display_name] + song_titles) if song_titles else (display_name,)
+
             title_card_config = TitleCardConfig(
                 enabled=True,
                 duration_seconds=total_duration_seconds,
-                songset_name=(
-                    (segments[0].item.song_title or "Worship Set") if segments else "Worship Set"
-                ),
-                song_count=len(segments),
+                lines=title_lines,
                 total_duration_seconds=total_duration_seconds,
             )
 

--- a/services/render-worker/tests/test_frame_renderer.py
+++ b/services/render-worker/tests/test_frame_renderer.py
@@ -165,8 +165,7 @@ class TestTitleCardConfig:
         c = TitleCardConfig(
             enabled=True,
             duration_seconds=5.0,
-            songset_name="Test",
-            song_count=3,
+            lines=("Test", "Song 1", "Song 2"),
             total_duration_seconds=300.0,
         )
         with pytest.raises(AttributeError):
@@ -176,12 +175,10 @@ class TestTitleCardConfig:
         c = TitleCardConfig(
             enabled=True,
             duration_seconds=5.0,
-            songset_name="My Set",
-            song_count=5,
+            lines=("My Set", "Song 1", "Song 2", "Song 3"),
             total_duration_seconds=600.0,
         )
-        assert c.songset_name == "My Set"
-        assert c.song_count == 5
+        assert c.lines == ("My Set", "Song 1", "Song 2", "Song 3")
         assert c.total_duration_seconds == 600.0
 
 
@@ -519,8 +516,7 @@ class TestRenderTitleCard:
         config = TitleCardConfig(
             enabled=True,
             duration_seconds=5.0,
-            songset_name="Test Set",
-            song_count=3,
+            lines=("Test Set", "Song 1", "Song 2", "Song 3"),
             total_duration_seconds=300.0,
         )
         result = renderer.render_title_card(config)
@@ -531,8 +527,7 @@ class TestRenderTitleCard:
         config = TitleCardConfig(
             enabled=True,
             duration_seconds=5.0,
-            songset_name="Test Set",
-            song_count=3,
+            lines=("Test Set", "Song 1", "Song 2", "Song 3"),
             total_duration_seconds=300.0,
         )
         result = renderer.render_title_card(config)
@@ -543,8 +538,7 @@ class TestRenderTitleCard:
         config = TitleCardConfig(
             enabled=True,
             duration_seconds=5.0,
-            songset_name="Test Set",
-            song_count=3,
+            lines=("Test Set", "Song 1", "Song 2", "Song 3"),
             total_duration_seconds=300.0,
         )
         result = renderer.render_title_card(config)
@@ -556,8 +550,7 @@ class TestRenderTitleCard:
         config = TitleCardConfig(
             enabled=True,
             duration_seconds=5.0,
-            songset_name="Test Set",
-            song_count=3,
+            lines=("Test Set", "Song 1", "Song 2", "Song 3"),
             total_duration_seconds=125.0,
         )
         result = renderer.render_title_card(config)
@@ -568,8 +561,7 @@ class TestRenderTitleCard:
         config = TitleCardConfig(
             enabled=True,
             duration_seconds=5.0,
-            songset_name="讚美之泉詩歌集",
-            song_count=5,
+            lines=("讚美之泉詩歌集", "歌曲一", "歌曲二", "歌曲三", "歌曲四", "歌曲五"),
             total_duration_seconds=600.0,
         )
         result = renderer.render_title_card(config)
@@ -580,8 +572,7 @@ class TestRenderTitleCard:
         config = TitleCardConfig(
             enabled=True,
             duration_seconds=5.0,
-            songset_name="Warm Set",
-            song_count=2,
+            lines=("Warm Set", "Song 1", "Song 2"),
             total_duration_seconds=180.0,
         )
         result = renderer.render_title_card(config)
@@ -623,8 +614,7 @@ class TestFrameRendererIntegration:
         config = TitleCardConfig(
             enabled=True,
             duration_seconds=5.0,
-            songset_name="Blue Set",
-            song_count=4,
+            lines=("Blue Set", "Song 1", "Song 2", "Song 3", "Song 4"),
             total_duration_seconds=240.0,
         )
         title_card = renderer.render_title_card(config)

--- a/services/render-worker/tests/test_pipeline.py
+++ b/services/render-worker/tests/test_pipeline.py
@@ -263,7 +263,8 @@ class TestFetchSongsetItems:
             },
         ]
         conn, cursor = _make_mock_conn(fetchall_result=rows)
-        items = fetch_songset_items(conn, "ss_001")
+        songset_name, items = fetch_songset_items(conn, "ss_001")
+        assert songset_name == "Worship Set"
         assert len(items) == 2
         assert items[0].id == "item_1"
         assert items[0].song_title == "Test Song"
@@ -272,7 +273,8 @@ class TestFetchSongsetItems:
 
     def test_empty_result(self):
         conn, cursor = _make_mock_conn(fetchall_result=[])
-        items = fetch_songset_items(conn, "ss_empty")
+        songset_name, items = fetch_songset_items(conn, "ss_empty")
+        assert songset_name == "Worship Set"
         assert items == []
 
     def test_query_joins_tables(self):
@@ -294,7 +296,7 @@ class TestFetchSongsetItems:
             }
         ]
         conn, cursor = _make_mock_conn(fetchall_result=rows)
-        fetch_songset_items(conn, "ss_001")
+        _, _ = fetch_songset_items(conn, "ss_001")
         sql = cursor.execute.call_args[0][0]
         assert "songset_items" in sql
         assert "recordings" in sql
@@ -303,13 +305,13 @@ class TestFetchSongsetItems:
 
     def test_query_uses_parameterized(self):
         conn, cursor = _make_mock_conn(fetchall_result=[])
-        fetch_songset_items(conn, "ss_001")
+        _, _ = fetch_songset_items(conn, "ss_001")
         params = cursor.execute.call_args[0][1]
         assert params == ("ss_001",)
 
     def test_query_orders_by_position(self):
         conn, cursor = _make_mock_conn(fetchall_result=[])
-        fetch_songset_items(conn, "ss_001")
+        _, _ = fetch_songset_items(conn, "ss_001")
         sql = cursor.execute.call_args[0][0]
         assert "ORDER BY si.position" in sql
 
@@ -332,7 +334,8 @@ class TestFetchSongsetItems:
             }
         ]
         conn, cursor = _make_mock_conn(fetchall_result=rows)
-        items = fetch_songset_items(conn, "ss_001")
+        songset_name, items = fetch_songset_items(conn, "ss_001")
+        assert songset_name == "Worship Set"
         assert len(items) == 1
         assert items[0].recording_hash_prefix is None
         assert items[0].song_title is None
@@ -360,7 +363,7 @@ class TestExecuteRenderPipeline:
              patch("sow_render_worker.pipeline.update_render_progress") as mock_update, \
              patch("sow_render_worker.pipeline.complete_render_job") as mock_complete, \
              patch("sow_render_worker.pipeline.fail_render_job") as mock_fail, \
-             patch("sow_render_worker.pipeline.fetch_songset_items", return_value=items), \
+             patch("sow_render_worker.pipeline.fetch_songset_items", return_value=("Worship Set", items)), \
              patch("sow_render_worker.pipeline.get_render_ratio", return_value=0.8), \
              patch("sow_render_worker.pipeline.generate_songset_audio", return_value=audio_result), \
              patch("sow_render_worker.pipeline.generate_chapters_manifest", return_value=_make_chapters_manifest()), \
@@ -404,7 +407,7 @@ class TestExecuteRenderPipeline:
              patch("sow_render_worker.pipeline.update_render_progress"), \
              patch("sow_render_worker.pipeline.complete_render_job"), \
              patch("sow_render_worker.pipeline.fail_render_job"), \
-             patch("sow_render_worker.pipeline.fetch_songset_items", return_value=items), \
+             patch("sow_render_worker.pipeline.fetch_songset_items", return_value=("Worship Set", items)), \
              patch("sow_render_worker.pipeline.get_render_ratio", return_value=0.4), \
              patch("sow_render_worker.pipeline.generate_songset_audio", return_value=audio_result), \
              patch("sow_render_worker.pipeline.generate_chapters_manifest", return_value=_make_chapters_manifest()), \
@@ -437,7 +440,7 @@ class TestExecuteRenderPipeline:
              patch("sow_render_worker.pipeline.start_render_job", return_value=job), \
              patch("sow_render_worker.pipeline.update_render_progress"), \
              patch("sow_render_worker.pipeline.fail_render_job") as mock_fail, \
-             patch("sow_render_worker.pipeline.fetch_songset_items", return_value=[]), \
+             patch("sow_render_worker.pipeline.fetch_songset_items", return_value=("Worship Set", [])), \
              patch("sow_render_worker.pipeline.get_render_ratio", return_value=0.8):
 
             with pytest.raises(ValueError, match="Songset has no items"):
@@ -467,7 +470,7 @@ class TestExecuteRenderPipeline:
              patch("sow_render_worker.pipeline.start_render_job", return_value=job), \
              patch("sow_render_worker.pipeline.update_render_progress"), \
              patch("sow_render_worker.pipeline.fail_render_job") as mock_fail, \
-             patch("sow_render_worker.pipeline.fetch_songset_items", return_value=[_make_songset_item()]), \
+             patch("sow_render_worker.pipeline.fetch_songset_items", return_value=("Worship Set", [_make_songset_item()])), \
              patch("sow_render_worker.pipeline.get_render_ratio", return_value=0.8):
 
             execute_render_pipeline(
@@ -499,7 +502,7 @@ class TestExecuteRenderPipeline:
              patch("sow_render_worker.pipeline.start_render_job", return_value=job), \
              patch("sow_render_worker.pipeline.update_render_progress"), \
              patch("sow_render_worker.pipeline.fail_render_job") as mock_fail, \
-             patch("sow_render_worker.pipeline.fetch_songset_items", return_value=items), \
+             patch("sow_render_worker.pipeline.fetch_songset_items", return_value=("Worship Set", items)), \
              patch("sow_render_worker.pipeline.get_render_ratio", return_value=0.8), \
              patch("sow_render_worker.pipeline.generate_songset_audio", return_value=audio_result), \
              patch("sow_render_worker.pipeline.VideoEngine") as mock_ve_class, \
@@ -585,7 +588,7 @@ class TestExecuteRenderPipeline:
              patch("sow_render_worker.pipeline.update_render_progress"), \
              patch("sow_render_worker.pipeline.complete_render_job"), \
              patch("sow_render_worker.pipeline.fail_render_job"), \
-             patch("sow_render_worker.pipeline.fetch_songset_items", return_value=items), \
+             patch("sow_render_worker.pipeline.fetch_songset_items", return_value=("Worship Set", items)), \
              patch("sow_render_worker.pipeline.get_render_ratio", return_value=0.8), \
              patch("sow_render_worker.pipeline.generate_songset_audio", return_value=audio_result), \
              patch("sow_render_worker.pipeline.generate_chapters_manifest", return_value=_make_chapters_manifest()), \
@@ -660,7 +663,7 @@ class TestExecuteRenderPipeline:
              patch("sow_render_worker.pipeline.update_render_progress") as mock_update, \
              patch("sow_render_worker.pipeline.complete_render_job"), \
              patch("sow_render_worker.pipeline.fail_render_job"), \
-             patch("sow_render_worker.pipeline.fetch_songset_items", return_value=items), \
+             patch("sow_render_worker.pipeline.fetch_songset_items", return_value=("Worship Set", items)), \
              patch("sow_render_worker.pipeline.get_render_ratio", return_value=0.8), \
              patch("sow_render_worker.pipeline.generate_songset_audio", return_value=audio_result), \
              patch("sow_render_worker.pipeline.generate_chapters_manifest", return_value=_make_chapters_manifest()), \
@@ -709,7 +712,7 @@ class TestExecuteRenderPipeline:
              patch("sow_render_worker.pipeline.update_render_progress") as mock_update, \
              patch("sow_render_worker.pipeline.complete_render_job"), \
              patch("sow_render_worker.pipeline.fail_render_job"), \
-             patch("sow_render_worker.pipeline.fetch_songset_items", return_value=items), \
+             patch("sow_render_worker.pipeline.fetch_songset_items", return_value=("Worship Set", items)), \
              patch("sow_render_worker.pipeline.get_render_ratio", return_value=0.8), \
              patch("sow_render_worker.pipeline.generate_songset_audio", return_value=audio_result), \
              patch("sow_render_worker.pipeline.generate_chapters_manifest", return_value=_make_chapters_manifest()), \
@@ -756,7 +759,7 @@ class TestExecuteRenderPipeline:
              patch("sow_render_worker.pipeline.update_render_progress") as mock_update, \
              patch("sow_render_worker.pipeline.complete_render_job"), \
              patch("sow_render_worker.pipeline.fail_render_job"), \
-             patch("sow_render_worker.pipeline.fetch_songset_items", return_value=items), \
+             patch("sow_render_worker.pipeline.fetch_songset_items", return_value=("Worship Set", items)), \
              patch("sow_render_worker.pipeline.get_render_ratio", return_value=0.8), \
              patch("sow_render_worker.pipeline.generate_songset_audio", return_value=audio_result), \
              patch("sow_render_worker.pipeline.generate_chapters_manifest", return_value=_make_chapters_manifest()), \
@@ -807,7 +810,7 @@ class TestExecuteRenderPipeline:
              patch("sow_render_worker.pipeline.update_render_progress", side_effect=mock_update_side_effect) as mock_update, \
              patch("sow_render_worker.pipeline.complete_render_job"), \
              patch("sow_render_worker.pipeline.fail_render_job"), \
-             patch("sow_render_worker.pipeline.fetch_songset_items", return_value=items), \
+             patch("sow_render_worker.pipeline.fetch_songset_items", return_value=("Worship Set", items)), \
              patch("sow_render_worker.pipeline.get_render_ratio", return_value=0.8), \
              patch("sow_render_worker.pipeline.generate_songset_audio", return_value=audio_result), \
              patch("sow_render_worker.pipeline.generate_chapters_manifest", return_value=_make_chapters_manifest()), \
@@ -868,7 +871,7 @@ class TestExecuteRenderPipeline:
              patch("sow_render_worker.pipeline.update_render_progress"), \
              patch("sow_render_worker.pipeline.complete_render_job"), \
              patch("sow_render_worker.pipeline.fail_render_job"), \
-             patch("sow_render_worker.pipeline.fetch_songset_items", return_value=items), \
+             patch("sow_render_worker.pipeline.fetch_songset_items", return_value=("Worship Set", items)), \
              patch("sow_render_worker.pipeline.get_render_ratio", return_value=0.8), \
              patch("sow_render_worker.pipeline.generate_songset_audio", return_value=audio_result), \
              patch("sow_render_worker.pipeline.generate_chapters_manifest", return_value=_make_chapters_manifest()), \
@@ -905,7 +908,7 @@ class TestExecuteRenderPipeline:
              patch("sow_render_worker.pipeline.update_render_progress"), \
              patch("sow_render_worker.pipeline.complete_render_job"), \
              patch("sow_render_worker.pipeline.fail_render_job"), \
-             patch("sow_render_worker.pipeline.fetch_songset_items", return_value=items), \
+             patch("sow_render_worker.pipeline.fetch_songset_items", return_value=("Worship Set", items)), \
              patch("sow_render_worker.pipeline.get_render_ratio", return_value=0.8), \
              patch("sow_render_worker.pipeline.generate_songset_audio", return_value=audio_result), \
              patch("sow_render_worker.pipeline.generate_chapters_manifest", return_value=_make_chapters_manifest()), \
@@ -939,7 +942,7 @@ class TestExecuteRenderPipeline:
              patch("sow_render_worker.pipeline.update_render_progress") as mock_update, \
              patch("sow_render_worker.pipeline.complete_render_job"), \
              patch("sow_render_worker.pipeline.fail_render_job"), \
-             patch("sow_render_worker.pipeline.fetch_songset_items", return_value=items), \
+             patch("sow_render_worker.pipeline.fetch_songset_items", return_value=("Worship Set", items)), \
              patch("sow_render_worker.pipeline.get_render_ratio", return_value=0.8), \
              patch("sow_render_worker.pipeline.generate_songset_audio", return_value=audio_result), \
              patch("sow_render_worker.pipeline.generate_chapters_manifest", return_value=_make_chapters_manifest()), \
@@ -1001,7 +1004,7 @@ class TestExecuteRenderPipeline:
              patch("sow_render_worker.pipeline.update_render_progress"), \
              patch("sow_render_worker.pipeline.complete_render_job"), \
              patch("sow_render_worker.pipeline.fail_render_job") as mock_fail, \
-             patch("sow_render_worker.pipeline.fetch_songset_items", return_value=items), \
+             patch("sow_render_worker.pipeline.fetch_songset_items", return_value=("Worship Set", items)), \
              patch("sow_render_worker.pipeline.get_render_ratio", return_value=0.8), \
              patch("sow_render_worker.pipeline.generate_songset_audio", return_value=audio_result), \
              patch("sow_render_worker.pipeline.generate_chapters_manifest", return_value=_make_chapters_manifest()), \
@@ -1033,7 +1036,7 @@ class TestExecuteRenderPipeline:
              patch("sow_render_worker.pipeline.update_render_progress"), \
              patch("sow_render_worker.pipeline.complete_render_job"), \
              patch("sow_render_worker.pipeline.fail_render_job") as mock_fail, \
-             patch("sow_render_worker.pipeline.fetch_songset_items", return_value=items), \
+             patch("sow_render_worker.pipeline.fetch_songset_items", return_value=("Worship Set", items)), \
              patch("sow_render_worker.pipeline.get_render_ratio", return_value=0.8), \
              patch("sow_render_worker.pipeline.generate_songset_audio", return_value=audio_result), \
              patch("sow_render_worker.pipeline.generate_chapters_manifest", return_value=_make_chapters_manifest()), \

--- a/services/render-worker/tests/test_video_engine.py
+++ b/services/render-worker/tests/test_video_engine.py
@@ -450,8 +450,7 @@ class TestEncodeVideoWithFFmpeg:
         title_card_config = TitleCardConfig(
             enabled=True,
             duration_seconds=10.0,
-            songset_name="Test Set",
-            song_count=1,
+            lines=("Test Set", "Song"),
             total_duration_seconds=10.0,
         )
 
@@ -530,8 +529,7 @@ class TestEncodeVideoWithFFmpeg:
         title_card_config = TitleCardConfig(
             enabled=True,
             duration_seconds=10.0,
-            songset_name="Test Set",
-            song_count=1,
+            lines=("Test Set", "Song"),
             total_duration_seconds=10.0,
         )
 
@@ -718,7 +716,7 @@ class TestGenerateVideo:
         title_card_config = call_kwargs[1].get("title_card_config") if "title_card_config" in call_kwargs[1] else call_kwargs[0][7] if len(call_kwargs[0]) > 7 else None
         assert title_card_config is not None
         assert title_card_config.enabled is True
-        assert title_card_config.song_count == 1
+        assert len(title_card_config.lines) >= 1
         assert call_kwargs[0][2] == math.ceil(180.0 * 24)
 
 

--- a/specs/download-audio-video-from-kab-menu-v2.md
+++ b/specs/download-audio-video-from-kab-menu-v2.md
@@ -1,0 +1,470 @@
+# Download Audio & Video from Songset KAB Menu — v2
+
+**Date:** 2026-05-24
+**Status:** Draft
+**Supersedes:** v1 (2026-05-24)
+
+---
+
+## 1. Problem
+
+Currently, downloading rendered artifacts to disk is only possible from the **Render Completed** screen (`RenderComplete.tsx`). Users must complete a render and stay on that screen to download MP3/MP4 files. There is no way to download artifacts from:
+
+- **Songset Editor screen** — the primary prep workspace
+- **Songset list page** — the overview of all songsets
+
+The Play screen's "download for offline" only caches to browser Cache Storage for offline playback — it does not save a file to disk.
+
+## 2. Goal
+
+Add **"Download Audio"** and **"Download Video"** menu items to the KAB (kebab/overflow) menu on both:
+
+1. **Songset Editor screen** (`SongsetEditor.tsx`)
+2. **Songset list page** (`SongsetRow.tsx`)
+
+### Design decisions (updated from v1)
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Visibility | Always visible, **disabled** when no completed render exists | Communicates feature availability; avoids "where's download?" confusion |
+| Scope | Both Editor and List page KAB menus | Consistent UX across both entry points |
+| Download mechanism | **Direct URL navigation** with `Content-Disposition: attachment` | Avoids buffering entire file in JS memory; browser handles download with native progress bar |
+| Signed URL | Existing `GET /api/signed-url` with `contentDisposition` param | R2 returns `Content-Disposition: attachment; filename="..."` header — browser triggers file save |
+| Progress indication | `toast.loading()` from sonner | Visible after KAB menu closes; no component state needed |
+| Error handling | Caller-only toasts; `downloadArtifact()` is toast-free | Eliminates double-toast bug from v1 |
+| Filename sanitization | Slugify: lowercase, hyphens, strip unsafe chars | Safe across OSes; works for Chinese names (e.g. "何等恩典" → "何等恩典", "Sunday Worship" → "sunday-worship") |
+| Abort support | `AbortController` on signed URL fetch | Prevents state updates on unmounted components |
+| Prop optionality | `onDownloadAudio?` / `onDownloadVideo?` (optional on both Editor and Row) | Consistent; safe if rendered from other contexts |
+
+## 3. Implementation Steps
+
+### Step 1: Create shared download utility
+
+**File:** `webapp/src/lib/download.ts` (NEW)
+
+```typescript
+export function sanitizeFilename(name: string): string {
+  return name
+    .trim()
+    .replace(/[/\\:*?"<>|#]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-{2,}/g, "-")
+    .replace(/^-|-$/g, "")
+    .toLowerCase();
+}
+
+export function downloadArtifact(url: string): void {
+  window.location.href = url;
+}
+```
+
+**Design notes:**
+- `sanitizeFilename` strips filesystem-unsafe chars, replaces whitespace with hyphens, collapses repeated hyphens, trims leading/trailing hyphens, lowercases. Chinese characters pass through unchanged (they are safe in filenames on modern OSes).
+- `downloadArtifact` is intentionally minimal — no toasts, no blob handling, no state. The signed URL carries `Content-Disposition: attachment; filename="..."` so the browser downloads the file and stays on the current page.
+- No `revokeObjectURL` concern — no blob URLs are created.
+
+### Step 2: Refactor `RenderComplete.tsx` to use shared utility
+
+**File:** `webapp/src/components/render/RenderComplete.tsx`
+
+**Current state (lines 50-88):** Three `isDownloading*` booleans + inline `handleDownload` using fetch-blob-createObjectURL pattern.
+
+**Changes:**
+1. Import `sanitizeFilename`, `downloadArtifact` from `@/lib/download`
+2. Remove `isDownloadingAudio`, `isDownloadingVideo`, `isDownloadingChapters` state variables (lines 50-52)
+3. Remove the inline `handleDownload` function (lines 54-88)
+4. Replace each download button's `onClick` with a new handler that:
+   - Shows `toast.loading("Preparing download...")` with a stored `toastId`
+   - Fetches a signed URL with `contentDisposition` param
+   - Calls `downloadArtifact(url)` on success
+   - Dismisses loading toast → shows success or error toast
+5. Remove `Loader2` spinner from download buttons (the loading toast replaces it)
+6. Remove `Download` icon import (no longer used in buttons — the browser's download bar provides feedback)
+
+**New handler pattern:**
+
+```typescript
+const handleDownloadFile = async (
+  fileType: "audio" | "video" | "json",
+  extension: string,
+) => {
+  const toastId = toast.loading("Preparing download...");
+  const controller = new AbortController();
+
+  try {
+    const filename = sanitizeFilename(songsetName);
+    const disposition = `attachment; filename="${filename}.${extension}"`;
+    const res = await fetch(
+      `/api/signed-url?renderJobId=${encodeURIComponent(jobId)}` +
+        `&fileType=${fileType}` +
+        `&contentDisposition=${encodeURIComponent(disposition)}`,
+      { signal: controller.signal }
+    );
+    if (!res.ok) throw new Error("Failed to get download URL");
+    const { url } = await res.json();
+
+    downloadArtifact(url);
+    toast.success("Download started", { id: toastId });
+  } catch (err) {
+    if (err instanceof DOMException && err.name === "AbortError") return;
+    toast.error("Download failed", { id: toastId });
+  }
+};
+```
+
+**Button changes** — each button becomes:
+
+```tsx
+{hasAudio && (
+  <Button
+    variant="outline"
+    className="w-full justify-start gap-3"
+    onClick={() => handleDownloadFile("audio", "mp3")}
+  >
+    <Music className="size-4" />
+    <span className="flex-1 text-left">Download Audio (MP3)</span>
+  </Button>
+)}
+```
+
+(Same pattern for Video and Chapters buttons.)
+
+**File:** `webapp/src/app/songsets/[id]/render/page.tsx`
+
+The parent currently pre-fetches signed URLs without `contentDisposition` (lines 192-205) and passes them as `mp3Url`/`mp4Url`/`chaptersUrl` props. After this refactor, `RenderComplete` fetches its own signed URLs on demand, so:
+
+1. Remove the `fetchSignedUrl` helper and the signed URL pre-fetching logic (lines 190-205)
+2. Remove `mp3Url`, `mp4Url`, `chaptersUrl` from the `JobData` interface (lines 40-42)
+3. Remove `mp3Url`, `mp4Url`, `chaptersUrl` from the `RenderComplete` props spread (lines 304-306)
+4. Update `RenderCompleteProps` to remove `mp3Url?`, `mp4Url?`, `chaptersUrl?` — replace with just `jobId` (already present) and `songsetName` (already present)
+
+### Step 3: Add `latestRenderJobId` to list page data flow
+
+**File:** `webapp/src/components/songset/SongsetList.tsx`
+- Add `latestRenderJobId: string | null` to the `Songset` interface (after line 31)
+
+**File:** `webapp/src/app/songsets/page.tsx`
+- Add `latestRenderJobId: songset.latestRenderJobId` to the transform at line 53-63
+
+**File:** `webapp/src/components/songset/SongsetRow.tsx`
+- Add `latestRenderJobId: string | null` to `SongsetRowProps` (after line 44)
+
+### Step 4: Add download menu items to `SongsetEditor.tsx`
+
+**File:** `webapp/src/components/songset/SongsetEditor.tsx`
+
+**Props changes** — add to `SongsetEditorProps` (after line 68):
+```typescript
+onDownloadAudio?: () => void;
+onDownloadVideo?: () => void;
+```
+
+**No state changes** — no `isDownloadingAudio`/`isDownloadingVideo` needed. The loading toast is visible after the menu closes.
+
+**Import changes:**
+- Add `FileAudio`, `FileVideo` from `lucide-react`
+- `Loader2` already imported (line 43) — no longer needed for download spinners but keep for other uses
+
+**Menu changes** — insert after "Share" (line 278-281), before the separator (line 282):
+
+```tsx
+<DropdownMenuItem
+  onClick={onDownloadAudio}
+  disabled={!songset.latestRenderJobId}
+>
+  <FileAudio className="size-4 mr-2" />
+  Download Audio
+</DropdownMenuItem>
+<DropdownMenuItem
+  onClick={onDownloadVideo}
+  disabled={!songset.latestRenderJobId}
+>
+  <FileVideo className="size-4 mr-2" />
+  Download Video
+</DropdownMenuItem>
+<DropdownMenuSeparator />
+```
+
+**Final menu order:**
+1. Render
+2. Play
+3. — separator —
+4. Edit description
+5. Duplicate
+6. Share
+7. Download Audio
+8. Download Video
+9. — separator —
+10. Delete
+
+### Step 5: Add download menu items to `SongsetRow.tsx`
+
+**File:** `webapp/src/components/songset/SongsetRow.tsx`
+
+**Props changes** — add to `SongsetRowProps` (after line 50):
+```typescript
+onDownloadAudio?: () => void;
+onDownloadVideo?: () => void;
+```
+
+**No state changes** — same rationale as Step 4.
+
+**Import changes:**
+- Add `FileAudio`, `FileVideo` from `lucide-react`
+- `Loader2` is not needed for download items (no spinner state)
+
+**Menu changes** — insert after "Share" (line 156-158), before the separator (line 160):
+
+```tsx
+<DropdownMenuItem
+  onClick={onDownloadAudio}
+  disabled={!latestRenderJobId}
+>
+  <FileAudio className="size-4 mr-2" />
+  Download Audio
+</DropdownMenuItem>
+<DropdownMenuItem
+  onClick={onDownloadVideo}
+  disabled={!latestRenderJobId}
+>
+  <FileVideo className="size-4 mr-2" />
+  Download Video
+</DropdownMenuItem>
+<DropdownMenuSeparator />
+```
+
+**Final menu order:**
+1. Rename
+2. Duplicate
+3. — separator —
+4. Render
+5. Play
+6. Share
+7. Download Audio
+8. Download Video
+9. — separator —
+10. Delete
+
+### Step 6: Wire download handlers in `songsets/[id]/page.tsx`
+
+**File:** `webapp/src/app/songsets/[id]/page.tsx`
+
+Add two handler functions:
+
+```typescript
+import { downloadArtifact, sanitizeFilename } from "@/lib/download";
+
+const handleDownloadAudio = useCallback(async () => {
+  if (!songset?.latestRenderJobId) return;
+
+  const toastId = toast.loading("Preparing download...");
+  const controller = new AbortController();
+
+  try {
+    const filename = sanitizeFilename(songset.name);
+    const disposition = `attachment; filename="${filename}.mp3"`;
+    const res = await fetch(
+      `/api/signed-url?renderJobId=${encodeURIComponent(songset.latestRenderJobId)}` +
+        `&fileType=audio` +
+        `&contentDisposition=${encodeURIComponent(disposition)}`,
+      { signal: controller.signal }
+    );
+    if (!res.ok) throw new Error("Failed to get download URL");
+    const { url } = await res.json();
+
+    downloadArtifact(url);
+    toast.success("Download started", { id: toastId });
+  } catch (err) {
+    if (err instanceof DOMException && err.name === "AbortError") return;
+    toast.error("Failed to download audio", { id: toastId });
+  }
+}, [songset?.latestRenderJobId, songset?.name]);
+
+const handleDownloadVideo = useCallback(async () => {
+  if (!songset?.latestRenderJobId) return;
+
+  const toastId = toast.loading("Preparing download...");
+  const controller = new AbortController();
+
+  try {
+    const filename = sanitizeFilename(songset.name);
+    const disposition = `attachment; filename="${filename}.mp4"`;
+    const res = await fetch(
+      `/api/signed-url?renderJobId=${encodeURIComponent(songset.latestRenderJobId)}` +
+        `&fileType=video` +
+        `&contentDisposition=${encodeURIComponent(disposition)}`,
+      { signal: controller.signal }
+    );
+    if (!res.ok) throw new Error("Failed to get download URL");
+    const { url } = await res.json();
+
+    downloadArtifact(url);
+    toast.success("Download started", { id: toastId });
+  } catch (err) {
+    if (err instanceof DOMException && err.name === "AbortError") return;
+    toast.error("Failed to download video", { id: toastId });
+  }
+}, [songset?.latestRenderJobId, songset?.name]);
+```
+
+Pass to `SongsetEditor`:
+```tsx
+<SongsetEditor
+  ...
+  onDownloadAudio={handleDownloadAudio}
+  onDownloadVideo={handleDownloadVideo}
+/>
+```
+
+### Step 7: Wire download handlers in `songsets/page.tsx`
+
+**File:** `webapp/src/app/songsets/page.tsx`
+
+Add two handler functions:
+
+```typescript
+import { downloadArtifact, sanitizeFilename } from "@/lib/download";
+
+const handleDownloadAudio = useCallback(async (id: string) => {
+  const songset = songsets.find((s) => s.id === id);
+  if (!songset?.latestRenderJobId) return;
+
+  const toastId = toast.loading("Preparing download...");
+  const controller = new AbortController();
+
+  try {
+    const filename = sanitizeFilename(songset.name);
+    const disposition = `attachment; filename="${filename}.mp3"`;
+    const res = await fetch(
+      `/api/signed-url?renderJobId=${encodeURIComponent(songset.latestRenderJobId)}` +
+        `&fileType=audio` +
+        `&contentDisposition=${encodeURIComponent(disposition)}`,
+      { signal: controller.signal }
+    );
+    if (!res.ok) throw new Error("Failed to get download URL");
+    const { url } = await res.json();
+
+    downloadArtifact(url);
+    toast.success("Download started", { id: toastId });
+  } catch (err) {
+    if (err instanceof DOMException && err.name === "AbortError") return;
+    toast.error("Failed to download audio", { id: toastId });
+  }
+}, [songsets]);
+
+const handleDownloadVideo = useCallback(async (id: string) => {
+  const songset = songsets.find((s) => s.id === id);
+  if (!songset?.latestRenderJobId) return;
+
+  const toastId = toast.loading("Preparing download...");
+  const controller = new AbortController();
+
+  try {
+    const filename = sanitizeFilename(songset.name);
+    const disposition = `attachment; filename="${filename}.mp4"`;
+    const res = await fetch(
+      `/api/signed-url?renderJobId=${encodeURIComponent(songset.latestRenderJobId)}` +
+        `&fileType=video` +
+        `&contentDisposition=${encodeURIComponent(disposition)}`,
+      { signal: controller.signal }
+    );
+    if (!res.ok) throw new Error("Failed to get download URL");
+    const { url } = await res.json();
+
+    downloadArtifact(url);
+    toast.success("Download started", { id: toastId });
+  } catch (err) {
+    if (err instanceof DOMException && err.name === "AbortError") return;
+    toast.error("Failed to download video", { id: toastId });
+  }
+}, [songsets]);
+```
+
+Pass to `SongsetList`:
+```tsx
+<SongsetList
+  ...
+  onDownloadAudio={handleDownloadAudio}
+  onDownloadVideo={handleDownloadVideo}
+/>
+```
+
+### Step 8: Thread callbacks through `SongsetList.tsx`
+
+**File:** `webapp/src/components/songset/SongsetList.tsx`
+
+- Add to `SongsetListProps`:
+  ```typescript
+  onDownloadAudio?: (id: string) => void;
+  onDownloadVideo?: (id: string) => void;
+  ```
+
+- Destructure in component function
+- Pass to `SongsetRow` in the render loop (line 238-248):
+  ```tsx
+  <SongsetRow
+    key={songset.id}
+    {...songset}
+    onRender={() => onRender?.(songset.id)}
+    onPlay={() => onPlay?.(songset.id)}
+    onRetry={() => onRetry?.(songset.id)}
+    onRename={() => openRenameDialog(songset.id, songset.name)}
+    onDuplicate={() => onDuplicate?.(songset.id)}
+    onShare={() => onShare?.(songset.id)}
+    onDownloadAudio={() => onDownloadAudio?.(songset.id)}
+    onDownloadVideo={() => onDownloadVideo?.(songset.id)}
+    onDelete={() => openDeleteDialog(songset.id)}
+  />
+  ```
+
+## 4. File Change Summary
+
+| File | Action | Description |
+|------|--------|-------------|
+| `webapp/src/lib/download.ts` | **NEW** | `sanitizeFilename()` + `downloadArtifact()` utilities |
+| `webapp/src/components/render/RenderComplete.tsx` | MODIFY | Remove fetch-blob pattern, use `downloadArtifact()` + `toast.loading()`, remove `isDownloading*` states |
+| `webapp/src/app/songsets/[id]/render/page.tsx` | MODIFY | Remove pre-fetched signed URLs; `RenderComplete` now fetches on demand |
+| `webapp/src/components/songset/SongsetEditor.tsx` | MODIFY | Add optional download props, add menu items (no state changes) |
+| `webapp/src/components/songset/SongsetRow.tsx` | MODIFY | Add `latestRenderJobId` + download props, add menu items (no state changes) |
+| `webapp/src/components/songset/SongsetList.tsx` | MODIFY | Add `latestRenderJobId` to `Songset` type, add callback props, thread to `SongsetRow` |
+| `webapp/src/app/songsets/[id]/page.tsx` | MODIFY | Add download handlers, pass to `SongsetEditor` |
+| `webapp/src/app/songsets/page.tsx` | MODIFY | Add `latestRenderJobId` to data flow, add download handlers, pass to `SongsetList` |
+
+## 5. No New API Endpoints
+
+The existing `GET /api/signed-url` endpoint already supports:
+- `renderJobId` + `fileType=audio` → signed URL for `renders/{jobId}/output.mp3`
+- `renderJobId` + `fileType=video` → signed URL for `renders/{jobId}/output.mp4`
+- `contentDisposition` → sets `ResponseContentDisposition` on the signed URL
+
+No backend changes required.
+
+## 6. v1 → v2 Changes Summary
+
+| Concern | v1 Approach | v2 Approach |
+|---------|-------------|-------------|
+| **Double error toasts** (#1) | `downloadArtifact()` shows toast + caller shows toast | `downloadArtifact()` is toast-free; caller owns all toasts |
+| **Invisible spinner** (#2) | `isDownloadingAudio`/`isDownloadingVideo` state + spinner in menu | `toast.loading("Preparing download...")` — visible after menu closes |
+| **Large files in memory** (#3) | `fetch → blob → createObjectURL → <a click>` | `window.location.href = signedUrl` with `Content-Disposition: attachment` |
+| **revokeObjectURL timing** (#4) | Called immediately after `link.click()` | Eliminated — no blob URLs created |
+| **Filename sanitization** (#5) | `name.replace(/\s+/g, "_")` | `sanitizeFilename()` — slugify, strip unsafe chars, lowercase |
+| **No AbortController** (#6) | None | `AbortController` on signed URL fetch; abort silently on unmount |
+| **Required vs optional props** (#7) | Required on `SongsetEditor`, optional on `SongsetRow` | Optional on both |
+
+## 7. Edge Cases
+
+| Case | Behavior |
+|------|----------|
+| No completed render (`latestRenderJobId` is null) | Both download items disabled (grayed out) |
+| Render completed but MP4 not generated (audio-only render) | "Download Video" enabled but click fails at signed URL fetch (R2 key not found → 404 from API → toast error). See §8 for future improvement. |
+| Stale artifacts (songset modified after render) | Download still works — user gets the old render. The stale banner already warns them. |
+| Signed URL fetch in progress | `toast.loading()` visible; menu item not disabled (menu is already closed). AbortController prevents stale updates if component unmounts. |
+| Signed URL expired (unlikely — 1hr default) | `fetch()` to `/api/signed-url` succeeds (generates fresh URL); the signed URL itself is newly minted. No issue. |
+| Browser blocks navigation to signed URL | Rare (popup blocker won't block `window.location.href` to same-tab). If it occurs, user sees error toast from the catch block. |
+
+## 8. Future Improvements (out of scope)
+
+- **Per-artifact availability check:** Currently we only check `latestRenderJobId !== null`. For full accuracy, the songset API could return `hasAudio`/`hasVideo` booleans (derived from `mp3R2Key`/`mp4R2Key` on the render job), and we'd disable "Download Video" when only audio was rendered. This requires an API change and is deferred.
+- **Share page download:** The share API already returns `allowDownload` and signed URLs. Adding download-to-file on the public share page is a separate feature.
+- **Chapters JSON download:** Could add "Download Chapters" as a third menu item, but low priority.
+- **Download progress bar:** `window.location.href` relies on the browser's built-in download progress. For a custom progress UI, we'd need to fall back to the fetch-blob approach (with streaming) for large files. This is a significant complexity increase and is deferred.

--- a/specs/download-audio-video-from-kab-menu.md
+++ b/specs/download-audio-video-from-kab-menu.md
@@ -1,0 +1,386 @@
+# Download Audio & Video from Songset KAB Menu
+
+**Date:** 2026-05-24
+**Status:** Draft
+
+---
+
+## 1. Problem
+
+Currently, downloading rendered artifacts to disk is only possible from the **Render Completed** screen (`RenderComplete.tsx`). Users must complete a render and stay on that screen to download MP3/MP4 files. There is no way to download artifacts from:
+
+- **Songset Editor screen** — the primary prep workspace
+- **Songset list page** — the overview of all songsets
+
+The Play screen's "download for offline" only caches to browser Cache Storage for offline playback — it does not save a file to disk.
+
+## 2. Goal
+
+Add **"Download Audio"** and **"Download Video"** menu items to the KAB (kebab/overflow) menu on both:
+
+1. **Songset Editor screen** (`SongsetEditor.tsx`)
+2. **Songset list page** (`SongsetRow.tsx`)
+
+### Design decisions (confirmed with user)
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Visibility | Always visible, **disabled** when no completed render exists | Communicates feature availability; avoids "where's download?" confusion |
+| Scope | Both Editor and List page KAB menus | Consistent UX across both entry points |
+| Download mechanism | Fetch-blob-`<a download>` (same as `RenderComplete.tsx`) | Reliable cross-browser, supports custom filename |
+| API | Existing `GET /api/signed-url?renderJobId=<id>&fileType=audio\|video` | No new endpoints needed |
+
+## 3. Implementation Steps
+
+### Step 1: Create shared download utility
+
+**File:** `webapp/src/lib/download.ts` (NEW)
+
+Extract the fetch-blob-download pattern from `RenderComplete.tsx:54-88` into a reusable function:
+
+```typescript
+import { toast } from "sonner";
+
+export async function downloadArtifact(
+  url: string,
+  filename: string,
+  onLoading?: (loading: boolean) => void
+): Promise<void> {
+  onLoading?.(true);
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error("Failed to download file");
+    }
+
+    const blob = await response.blob();
+    const downloadUrl = window.URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = downloadUrl;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    window.URL.revokeObjectURL(downloadUrl);
+
+    toast.success(`Downloaded ${filename}`);
+  } catch (error) {
+    toast.error("Download failed");
+    console.error("Download error:", error);
+  } finally {
+    onLoading?.(false);
+  }
+}
+```
+
+### Step 2: Refactor `RenderComplete.tsx` to use shared utility
+
+**File:** `webapp/src/components/render/RenderComplete.tsx`
+
+- Import `downloadArtifact` from `@/lib/download`
+- Replace the inline `handleDownload` function (lines 54-88) with calls to `downloadArtifact`
+- Remove the three `isDownloading*` state variables; replace with local state or pass `setIsDownloading*` as the `onLoading` callback
+
+This is optional cleanup but keeps the download logic DRY.
+
+### Step 3: Add `latestRenderJobId` to list page data flow
+
+The list page currently drops `latestRenderJobId` from the API response. We need it to determine whether downloads are available.
+
+**File:** `webapp/src/components/songset/SongsetList.tsx`
+- Add `latestRenderJobId: string | null` to the `Songset` interface (line 21-32)
+
+**File:** `webapp/src/app/songsets/page.tsx`
+- Add `latestRenderJobId` to `ApiSongset` interface (line 8-18) — already present at line 16
+- Pass `latestRenderJobId: songset.latestRenderJobId` in the transform at line 53-63
+
+**File:** `webapp/src/components/songset/SongsetRow.tsx`
+- Add `latestRenderJobId: string | null` to `SongsetRowProps` (line 34-53)
+
+### Step 4: Add download menu items to `SongsetEditor.tsx`
+
+**File:** `webapp/src/components/songset/SongsetEditor.tsx`
+
+**Props changes:**
+- Add to `SongsetEditorProps`:
+  ```typescript
+  onDownloadAudio: () => void;
+  onDownloadVideo: () => void;
+  ```
+
+**State changes:**
+- Add `isDownloadingAudio` and `isDownloadingVideo` boolean states
+
+**Import changes:**
+- Add `Download`, `FileAudio`, `FileVideo` from `lucide-react`
+- Add `Loader2` (already imported)
+
+**Menu changes** — insert after "Share" (line 278-280), before the separator (line 282):
+
+```tsx
+<DropdownMenuSeparator />
+<DropdownMenuItem
+  onClick={onDownloadAudio}
+  disabled={!songset.latestRenderJobId || isDownloadingAudio}
+>
+  {isDownloadingAudio ? (
+    <Loader2 className="size-4 mr-2 animate-spin" />
+  ) : (
+    <FileAudio className="size-4 mr-2" />
+  )}
+  Download Audio
+</DropdownMenuItem>
+<DropdownMenuItem
+  onClick={onDownloadVideo}
+  disabled={!songset.latestRenderJobId || isDownloadingVideo}
+>
+  {isDownloadingVideo ? (
+    <Loader2 className="size-4 mr-2 animate-spin" />
+  ) : (
+    <FileVideo className="size-4 mr-2" />
+  )}
+  Download Video
+</DropdownMenuItem>
+```
+
+The `disabled` condition uses `!songset.latestRenderJobId` — when there's no completed render, both items are grayed out. The `isDownloading*` states prevent double-clicks during an active download.
+
+**Final menu order:**
+1. Render
+2. Play
+3. — separator —
+4. Edit description
+5. Duplicate
+6. Share
+7. — separator —
+8. Download Audio
+9. Download Video
+10. — separator —
+11. Delete
+
+### Step 5: Add download menu items to `SongsetRow.tsx`
+
+**File:** `webapp/src/components/songset/SongsetRow.tsx`
+
+**Props changes:**
+- Add to `SongsetRowProps`:
+  ```typescript
+  onDownloadAudio?: () => void;
+  onDownloadVideo?: () => void;
+  ```
+
+**State changes:**
+- Add `isDownloadingAudio` and `isDownloadingVideo` boolean states
+
+**Import changes:**
+- Add `Download`, `FileAudio`, `FileVideo` from `lucide-react`
+- Add `Loader2` (not currently imported)
+
+**Menu changes** — insert after "Share" (line 156-159), before the separator (line 160):
+
+```tsx
+<DropdownMenuSeparator />
+<DropdownMenuItem
+  onClick={onDownloadAudio}
+  disabled={!latestRenderJobId || isDownloadingAudio}
+>
+  {isDownloadingAudio ? (
+    <Loader2 className="size-4 mr-2 animate-spin" />
+  ) : (
+    <FileAudio className="size-4 mr-2" />
+  )}
+  Download Audio
+</DropdownMenuItem>
+<DropdownMenuItem
+  onClick={onDownloadVideo}
+  disabled={!latestRenderJobId || isDownloadingVideo}
+>
+  {isDownloadingVideo ? (
+    <Loader2 className="size-4 mr-2 animate-spin" />
+  ) : (
+    <FileVideo className="size-4 mr-2" />
+  )}
+  Download Video
+</DropdownMenuItem>
+```
+
+**Final menu order:**
+1. Rename
+2. Duplicate
+3. — separator —
+4. Render
+5. Play
+6. Share
+7. — separator —
+8. Download Audio
+9. Download Video
+10. — separator —
+11. Delete
+
+### Step 6: Wire download handlers in `songsets/[id]/page.tsx`
+
+**File:** `webapp/src/app/songsets/[id]/page.tsx`
+
+Add two handler functions:
+
+```typescript
+const handleDownloadAudio = useCallback(async () => {
+  if (!songset?.latestRenderJobId) return;
+
+  try {
+    const res = await fetch(
+      `/api/signed-url?renderJobId=${songset.latestRenderJobId}&fileType=audio`
+    );
+    if (!res.ok) throw new Error("Failed to get download URL");
+    const { url } = await res.json();
+
+    const filename = `${songset.name.replace(/\s+/g, "_")}.mp3`;
+    await downloadArtifact(url, filename);
+  } catch {
+    toast.error("Failed to download audio");
+  }
+}, [songset?.latestRenderJobId, songset?.name]);
+
+const handleDownloadVideo = useCallback(async () => {
+  if (!songset?.latestRenderJobId) return;
+
+  try {
+    const res = await fetch(
+      `/api/signed-url?renderJobId=${songset.latestRenderJobId}&fileType=video`
+    );
+    if (!res.ok) throw new Error("Failed to get download URL");
+    const { url } = await res.json();
+
+    const filename = `${songset.name.replace(/\s+/g, "_")}.mp4`;
+    await downloadArtifact(url, filename);
+  } catch {
+    toast.error("Failed to download video");
+  }
+}, [songset?.latestRenderJobId, songset?.name]);
+```
+
+Pass to `SongsetEditor`:
+```tsx
+<SongsetEditor
+  ...
+  onDownloadAudio={handleDownloadAudio}
+  onDownloadVideo={handleDownloadVideo}
+/>
+```
+
+### Step 7: Wire download handlers in `songsets/page.tsx`
+
+**File:** `webapp/src/app/songsets/page.tsx`
+
+Add two handler functions that take a songset ID, look up the `latestRenderJobId`, fetch a signed URL, and download:
+
+```typescript
+const handleDownloadAudio = useCallback(async (id: string) => {
+  const songset = songsets.find((s) => s.id === id);
+  if (!songset?.latestRenderJobId) return;
+
+  try {
+    const res = await fetch(
+      `/api/signed-url?renderJobId=${songset.latestRenderJobId}&fileType=audio`
+    );
+    if (!res.ok) throw new Error("Failed to get download URL");
+    const { url } = await res.json();
+
+    const filename = `${songset.name.replace(/\s+/g, "_")}.mp3`;
+    await downloadArtifact(url, filename);
+  } catch {
+    toast.error("Failed to download audio");
+  }
+}, [songsets]);
+
+const handleDownloadVideo = useCallback(async (id: string) => {
+  const songset = songsets.find((s) => s.id === id);
+  if (!songset?.latestRenderJobId) return;
+
+  try {
+    const res = await fetch(
+      `/api/signed-url?renderJobId=${songset.latestRenderJobId}&fileType=video`
+    );
+    if (!res.ok) throw new Error("Failed to get download URL");
+    const { url } = await res.json();
+
+    const filename = `${songset.name.replace(/\s+/g, "_")}.mp4`;
+    await downloadArtifact(url, filename);
+  } catch {
+    toast.error("Failed to download video");
+  }
+}, [songsets]);
+```
+
+Pass to `SongsetList`:
+```tsx
+<SongsetList
+  ...
+  onDownloadAudio={handleDownloadAudio}
+  onDownloadVideo={handleDownloadVideo}
+/>
+```
+
+### Step 8: Thread callbacks through `SongsetList.tsx`
+
+**File:** `webapp/src/components/songset/SongsetList.tsx`
+
+- Add to `SongsetListProps`:
+  ```typescript
+  onDownloadAudio?: (id: string) => void;
+  onDownloadVideo?: (id: string) => void;
+  ```
+
+- Destructure in component function
+- Pass to `SongsetRow` in the render loop (line 238-248):
+  ```tsx
+  <SongsetRow
+    key={songset.id}
+    {...songset}
+    onRender={() => onRender?.(songset.id)}
+    onPlay={() => onPlay?.(songset.id)}
+    onRetry={() => onRetry?.(songset.id)}
+    onRename={() => openRenameDialog(songset.id, songset.name)}
+    onDuplicate={() => onDuplicate?.(songset.id)}
+    onShare={() => onShare?.(songset.id)}
+    onDownloadAudio={() => onDownloadAudio?.(songset.id)}
+    onDownloadVideo={() => onDownloadVideo?.(songset.id)}
+    onDelete={() => openDeleteDialog(songset.id)}
+  />
+  ```
+
+## 4. File Change Summary
+
+| File | Action | Description |
+|------|--------|-------------|
+| `webapp/src/lib/download.ts` | **NEW** | Shared `downloadArtifact()` utility |
+| `webapp/src/components/render/RenderComplete.tsx` | MODIFY | Refactor to use shared utility (optional) |
+| `webapp/src/components/songset/SongsetEditor.tsx` | MODIFY | Add download props, state, menu items |
+| `webapp/src/components/songset/SongsetRow.tsx` | MODIFY | Add download props, state, menu items |
+| `webapp/src/components/songset/SongsetList.tsx` | MODIFY | Add `latestRenderJobId` to `Songset` type, add callback props, thread to `SongsetRow` |
+| `webapp/src/app/songsets/[id]/page.tsx` | MODIFY | Add download handlers, pass to `SongsetEditor` |
+| `webapp/src/app/songsets/page.tsx` | MODIFY | Add `latestRenderJobId` to data flow, add download handlers, pass to `SongsetList` |
+
+## 5. No New API Endpoints
+
+The existing `GET /api/signed-url` endpoint already supports:
+- `renderJobId` + `fileType=audio` → signed URL for `renders/{jobId}/output.mp3`
+- `renderJobId` + `fileType=video` → signed URL for `renders/{jobId}/output.mp4`
+
+No backend changes required.
+
+## 6. Edge Cases
+
+| Case | Behavior |
+|------|----------|
+| No completed render (`latestRenderJobId` is null) | Both download items disabled (grayed out) |
+| Render completed but MP4 not generated (audio-only render) | "Download Video" disabled; "Download Audio" enabled. **Note:** Currently we only check `latestRenderJobId`, not individual artifact existence. For full accuracy, we'd need to also check `mp3R2Key`/`mp4R2Key` on the render job. See §7. |
+| Stale artifacts (songset modified after render) | Download still works — user gets the old render. The stale banner already warns them. |
+| Download in progress | Menu item shows spinner, disabled to prevent double-click |
+| Signed URL expired (unlikely — 1hr default) | `fetch()` fails, toast shows "Download failed" |
+
+## 7. Future Improvements (out of scope)
+
+- **Per-artifact availability check:** Currently we only check `latestRenderJobId !== null`. For full accuracy, the songset API could return `hasAudio`/`hasVideo` booleans (derived from `mp3R2Key`/`mp4R2Key` on the render job), and we'd disable "Download Video" when only audio was rendered. This requires an API change and is deferred.
+- **Share page download:** The share API already returns `allowDownload` and signed URLs. Adding download-to-file on the public share page is a separate feature.
+- **Chapters JSON download:** Could add "Download Chapters" as a third menu item, but low priority.

--- a/specs/pr70-code-review-fixes.md
+++ b/specs/pr70-code-review-fixes.md
@@ -1,0 +1,225 @@
+# PR #70 Code Review Fixes
+
+## Overview
+
+Address 3 inline review comments from gemini-code-assist on PR #70 (feat(webapp): add download audio/video to songset KAB menus).
+
+## Review Comments Summary
+
+### Comment 1 — `webapp/src/lib/download.ts:11-13`
+**Issue:** `window.location.href` can cause unexpected navigation if the server doesn't return `Content-Disposition: attachment`.  
+**Priority:** Medium  
+**Fix:** Replace with hidden anchor element approach (as suggested by reviewer).
+
+### Comment 2 — `webapp/src/app/songsets/[id]/page.tsx:340-364`
+**Issue:** 
+- (a) `AbortController` is instantiated but never aborted — dead code
+- (b) Download logic is duplicated across audio/video handlers and across multiple files  
+**Priority:** Medium  
+**Fix:** Extract a shared `fetchSignedUrlAndDownload()` utility in `lib/download.ts` that handles the signed URL fetch + download trigger. Remove AbortController and AbortError check. Simplify all call sites.
+
+### Comment 3 — `webapp/src/components/render/RenderComplete.tsx:49-74`
+**Issue:**
+- (a) `handleDownloadFile` not wrapped in `useCallback`
+- (b) Same redundant AbortController  
+**Priority:** Medium  
+**Fix:** Wrap in `useCallback`, remove AbortController, use the new shared utility.
+
+---
+
+## Implementation Plan
+
+### Step 1: Update `webapp/src/lib/download.ts`
+
+Add `fetchSignedUrlAndDownload()` function and fix `downloadArtifact()`:
+
+```ts
+export function sanitizeFilename(name: string): string {
+  return name
+    .trim()
+    .replace(/[/\\:*?"<>|#]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-{2,}/g, "-")
+    .replace(/^-|-$/g, "")
+    .toLowerCase();
+}
+
+export function downloadArtifact(url: string): void {
+  const link = document.createElement("a");
+  link.href = url;
+  link.style.display = "none";
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+}
+
+export async function fetchSignedUrlAndDownload(
+  renderJobId: string,
+  fileType: "audio" | "video" | "json",
+  filename: string,
+  extension: string,
+): Promise<void> {
+  const disposition = `attachment; filename="${filename}.${extension}"`;
+  const res = await fetch(
+    `/api/signed-url?renderJobId=${encodeURIComponent(renderJobId)}` +
+      `&fileType=${fileType}` +
+      `&contentDisposition=${encodeURIComponent(disposition)}`
+  );
+  if (!res.ok) throw new Error("Failed to get download URL");
+  const { url } = await res.json();
+  downloadArtifact(url);
+}
+```
+
+### Step 2: Update `webapp/src/app/songsets/[id]/page.tsx`
+
+Simplify `handleDownloadAudio` and `handleDownloadVideo`:
+
+```ts
+import { downloadArtifact, sanitizeFilename, fetchSignedUrlAndDownload } from "@/lib/download";
+
+// Handle download audio
+const handleDownloadAudio = useCallback(async () => {
+  if (!songset?.latestRenderJobId) return;
+  const toastId = toast.loading("Preparing download...");
+  try {
+    await fetchSignedUrlAndDownload(
+      songset.latestRenderJobId,
+      "audio",
+      sanitizeFilename(songset.name),
+      "mp3"
+    );
+    toast.success("Download started", { id: toastId });
+  } catch {
+    toast.error("Failed to download audio", { id: toastId });
+  }
+}, [songset]);
+
+// Handle download video
+const handleDownloadVideo = useCallback(async () => {
+  if (!songset?.latestRenderJobId) return;
+  const toastId = toast.loading("Preparing download...");
+  try {
+    await fetchSignedUrlAndDownload(
+      songset.latestRenderJobId,
+      "video",
+      sanitizeFilename(songset.name),
+      "mp4"
+    );
+    toast.success("Download started", { id: toastId });
+  } catch {
+    toast.error("Failed to download video", { id: toastId });
+  }
+}, [songset]);
+```
+
+### Step 3: Update `webapp/src/app/songsets/page.tsx`
+
+Same simplification for the list page's `handleDownloadAudio` and `handleDownloadVideo`:
+
+```ts
+import { downloadArtifact, sanitizeFilename, fetchSignedUrlAndDownload } from "@/lib/download";
+
+const handleDownloadAudio = useCallback(async (id: string) => {
+  const songset = songsets.find((s) => s.id === id);
+  if (!songset?.latestRenderJobId) return;
+  const toastId = toast.loading("Preparing download...");
+  try {
+    await fetchSignedUrlAndDownload(
+      songset.latestRenderJobId,
+      "audio",
+      sanitizeFilename(songset.name),
+      "mp3"
+    );
+    toast.success("Download started", { id: toastId });
+  } catch {
+    toast.error("Failed to download audio", { id: toastId });
+  }
+}, [songsets]);
+
+const handleDownloadVideo = useCallback(async (id: string) => {
+  const songset = songsets.find((s) => s.id === id);
+  if (!songset?.latestRenderJobId) return;
+  const toastId = toast.loading("Preparing download...");
+  try {
+    await fetchSignedUrlAndDownload(
+      songset.latestRenderJobId,
+      "video",
+      sanitizeFilename(songset.name),
+      "mp4"
+    );
+    toast.success("Download started", { id: toastId });
+  } catch {
+    toast.error("Failed to download video", { id: toastId });
+  }
+}, [songsets]);
+```
+
+### Step 4: Update `webapp/src/components/render/RenderComplete.tsx`
+
+Wrap `handleDownloadFile` in `useCallback` and use shared utility:
+
+```ts
+import { useCallback } from "react"
+import { sanitizeFilename, downloadArtifact, fetchSignedUrlAndDownload } from "@/lib/download"
+
+const handleDownloadFile = useCallback(async (
+  fileType: "audio" | "video" | "json",
+  extension: string,
+) => {
+  const toastId = toast.loading("Preparing download...");
+  try {
+    await fetchSignedUrlAndDownload(jobId, fileType, sanitizeFilename(songsetName), extension);
+    toast.success("Download started", { id: toastId });
+  } catch {
+    toast.error("Download failed", { id: toastId });
+  }
+}, [jobId, songsetName]);
+```
+
+### Step 5: Update test mock in `webapp/src/test/components/render/RenderComplete.test.tsx`
+
+Add `fetchSignedUrlAndDownload` to the mock:
+
+```ts
+vi.mock("@/lib/download", () => ({
+  sanitizeFilename: (name: string) => name.toLowerCase().replace(/\s+/g, "-"),
+  downloadArtifact: vi.fn(),
+  fetchSignedUrlAndDownload: vi.fn(),
+}))
+```
+
+---
+
+## Verification
+
+1. Run `pnpm lint` from `webapp/`
+2. Run `pnpm test` from `webapp/`
+3. Run `pnpm build` from `webapp/`
+
+---
+
+## PR Comment Replies
+
+After implementing, reply to each comment:
+
+### Reply to Comment 1 (download.ts:11-13)
+```
+Fixed in [commit hash]. Replaced `window.location.href` with hidden anchor element approach as suggested.
+```
+
+### Reply to Comment 2 (songsets/[id]/page.tsx:340-364)
+```
+Fixed in [commit hash]. 
+- Removed redundant AbortController and AbortError check
+- Extracted shared `fetchSignedUrlAndDownload()` utility in `lib/download.ts`
+- Simplified all download handlers to use the new utility
+```
+
+### Reply to Comment 3 (RenderComplete.tsx:49-74)
+```
+Fixed in [commit hash].
+- Wrapped `handleDownloadFile` in `useCallback`
+- Removed redundant AbortController and AbortError check
+- Now uses shared `fetchSignedUrlAndDownload()` utility
+```

--- a/specs/title-card-custom-lines-v2.md
+++ b/specs/title-card-custom-lines-v2.md
@@ -1,0 +1,755 @@
+# Title Card: Custom Lines of Text (v2)
+
+## Problem
+
+The title card currently renders a hardcoded layout: one heading line (derived from the first song's title) and one subtitle line (`{count} 首歌曲 · {mm:ss}`). Users cannot customize what text appears on the title card.
+
+The desired behavior is:
+1. Users can optionally provide custom lines of text for the title card
+2. Each line is rendered as a separate line, centered both vertically and horizontally
+3. When no custom lines are given, the default is: **songset name** as the first line, followed by **all song titles** from the songset
+4. The first line (heading) renders 20 pts larger than the remaining lines
+5. Font size auto-scales so all lines fit on screen
+
+---
+
+## Current State
+
+### Data flow
+
+```
+RenderForm (browser)
+  includeTitleCard: boolean
+  titleCardDurationSeconds: number
+       |
+       v
+POST /api/render-jobs  (Zod validation)
+       |
+       v
+job-manager.createRenderJob()  →  INSERT INTO render_jobs
+       |
+       v
+SQS → Lambda → pipeline.execute_render_pipeline()
+       |
+       v
+VideoEngine(include_title_card, title_card_duration_seconds)
+       |
+       v
+TitleCardConfig(songset_name=segments[0].item.song_title, song_count, total_duration_seconds)
+       |
+       v
+FrameRenderer.render_title_card(config)
+  → heading at 40% height (2x base font size)
+  → subtitle "{count} 首歌曲 · {mm:ss}" at 55% height (1x base font size)
+```
+
+### Key files
+
+| File | Lines | Role |
+|------|-------|------|
+| `webapp/src/components/render/RenderForm.tsx` | 24-33, 242-280 | Form UI: checkbox + duration selector |
+| `webapp/src/app/songsets/[id]/render/page.tsx` | 84-94, 137-173 | Render page: fetches songset, submits form |
+| `webapp/src/app/api/render-jobs/route.ts` | 7-16 | Zod schema for POST body |
+| `webapp/src/lib/render/job-manager.ts` | 112-155 | Creates render job in DB |
+| `webapp/src/db/schema.ts` | 204-247 | `render_jobs` table schema |
+| `services/render-worker/src/sow_render_worker/db.py` | 49-50 | `RenderJob` dataclass |
+| `services/render-worker/src/sow_render_worker/pipeline.py` | 347-354 | Wires job params to VideoEngine |
+| `services/render-worker/src/sow_render_worker/video_engine.py` | 63-82, 202-212 | VideoEngine constructor + TitleCardConfig construction |
+| `services/render-worker/src/sow_render_worker/frame_renderer.py` | 47-53, 420-453 | `TitleCardConfig` dataclass + `render_title_card()` |
+
+### Current `TitleCardConfig`
+
+```python
+@dataclass(frozen=True)
+class TitleCardConfig:
+    enabled: bool
+    duration_seconds: float
+    songset_name: str
+    song_count: int
+    total_duration_seconds: float
+```
+
+### Current `render_title_card()` output
+
+- Solid background from template
+- `config.songset_name` centered at 40% height, font size = `base_font_size * 2` (auto-fitted to width)
+- Subtitle `"{song_count} 首歌曲 · {duration_text}"` centered at 55% height, font size = `base_font_size`
+
+### Current `RenderFormData` (TypeScript)
+
+```typescript
+export interface RenderFormData {
+  audioEnabled: boolean
+  videoEnabled: boolean
+  template: "dark" | "gradient_warm" | "gradient_blue"
+  resolution: "720p" | "1080p"
+  fontSizePreset: "S" | "M" | "L" | "XL"
+  includeTitleCard: boolean
+  titleCardDurationSeconds: number
+  offlineEnabled: boolean
+}
+```
+
+---
+
+## Proposed Changes
+
+### 1. `TitleCardConfig` — replace `songset_name`/`song_count` with `lines`
+
+**File:** `services/render-worker/src/sow_render_worker/frame_renderer.py` (lines 47-53)
+
+```python
+# Before:
+@dataclass(frozen=True)
+class TitleCardConfig:
+    enabled: bool
+    duration_seconds: float
+    songset_name: str
+    song_count: int
+    total_duration_seconds: float
+
+# After:
+@dataclass(frozen=True)
+class TitleCardConfig:
+    enabled: bool
+    duration_seconds: float
+    lines: tuple[str, ...]
+    total_duration_seconds: float
+```
+
+- `lines` is a tuple of strings, each rendered as a separate line
+- Empty tuple means title card is effectively blank (shouldn't happen in practice — see defaults below)
+- Using `tuple` instead of `list` for immutability (matching the `frozen=True` dataclass)
+
+### 2. `render_title_card()` — multi-line centered rendering with auto-scaling
+
+**File:** `services/render-worker/src/sow_render_worker/frame_renderer.py` (lines 420-453)
+
+New rendering logic:
+
+1. **Heading font size**: Start with `base_font_size * 2` (same as current heading), auto-fit each line's width to screen
+2. **Body font size**: `heading_font_size - 20` (heading is 20 pts larger than body)
+3. **Auto-scale**: If all lines don't fit vertically within the screen height (with margins), reduce both heading and body font sizes proportionally until they fit. Minimum body font size = 16px; if lines still don't fit, render at minimum size (lines beyond screen height are not rendered).
+4. **Vertical centering**: Calculate total text block height (sum of line heights + inter-line spacing), then center the block vertically on screen
+5. **Horizontal centering**: Each line is individually centered horizontally (anchor="mt")
+6. **Inter-line spacing**: 1.2× the body font size between lines; 1.5× the body font size between the heading (first line) and the second line
+
+**Note on vertical centering accuracy**: The auto-scale loop calculates `total_height` using target font sizes, but `fit_text()` may reduce font sizes for long lines during rendering, making actual rendered heights slightly smaller than calculated. This results in minor vertical centering inaccuracy (a few pixels), which is imperceptible on a title card and acceptable.
+
+Pseudocode:
+
+```python
+def render_title_card(self, config: TitleCardConfig) -> Image.Image:
+    width, height = self.resolution
+    img = Image.new("RGBA", (width, height), (*self.template.background_color, 255))
+    draw = ImageDraw.Draw(img)
+    text_r, text_g, text_b = self.template.text_color
+
+    if not config.lines:
+        return img
+
+    margin = 40  # horizontal margin in px
+    min_body_font_size = 16
+    line_spacing_factor = 1.2
+    heading_gap_factor = 1.5
+
+    # Start with target sizes
+    heading_font_size_target = self.base_font_size * 2
+    body_font_size_target = heading_font_size_target - 20
+
+    # Auto-fit: reduce font sizes until all lines fit vertically
+    heading_font_size = heading_font_size_target
+    body_font_size = body_font_size_target
+
+    while True:
+        heading_font = self._get_font(heading_font_size)
+        body_font = self._get_font(body_font_size)
+
+        # Calculate total block height
+        total_height = 0
+        for i, line in enumerate(config.lines):
+            font = heading_font if i == 0 else body_font
+            bbox = draw.textbbox((0, 0), line, font=font)
+            line_height = bbox[3] - bbox[1]
+            total_height += line_height
+            if i == 0 and len(config.lines) > 1:
+                total_height += int(body_font_size * heading_gap_factor)
+            elif i > 0:
+                total_height += int(body_font_size * line_spacing_factor)
+
+        if total_height <= height - margin * 2 or body_font_size <= min_body_font_size:
+            break
+
+        heading_font_size -= 2
+        body_font_size = max(min_body_font_size, heading_font_size - 20)
+
+    # Render lines centered vertically and horizontally
+    y_start = (height - total_height) // 2
+    current_y = y_start
+
+    for i, line in enumerate(config.lines):
+        font = heading_font if i == 0 else body_font
+        # Auto-fit line width
+        fitted_size = self.fit_text(draw, line, heading_font_size if i == 0 else body_font_size, width - margin * 2)
+        font = self._get_font(fitted_size)
+        draw.text(
+            (width // 2, current_y),
+            line,
+            fill=(text_r, text_g, text_b),
+            font=font,
+            anchor="mt",
+        )
+        bbox = draw.textbbox((0, 0), line, font=font)
+        line_height = bbox[3] - bbox[1]
+        current_y += line_height
+        if i == 0 and len(config.lines) > 1:
+            current_y += int(body_font_size * heading_gap_factor)
+        elif i > 0:
+            current_y += int(body_font_size * line_spacing_factor)
+
+    return img
+```
+
+### 3. `VideoEngine` — accept `title_card_lines` parameter
+
+**File:** `services/render-worker/src/sow_render_worker/video_engine.py`
+
+#### 3a. Constructor (lines 63-82)
+
+Add `title_card_lines: list[str] | None = None` parameter:
+
+```python
+def __init__(
+    self,
+    asset_fetcher: AssetFetcherProtocol,
+    template: VideoTemplateName = "dark",
+    font_size_preset: FontSizePreset = "M",
+    resolution: str = "1080p",
+    fps: int = 24,
+    include_title_card: bool = True,
+    title_card_duration_seconds: float = 5.0,
+    title_card_lines: list[str] | None = None,  # NEW
+    ffmpeg_path: str | None = None,
+    ffprobe_path: str | None = None,
+):
+    # ... existing assignments ...
+    self.title_card_lines = title_card_lines  # NEW
+```
+
+#### 3b. `generate_video()` — construct `TitleCardConfig` with lines (lines 202-212)
+
+Replace the current `TitleCardConfig` construction:
+
+```python
+# Before:
+title_card_config = TitleCardConfig(
+    enabled=True,
+    duration_seconds=total_duration_seconds,
+    songset_name=(segments[0].item.song_title or "Worship Set") if segments else "Worship Set",
+    song_count=len(segments),
+    total_duration_seconds=total_duration_seconds,
+)
+
+# After:
+# Normalize: treat empty list same as None (use defaults)
+if self.title_card_lines:
+    # User-provided custom lines (non-empty)
+    title_lines = tuple(self.title_card_lines)
+else:
+    # Default: songset name + all song titles
+    song_titles = [seg.item.song_title for seg in segments if seg.item.song_title]
+    display_name = self.songset_name or "Worship Set"
+    title_lines = tuple([display_name] + song_titles) if song_titles else (display_name,)
+
+title_card_config = TitleCardConfig(
+    enabled=True,
+    duration_seconds=total_duration_seconds,
+    lines=title_lines,
+    total_duration_seconds=total_duration_seconds,
+)
+```
+
+**Key change from v1**: The guard is `if self.title_card_lines:` (truthy check) instead of `if self.title_card_lines is not None:`. This treats empty list `[]` the same as `None`, ensuring both fall back to defaults.
+
+**Problem:** The `songset_name` (the user-given name of the songset, e.g. "Sunday Morning Worship") is not currently available in the VideoEngine. It only has access to `segments` (which have `song_title` per segment).
+
+**Solution:** Pass `songset_name` as a new constructor parameter to `VideoEngine`. The pipeline already has access to the songset's `name` field via the database.
+
+### 4. `VideoEngine` — accept `songset_name` parameter
+
+**File:** `services/render-worker/src/sow_render_worker/video_engine.py`
+
+#### 4a. Constructor
+
+Add `songset_name: str = ""` parameter:
+
+```python
+def __init__(
+    self,
+    asset_fetcher: AssetFetcherProtocol,
+    template: VideoTemplateName = "dark",
+    font_size_preset: FontSizePreset = "M",
+    resolution: str = "1080p",
+    fps: int = 24,
+    include_title_card: bool = True,
+    title_card_duration_seconds: float = 5.0,
+    title_card_lines: list[str] | None = None,
+    songset_name: str = "",  # NEW
+    ffmpeg_path: str | None = None,
+    ffprobe_path: str | None = None,
+):
+    # ... existing assignments ...
+    self.songset_name = songset_name  # NEW
+```
+
+### 5. Pipeline — fetch songset name and pass to VideoEngine
+
+**File:** `services/render-worker/src/sow_render_worker/pipeline.py`
+
+#### 5a. Extend `fetch_songset_items()` to return songset name (around line 99)
+
+Instead of adding a separate `fetch_songset_name()` function (which would be an extra DB roundtrip), extend the existing query to also return the songset name:
+
+```python
+def fetch_songset_items(
+    conn: psycopg2.extensions.connection,
+    songset_id: str,
+) -> tuple[str, list[SongsetItem]]:
+    """
+    Returns: (songset_name, list of SongsetItem)
+    """
+    with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        # First, get the songset name
+        cur.execute(
+            "SELECT name FROM songsets WHERE id = %s",
+            (songset_id,),
+        )
+        songset_row = cur.fetchone()
+        songset_name = songset_row["name"] if songset_row else "Worship Set"
+        
+        # Then, fetch songset items (existing query)
+        cur.execute(
+            """
+            SELECT 
+                si.id,
+                si.song_id,
+                si.recording_hash_prefix,
+                si.position,
+                si.gap_beats,
+                si.crossfade_start_beats,
+                si.crossfade_end_beats,
+                si.tempo_bpm,
+                si.duration_seconds,
+                s.title as song_title
+            FROM songset_items si
+            LEFT JOIN recordings r ON si.recording_hash_prefix = r.hash_prefix
+            LEFT JOIN songs s ON si.song_id = s.id
+            WHERE si.songset_id = %s
+            ORDER BY si.position
+            """,
+            (songset_id,),
+        )
+        # ... existing row-to-SongsetItem mapping ...
+        
+    return songset_name, items
+```
+
+#### 5b. Pass to VideoEngine (lines 347-354)
+
+```python
+# Before:
+video_engine = VideoEngine(
+    asset_fetcher,
+    template=job.template,
+    font_size_preset=job.font_size_preset,
+    resolution=job.resolution,
+    include_title_card=job.include_title_card,
+    title_card_duration_seconds=job.title_card_duration_seconds or 5.0,
+)
+
+# After:
+songset_name, songset_items = fetch_songset_items(conn, job.songset_id)
+# Normalize: treat empty list same as None
+title_card_lines = job.title_card_lines if job.title_card_lines else None
+
+video_engine = VideoEngine(
+    asset_fetcher,
+    template=job.template,
+    font_size_preset=job.font_size_preset,
+    resolution=job.resolution,
+    include_title_card=job.include_title_card,
+    title_card_duration_seconds=job.title_card_duration_seconds or 5.0,
+    title_card_lines=title_card_lines,
+    songset_name=songset_name,
+)
+```
+
+**Note on `title_card_duration_seconds`**: The fallback `or 5.0` is inconsistent with the DB default (10) and form default (10). This is a pre-existing issue. The form always sends a value (defaulting to 10), so the fallback only affects programmatic API calls that omit the field. Consider aligning these defaults in a future cleanup.
+
+### 6. `RenderJob` dataclass — add `title_card_lines` field
+
+**File:** `services/render-worker/src/sow_render_worker/db.py` (lines 49-50)
+
+```python
+# Add after line 50:
+title_card_lines: Optional[list[str]] = None
+```
+
+Update `_row_to_render_job()` (around line 102) to parse the new column:
+
+```python
+import json  # Add at top of file
+
+def _row_to_render_job(row: dict[str, Any]) -> RenderJob:
+    # Parse JSON-encoded title_card_lines from DB
+    title_card_lines_raw = row.get("title_card_lines")
+    title_card_lines = None
+    if title_card_lines_raw:
+        try:
+            parsed = json.loads(title_card_lines_raw)
+            # Normalize: treat empty list same as None
+            title_card_lines = parsed if parsed else None
+        except json.JSONDecodeError:
+            # Log warning but don't fail the job
+            title_card_lines = None
+    
+    return RenderJob(
+        # ... existing fields ...
+        title_card_lines=title_card_lines,
+    )
+```
+
+**Key change from v1**: JSON parsing is done in `_row_to_render_job()`, and empty lists are normalized to `None`.
+
+### 7. Database schema — add `title_card_lines` column
+
+**File:** `webapp/src/db/schema.ts` (after line 237)
+
+```typescript
+titleCardLines: text("title_card_lines"),  // JSON array of strings, nullable
+```
+
+The column stores a JSON-encoded array of strings (e.g. `'["Sunday Worship","Amazing Grace","How Great Thou Art"]'`). Using `text` type with JSON encoding avoids adding a PostgreSQL `jsonb` column, keeping the migration simple.
+
+**Migration:** `npx drizzle-kit generate` then `npx drizzle-kit push` (or migrate).
+
+### 8. API route — accept `titleCardLines` in POST body
+
+**File:** `webapp/src/app/api/render-jobs/route.ts` (line 7-16)
+
+Add to Zod schema:
+
+```typescript
+titleCardLines: z.array(z.string().min(1).max(200)).min(1).max(20).optional(),
+```
+
+- Each line: 1-200 characters (no empty strings)
+- Min 1 line, max 20 lines
+- Optional: when omitted, the render worker uses the default (songset name + song titles)
+
+**Key change from v1**: Changed `.min(0)` to `.min(1)`. Since empty arrays are normalized to `undefined` at the API layer (see job-manager below), there's no reason to accept `[]`.
+
+### 9. Job manager — persist `titleCardLines`
+
+**File:** `webapp/src/lib/render/job-manager.ts` (lines 129-155)
+
+Add to the INSERT values:
+
+```typescript
+titleCardLines: input.titleCardLines && input.titleCardLines.length > 0 
+  ? JSON.stringify(input.titleCardLines) 
+  : null,
+```
+
+**Key change from v1**: Explicitly store `null` for empty arrays, not `"[]"`. This ensures the render worker receives `None` (not `[]`) when no custom lines are provided.
+
+Add to the `CreateRenderJobInput` type and the `RenderJob` return type mapping.
+
+### 10. `RenderFormData` — add `titleCardLines` field
+
+**File:** `webapp/src/components/render/RenderForm.tsx` (lines 24-33)
+
+```typescript
+export interface RenderFormData {
+  audioEnabled: boolean
+  videoEnabled: boolean
+  template: "dark" | "gradient_warm" | "gradient_blue"
+  resolution: "720p" | "1080p"
+  fontSizePreset: "S" | "M" | "L" | "XL"
+  includeTitleCard: boolean
+  titleCardDurationSeconds: number
+  titleCardLines: string[]  // NEW
+  offlineEnabled: boolean
+}
+```
+
+Default value: `[]` (empty array = use default song titles).
+
+### 11. RenderForm UI — add textarea for custom title card lines
+
+**File:** `webapp/src/components/render/RenderForm.tsx` (inside the Title Card card, lines 259-280)
+
+When `includeTitleCard` is checked, show a `<textarea>` below the duration selector:
+
+```tsx
+{formData.includeTitleCard && (
+  <div className="space-y-2 pl-6">
+    <Label htmlFor="titleCardDuration">Duration</Label>
+    {/* ... existing duration selector ... */}
+
+    <div className="space-y-2 pt-2">
+      <Label htmlFor="titleCardLines">Custom title card text</Label>
+      <p className="text-sm text-muted-foreground">
+        One line per entry. Leave empty to use songset name and song titles.
+      </p>
+      <textarea
+        id="titleCardLines"
+        className="flex min-h-[100px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        placeholder={"Sunday Morning Worship\nAmazing Grace\nHow Great Thou Art"}
+        value={formData.titleCardLines.join("\n")}
+        onChange={(e) => {
+          const lines = e.target.value.split("\n").filter((line) => line.trim() !== "")
+          updateField("titleCardLines", lines)
+        }}
+      />
+    </div>
+  </div>
+)}
+```
+
+**Behavior:**
+- Empty textarea → `titleCardLines = []` → API receives `undefined` → DB stores `null` → render worker uses default (songset name + song titles)
+- User types lines → `titleCardLines = ["line1", "line2", ...]` → API receives the array → DB stores JSON → render worker uses these exact lines
+- Blank lines are filtered out (`.filter(line => line.trim() !== "")`)
+- Each non-empty line becomes one centered line on the title card
+
+**Note on blank line filtering**: Blank lines are intentionally removed because a centered multi-line layout makes blank spacing lines meaningless. If users want visual spacing, they should adjust the font size preset instead.
+
+### 12. Render page — pass song titles to RenderForm for preview
+
+**File:** `webapp/src/app/songsets/[id]/render/page.tsx`
+
+#### 12a. Extend `SongsetData` to include song titles (lines 26-32)
+
+```typescript
+interface SongsetData {
+  id: string
+  name: string
+  description: string | null
+  markedLineCount: number
+  renderState: RenderState
+  songTitles: string[]  // NEW
+}
+```
+
+#### 12b. Extract song titles from API response (lines 84-94)
+
+```typescript
+setSongset({
+  id: data.id,
+  name: data.name,
+  description: data.description,
+  markedLineCount: data.items?.reduce(
+    (sum: number, item: { markedLineCount?: number }) =>
+      sum + (item.markedLineCount || 0),
+    0
+  ) || 0,
+  renderState,
+  songTitles: data.items?.map((item: { song?: { title: string } | null }) =>
+    item.song?.title ?? "Unknown Song"
+  ) ?? [],
+})
+```
+
+#### 12c. Pass `songTitles` and `songsetName` to `RenderForm` (lines 261-267)
+
+```tsx
+<RenderForm
+  songsetId={songsetId}
+  markedLineCount={songset.markedLineCount}
+  songsetName={songset.name}  // NEW
+  songTitles={songset.songTitles}  // NEW
+  initialData={initialData}
+  onSubmit={handleSubmit}
+  onCancel={() => router.push(`/songsets/${songsetId}`)}
+/>
+```
+
+#### 12d. Update `RenderFormProps` (lines 35-42)
+
+```typescript
+interface RenderFormProps {
+  songsetId: string
+  initialData?: Partial<RenderFormData>
+  markedLineCount?: number
+  songsetName?: string  // NEW
+  songTitles?: string[]  // NEW
+  onSubmit: (data: RenderFormData) => void
+  onCancel: () => void
+  isSubmitting?: boolean
+}
+```
+
+#### 12e. Show default lines preview in RenderForm
+
+Below the textarea, when `titleCardLines` is empty and `songTitles` is provided, show a muted preview of what the default title card will look like:
+
+```tsx
+{formData.titleCardLines.length === 0 && songTitles && songTitles.length > 0 && (
+  <div className="rounded-md border border-dashed border-muted-foreground/25 bg-muted/50 p-3">
+    <p className="text-xs text-muted-foreground mb-1">Default title card lines:</p>
+    <p className="text-sm text-muted-foreground">
+      {songsetName || "Worship Set"}<br />
+      {songTitles.join("\n")}
+    </p>
+  </div>
+)}
+```
+
+### 13. Render page — include `titleCardLines` in POST body
+
+**File:** `webapp/src/app/songsets/[id]/render/page.tsx` (lines 140-152)
+
+```typescript
+body: JSON.stringify({
+  songsetId,
+  template: formData.template,
+  resolution: formData.resolution,
+  audioEnabled: formData.audioEnabled,
+  videoEnabled: formData.videoEnabled,
+  fontSizePreset: formData.fontSizePreset,
+  includeTitleCard: formData.includeTitleCard,
+  titleCardDurationSeconds: formData.titleCardDurationSeconds,
+  titleCardLines: formData.titleCardLines.length > 0 ? formData.titleCardLines : undefined,
+}),
+```
+
+When `titleCardLines` is empty, send `undefined` (omitted from JSON) so the API treats it as "use defaults".
+
+### 14. Render page — restore `titleCardLines` from previous job
+
+**File:** `webapp/src/app/songsets/[id]/render/page.tsx` (lines 105-113)
+
+When loading initial data from a previous completed job:
+
+```typescript
+setInitialData({
+  template: job.template as RenderFormData["template"],
+  resolution: job.resolution as RenderFormData["resolution"],
+  audioEnabled: job.audioEnabled,
+  videoEnabled: job.videoEnabled,
+  fontSizePreset: job.fontSizePreset as RenderFormData["fontSizePreset"],
+  includeTitleCard: job.includeTitleCard,
+  titleCardDurationSeconds: job.titleCardDurationSeconds,
+  titleCardLines: job.titleCardLines ?? [],  // NEW
+})
+```
+
+---
+
+## Implementation Order
+
+1. **Database**: Add `title_card_lines` column to `render_jobs` table (schema + migration)
+2. **Render worker — data model**: Update `RenderJob` dataclass, `_row_to_render_job()` with JSON parsing, `TitleCardConfig`
+3. **Render worker — rendering**: Rewrite `render_title_card()` with multi-line auto-scaling logic
+4. **Render worker — VideoEngine**: Add `title_card_lines` and `songset_name` params, update `generate_video()`
+5. **Render worker — pipeline**: Extend `fetch_songset_items()` to return songset name, wire new params to VideoEngine
+6. **Render worker — tests**: Add/update tests for new `render_title_card()` behavior
+7. **Webapp — API**: Update Zod schema, job-manager INSERT/mapping
+8. **Webapp — UI**: Update `RenderFormData`, `RenderForm` (textarea + preview), render page (song titles extraction + POST body)
+9. **Webapp — tests**: Update any existing render form tests
+10. **Integration test**: End-to-end render with custom title card lines
+
+---
+
+## Edge Cases
+
+### Empty `titleCardLines` (default behavior)
+
+When `titleCardLines` is `None` (Python) / `undefined` (API) / `[]` (form), the render worker constructs defaults:
+- First line: songset name (from `songsets.name`), or "Worship Set" if empty
+- Remaining lines: all song titles from the songset items (in order)
+
+If the songset has no songs (empty songset), fall back to `("Worship Set",)`.
+
+### Very long lines
+
+The existing `fit_text()` method already handles horizontal overflow by reducing font size until the text fits within the screen width minus margins. This continues to work per-line.
+
+### Many lines (10+ songs)
+
+Auto-scaling reduces font sizes until all lines fit vertically. If body font size hits the minimum (16px) and lines still don't fit, they render at minimum size. Lines beyond the screen height are simply not rendered (the `current_y` advances past the bottom). This is unlikely in practice — even 15 lines at 16px body / 36px heading fit within 1080p height.
+
+### Single line
+
+If only one line is provided, it renders as the heading (20 pts larger than body, but body is never used). The line is centered both vertically and horizontally.
+
+### Lines with only whitespace
+
+The textarea filters out blank/whitespace-only lines before submitting. The render worker also normalizes empty strings during JSON parsing as a safety measure.
+
+### Unicode / CJK characters
+
+The existing font rendering handles CJK characters (Chinese song titles). No change needed — PIL/Pillow renders whatever the font supports.
+
+### Empty songset name
+
+If the songset has no name (empty string or null in DB), the default lines use "Worship Set" as the heading instead of a blank line.
+
+---
+
+## Verification Checklist
+
+- [ ] `title_card_lines` column added to `render_jobs` table
+- [ ] `TitleCardConfig` uses `lines: tuple[str, ...]` instead of `songset_name`/`song_count`
+- [ ] `render_title_card()` renders multiple lines centered vertically and horizontally
+- [ ] First line (heading) is 20 pts larger than remaining lines
+- [ ] Font size auto-scales to fit all lines on screen
+- [ ] Default lines = [songset name, ...song titles] when no custom lines provided
+- [ ] Empty songset name falls back to "Worship Set"
+- [ ] `VideoEngine` accepts `title_card_lines` and `songset_name` params
+- [ ] `VideoEngine.generate_video()` treats empty list same as None (uses defaults)
+- [ ] Pipeline fetches songset name via extended `fetch_songset_items()`
+- [ ] Pipeline passes songset name + title_card_lines to VideoEngine
+- [ ] Pipeline normalizes empty list to None before passing to VideoEngine
+- [ ] `_row_to_render_job()` parses JSON-encoded `title_card_lines` from DB
+- [ ] `_row_to_render_job()` normalizes empty list to None
+- [ ] API route validates `titleCardLines` (array of strings, min 1, max 20, max 200 chars each)
+- [ ] Job manager persists `titleCardLines` as JSON in DB, or `null` for empty array
+- [ ] `RenderFormData` includes `titleCardLines: string[]`
+- [ ] RenderForm shows textarea when title card is enabled
+- [ ] RenderForm shows default lines preview when textarea is empty
+- [ ] Render page extracts song titles from API response
+- [ ] Render page includes `titleCardLines` in POST body (undefined if empty)
+- [ ] Previous job's `titleCardLines` restored in initial form data
+- [ ] Render worker tests pass for new `render_title_card()` behavior
+- [ ] End-to-end render with custom lines produces correct video
+- [ ] End-to-end render with empty custom lines uses defaults
+
+---
+
+## Changes from v1
+
+1. **Empty array normalization (both layers)**: 
+   - API/job-manager stores `null` for empty arrays (not `"[]"`)
+   - Render worker `_row_to_render_job()` normalizes empty list to `None`
+   - Pipeline normalizes empty list to `None` before passing to VideoEngine
+   - VideoEngine uses truthy check (`if self.title_card_lines:`) instead of `is not None`
+
+2. **JSON parsing in `_row_to_render_job()`**: 
+   - Added `import json` and proper parsing with error handling
+   - Empty list normalized to `None`
+
+3. **Empty songset name fallback**: 
+   - `fetch_songset_items()` returns "Worship Set" as fallback
+   - `VideoEngine.generate_video()` uses `songset_name or "Worship Set"`
+
+4. **Removed truncation mention**: The edge case section no longer claims truncation is implemented. Lines render at minimum font size; overflow is simply not visible.
+
+5. **Vertical centering accuracy note**: Documented that minor inaccuracy from `fit_text` is accepted.
+
+6. **Combined `fetch_songset_name` with `fetch_songset_items`**: Single DB roundtrip instead of two.
+
+7. **Zod schema `.min(1)`**: Changed from `.min(0)` since empty arrays are normalized to `undefined`.
+
+8. **Blank line filtering note**: Added explanation that blank lines are intentionally removed for centered layouts.

--- a/specs/title-card-custom-lines.md
+++ b/specs/title-card-custom-lines.md
@@ -1,0 +1,648 @@
+# Title Card: Custom Lines of Text
+
+## Problem
+
+The title card currently renders a hardcoded layout: one heading line (derived from the first song's title) and one subtitle line (`{count} 首歌曲 · {mm:ss}`). Users cannot customize what text appears on the title card.
+
+The desired behavior is:
+1. Users can optionally provide custom lines of text for the title card
+2. Each line is rendered as a separate line, centered both vertically and horizontally
+3. When no custom lines are given, the default is: **songset name** as the first line, followed by **all song titles** from the songset
+4. The first line (heading) renders 20 pts larger than the remaining lines
+5. Font size auto-scales so all lines fit on screen
+
+---
+
+## Current State
+
+### Data flow
+
+```
+RenderForm (browser)
+  includeTitleCard: boolean
+  titleCardDurationSeconds: number
+       |
+       v
+POST /api/render-jobs  (Zod validation)
+       |
+       v
+job-manager.createRenderJob()  →  INSERT INTO render_jobs
+       |
+       v
+SQS → Lambda → pipeline.execute_render_pipeline()
+       |
+       v
+VideoEngine(include_title_card, title_card_duration_seconds)
+       |
+       v
+TitleCardConfig(songset_name=segments[0].item.song_title, song_count, total_duration_seconds)
+       |
+       v
+FrameRenderer.render_title_card(config)
+  → heading at 40% height (2x base font size)
+  → subtitle "{count} 首歌曲 · {mm:ss}" at 55% height (1x base font size)
+```
+
+### Key files
+
+| File | Lines | Role |
+|------|-------|------|
+| `webapp/src/components/render/RenderForm.tsx` | 24-33, 242-280 | Form UI: checkbox + duration selector |
+| `webapp/src/app/songsets/[id]/render/page.tsx` | 84-94, 137-173 | Render page: fetches songset, submits form |
+| `webapp/src/app/api/render-jobs/route.ts` | 7-16 | Zod schema for POST body |
+| `webapp/src/lib/render/job-manager.ts` | 112-155 | Creates render job in DB |
+| `webapp/src/db/schema.ts` | 204-247 | `render_jobs` table schema |
+| `services/render-worker/src/sow_render_worker/db.py` | 49-50 | `RenderJob` dataclass |
+| `services/render-worker/src/sow_render_worker/pipeline.py` | 347-354 | Wires job params to VideoEngine |
+| `services/render-worker/src/sow_render_worker/video_engine.py` | 63-82, 202-212 | VideoEngine constructor + TitleCardConfig construction |
+| `services/render-worker/src/sow_render_worker/frame_renderer.py` | 47-53, 420-453 | `TitleCardConfig` dataclass + `render_title_card()` |
+
+### Current `TitleCardConfig`
+
+```python
+@dataclass(frozen=True)
+class TitleCardConfig:
+    enabled: bool
+    duration_seconds: float
+    songset_name: str
+    song_count: int
+    total_duration_seconds: float
+```
+
+### Current `render_title_card()` output
+
+- Solid background from template
+- `config.songset_name` centered at 40% height, font size = `base_font_size * 2` (auto-fitted to width)
+- Subtitle `"{song_count} 首歌曲 · {duration_text}"` centered at 55% height, font size = `base_font_size`
+
+### Current `RenderFormData` (TypeScript)
+
+```typescript
+export interface RenderFormData {
+  audioEnabled: boolean
+  videoEnabled: boolean
+  template: "dark" | "gradient_warm" | "gradient_blue"
+  resolution: "720p" | "1080p"
+  fontSizePreset: "S" | "M" | "L" | "XL"
+  includeTitleCard: boolean
+  titleCardDurationSeconds: number
+  offlineEnabled: boolean
+}
+```
+
+---
+
+## Proposed Changes
+
+### 1. `TitleCardConfig` — replace `songset_name`/`song_count` with `lines`
+
+**File:** `services/render-worker/src/sow_render_worker/frame_renderer.py` (lines 47-53)
+
+```python
+# Before:
+@dataclass(frozen=True)
+class TitleCardConfig:
+    enabled: bool
+    duration_seconds: float
+    songset_name: str
+    song_count: int
+    total_duration_seconds: float
+
+# After:
+@dataclass(frozen=True)
+class TitleCardConfig:
+    enabled: bool
+    duration_seconds: float
+    lines: tuple[str, ...]
+    total_duration_seconds: float
+```
+
+- `lines` is a tuple of strings, each rendered as a separate line
+- Empty tuple means title card is effectively blank (shouldn't happen in practice — see defaults below)
+- Using `tuple` instead of `list` for immutability (matching the `frozen=True` dataclass)
+
+### 2. `render_title_card()` — multi-line centered rendering with auto-scaling
+
+**File:** `services/render-worker/src/sow_render_worker/frame_renderer.py` (lines 420-453)
+
+New rendering logic:
+
+1. **Heading font size**: Start with `base_font_size * 2` (same as current heading), auto-fit each line's width to screen
+2. **Body font size**: `heading_font_size - 20` (heading is 20 pts larger than body)
+3. **Auto-scale**: If all lines don't fit vertically within the screen height (with margins), reduce both heading and body font sizes proportionally until they fit. Minimum body font size = 16px; if lines still don't fit, truncate the line list.
+4. **Vertical centering**: Calculate total text block height (sum of line heights + inter-line spacing), then center the block vertically on screen
+5. **Horizontal centering**: Each line is individually centered horizontally (anchor="mt")
+6. **Inter-line spacing**: 1.2× the body font size between lines; 1.5× the body font size between the heading (first line) and the second line
+
+Pseudocode:
+
+```python
+def render_title_card(self, config: TitleCardConfig) -> Image.Image:
+    width, height = self.resolution
+    img = Image.new("RGBA", (width, height), (*self.template.background_color, 255))
+    draw = ImageDraw.Draw(img)
+    text_r, text_g, text_b = self.template.text_color
+
+    if not config.lines:
+        return img
+
+    margin = 40  # horizontal margin in px
+    min_body_font_size = 16
+    line_spacing_factor = 1.2
+    heading_gap_factor = 1.5
+
+    # Start with target sizes
+    heading_font_size_target = self.base_font_size * 2
+    body_font_size_target = heading_font_size_target - 20
+
+    # Auto-fit: reduce font sizes until all lines fit vertically
+    heading_font_size = heading_font_size_target
+    body_font_size = body_font_size_target
+
+    while True:
+        heading_font = self._get_font(heading_font_size)
+        body_font = self._get_font(body_font_size)
+
+        # Calculate total block height
+        total_height = 0
+        for i, line in enumerate(config.lines):
+            font = heading_font if i == 0 else body_font
+            bbox = draw.textbbox((0, 0), line, font=font)
+            line_height = bbox[3] - bbox[1]
+            total_height += line_height
+            if i == 0 and len(config.lines) > 1:
+                total_height += int(body_font_size * heading_gap_factor)
+            elif i > 0:
+                total_height += int(body_font_size * line_spacing_factor)
+
+        if total_height <= height - margin * 2 or body_font_size <= min_body_font_size:
+            break
+
+        heading_font_size -= 2
+        body_font_size = max(min_body_font_size, heading_font_size - 20)
+
+    # Render lines centered vertically and horizontally
+    y_start = (height - total_height) // 2
+    current_y = y_start
+
+    for i, line in enumerate(config.lines):
+        font = heading_font if i == 0 else body_font
+        # Auto-fit line width
+        fitted_size = self.fit_text(draw, line, heading_font_size if i == 0 else body_font_size, width - margin * 2)
+        font = self._get_font(fitted_size)
+        draw.text(
+            (width // 2, current_y),
+            line,
+            fill=(text_r, text_g, text_b),
+            font=font,
+            anchor="mt",
+        )
+        bbox = draw.textbbox((0, 0), line, font=font)
+        line_height = bbox[3] - bbox[1]
+        current_y += line_height
+        if i == 0 and len(config.lines) > 1:
+            current_y += int(body_font_size * heading_gap_factor)
+        elif i > 0:
+            current_y += int(body_font_size * line_spacing_factor)
+
+    return img
+```
+
+### 3. `VideoEngine` — accept `title_card_lines` parameter
+
+**File:** `services/render-worker/src/sow_render_worker/video_engine.py`
+
+#### 3a. Constructor (lines 63-82)
+
+Add `title_card_lines: list[str] | None = None` parameter:
+
+```python
+def __init__(
+    self,
+    asset_fetcher: AssetFetcherProtocol,
+    template: VideoTemplateName = "dark",
+    font_size_preset: FontSizePreset = "M",
+    resolution: str = "1080p",
+    fps: int = 24,
+    include_title_card: bool = True,
+    title_card_duration_seconds: float = 5.0,
+    title_card_lines: list[str] | None = None,  # NEW
+    ffmpeg_path: str | None = None,
+    ffprobe_path: str | None = None,
+):
+    # ... existing assignments ...
+    self.title_card_lines = title_card_lines  # NEW
+```
+
+#### 3b. `generate_video()` — construct `TitleCardConfig` with lines (lines 202-212)
+
+Replace the current `TitleCardConfig` construction:
+
+```python
+# Before:
+title_card_config = TitleCardConfig(
+    enabled=True,
+    duration_seconds=total_duration_seconds,
+    songset_name=(segments[0].item.song_title or "Worship Set") if segments else "Worship Set",
+    song_count=len(segments),
+    total_duration_seconds=total_duration_seconds,
+)
+
+# After:
+if self.title_card_lines is not None:
+    # User-provided custom lines
+    title_lines = tuple(self.title_card_lines)
+else:
+    # Default: songset name + all song titles
+    song_titles = [seg.item.song_title for seg in segments if seg.item.song_title]
+    title_lines = tuple([songset_name] + song_titles) if song_titles else (songset_name,)
+
+title_card_config = TitleCardConfig(
+    enabled=True,
+    duration_seconds=total_duration_seconds,
+    lines=title_lines,
+    total_duration_seconds=total_duration_seconds,
+)
+```
+
+**Problem:** The `songset_name` (the user-given name of the songset, e.g. "Sunday Morning Worship") is not currently available in the VideoEngine. It only has access to `segments` (which have `song_title` per segment).
+
+**Solution:** Pass `songset_name` as a new constructor parameter to `VideoEngine`. The pipeline already has access to the songset's `name` field via the database.
+
+### 4. `VideoEngine` — accept `songset_name` parameter
+
+**File:** `services/render-worker/src/sow_render_worker/video_engine.py`
+
+#### 4a. Constructor
+
+Add `songset_name: str = ""` parameter:
+
+```python
+def __init__(
+    self,
+    asset_fetcher: AssetFetcherProtocol,
+    template: VideoTemplateName = "dark",
+    font_size_preset: FontSizePreset = "M",
+    resolution: str = "1080p",
+    fps: int = 24,
+    include_title_card: bool = True,
+    title_card_duration_seconds: float = 5.0,
+    title_card_lines: list[str] | None = None,
+    songset_name: str = "",  # NEW
+    ffmpeg_path: str | None = None,
+    ffprobe_path: str | None = None,
+):
+    # ... existing assignments ...
+    self.songset_name = songset_name  # NEW
+```
+
+### 5. Pipeline — fetch songset name and pass to VideoEngine
+
+**File:** `services/render-worker/src/sow_render_worker/pipeline.py`
+
+#### 5a. Fetch songset name (around line 173)
+
+The pipeline already calls `get_render_job()` which returns the job with `songset_id`. It then calls `fetch_songset_items()`. We need to also fetch the songset's `name` field.
+
+Add a new function or extend the existing query:
+
+```python
+def fetch_songset_name(conn, songset_id: str) -> str:
+    with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(
+            "SELECT name FROM songsets WHERE id = %s",
+            (songset_id,),
+        )
+        row = cur.fetchone()
+        return row["name"] if row else ""
+```
+
+#### 5b. Pass to VideoEngine (lines 347-354)
+
+```python
+# Before:
+video_engine = VideoEngine(
+    asset_fetcher,
+    template=job.template,
+    font_size_preset=job.font_size_preset,
+    resolution=job.resolution,
+    include_title_card=job.include_title_card,
+    title_card_duration_seconds=job.title_card_duration_seconds or 5.0,
+)
+
+# After:
+songset_name = fetch_songset_name(conn, job.songset_id)
+title_card_lines = job.title_card_lines  # from DB (new column)
+
+video_engine = VideoEngine(
+    asset_fetcher,
+    template=job.template,
+    font_size_preset=job.font_size_preset,
+    resolution=job.resolution,
+    include_title_card=job.include_title_card,
+    title_card_duration_seconds=job.title_card_duration_seconds or 5.0,
+    title_card_lines=title_card_lines,
+    songset_name=songset_name,
+)
+```
+
+### 6. `RenderJob` dataclass — add `title_card_lines` field
+
+**File:** `services/render-worker/src/sow_render_worker/db.py` (lines 49-50)
+
+```python
+# Add after line 50:
+title_card_lines: Optional[list[str]] = None
+```
+
+Update `_row_to_render_job()` (around line 102) to parse the new column:
+
+```python
+title_card_lines=row.get("title_card_lines"),  # JSON array from DB
+```
+
+### 7. Database schema — add `title_card_lines` column
+
+**File:** `webapp/src/db/schema.ts` (after line 237)
+
+```typescript
+titleCardLines: text("title_card_lines"),  // JSON array of strings, nullable
+```
+
+The column stores a JSON-encoded array of strings (e.g. `'["Sunday Worship","Amazing Grace","How Great Thou Art"]'`). Using `text` type with JSON encoding avoids adding a PostgreSQL `jsonb` column, keeping the migration simple. The render worker will `json.loads()` the value.
+
+**Migration:** `npx drizzle-kit generate` then `npx drizzle-kit push` (or migrate).
+
+### 8. API route — accept `titleCardLines` in POST body
+
+**File:** `webapp/src/app/api/render-jobs/route.ts` (line 7-16)
+
+Add to Zod schema:
+
+```typescript
+titleCardLines: z.array(z.string().min(1).max(200)).min(0).max(20).optional(),
+```
+
+- Each line: 1-200 characters
+- Max 20 lines
+- Optional: when omitted, the render worker uses the default (songset name + song titles)
+
+### 9. Job manager — persist `titleCardLines`
+
+**File:** `webapp/src/lib/render/job-manager.ts` (lines 129-155)
+
+Add to the INSERT values:
+
+```typescript
+titleCardLines: input.titleCardLines ? JSON.stringify(input.titleCardLines) : null,
+```
+
+Add to the `CreateRenderJobInput` type and the `RenderJob` return type mapping.
+
+### 10. `RenderFormData` — add `titleCardLines` field
+
+**File:** `webapp/src/components/render/RenderForm.tsx` (lines 24-33)
+
+```typescript
+export interface RenderFormData {
+  audioEnabled: boolean
+  videoEnabled: boolean
+  template: "dark" | "gradient_warm" | "gradient_blue"
+  resolution: "720p" | "1080p"
+  fontSizePreset: "S" | "M" | "L" | "XL"
+  includeTitleCard: boolean
+  titleCardDurationSeconds: number
+  titleCardLines: string[]  // NEW
+  offlineEnabled: boolean
+}
+```
+
+Default value: `[]` (empty array = use default song titles).
+
+### 11. RenderForm UI — add textarea for custom title card lines
+
+**File:** `webapp/src/components/render/RenderForm.tsx` (inside the Title Card card, lines 259-280)
+
+When `includeTitleCard` is checked, show a `<textarea>` below the duration selector:
+
+```tsx
+{formData.includeTitleCard && (
+  <div className="space-y-2 pl-6">
+    <Label htmlFor="titleCardDuration">Duration</Label>
+    {/* ... existing duration selector ... */}
+
+    <div className="space-y-2 pt-2">
+      <Label htmlFor="titleCardLines">Custom title card text</Label>
+      <p className="text-sm text-muted-foreground">
+        One line per entry. Leave empty to use songset name and song titles.
+      </p>
+      <textarea
+        id="titleCardLines"
+        className="flex min-h-[100px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        placeholder={"Sunday Morning Worship\nAmazing Grace\nHow Great Thou Art"}
+        value={formData.titleCardLines.join("\n")}
+        onChange={(e) => {
+          const lines = e.target.value.split("\n").filter((line) => line.trim() !== "")
+          updateField("titleCardLines", lines)
+        }}
+      />
+    </div>
+  </div>
+)}
+```
+
+**Behavior:**
+- Empty textarea → `titleCardLines = []` → render worker uses default (songset name + song titles)
+- User types lines → `titleCardLines = ["line1", "line2", ...]` → render worker uses these exact lines
+- Blank lines are filtered out (`.filter(line => line.trim() !== "")`)
+- Each non-empty line becomes one centered line on the title card
+
+### 12. Render page — pass song titles to RenderForm for preview
+
+**File:** `webapp/src/app/songsets/[id]/render/page.tsx`
+
+#### 12a. Extend `SongsetData` to include song titles (lines 26-32)
+
+```typescript
+interface SongsetData {
+  id: string
+  name: string
+  description: string | null
+  markedLineCount: number
+  renderState: RenderState
+  songTitles: string[]  // NEW
+}
+```
+
+#### 12b. Extract song titles from API response (lines 84-94)
+
+```typescript
+setSongset({
+  id: data.id,
+  name: data.name,
+  description: data.description,
+  markedLineCount: data.items?.reduce(
+    (sum: number, item: { markedLineCount?: number }) =>
+      sum + (item.markedLineCount || 0),
+    0
+  ) || 0,
+  renderState,
+  songTitles: data.items?.map((item: { song?: { title: string } | null }) =>
+    item.song?.title ?? "Unknown Song"
+  ) ?? [],
+})
+```
+
+#### 12c. Pass `songTitles` to `RenderForm` (lines 261-267)
+
+```tsx
+<RenderForm
+  songsetId={songsetId}
+  markedLineCount={songset.markedLineCount}
+  songTitles={songset.songTitles}  // NEW
+  initialData={initialData}
+  onSubmit={handleSubmit}
+  onCancel={() => router.push(`/songsets/${songsetId}`)}
+/>
+```
+
+#### 12d. Update `RenderFormProps` (lines 35-42)
+
+```typescript
+interface RenderFormProps {
+  songsetId: string
+  initialData?: Partial<RenderFormData>
+  markedLineCount?: number
+  songTitles?: string[]  // NEW
+  onSubmit: (data: RenderFormData) => void
+  onCancel: () => void
+  isSubmitting?: boolean
+}
+```
+
+#### 12e. Show default lines preview in RenderForm
+
+Below the textarea, when `titleCardLines` is empty and `songTitles` is provided, show a muted preview of what the default title card will look like:
+
+```tsx
+{formData.titleCardLines.length === 0 && songTitles && songTitles.length > 0 && (
+  <div className="rounded-md border border-dashed border-muted-foreground/25 bg-muted/50 p-3">
+    <p className="text-xs text-muted-foreground mb-1">Default title card lines:</p>
+    <p className="text-sm text-muted-foreground">
+      {songsetName}<br />
+      {songTitles.join("\n")}
+    </p>
+  </div>
+)}
+```
+
+This requires also passing `songsetName` to `RenderForm` (or deriving it from the songset data). Add `songsetName?: string` to `RenderFormProps`.
+
+### 13. Render page — include `titleCardLines` in POST body
+
+**File:** `webapp/src/app/songsets/[id]/render/page.tsx` (lines 140-152)
+
+```typescript
+body: JSON.stringify({
+  songsetId,
+  template: formData.template,
+  resolution: formData.resolution,
+  audioEnabled: formData.audioEnabled,
+  videoEnabled: formData.videoEnabled,
+  fontSizePreset: formData.fontSizePreset,
+  includeTitleCard: formData.includeTitleCard,
+  titleCardDurationSeconds: formData.titleCardDurationSeconds,
+  titleCardLines: formData.titleCardLines.length > 0 ? formData.titleCardLines : undefined,
+}),
+```
+
+When `titleCardLines` is empty, send `undefined` (omitted from JSON) so the API treats it as "use defaults".
+
+### 14. Render page — restore `titleCardLines` from previous job
+
+**File:** `webapp/src/app/songsets/[id]/render/page.tsx` (lines 105-113)
+
+When loading initial data from a previous completed job:
+
+```typescript
+setInitialData({
+  template: job.template as RenderFormData["template"],
+  resolution: job.resolution as RenderFormData["resolution"],
+  audioEnabled: job.audioEnabled,
+  videoEnabled: job.videoEnabled,
+  fontSizePreset: job.fontSizePreset as RenderFormData["fontSizePreset"],
+  includeTitleCard: job.includeTitleCard,
+  titleCardDurationSeconds: job.titleCardDurationSeconds,
+  titleCardLines: job.titleCardLines ?? [],  // NEW
+})
+```
+
+---
+
+## Implementation Order
+
+1. **Database**: Add `title_card_lines` column to `render_jobs` table (schema + migration)
+2. **Render worker — data model**: Update `RenderJob` dataclass, `_row_to_render_job()`, `TitleCardConfig`
+3. **Render worker — rendering**: Rewrite `render_title_card()` with multi-line auto-scaling logic
+4. **Render worker — VideoEngine**: Add `title_card_lines` and `songset_name` params, update `generate_video()`
+5. **Render worker — pipeline**: Add `fetch_songset_name()`, wire new params to VideoEngine
+6. **Render worker — tests**: Add/update tests for new `render_title_card()` behavior
+7. **Webapp — API**: Update Zod schema, job-manager INSERT/mapping
+8. **Webapp — UI**: Update `RenderFormData`, `RenderForm` (textarea + preview), render page (song titles extraction + POST body)
+9. **Webapp — tests**: Update any existing render form tests
+10. **Integration test**: End-to-end render with custom title card lines
+
+---
+
+## Edge Cases
+
+### Empty `titleCardLines` (default behavior)
+
+When `titleCardLines` is `None` (Python) / `undefined` (API) / `[]` (form), the render worker constructs defaults:
+- First line: songset name (from `songsets.name`)
+- Remaining lines: all song titles from the songset items (in order)
+
+If the songset has no name and no songs (empty songset), fall back to `("Worship Set",)`.
+
+### Very long lines
+
+The existing `fit_text()` method already handles horizontal overflow by reducing font size until the text fits within the screen width minus margins. This continues to work per-line.
+
+### Many lines (10+ songs)
+
+Auto-scaling reduces font sizes until all lines fit vertically. If body font size hits the minimum (16px) and lines still don't fit, the last lines are simply not rendered (the loop stops when `current_y` exceeds the screen height). This is unlikely in practice — even 15 lines at 16px body / 36px heading fit within 1080p height.
+
+### Single line
+
+If only one line is provided, it renders as the heading (20 pts larger than body, but body is never used). The line is centered both vertically and horizontally.
+
+### Lines with only whitespace
+
+The textarea filters out blank/whitespace-only lines before submitting. The render worker should also strip empty strings from the list as a safety measure.
+
+### Unicode / CJK characters
+
+The existing font rendering handles CJK characters (Chinese song titles). No change needed — PIL/Pillow renders whatever the font supports.
+
+---
+
+## Verification Checklist
+
+- [ ] `title_card_lines` column added to `render_jobs` table
+- [ ] `TitleCardConfig` uses `lines: tuple[str, ...]` instead of `songset_name`/`song_count`
+- [ ] `render_title_card()` renders multiple lines centered vertically and horizontally
+- [ ] First line (heading) is 20 pts larger than remaining lines
+- [ ] Font size auto-scales to fit all lines on screen
+- [ ] Default lines = [songset name, ...song titles] when no custom lines provided
+- [ ] `VideoEngine` accepts `title_card_lines` and `songset_name` params
+- [ ] Pipeline fetches songset name and passes it + title_card_lines to VideoEngine
+- [ ] API route validates `titleCardLines` (array of strings, max 20, max 200 chars each)
+- [ ] Job manager persists `titleCardLines` as JSON in DB
+- [ ] `RenderFormData` includes `titleCardLines: string[]`
+- [ ] RenderForm shows textarea when title card is enabled
+- [ ] RenderForm shows default lines preview when textarea is empty
+- [ ] Render page extracts song titles from API response
+- [ ] Render page includes `titleCardLines` in POST body
+- [ ] Previous job's `titleCardLines` restored in initial form data
+- [ ] Render worker tests pass for new `render_title_card()` behavior
+- [ ] End-to-end render with custom lines produces correct video

--- a/webapp/drizzle.config.ts
+++ b/webapp/drizzle.config.ts
@@ -5,6 +5,6 @@ export default defineConfig({
   out: "./drizzle",
   dialect: "postgresql",
   dbCredentials: {
-    url: process.env.DATABASE_URL ?? "postgresql://localhost/sow",
+    url: process.env.SOW_DATABASE_URL ?? "postgresql://localhost/sow",
   },
 });

--- a/webapp/drizzle/0007_goofy_shadow_king.sql
+++ b/webapp/drizzle/0007_goofy_shadow_king.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "render_jobs" ADD COLUMN "title_card_lines" text;--> statement-breakpoint
+ALTER TABLE "songs" ADD COLUMN "search_vector" "tsvector" GENERATED ALWAYS AS (setweight(to_tsvector('simple', coalesce("title", '')), 'A') ||
+          setweight(to_tsvector('simple', coalesce("title_pinyin", '')), 'A') ||
+          setweight(to_tsvector('simple', coalesce("composer", '')), 'B') ||
+          setweight(to_tsvector('simple', coalesce("lyricist", '')), 'B') ||
+          setweight(to_tsvector('simple', coalesce("album_name", '')), 'B')) STORED;--> statement-breakpoint
+CREATE INDEX "idx_songs_search_vector" ON "songs" USING btree ("search_vector");

--- a/webapp/drizzle/meta/0007_snapshot.json
+++ b/webapp/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,1583 @@
+{
+  "id": "355a8db6-465b-4d00-9f4e-92c235cef65d",
+  "prevId": "fa0cabd6-6f90-4622-ae74-bbc26805fd0a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "account_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "userId": {
+          "name": "userId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "account_providerId_accountId_unique": {
+          "name": "account_providerId_accountId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "providerId",
+            "accountId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lyric_mark": {
+      "name": "lyric_mark",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recording_content_hash": {
+          "name": "recording_content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp_seconds": {
+          "name": "timestamp_seconds",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lyric_mark_user_id_user_id_fk": {
+          "name": "lyric_mark_user_id_user_id_fk",
+          "tableFrom": "lyric_mark",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lyric_mark_recording_content_hash_recordings_content_hash_fk": {
+          "name": "lyric_mark_recording_content_hash_recordings_content_hash_fk",
+          "tableFrom": "lyric_mark",
+          "tableTo": "recordings",
+          "columnsFrom": [
+            "recording_content_hash"
+          ],
+          "columnsTo": [
+            "content_hash"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lyric_mark_user_id_recording_content_hash_timestamp_seconds_unique": {
+          "name": "lyric_mark_user_id_recording_content_hash_timestamp_seconds_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "recording_content_hash",
+            "timestamp_seconds"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recordings": {
+      "name": "recordings",
+      "schema": "",
+      "columns": {
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "hash_prefix": {
+          "name": "hash_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "song_id": {
+          "name": "song_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_filename": {
+          "name": "original_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "r2_audio_url": {
+          "name": "r2_audio_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "r2_stems_url": {
+          "name": "r2_stems_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "r2_lrc_url": {
+          "name": "r2_lrc_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tempo_bpm": {
+          "name": "tempo_bpm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musical_key": {
+          "name": "musical_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musical_mode": {
+          "name": "musical_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_confidence": {
+          "name": "key_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loudness_db": {
+          "name": "loudness_db",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "beats": {
+          "name": "beats",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "downbeats": {
+          "name": "downbeats",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sections": {
+          "name": "sections",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embeddings_shape": {
+          "name": "embeddings_shape",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "analysis_status": {
+          "name": "analysis_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "analysis_job_id": {
+          "name": "analysis_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lrc_status": {
+          "name": "lrc_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "lrc_job_id": {
+          "name": "lrc_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "youtube_url": {
+          "name": "youtube_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility_status": {
+          "name": "visibility_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "download_status": {
+          "name": "download_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recordings_song_id_songs_id_fk": {
+          "name": "recordings_song_id_songs_id_fk",
+          "tableFrom": "recordings",
+          "tableTo": "songs",
+          "columnsFrom": [
+            "song_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "recordings_hash_prefix_unique": {
+          "name": "recordings_hash_prefix_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hash_prefix"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.render_jobs": {
+      "name": "render_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "songset_id": {
+          "name": "songset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phase_index": {
+          "name": "phase_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_phases": {
+          "name": "total_phases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percent_complete": {
+          "name": "percent_complete",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "estimated_seconds_left": {
+          "name": "estimated_seconds_left",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "elapsed_seconds": {
+          "name": "elapsed_seconds",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_total_seconds": {
+          "name": "estimated_total_seconds",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_duration_seconds": {
+          "name": "total_duration_seconds",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template": {
+          "name": "template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'dark'"
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'720p'"
+        },
+        "audio_enabled": {
+          "name": "audio_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "video_enabled": {
+          "name": "video_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "font_size_preset": {
+          "name": "font_size_preset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'M'"
+        },
+        "include_title_card": {
+          "name": "include_title_card",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "title_card_duration_seconds": {
+          "name": "title_card_duration_seconds",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "title_card_lines": {
+          "name": "title_card_lines",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mp3_r2_key": {
+          "name": "mp3_r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mp4_r2_key": {
+          "name": "mp4_r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chapters_r2_key": {
+          "name": "chapters_r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "render_jobs_songset_id_songsets_id_fk": {
+          "name": "render_jobs_songset_id_songsets_id_fk",
+          "tableFrom": "render_jobs",
+          "tableTo": "songsets",
+          "columnsFrom": [
+            "songset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "render_jobs_user_id_user_id_fk": {
+          "name": "render_jobs_user_id_user_id_fk",
+          "tableFrom": "render_jobs",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "session_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "userId": {
+          "name": "userId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.song_embedding": {
+      "name": "song_embedding",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recording_content_hash": {
+          "name": "recording_content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_song_embedding_hash": {
+          "name": "idx_song_embedding_hash",
+          "columns": [
+            {
+              "expression": "recording_content_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "song_embedding_recording_content_hash_recordings_content_hash_fk": {
+          "name": "song_embedding_recording_content_hash_recordings_content_hash_fk",
+          "tableFrom": "song_embedding",
+          "tableTo": "recordings",
+          "columnsFrom": [
+            "recording_content_hash"
+          ],
+          "columnsTo": [
+            "content_hash"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "song_embedding_recording_content_hash_model_version_unique": {
+          "name": "song_embedding_recording_content_hash_model_version_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "recording_content_hash",
+            "model_version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.songs": {
+      "name": "songs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title_pinyin": {
+          "name": "title_pinyin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "composer": {
+          "name": "composer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lyricist": {
+          "name": "lyricist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_name": {
+          "name": "album_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_series": {
+          "name": "album_series",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musical_key": {
+          "name": "musical_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lyrics_raw": {
+          "name": "lyrics_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lyrics_lines": {
+          "name": "lyrics_lines",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sections": {
+          "name": "sections",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "table_row_number": {
+          "name": "table_row_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scraped_at": {
+          "name": "scraped_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('simple', coalesce(\"title\", '')), 'A') ||\n          setweight(to_tsvector('simple', coalesce(\"title_pinyin\", '')), 'A') ||\n          setweight(to_tsvector('simple', coalesce(\"composer\", '')), 'B') ||\n          setweight(to_tsvector('simple', coalesce(\"lyricist\", '')), 'B') ||\n          setweight(to_tsvector('simple', coalesce(\"album_name\", '')), 'B')",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "idx_songs_search_vector": {
+          "name": "idx_songs_search_vector",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.songset_items": {
+      "name": "songset_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "songset_id": {
+          "name": "songset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "song_id": {
+          "name": "song_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recording_hash_prefix": {
+          "name": "recording_hash_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gap_beats": {
+          "name": "gap_beats",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 2
+        },
+        "crossfade_enabled": {
+          "name": "crossfade_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "crossfade_duration_seconds": {
+          "name": "crossfade_duration_seconds",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_shift_semitones": {
+          "name": "key_shift_semitones",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "tempo_ratio": {
+          "name": "tempo_ratio",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "songset_items_songset_id_songsets_id_fk": {
+          "name": "songset_items_songset_id_songsets_id_fk",
+          "tableFrom": "songset_items",
+          "tableTo": "songsets",
+          "columnsFrom": [
+            "songset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.songset_share": {
+      "name": "songset_share",
+      "schema": "",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "songset_id": {
+          "name": "songset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "render_job_id": {
+          "name": "render_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allow_download": {
+          "name": "allow_download",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "songset_share_songset_id_songsets_id_fk": {
+          "name": "songset_share_songset_id_songsets_id_fk",
+          "tableFrom": "songset_share",
+          "tableTo": "songsets",
+          "columnsFrom": [
+            "songset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "songset_share_created_by_user_id_user_id_fk": {
+          "name": "songset_share_created_by_user_id_user_id_fk",
+          "tableFrom": "songset_share",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.songsets": {
+      "name": "songsets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "latest_render_job_id": {
+          "name": "latest_render_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_failed_render_job_id": {
+          "name": "last_failed_render_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "songsets_user_id_user_id_fk": {
+          "name": "songsets_user_id_user_id_fk",
+          "tableFrom": "songsets",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_lrc_override": {
+      "name": "user_lrc_override",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recording_content_hash": {
+          "name": "recording_content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lrc_content": {
+          "name": "lrc_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_lrc_override_user_id_user_id_fk": {
+          "name": "user_lrc_override_user_id_user_id_fk",
+          "tableFrom": "user_lrc_override",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_lrc_override_recording_content_hash_recordings_content_hash_fk": {
+          "name": "user_lrc_override_recording_content_hash_recordings_content_hash_fk",
+          "tableFrom": "user_lrc_override",
+          "tableTo": "recordings",
+          "columnsFrom": [
+            "recording_content_hash"
+          ],
+          "columnsTo": [
+            "content_hash"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_lrc_override_user_id_recording_content_hash_unique": {
+          "name": "user_lrc_override_user_id_recording_content_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "recording_content_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "offline_auto_cache": {
+          "name": "offline_auto_cache",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "default_gap_beats": {
+          "name": "default_gap_beats",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "default_video_template": {
+          "name": "default_video_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'dark'"
+        },
+        "default_resolution": {
+          "name": "default_resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'720p'"
+        },
+        "lyrics_loop_window_seconds": {
+          "name": "lyrics_loop_window_seconds",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "default_font_size_preset": {
+          "name": "default_font_size_preset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'M'"
+        },
+        "default_key_shift_semitones": {
+          "name": "default_key_shift_semitones",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "timing_review_font": {
+          "name": "timing_review_font",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sans'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_user_id_fk": {
+          "name": "user_settings_user_id_user_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "user_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "verification_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/webapp/drizzle/meta/_journal.json
+++ b/webapp/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1779250000000,
       "tag": "0006_add_songs_search_vector",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1779625440433,
+      "tag": "0007_goofy_shadow_king",
+      "breakpoints": true
     }
   ]
 }

--- a/webapp/src/app/api/render-jobs/route.ts
+++ b/webapp/src/app/api/render-jobs/route.ts
@@ -13,6 +13,7 @@ const createRenderJobSchema = z.object({
   fontSizePreset: z.enum(["S", "M", "L", "XL"]).optional(),
   includeTitleCard: z.boolean().optional(),
   titleCardDurationSeconds: z.number().min(5).max(30).optional(),
+  titleCardLines: z.array(z.string().min(1).max(200)).min(1).max(20).optional(),
 });
 
 export async function POST(request: NextRequest) {

--- a/webapp/src/app/songsets/[id]/page.tsx
+++ b/webapp/src/app/songsets/[id]/page.tsx
@@ -9,7 +9,7 @@ import { SongListItem } from "@/components/songset/SongList";
 import { RenderState } from "@/components/songset/RenderStateButton";
 import { TransitionSettings } from "@/components/songset/TransitionPanel";
 import { toast } from "sonner";
-import { downloadArtifact, sanitizeFilename } from "@/lib/download";
+import { sanitizeFilename, fetchSignedUrlAndDownload } from "@/lib/download";
 
 interface ApiSongset {
   id: string;
@@ -339,54 +339,34 @@ export default function SongsetEditorPage() {
   // Handle download audio
   const handleDownloadAudio = useCallback(async () => {
     if (!songset?.latestRenderJobId) return;
-
     const toastId = toast.loading("Preparing download...");
-    const controller = new AbortController();
-
     try {
-      const filename = sanitizeFilename(songset.name);
-      const disposition = `attachment; filename="${filename}.mp3"`;
-      const res = await fetch(
-        `/api/signed-url?renderJobId=${encodeURIComponent(songset.latestRenderJobId)}` +
-          `&fileType=audio` +
-          `&contentDisposition=${encodeURIComponent(disposition)}`,
-        { signal: controller.signal }
+      await fetchSignedUrlAndDownload(
+        songset.latestRenderJobId,
+        "audio",
+        sanitizeFilename(songset.name),
+        "mp3"
       );
-      if (!res.ok) throw new Error("Failed to get download URL");
-      const { url } = await res.json();
-
-      downloadArtifact(url);
       toast.success("Download started", { id: toastId });
     } catch (err) {
-      if (err instanceof DOMException && err.name === "AbortError") return;
-      toast.error("Failed to download audio", { id: toastId });
+      toast.error(err instanceof Error ? err.message : "Failed to download audio", { id: toastId });
     }
   }, [songset]);
 
   // Handle download video
   const handleDownloadVideo = useCallback(async () => {
     if (!songset?.latestRenderJobId) return;
-
     const toastId = toast.loading("Preparing download...");
-    const controller = new AbortController();
-
     try {
-      const filename = sanitizeFilename(songset.name);
-      const disposition = `attachment; filename="${filename}.mp4"`;
-      const res = await fetch(
-        `/api/signed-url?renderJobId=${encodeURIComponent(songset.latestRenderJobId)}` +
-          `&fileType=video` +
-          `&contentDisposition=${encodeURIComponent(disposition)}`,
-        { signal: controller.signal }
+      await fetchSignedUrlAndDownload(
+        songset.latestRenderJobId,
+        "video",
+        sanitizeFilename(songset.name),
+        "mp4"
       );
-      if (!res.ok) throw new Error("Failed to get download URL");
-      const { url } = await res.json();
-
-      downloadArtifact(url);
       toast.success("Download started", { id: toastId });
     } catch (err) {
-      if (err instanceof DOMException && err.name === "AbortError") return;
-      toast.error("Failed to download video", { id: toastId });
+      toast.error(err instanceof Error ? err.message : "Failed to download video", { id: toastId });
     }
   }, [songset]);
 

--- a/webapp/src/app/songsets/[id]/page.tsx
+++ b/webapp/src/app/songsets/[id]/page.tsx
@@ -8,6 +8,8 @@ import { SongCardData } from "@/components/songset/SongCard";
 import { SongListItem } from "@/components/songset/SongList";
 import { RenderState } from "@/components/songset/RenderStateButton";
 import { TransitionSettings } from "@/components/songset/TransitionPanel";
+import { toast } from "sonner";
+import { downloadArtifact, sanitizeFilename } from "@/lib/download";
 
 interface ApiSongset {
   id: string;
@@ -334,6 +336,60 @@ export default function SongsetEditorPage() {
     router.push(`/songsets/${songsetId}?share=true`);
   }, [songsetId, router]);
 
+  // Handle download audio
+  const handleDownloadAudio = useCallback(async () => {
+    if (!songset?.latestRenderJobId) return;
+
+    const toastId = toast.loading("Preparing download...");
+    const controller = new AbortController();
+
+    try {
+      const filename = sanitizeFilename(songset.name);
+      const disposition = `attachment; filename="${filename}.mp3"`;
+      const res = await fetch(
+        `/api/signed-url?renderJobId=${encodeURIComponent(songset.latestRenderJobId)}` +
+          `&fileType=audio` +
+          `&contentDisposition=${encodeURIComponent(disposition)}`,
+        { signal: controller.signal }
+      );
+      if (!res.ok) throw new Error("Failed to get download URL");
+      const { url } = await res.json();
+
+      downloadArtifact(url);
+      toast.success("Download started", { id: toastId });
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") return;
+      toast.error("Failed to download audio", { id: toastId });
+    }
+  }, [songset]);
+
+  // Handle download video
+  const handleDownloadVideo = useCallback(async () => {
+    if (!songset?.latestRenderJobId) return;
+
+    const toastId = toast.loading("Preparing download...");
+    const controller = new AbortController();
+
+    try {
+      const filename = sanitizeFilename(songset.name);
+      const disposition = `attachment; filename="${filename}.mp4"`;
+      const res = await fetch(
+        `/api/signed-url?renderJobId=${encodeURIComponent(songset.latestRenderJobId)}` +
+          `&fileType=video` +
+          `&contentDisposition=${encodeURIComponent(disposition)}`,
+        { signal: controller.signal }
+      );
+      if (!res.ok) throw new Error("Failed to get download URL");
+      const { url } = await res.json();
+
+      downloadArtifact(url);
+      toast.success("Download started", { id: toastId });
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") return;
+      toast.error("Failed to download video", { id: toastId });
+    }
+  }, [songset]);
+
   // Handle add songs
   const handleAddSongs = useCallback(() => {
     setIsBrowseSheetOpen(true);
@@ -433,6 +489,8 @@ export default function SongsetEditorPage() {
         onDuplicate={handleDuplicate}
         onDelete={handleDelete}
         onShare={handleShare}
+        onDownloadAudio={handleDownloadAudio}
+        onDownloadVideo={handleDownloadVideo}
         onAddSongs={handleAddSongs}
       />
       <BrowseSheet

--- a/webapp/src/app/songsets/[id]/render/page.tsx
+++ b/webapp/src/app/songsets/[id]/render/page.tsx
@@ -37,9 +37,6 @@ interface RenderJobData {
   mp3R2Key: string | null
   mp4R2Key: string | null
   chaptersR2Key: string | null
-  mp3Url?: string
-  mp4Url?: string
-  chaptersUrl?: string
   elapsedSeconds?: number
 }
 
@@ -187,24 +184,7 @@ export default function RenderPage() {
         const response = await fetch(`/api/render-jobs/${jobId}`)
         if (response.ok) {
           const job = await response.json()
-          const signedUrls: { mp3Url?: string; mp4Url?: string; chaptersUrl?: string } = {}
-
-          const fetchSignedUrl = async (fileType: string) => {
-            const res = await fetch(
-              `/api/signed-url?renderJobId=${encodeURIComponent(job.id)}&fileType=${fileType}`
-            )
-            if (res.ok) {
-              const data = await res.json()
-              return data.url as string
-            }
-            return undefined
-          }
-
-          if (job.mp3R2Key) signedUrls.mp3Url = await fetchSignedUrl("audio")
-          if (job.mp4R2Key) signedUrls.mp4Url = await fetchSignedUrl("video")
-          if (job.chaptersR2Key) signedUrls.chaptersUrl = await fetchSignedUrl("json")
-
-          setJobData({ ...job, ...signedUrls })
+          setJobData(job)
         }
       } catch (err) {
         console.error("Failed to fetch job data:", err)
@@ -301,9 +281,9 @@ export default function RenderPage() {
             jobId={jobId!}
             songsetId={songsetId}
             songsetName={songset.name}
-            mp3Url={jobData.mp3Url}
-            mp4Url={jobData.mp4Url}
-            chaptersUrl={jobData.chaptersUrl}
+            hasAudio={!!jobData.mp3R2Key}
+            hasVideo={!!jobData.mp4R2Key}
+            hasChapters={!!jobData.chaptersR2Key}
             elapsedSeconds={jobData.elapsedSeconds}
             onDone={handleDone}
             onShare={handleShare}

--- a/webapp/src/app/songsets/[id]/render/page.tsx
+++ b/webapp/src/app/songsets/[id]/render/page.tsx
@@ -29,6 +29,7 @@ interface SongsetData {
   description: string | null
   markedLineCount: number
   renderState: RenderState
+  songTitles: string[]
 }
 
 interface RenderJobData {
@@ -91,6 +92,9 @@ export default function RenderPage() {
             0
           ) || 0,
           renderState,
+          songTitles: data.items?.map((item: { song?: { title: string } | null }) =>
+            item.song?.title ?? "Unknown Song"
+          ) ?? [],
         })
 
         // Check if there's an active render job
@@ -110,6 +114,7 @@ export default function RenderPage() {
                 fontSizePreset: job.fontSizePreset as RenderFormData["fontSizePreset"],
                 includeTitleCard: job.includeTitleCard,
                 titleCardDurationSeconds: job.titleCardDurationSeconds,
+                titleCardLines: job.titleCardLines ?? [],
               })
             }
           }
@@ -149,6 +154,7 @@ export default function RenderPage() {
             fontSizePreset: formData.fontSizePreset,
             includeTitleCard: formData.includeTitleCard,
             titleCardDurationSeconds: formData.titleCardDurationSeconds,
+            titleCardLines: formData.titleCardLines.length > 0 ? formData.titleCardLines : undefined,
           }),
         })
 
@@ -261,6 +267,8 @@ export default function RenderPage() {
           <RenderForm
             songsetId={songsetId}
             markedLineCount={songset.markedLineCount}
+            songsetName={songset.name}
+            songTitles={songset.songTitles}
             initialData={initialData}
             onSubmit={handleSubmit}
             onCancel={() => router.push(`/songsets/${songsetId}`)}

--- a/webapp/src/app/songsets/page.tsx
+++ b/webapp/src/app/songsets/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 import { SongsetList, Songset } from "@/components/songset/SongsetList";
 import { RenderState } from "@/components/songset/RenderStateButton";
 import { toast } from "sonner";
+import { downloadArtifact, sanitizeFilename } from "@/lib/download";
 
 interface ApiSongset {
   id: string;
@@ -57,7 +58,7 @@ export default function SongsetsPage() {
           itemCount: songset.itemCount,
           updatedAt: new Date(songset.updatedAt),
           renderState: songset.renderState,
-          // These would come from the API in a real implementation
+          latestRenderJobId: songset.latestRenderJobId,
           isOfflineAvailable: false,
           isArtifactsStale: songset.renderState === "stale",
         }));
@@ -161,9 +162,62 @@ export default function SongsetsPage() {
   );
 
   const handleShare = useCallback((id: string) => {
-    // Navigate to share dialog/page
     window.location.href = `/songsets/${id}?share=true`;
   }, []);
+
+  const handleDownloadAudio = useCallback(async (id: string) => {
+    const songset = songsets.find((s) => s.id === id);
+    if (!songset?.latestRenderJobId) return;
+
+    const toastId = toast.loading("Preparing download...");
+    const controller = new AbortController();
+
+    try {
+      const filename = sanitizeFilename(songset.name);
+      const disposition = `attachment; filename="${filename}.mp3"`;
+      const res = await fetch(
+        `/api/signed-url?renderJobId=${encodeURIComponent(songset.latestRenderJobId)}` +
+          `&fileType=audio` +
+          `&contentDisposition=${encodeURIComponent(disposition)}`,
+        { signal: controller.signal }
+      );
+      if (!res.ok) throw new Error("Failed to get download URL");
+      const { url } = await res.json();
+
+      downloadArtifact(url);
+      toast.success("Download started", { id: toastId });
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") return;
+      toast.error("Failed to download audio", { id: toastId });
+    }
+  }, [songsets]);
+
+  const handleDownloadVideo = useCallback(async (id: string) => {
+    const songset = songsets.find((s) => s.id === id);
+    if (!songset?.latestRenderJobId) return;
+
+    const toastId = toast.loading("Preparing download...");
+    const controller = new AbortController();
+
+    try {
+      const filename = sanitizeFilename(songset.name);
+      const disposition = `attachment; filename="${filename}.mp4"`;
+      const res = await fetch(
+        `/api/signed-url?renderJobId=${encodeURIComponent(songset.latestRenderJobId)}` +
+          `&fileType=video` +
+          `&contentDisposition=${encodeURIComponent(disposition)}`,
+        { signal: controller.signal }
+      );
+      if (!res.ok) throw new Error("Failed to get download URL");
+      const { url } = await res.json();
+
+      downloadArtifact(url);
+      toast.success("Download started", { id: toastId });
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") return;
+      toast.error("Failed to download video", { id: toastId });
+    }
+  }, [songsets]);
 
   const handleDelete = useCallback(
     async (id: string) => {
@@ -202,6 +256,8 @@ export default function SongsetsPage() {
         onRename={handleRename}
         onDuplicate={handleDuplicate}
         onShare={handleShare}
+        onDownloadAudio={handleDownloadAudio}
+        onDownloadVideo={handleDownloadVideo}
         onDelete={handleDelete}
       />
     </div>

--- a/webapp/src/app/songsets/page.tsx
+++ b/webapp/src/app/songsets/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 import { SongsetList, Songset } from "@/components/songset/SongsetList";
 import { RenderState } from "@/components/songset/RenderStateButton";
 import { toast } from "sonner";
-import { downloadArtifact, sanitizeFilename } from "@/lib/download";
+import { sanitizeFilename, fetchSignedUrlAndDownload } from "@/lib/download";
 
 interface ApiSongset {
   id: string;
@@ -168,54 +168,34 @@ export default function SongsetsPage() {
   const handleDownloadAudio = useCallback(async (id: string) => {
     const songset = songsets.find((s) => s.id === id);
     if (!songset?.latestRenderJobId) return;
-
     const toastId = toast.loading("Preparing download...");
-    const controller = new AbortController();
-
     try {
-      const filename = sanitizeFilename(songset.name);
-      const disposition = `attachment; filename="${filename}.mp3"`;
-      const res = await fetch(
-        `/api/signed-url?renderJobId=${encodeURIComponent(songset.latestRenderJobId)}` +
-          `&fileType=audio` +
-          `&contentDisposition=${encodeURIComponent(disposition)}`,
-        { signal: controller.signal }
+      await fetchSignedUrlAndDownload(
+        songset.latestRenderJobId,
+        "audio",
+        sanitizeFilename(songset.name),
+        "mp3"
       );
-      if (!res.ok) throw new Error("Failed to get download URL");
-      const { url } = await res.json();
-
-      downloadArtifact(url);
       toast.success("Download started", { id: toastId });
     } catch (err) {
-      if (err instanceof DOMException && err.name === "AbortError") return;
-      toast.error("Failed to download audio", { id: toastId });
+      toast.error(err instanceof Error ? err.message : "Failed to download audio", { id: toastId });
     }
   }, [songsets]);
 
   const handleDownloadVideo = useCallback(async (id: string) => {
     const songset = songsets.find((s) => s.id === id);
     if (!songset?.latestRenderJobId) return;
-
     const toastId = toast.loading("Preparing download...");
-    const controller = new AbortController();
-
     try {
-      const filename = sanitizeFilename(songset.name);
-      const disposition = `attachment; filename="${filename}.mp4"`;
-      const res = await fetch(
-        `/api/signed-url?renderJobId=${encodeURIComponent(songset.latestRenderJobId)}` +
-          `&fileType=video` +
-          `&contentDisposition=${encodeURIComponent(disposition)}`,
-        { signal: controller.signal }
+      await fetchSignedUrlAndDownload(
+        songset.latestRenderJobId,
+        "video",
+        sanitizeFilename(songset.name),
+        "mp4"
       );
-      if (!res.ok) throw new Error("Failed to get download URL");
-      const { url } = await res.json();
-
-      downloadArtifact(url);
       toast.success("Download started", { id: toastId });
     } catch (err) {
-      if (err instanceof DOMException && err.name === "AbortError") return;
-      toast.error("Failed to download video", { id: toastId });
+      toast.error(err instanceof Error ? err.message : "Failed to download video", { id: toastId });
     }
   }, [songsets]);
 

--- a/webapp/src/components/render/RenderComplete.tsx
+++ b/webapp/src/components/render/RenderComplete.tsx
@@ -1,28 +1,26 @@
 "use client"
 
-import { useState } from "react"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Separator } from "@/components/ui/separator"
 import {
   CheckCircle2,
-  Download,
   Share2,
   Music,
   Video,
   FileJson,
-  Loader2,
   Timer,
 } from "lucide-react"
 import { toast } from "sonner"
+import { sanitizeFilename, downloadArtifact } from "@/lib/download"
 
 interface RenderCompleteProps {
   jobId: string
   songsetId: string
   songsetName: string
-  mp3Url?: string
-  mp4Url?: string
-  chaptersUrl?: string
+  hasAudio: boolean
+  hasVideo: boolean
+  hasChapters: boolean
   elapsedSeconds?: number
   onDone: () => void
   onShare: () => void
@@ -38,79 +36,61 @@ function formatDuration(seconds: number): string {
 }
 
 export function RenderComplete({
+  jobId,
   songsetId,
   songsetName,
-  mp3Url,
-  mp4Url,
-  chaptersUrl,
+  hasAudio,
+  hasVideo,
+  hasChapters,
   elapsedSeconds,
   onDone,
   onShare,
 }: RenderCompleteProps) {
-  const [isDownloadingAudio, setIsDownloadingAudio] = useState(false)
-  const [isDownloadingVideo, setIsDownloadingVideo] = useState(false)
-  const [isDownloadingChapters, setIsDownloadingChapters] = useState(false)
-
-  const handleDownload = async (
-    url: string | undefined,
-    filename: string,
-    setLoading: (loading: boolean) => void
+  const handleDownloadFile = async (
+    fileType: "audio" | "video" | "json",
+    extension: string,
   ) => {
-    if (!url) {
-      toast.error("File not available")
-      return
-    }
+    const toastId = toast.loading("Preparing download...");
+    const controller = new AbortController();
 
-    setLoading(true)
     try {
-      const response = await fetch(url)
-      if (!response.ok) {
-        throw new Error("Failed to download file")
-      }
+      const filename = sanitizeFilename(songsetName);
+      const disposition = `attachment; filename="${filename}.${extension}"`;
+      const res = await fetch(
+        `/api/signed-url?renderJobId=${encodeURIComponent(jobId)}` +
+          `&fileType=${fileType}` +
+          `&contentDisposition=${encodeURIComponent(disposition)}`,
+        { signal: controller.signal }
+      );
+      if (!res.ok) throw new Error("Failed to get download URL");
+      const { url } = await res.json();
 
-      const blob = await response.blob()
-      const downloadUrl = window.URL.createObjectURL(blob)
-      const link = document.createElement("a")
-      link.href = downloadUrl
-      link.download = filename
-      document.body.appendChild(link)
-      link.click()
-      document.body.removeChild(link)
-      window.URL.revokeObjectURL(downloadUrl)
-
-      toast.success(`Downloaded ${filename}`)
-    } catch (error) {
-      toast.error("Download failed")
-      console.error("Download error:", error)
-    } finally {
-      setLoading(false)
+      downloadArtifact(url);
+      toast.success("Download started", { id: toastId });
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") return;
+      toast.error("Download failed", { id: toastId });
     }
-  }
+  };
 
   const handleShare = async () => {
-    // Check if Web Share API is available
-    if (navigator.share && (mp3Url || mp4Url)) {
+    if (navigator.share) {
       try {
         await navigator.share({
           title: songsetName,
           text: `Check out "${songsetName}" on Stream of Worship`,
           url: `${window.location.origin}/songsets/${songsetId}`,
-        })
+        });
       } catch (error) {
-        // User cancelled or share failed
         if ((error as Error).name !== "AbortError") {
-          console.error("Share failed:", error)
-          onShare()
+          console.error("Share failed:", error);
+          onShare();
         }
       }
     } else {
-      onShare()
+      onShare();
     }
   }
-
-  const hasAudio = !!mp3Url
-  const hasVideo = !!mp4Url
-  const hasChapters = !!chaptersUrl
 
   return (
     <Card className="w-full">
@@ -140,22 +120,10 @@ export function RenderComplete({
             <Button
               variant="outline"
               className="w-full justify-start gap-3"
-              onClick={() =>
-                handleDownload(
-                  mp3Url,
-                  `${songsetName.replace(/\s+/g, "_")}.mp3`,
-                  setIsDownloadingAudio
-                )
-              }
-              disabled={isDownloadingAudio}
+              onClick={() => handleDownloadFile("audio", "mp3")}
             >
-              {isDownloadingAudio ? (
-                <Loader2 className="size-4 animate-spin" />
-              ) : (
-                <Music className="size-4" />
-              )}
+              <Music className="size-4" />
               <span className="flex-1 text-left">Download Audio (MP3)</span>
-              <Download className="size-4" />
             </Button>
           )}
 
@@ -163,22 +131,10 @@ export function RenderComplete({
             <Button
               variant="outline"
               className="w-full justify-start gap-3"
-              onClick={() =>
-                handleDownload(
-                  mp4Url,
-                  `${songsetName.replace(/\s+/g, "_")}.mp4`,
-                  setIsDownloadingVideo
-                )
-              }
-              disabled={isDownloadingVideo}
+              onClick={() => handleDownloadFile("video", "mp4")}
             >
-              {isDownloadingVideo ? (
-                <Loader2 className="size-4 animate-spin" />
-              ) : (
-                <Video className="size-4" />
-              )}
+              <Video className="size-4" />
               <span className="flex-1 text-left">Download Video (MP4)</span>
-              <Download className="size-4" />
             </Button>
           )}
 
@@ -186,22 +142,10 @@ export function RenderComplete({
             <Button
               variant="outline"
               className="w-full justify-start gap-3"
-              onClick={() =>
-                handleDownload(
-                  chaptersUrl,
-                  `${songsetName.replace(/\s+/g, "_")}_chapters.json`,
-                  setIsDownloadingChapters
-                )
-              }
-              disabled={isDownloadingChapters}
+              onClick={() => handleDownloadFile("json", "json")}
             >
-              {isDownloadingChapters ? (
-                <Loader2 className="size-4 animate-spin" />
-              ) : (
-                <FileJson className="size-4" />
-              )}
+              <FileJson className="size-4" />
               <span className="flex-1 text-left">Download Chapters (JSON)</span>
-              <Download className="size-4" />
             </Button>
           )}
         </div>

--- a/webapp/src/components/render/RenderComplete.tsx
+++ b/webapp/src/components/render/RenderComplete.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useCallback } from "react"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Separator } from "@/components/ui/separator"
@@ -12,7 +13,7 @@ import {
   Timer,
 } from "lucide-react"
 import { toast } from "sonner"
-import { sanitizeFilename, downloadArtifact } from "@/lib/download"
+import { sanitizeFilename, fetchSignedUrlAndDownload } from "@/lib/download"
 
 interface RenderCompleteProps {
   jobId: string
@@ -46,32 +47,18 @@ export function RenderComplete({
   onDone,
   onShare,
 }: RenderCompleteProps) {
-  const handleDownloadFile = async (
+  const handleDownloadFile = useCallback(async (
     fileType: "audio" | "video" | "json",
     extension: string,
   ) => {
     const toastId = toast.loading("Preparing download...");
-    const controller = new AbortController();
-
     try {
-      const filename = sanitizeFilename(songsetName);
-      const disposition = `attachment; filename="${filename}.${extension}"`;
-      const res = await fetch(
-        `/api/signed-url?renderJobId=${encodeURIComponent(jobId)}` +
-          `&fileType=${fileType}` +
-          `&contentDisposition=${encodeURIComponent(disposition)}`,
-        { signal: controller.signal }
-      );
-      if (!res.ok) throw new Error("Failed to get download URL");
-      const { url } = await res.json();
-
-      downloadArtifact(url);
+      await fetchSignedUrlAndDownload(jobId, fileType, sanitizeFilename(songsetName), extension);
       toast.success("Download started", { id: toastId });
     } catch (err) {
-      if (err instanceof DOMException && err.name === "AbortError") return;
-      toast.error("Download failed", { id: toastId });
+      toast.error(err instanceof Error ? err.message : "Download failed", { id: toastId });
     }
-  };
+  }, [jobId, songsetName]);
 
   const handleShare = async () => {
     if (navigator.share) {

--- a/webapp/src/components/render/RenderForm.tsx
+++ b/webapp/src/components/render/RenderForm.tsx
@@ -29,6 +29,7 @@ export interface RenderFormData {
   fontSizePreset: "S" | "M" | "L" | "XL"
   includeTitleCard: boolean
   titleCardDurationSeconds: number
+  titleCardLines: string[]
   offlineEnabled: boolean
 }
 
@@ -36,6 +37,8 @@ interface RenderFormProps {
   songsetId: string
   initialData?: Partial<RenderFormData>
   markedLineCount?: number
+  songsetName?: string
+  songTitles?: string[]
   onSubmit: (data: RenderFormData) => void
   onCancel: () => void
   isSubmitting?: boolean
@@ -91,6 +94,8 @@ export function RenderForm({
   songsetId,
   initialData,
   markedLineCount = 0,
+  songsetName,
+  songTitles,
   onSubmit,
   onCancel,
   isSubmitting = false,
@@ -103,6 +108,7 @@ export function RenderForm({
     fontSizePreset: initialData?.fontSizePreset ?? "M",
     includeTitleCard: initialData?.includeTitleCard ?? false,
     titleCardDurationSeconds: initialData?.titleCardDurationSeconds ?? 10,
+    titleCardLines: initialData?.titleCardLines ?? [],
     offlineEnabled: initialData?.offlineEnabled ?? false,
   })
 
@@ -257,25 +263,54 @@ export function RenderForm({
             </div>
 
             {formData.includeTitleCard && (
-              <div className="space-y-2 pl-6">
-                <Label htmlFor="titleCardDuration">Duration</Label>
-                <Select
-                  value={(formData.titleCardDurationSeconds ?? 10).toString()}
-                  onValueChange={(value) =>
-                    updateField("titleCardDurationSeconds", parseInt(value ?? "10", 10))
-                  }
-                >
-                  <SelectTrigger id="titleCardDuration">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {TITLE_CARD_DURATIONS.map((d) => (
-                      <SelectItem key={d.value} value={d.value.toString()}>
-                        {d.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+              <div className="space-y-4 pl-6">
+                <div className="space-y-2">
+                  <Label htmlFor="titleCardDuration">Duration</Label>
+                  <Select
+                    value={(formData.titleCardDurationSeconds ?? 10).toString()}
+                    onValueChange={(value) =>
+                      updateField("titleCardDurationSeconds", parseInt(value ?? "10", 10))
+                    }
+                  >
+                    <SelectTrigger id="titleCardDuration">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {TITLE_CARD_DURATIONS.map((d) => (
+                        <SelectItem key={d.value} value={d.value.toString()}>
+                          {d.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="titleCardLines">Custom title card text</Label>
+                  <p className="text-sm text-muted-foreground">
+                    One line per entry. Leave empty to use songset name and song titles.
+                  </p>
+                  <textarea
+                    id="titleCardLines"
+                    className="flex min-h-[100px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                    placeholder={"Sunday Morning Worship\nAmazing Grace\nHow Great Thou Art"}
+                    value={formData.titleCardLines.join("\n")}
+                    onChange={(e) => {
+                      const lines = e.target.value.split("\n").filter((line) => line.trim() !== "")
+                      updateField("titleCardLines", lines)
+                    }}
+                  />
+                </div>
+
+                {formData.titleCardLines.length === 0 && songTitles && songTitles.length > 0 && (
+                  <div className="rounded-md border border-dashed border-muted-foreground/25 bg-muted/50 p-3">
+                    <p className="text-xs text-muted-foreground mb-1">Default title card lines:</p>
+                    <p className="text-sm text-muted-foreground whitespace-pre-line">
+                      {songsetName || "Worship Set"}{"\n"}
+                      {songTitles.join("\n")}
+                    </p>
+                  </div>
+                )}
               </div>
             )}
           </CardContent>

--- a/webapp/src/components/songset/SongsetEditor.tsx
+++ b/webapp/src/components/songset/SongsetEditor.tsx
@@ -41,6 +41,8 @@ import {
   Monitor,
   Plus,
   Loader2,
+  FileAudio,
+  FileVideo,
 } from "lucide-react";
 
 export interface SongsetEditorProps {
@@ -66,6 +68,8 @@ export interface SongsetEditorProps {
   onDuplicate: () => Promise<void>;
   onDelete: () => Promise<void>;
   onShare: () => void;
+  onDownloadAudio?: () => void;
+  onDownloadVideo?: () => void;
   onAddSongs: () => void;
   className?: string;
 }
@@ -83,6 +87,8 @@ export function SongsetEditor({
   onDuplicate,
   onDelete,
   onShare,
+  onDownloadAudio,
+  onDownloadVideo,
   onAddSongs,
   className,
 }: SongsetEditorProps) {
@@ -278,6 +284,20 @@ export function SongsetEditor({
               <DropdownMenuItem onClick={onShare}>
                 <Share2 className="size-4 mr-2" />
                 Share
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={onDownloadAudio}
+                disabled={!songset.latestRenderJobId}
+              >
+                <FileAudio className="size-4 mr-2" />
+                Download Audio
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={onDownloadVideo}
+                disabled={!songset.latestRenderJobId}
+              >
+                <FileVideo className="size-4 mr-2" />
+                Download Video
               </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem

--- a/webapp/src/components/songset/SongsetList.tsx
+++ b/webapp/src/components/songset/SongsetList.tsx
@@ -29,6 +29,7 @@ export interface Songset {
   renderProgress?: number;
   isOfflineAvailable?: boolean;
   isArtifactsStale?: boolean;
+  latestRenderJobId: string | null;
 }
 
 interface SongsetListProps {
@@ -42,6 +43,8 @@ interface SongsetListProps {
   onRename?: (id: string, name: string) => Promise<void>;
   onDuplicate?: (id: string) => Promise<void>;
   onShare?: (id: string) => void;
+  onDownloadAudio?: (id: string) => void;
+  onDownloadVideo?: (id: string) => void;
   onDelete?: (id: string) => Promise<void>;
   className?: string;
 }
@@ -57,6 +60,8 @@ export function SongsetList({
   onRename,
   onDuplicate,
   onShare,
+  onDownloadAudio,
+  onDownloadVideo,
   onDelete,
   className,
 }: SongsetListProps) {
@@ -244,6 +249,8 @@ export function SongsetList({
             onRename={() => openRenameDialog(songset.id, songset.name)}
             onDuplicate={() => onDuplicate?.(songset.id)}
             onShare={() => onShare?.(songset.id)}
+            onDownloadAudio={() => onDownloadAudio?.(songset.id)}
+            onDownloadVideo={() => onDownloadVideo?.(songset.id)}
             onDelete={() => openDeleteDialog(songset.id)}
           />
         ))}

--- a/webapp/src/components/songset/SongsetRow.tsx
+++ b/webapp/src/components/songset/SongsetRow.tsx
@@ -29,6 +29,8 @@ import {
   WifiOff,
   Music,
   Clock,
+  FileAudio,
+  FileVideo,
 } from "lucide-react";
 
 export interface SongsetRowProps {
@@ -42,12 +44,15 @@ export interface SongsetRowProps {
   renderProgress?: number;
   isOfflineAvailable?: boolean;
   isArtifactsStale?: boolean;
+  latestRenderJobId: string | null;
   onRender?: () => void;
   onPlay?: () => void;
   onRetry?: () => void;
   onRename?: () => void;
   onDuplicate?: () => void;
   onShare?: () => void;
+  onDownloadAudio?: () => void;
+  onDownloadVideo?: () => void;
   onDelete?: () => void;
   className?: string;
 }
@@ -63,12 +68,15 @@ export function SongsetRow({
   renderProgress = 0,
   isOfflineAvailable = false,
   isArtifactsStale = false,
+  latestRenderJobId,
   onRender,
   onPlay,
   onRetry,
   onRename,
   onDuplicate,
   onShare,
+  onDownloadAudio,
+  onDownloadVideo,
   onDelete,
   className,
 }: SongsetRowProps) {
@@ -156,6 +164,20 @@ export function SongsetRow({
                   <DropdownMenuItem onClick={onShare}>
                     <Share2 className="size-4 mr-2" />
                     Share
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onClick={onDownloadAudio}
+                    disabled={!latestRenderJobId}
+                  >
+                    <FileAudio className="size-4 mr-2" />
+                    Download Audio
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onClick={onDownloadVideo}
+                    disabled={!latestRenderJobId}
+                  >
+                    <FileVideo className="size-4 mr-2" />
+                    Download Video
                   </DropdownMenuItem>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem

--- a/webapp/src/db/schema.ts
+++ b/webapp/src/db/schema.ts
@@ -235,6 +235,7 @@ export const renderJobs = pgTable("render_jobs", {
   fontSizePreset: text("font_size_preset").notNull().default("M"),
   includeTitleCard: boolean("include_title_card").notNull().default(false),
   titleCardDurationSeconds: real("title_card_duration_seconds").default(10),
+  titleCardLines: text("title_card_lines"),
 
   // Output R2 keys (set when render completes)
   mp3R2Key: text("mp3_r2_key"),

--- a/webapp/src/lib/download.ts
+++ b/webapp/src/lib/download.ts
@@ -1,0 +1,13 @@
+export function sanitizeFilename(name: string): string {
+  return name
+    .trim()
+    .replace(/[/\\:*?"<>|#]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-{2,}/g, "-")
+    .replace(/^-|-$/g, "")
+    .toLowerCase();
+}
+
+export function downloadArtifact(url: string): void {
+  window.location.href = url;
+}

--- a/webapp/src/lib/download.ts
+++ b/webapp/src/lib/download.ts
@@ -9,5 +9,43 @@ export function sanitizeFilename(name: string): string {
 }
 
 export function downloadArtifact(url: string): void {
-  window.location.href = url;
+  const link = document.createElement("a");
+  link.href = url;
+  link.style.display = "none";
+  document.body.appendChild(link);
+  try {
+    link.click();
+  } finally {
+    document.body.removeChild(link);
+  }
+}
+
+export async function fetchSignedUrlAndDownload(
+  renderJobId: string,
+  fileType: "audio" | "video" | "json",
+  filename: string,
+  extension: string,
+): Promise<void> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 30_000);
+
+  const disposition = `attachment; filename="${filename}.${extension}"`;
+  const res = await fetch(
+    `/api/signed-url?renderJobId=${encodeURIComponent(renderJobId)}` +
+      `&fileType=${fileType}` +
+      `&contentDisposition=${encodeURIComponent(disposition)}`,
+    { signal: controller.signal }
+  );
+  clearTimeout(timeoutId);
+
+  if (!res.ok) {
+    let message = "Failed to get download URL";
+    try {
+      const body = await res.json();
+      if (body.error) message = body.error;
+    } catch { /* keep default message */ }
+    throw new Error(message);
+  }
+  const { url } = await res.json();
+  downloadArtifact(url);
 }

--- a/webapp/src/lib/render/job-manager.ts
+++ b/webapp/src/lib/render/job-manager.ts
@@ -30,6 +30,7 @@ export interface CreateRenderJobInput {
   fontSizePreset?: string;
   includeTitleCard?: boolean;
   titleCardDurationSeconds?: number;
+  titleCardLines?: string[];
 }
 
 export interface RenderJob {
@@ -54,6 +55,7 @@ export interface RenderJob {
   fontSizePreset: string;
   includeTitleCard: boolean;
   titleCardDurationSeconds: number | null;
+  titleCardLines: string[] | null;
   mp3R2Key: string | null;
   mp4R2Key: string | null;
   chaptersR2Key: string | null;
@@ -78,6 +80,16 @@ export function getPhaseIndex(phase: RenderPhase): number {
 }
 
 function mapRowToRenderJob(row: typeof renderJobs.$inferSelect): RenderJob {
+  let titleCardLines: string[] | null = null;
+  if (row.titleCardLines) {
+    try {
+      const parsed = JSON.parse(row.titleCardLines);
+      titleCardLines = parsed && parsed.length > 0 ? parsed : null;
+    } catch {
+      titleCardLines = null;
+    }
+  }
+
   return {
     id: row.id,
     songsetId: row.songsetId,
@@ -100,6 +112,7 @@ function mapRowToRenderJob(row: typeof renderJobs.$inferSelect): RenderJob {
     fontSizePreset: row.fontSizePreset,
     includeTitleCard: row.includeTitleCard ?? false,
     titleCardDurationSeconds: row.titleCardDurationSeconds,
+    titleCardLines,
     mp3R2Key: row.mp3R2Key,
     mp4R2Key: row.mp4R2Key,
     chaptersR2Key: row.chaptersR2Key,
@@ -149,6 +162,10 @@ export async function createRenderJob(
       fontSizePreset: input.fontSizePreset ?? "M",
       includeTitleCard: input.includeTitleCard ?? false,
       titleCardDurationSeconds: input.titleCardDurationSeconds ?? null,
+      titleCardLines:
+        input.titleCardLines && input.titleCardLines.length > 0
+          ? JSON.stringify(input.titleCardLines)
+          : null,
       createdAt: now,
       updatedAt: now,
     })

--- a/webapp/src/test/components/render/RenderComplete.test.tsx
+++ b/webapp/src/test/components/render/RenderComplete.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import { render, screen, fireEvent, waitFor, act } from "@testing-library/react"
 import { RenderComplete } from "@/components/render/RenderComplete"
+import { fetchSignedUrlAndDownload } from "@/lib/download"
 
 vi.mock("sonner", () => ({
   toast: {
@@ -13,6 +14,7 @@ vi.mock("sonner", () => ({
 vi.mock("@/lib/download", () => ({
   sanitizeFilename: (name: string) => name.toLowerCase().replace(/\s+/g, "-"),
   downloadArtifact: vi.fn(),
+  fetchSignedUrlAndDownload: vi.fn(),
 }))
 
 describe("RenderComplete", () => {
@@ -30,17 +32,8 @@ describe("RenderComplete", () => {
     onShare: mockShare,
   }
 
-  let fetchMock: ReturnType<typeof vi.fn>
-
   beforeEach(async () => {
     vi.clearAllMocks()
-    
-    fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: vi.fn().mockResolvedValue({ url: "https://r2.example.com/signed-url" }),
-    })
-    
-    vi.stubGlobal("fetch", fetchMock)
   })
 
   afterEach(() => {
@@ -119,7 +112,7 @@ describe("RenderComplete", () => {
       expect(screen.getByRole("button", { name: /download chapters/i })).toBeInTheDocument()
     })
 
-    it("calls handleDownloadFile when audio button clicked", async () => {
+    it("calls fetchSignedUrlAndDownload when audio button clicked", async () => {
       render(<RenderComplete {...defaultProps} hasAudio={true} />)
       
       const downloadButton = screen.getByRole("button", { name: /download audio/i })
@@ -129,14 +122,19 @@ describe("RenderComplete", () => {
       })
 
       await waitFor(() => {
-        expect(fetchMock).toHaveBeenCalled()
+        expect(fetchSignedUrlAndDownload).toHaveBeenCalledWith(
+          "test-job-id",
+          "audio",
+          "sunday-worship",
+          "mp3"
+        )
       })
     })
 
     it("shows error when signed URL fetch fails", async () => {
       const { toast } = await import("sonner")
       
-      fetchMock.mockRejectedValue(new Error("Network error"))
+      vi.mocked(fetchSignedUrlAndDownload).mockRejectedValue(new Error("Network error"))
       
       render(<RenderComplete {...defaultProps} hasAudio={true} />)
       
@@ -147,7 +145,7 @@ describe("RenderComplete", () => {
       })
 
       await waitFor(() => {
-        expect(toast.error).toHaveBeenCalledWith("Download failed", { id: "toast-id" })
+        expect(toast.error).toHaveBeenCalledWith("Network error", { id: "toast-id" })
       })
     })
   })

--- a/webapp/src/test/components/render/RenderComplete.test.tsx
+++ b/webapp/src/test/components/render/RenderComplete.test.tsx
@@ -1,13 +1,18 @@
-import { describe, it, expect, vi, beforeEach } from "vitest"
-import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react"
 import { RenderComplete } from "@/components/render/RenderComplete"
 
-// Mock sonner toast
 vi.mock("sonner", () => ({
   toast: {
     success: vi.fn(),
     error: vi.fn(),
+    loading: vi.fn().mockReturnValue("toast-id"),
   },
+}))
+
+vi.mock("@/lib/download", () => ({
+  sanitizeFilename: (name: string) => name.toLowerCase().replace(/\s+/g, "-"),
+  downloadArtifact: vi.fn(),
 }))
 
 describe("RenderComplete", () => {
@@ -18,22 +23,28 @@ describe("RenderComplete", () => {
     jobId: "test-job-id",
     songsetId: "test-songset",
     songsetName: "Sunday Worship",
+    hasAudio: false,
+    hasVideo: false,
+    hasChapters: false,
     onDone: mockDone,
     onShare: mockShare,
   }
 
-  beforeEach(() => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(async () => {
     vi.clearAllMocks()
     
-    // Mock fetch for downloads
-    global.fetch = vi.fn().mockResolvedValue({
+    fetchMock = vi.fn().mockResolvedValue({
       ok: true,
-      blob: vi.fn().mockResolvedValue(new Blob()),
+      json: vi.fn().mockResolvedValue({ url: "https://r2.example.com/signed-url" }),
     })
     
-    // Mock URL.createObjectURL
-    global.URL.createObjectURL = vi.fn().mockReturnValue("blob:test")
-    global.URL.revokeObjectURL = vi.fn()
+    vi.stubGlobal("fetch", fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
   })
 
   describe("rendering", () => {
@@ -83,57 +94,60 @@ describe("RenderComplete", () => {
   })
 
   describe("download buttons", () => {
-    it("renders audio download button when mp3Url provided", () => {
-      render(<RenderComplete {...defaultProps} mp3Url="https://r2.example.com/audio.mp3" />)
+    it("renders audio download button when hasAudio is true", () => {
+      render(<RenderComplete {...defaultProps} hasAudio={true} />)
       expect(screen.getByRole("button", { name: /download audio/i })).toBeInTheDocument()
     })
 
-    it("does not render audio button when mp3Url not provided", () => {
+    it("does not render audio button when hasAudio is false", () => {
       render(<RenderComplete {...defaultProps} />)
       expect(screen.queryByRole("button", { name: /download audio/i })).not.toBeInTheDocument()
     })
 
-    it("renders video download button when mp4Url provided", () => {
-      render(<RenderComplete {...defaultProps} mp4Url="https://r2.example.com/video.mp4" />)
+    it("renders video download button when hasVideo is true", () => {
+      render(<RenderComplete {...defaultProps} hasVideo={true} />)
       expect(screen.getByRole("button", { name: /download video/i })).toBeInTheDocument()
     })
 
-    it("does not render video button when mp4Url not provided", () => {
+    it("does not render video button when hasVideo is false", () => {
       render(<RenderComplete {...defaultProps} />)
       expect(screen.queryByRole("button", { name: /download video/i })).not.toBeInTheDocument()
     })
 
-    it("renders chapters download button when chaptersUrl provided", () => {
-      render(<RenderComplete {...defaultProps} chaptersUrl="https://r2.example.com/chapters.json" />)
+    it("renders chapters download button when hasChapters is true", () => {
+      render(<RenderComplete {...defaultProps} hasChapters={true} />)
       expect(screen.getByRole("button", { name: /download chapters/i })).toBeInTheDocument()
     })
 
-    it("downloads audio when button clicked", async () => {
-      const { toast } = await import("sonner")
-      
-      render(<RenderComplete {...defaultProps} mp3Url="https://r2.example.com/audio.mp3" />)
+    it("calls handleDownloadFile when audio button clicked", async () => {
+      render(<RenderComplete {...defaultProps} hasAudio={true} />)
       
       const downloadButton = screen.getByRole("button", { name: /download audio/i })
-      fireEvent.click(downloadButton)
+      
+      await act(async () => {
+        fireEvent.click(downloadButton)
+      })
 
       await waitFor(() => {
-        expect(global.fetch).toHaveBeenCalledWith("https://r2.example.com/audio.mp3")
-        expect(toast.success).toHaveBeenCalledWith(expect.stringContaining("Downloaded"))
+        expect(fetchMock).toHaveBeenCalled()
       })
     })
 
-    it("shows error when download fails", async () => {
+    it("shows error when signed URL fetch fails", async () => {
       const { toast } = await import("sonner")
       
-      global.fetch = vi.fn().mockRejectedValue(new Error("Network error"))
+      fetchMock.mockRejectedValue(new Error("Network error"))
       
-      render(<RenderComplete {...defaultProps} mp3Url="https://r2.example.com/audio.mp3" />)
+      render(<RenderComplete {...defaultProps} hasAudio={true} />)
       
       const downloadButton = screen.getByRole("button", { name: /download audio/i })
-      fireEvent.click(downloadButton)
+      
+      await act(async () => {
+        fireEvent.click(downloadButton)
+      })
 
       await waitFor(() => {
-        expect(toast.error).toHaveBeenCalledWith("Download failed")
+        expect(toast.error).toHaveBeenCalledWith("Download failed", { id: "toast-id" })
       })
     })
   })
@@ -158,20 +172,20 @@ describe("RenderComplete", () => {
     })
 
     it("uses Web Share API when available", async () => {
-      const mockShare = vi.fn().mockResolvedValue(undefined)
+      const mockNavigatorShare = vi.fn().mockResolvedValue(undefined)
       Object.defineProperty(navigator, "share", {
-        value: mockShare,
+        value: mockNavigatorShare,
         writable: true,
         configurable: true,
       })
 
-      render(<RenderComplete {...defaultProps} mp3Url="https://r2.example.com/audio.mp3" />)
+      render(<RenderComplete {...defaultProps} hasAudio={true} />)
       
       const shareButton = screen.getByRole("button", { name: /share songset/i })
       fireEvent.click(shareButton)
 
       await waitFor(() => {
-        expect(mockShare).toHaveBeenCalledWith(
+        expect(mockNavigatorShare).toHaveBeenCalledWith(
           expect.objectContaining({
             title: "Sunday Worship",
             text: expect.stringContaining("Sunday Worship"),


### PR DESCRIPTION
## Summary

This PR includes two features and code review fixes:

### 1. Download Audio/Video from KAB Menu

Add **Download Audio** and **Download Video** menu items to the kebab (overflow) menu on both:
1. **Songset Editor screen** (`/songsets/[id]`)
2. **Songset list page** (`/songsets`)

This allows users to download rendered artifacts directly from the songset management views, not just from the Render Completed screen.

### 2. Title Card Custom Lines

Users can now customize the text that appears on the title card:
- Custom lines of text (one per line in a textarea)
- Each line is rendered centered both vertically and horizontally
- First line (heading) renders 20 pts larger than remaining lines
- Font size auto-scales so all lines fit on screen
- Default: songset name + all song titles when no custom lines provided

### 3. Code Review Fixes

Addressed inline review comments from gemini-code-assist:
- Replaced `window.location.href` with hidden anchor element in `downloadArtifact()`
- Extracted shared `fetchSignedUrlAndDownload()` utility with 30s timeout
- Removed redundant `AbortController` and `AbortError` checks
- Wrapped `handleDownloadFile` in `useCallback` in `RenderComplete`
- Propagated API error messages for better user feedback

---

## Changes

### Title Card Custom Lines

#### Database
- `webapp/src/db/schema.ts` - Added `titleCardLines` column to `render_jobs` table
- `webapp/drizzle/0007_goofy_shadow_king.sql` - Migration for new column

#### Render Worker
- `services/render-worker/src/sow_render_worker/db.py` - Added `title_card_lines` field to `RenderJob` dataclass with JSON parsing
- `services/render-worker/src/sow_render_worker/frame_renderer.py` - Updated `TitleCardConfig` to use `lines: tuple[str, ...]` instead of `songset_name`/`song_count`; rewrote `render_title_card()` with multi-line auto-scaling logic
- `services/render-worker/src/sow_render_worker/video_engine.py` - Added `title_card_lines` and `songset_name` constructor params; updated `generate_video()` to construct `TitleCardConfig` with lines
- `services/render-worker/src/sow_render_worker/pipeline.py` - Extended `fetch_songset_items()` to return songset name; pass `title_card_lines` and `songset_name` to `VideoEngine`

#### Webapp API
- `webapp/src/app/api/render-jobs/route.ts` - Added `titleCardLines` to Zod schema
- `webapp/src/lib/render/job-manager.ts` - Added `titleCardLines` to `CreateRenderJobInput` and `RenderJob` interfaces; persist as JSON in DB

#### Webapp UI
- `webapp/src/components/render/RenderForm.tsx` - Added `titleCardLines` to `RenderFormData`; added textarea for custom title card lines; show default lines preview when textarea is empty
- `webapp/src/app/songsets/[id]/render/page.tsx` - Extract song titles from API response; pass `songsetName` and `songTitles` to `RenderForm`; include `titleCardLines` in POST body

#### Tests
- `services/render-worker/tests/test_frame_renderer.py` - Updated tests for new `TitleCardConfig` structure
- `services/render-worker/tests/test_pipeline.py` - Updated tests for `fetch_songset_items` tuple return
- `services/render-worker/tests/test_video_engine.py` - Updated tests for new constructor params

---

### Download Audio/Video from KAB Menu

#### New Files
- `webapp/src/lib/download.ts` - Shared download utilities:
  - `sanitizeFilename()` - Strips unsafe chars, replaces whitespace with hyphens
  - `downloadArtifact()` - Creates hidden anchor element for browser-native download
  - `fetchSignedUrlAndDownload()` - Fetches signed URL and triggers download

#### Modified Files

##### Core Download Refactor
- `webapp/src/components/render/RenderComplete.tsx`
  - Uses `fetchSignedUrlAndDownload()` utility
  - `handleDownloadFile` wrapped in `useCallback`
  - Props changed: `mp3Url/mp4Url/chaptersUrl` → `hasAudio/hasVideo/hasChapters`

- `webapp/src/app/songsets/[id]/render/page.tsx`
  - Removed pre-fetched signed URLs
  - `RenderComplete` now fetches signed URLs on demand

##### KAB Menu Additions
- `webapp/src/components/songset/SongsetEditor.tsx`
  - Added `onDownloadAudio?` and `onDownloadVideo?` props
  - Added "Download Audio" and "Download Video" menu items
  - Disabled when `!songset.latestRenderJobId`

- `webapp/src/components/songset/SongsetRow.tsx`
  - Added `latestRenderJobId` prop
  - Added `onDownloadAudio?` and `onDownloadVideo?` props
  - Added "Download Audio" and "Download Video" menu items
  - Disabled when `!latestRenderJobId`

##### Data Flow
- `webapp/src/components/songset/SongsetList.tsx`
  - Added `latestRenderJobId` to `Songset` interface
  - Added `onDownloadAudio?` and `onDownloadVideo?` callback props
  - Threaded callbacks to `SongsetRow`

- `webapp/src/app/songsets/page.tsx`
  - Added `latestRenderJobId` to data transform
  - Added `handleDownloadAudio` and `handleDownloadVideo` handlers using `fetchSignedUrlAndDownload()`
  - Wrapped handlers in `useCallback`

- `webapp/src/app/songsets/[id]/page.tsx`
  - Added `handleDownloadAudio` and `handleDownloadVideo` handlers using `fetchSignedUrlAndDownload()`
  - Wrapped handlers in `useCallback`
  - Passed handlers to `SongsetEditor`

##### Tests
- `webapp/src/test/components/render/RenderComplete.test.tsx`
  - Updated for new props (`hasAudio`, `hasVideo`, `hasChapters`)
  - Updated mocks for `fetchSignedUrlAndDownload`

---

### Other Fixes

- `webapp/drizzle.config.ts` - Use `SOW_DATABASE_URL` environment variable for database connection

---

## Design Decisions

### Title Card Custom Lines

| Decision | Choice | Rationale |
|----------|--------|-----------|
| Empty array handling | Normalized to `null` at all layers | Ensures consistent fallback to defaults |
| JSON storage | Text column with JSON encoding | Simple migration, avoids jsonb column |
| Zod validation | min(1) lines, max(20) lines, max 200 chars each | Reasonable limits for UI |
| Blank line filtering | Removed in textarea onChange | Meaningless in centered layout |

### Download Audio/Video

| Decision | Choice | Rationale |
|----------|--------|-----------|
| Visibility | Always visible, **disabled** when no completed render | Communicates feature availability; avoids confusion |
| Download mechanism | Hidden anchor element with `Content-Disposition: attachment` | Avoids buffering files in JS memory; browser handles download natively; safer than `window.location.href` |
| Progress indication | `toast.loading()` from sonner | Visible after menu closes; no component state needed |
| Error handling | Propagate API error messages | Better user feedback |
| Filename sanitization | Slugify: lowercase, hyphens, strip unsafe chars | Safe across OSes; works for Chinese names |
| Shared utility | `fetchSignedUrlAndDownload()` | DRY; consistent timeout handling |
| Prop optionality | `onDownloadAudio?` / `onDownloadVideo?` (optional) | Consistent; safe if rendered from other contexts |

---

## Menu Order

**Songset Editor KAB Menu:**
1. Render
2. Play
3. — separator —
4. Edit description
5. Duplicate
6. Share
7. **Download Audio** (NEW)
8. **Download Video** (NEW)
9. — separator —
10. Delete

**Songset Row KAB Menu:**
1. Rename
2. Duplicate
3. — separator —
4. Render
5. Play
6. Share
7. **Download Audio** (NEW)
8. **Download Video** (NEW)
9. — separator —
10. Delete

---

## Testing

- All 401 render-worker tests pass
- All 1339 webapp tests pass
- ESLint passes (0 errors, 2 warnings unrelated to this change)

---

## Related

- Implements spec: `specs/download-audio-video-from-kab-menu-v2.md`
- Implements spec: `specs/title-card-custom-lines-v2.md`
- Code review fixes: `specs/pr70-code-review-fixes.md`