### PR TITLE
feat(webapp): standardize environment variable names with SOW_ prefix

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,10 +71,10 @@ jobs:
 
       - name: Push DB schema
         env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          SOW_DATABASE_URL: ${{ secrets.SOW_DATABASE_URL }}
         run: |
-          if [ -z "$DATABASE_URL" ]; then
-            echo "Error: DATABASE_URL secret is not configured"
+          if [ -z "$SOW_DATABASE_URL" ]; then
+            echo "Error: SOW_DATABASE_URL secret is not configured"
             exit 1
           fi
           npx drizzle-kit push --force
@@ -101,8 +101,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.SOW_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.SOW_AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
 
       - name: Login to Amazon ECR

--- a/specs/align-webapp-env-vars-sow-prefix.md
+++ b/specs/align-webapp-env-vars-sow-prefix.md
@@ -1,0 +1,203 @@
+# Align Webapp Env Vars to `SOW_` Prefix
+
+## Summary
+
+Rename all project-specific environment variables in the webapp to use the `SOW_` prefix, aligning with the standardized naming convention in `/opt/sow/.env.server` and the render-worker service. Better Auth and `NEXT_PUBLIC_*` variables are excluded per user decision.
+
+## Variable Mapping
+
+| Current | New | Notes |
+|---|---|---|
+| `DATABASE_URL` | `SOW_DATABASE_URL` | Already used in `drizzle.config.ts` |
+| `R2_ACCOUNT_ID` | `SOW_R2_ENDPOINT_URL` | Switch from account ID to full endpoint URL (like render-worker) |
+| `R2_ACCESS_KEY_ID` | `SOW_R2_ACCESS_KEY_ID` | |
+| `R2_SECRET_ACCESS_KEY` | `SOW_R2_SECRET_ACCESS_KEY` | |
+| `R2_BUCKET_NAME` | `SOW_R2_BUCKET` | Shorter, matches render-worker |
+| `AWS_REGION` | `SOW_AWS_REGION` | |
+| `SQS_QUEUE_URL` | `SOW_SQS_QUEUE_URL` | |
+| `AWS_ACCESS_KEY_ID` | `SOW_AWS_ACCESS_KEY_ID` | Uppercase AWS SDK convention |
+| `AWS_SECRET_ACCESS_KEY` | `SOW_AWS_SECRET_ACCESS_KEY` | Uppercase AWS SDK convention |
+| `SQS_ENDPOINT_URL` | `SOW_SQS_ENDPOINT_URL` | |
+| `R2_PUBLIC_DOMAIN` (in `.env.production.example`) | `NEXT_PUBLIC_R2_PUBLIC_DOMAIN` | Bug fix: production example was missing `NEXT_PUBLIC_` prefix |
+| `BETTER_AUTH_SECRET` | (no change) | |
+| `BETTER_AUTH_URL` | (no change) | |
+| `NEXT_PUBLIC_*` | (no change) | Next.js convention |
+| `SOW_RENDER_WORKER_MODE` | (already SOW_) | |
+| `SOW_RENDER_WORKER_REST_URL` | (already SOW_) | |
+
+> **Note:** `webapp/drizzle.config.ts` already uses `SOW_DATABASE_URL` (line 8), creating a pre-existing inconsistency with `src/db/index.ts` which uses `DATABASE_URL`. This change resolves that inconsistency. No modification to `drizzle.config.ts` is needed.
+
+## Files to Modify (12 files)
+
+### 1. `webapp/src/db/index.ts` (lines 5-6, 9)
+
+- `process.env.DATABASE_URL` → `process.env.SOW_DATABASE_URL`
+- Error message: `"DATABASE_URL environment variable is required"` → `"SOW_DATABASE_URL environment variable is required"`
+
+### 2. `webapp/src/lib/r2/client.ts` — interface + constructor refactor
+
+**`R2Config` interface (line 8-14):**
+
+- Remove `accountId: string`
+- Add `endpointUrl: string`
+
+> **Breaking change:** `accountId: string → endpointUrl: string` changes the exported `R2Config` interface. Currently only used within the webapp, but any external consumer would break.
+
+**`R2Client` constructor (line 56-68):**
+
+- Replace `const endpoint = \`https://${config.accountId}.r2.cloudflarestorage.com\`;` with `const endpoint = config.endpointUrl;`
+
+**`createR2ClientFromEnv()` (lines 226-244):**
+
+- `process.env.R2_ACCOUNT_ID` → `process.env.SOW_R2_ENDPOINT_URL`
+- `process.env.R2_ACCESS_KEY_ID` → `process.env.SOW_R2_ACCESS_KEY_ID`
+- `process.env.R2_SECRET_ACCESS_KEY` → `process.env.SOW_R2_SECRET_ACCESS_KEY`
+- `process.env.R2_BUCKET_NAME` → `process.env.SOW_R2_BUCKET`
+- Variable names: `accountId` → `endpointUrl`, `bucketName` → `bucketName` (keep)
+- Error message update: `"Set R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, and R2_BUCKET_NAME environment variables."` → `"Set SOW_R2_ENDPOINT_URL, SOW_R2_ACCESS_KEY_ID, SOW_R2_SECRET_ACCESS_KEY, and SOW_R2_BUCKET environment variables."`
+- Constructor call: `accountId` → `endpointUrl`
+
+### 3. `webapp/src/lib/sqs/client.ts` (lines 53-78)
+
+- `process.env.AWS_REGION` → `process.env.SOW_AWS_REGION`
+- `process.env.SQS_QUEUE_URL` → `process.env.SOW_SQS_QUEUE_URL`
+- `process.env.SQS_ENDPOINT_URL` → `process.env.SOW_SQS_ENDPOINT_URL`
+- `process.env.AWS_ACCESS_KEY_ID` → `process.env.SOW_AWS_ACCESS_KEY_ID`
+- `process.env.AWS_SECRET_ACCESS_KEY` → `process.env.SOW_AWS_SECRET_ACCESS_KEY`
+- Error messages: `"AWS_REGION"` → `"SOW_AWS_REGION"`, `"SQS_QUEUE_URL"` → `"SOW_SQS_QUEUE_URL"`
+
+### 4. `webapp/.env.example` — rename all vars
+
+```
+DATABASE_URL → SOW_DATABASE_URL
+R2_ACCOUNT_ID → SOW_R2_ENDPOINT_URL (value changes from blank to https://your-account-id.r2.cloudflarestorage.com)
+R2_ACCESS_KEY_ID → SOW_R2_ACCESS_KEY_ID
+R2_SECRET_ACCESS_KEY → SOW_R2_SECRET_ACCESS_KEY
+R2_BUCKET_NAME → SOW_R2_BUCKET
+AWS_REGION → SOW_AWS_REGION
+SQS_QUEUE_URL → SOW_SQS_QUEUE_URL
+AWS_ACCESS_KEY_ID → SOW_AWS_ACCESS_KEY_ID
+AWS_SECRET_ACCESS_KEY → SOW_AWS_SECRET_ACCESS_KEY
+SQS_ENDPOINT_URL → SOW_SQS_ENDPOINT_URL
+```
+
+### 5. `webapp/.env.production.example` — rename all vars + fix `R2_PUBLIC_DOMAIN` bug
+
+Same renames as above, plus:
+
+- `R2_PUBLIC_DOMAIN` → `NEXT_PUBLIC_R2_PUBLIC_DOMAIN` (bug fix: was missing `NEXT_PUBLIC_` prefix)
+
+### 6. `webapp/README.md` — update env var list (lines 17-22) and psql command (line 39)
+
+- Replace bullet list with `SOW_`-prefixed names
+- `psql "$DATABASE_URL"` → `psql "$SOW_DATABASE_URL"`
+
+### 7. `webapp/DEPLOY-VERCEL.md` — update variable reference table and all inline references
+
+- Lines 37-38: `vercel env add DATABASE_URL` → `vercel env add SOW_DATABASE_URL`, `vercel env add R2_ACCOUNT_ID` → `vercel env add SOW_R2_ENDPOINT_URL`
+- Lines 46-60: Variable reference table — rename all rows
+- Line 77: `vercel env add DATABASE_URL production` → `vercel env add SOW_DATABASE_URL production`
+- Lines 224-225: `export DATABASE_URL=` → `export SOW_DATABASE_URL=`
+- Line 242: `R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_BUCKET_NAME` → `SOW_R2_ENDPOINT_URL, SOW_R2_ACCESS_KEY_ID, SOW_R2_SECRET_ACCESS_KEY, SOW_R2_BUCKET`
+- Line 250: `AWS_REGION, SQS_QUEUE_URL, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY` → `SOW_AWS_REGION, SOW_SQS_QUEUE_URL, SOW_AWS_ACCESS_KEY_ID, SOW_AWS_SECRET_ACCESS_KEY`
+
+### 8. `webapp/src/test/lib/r2/client.test.ts` — update all env var references
+
+**`mockConfig` object (lines 29-35):**
+
+- `accountId: "test-account"` → `endpointUrl: "https://test-account.r2.cloudflarestorage.com"`
+- This affects **all 15+ constructor test cases** (lines 43, 53, 66, 80, 90, 100, 117, 133, 149, 165, 181, 196, 206, 216), not just the `createR2ClientFromEnv()` tests at the bottom.
+
+**`createR2ClientFromEnv()` tests (lines 269-309):**
+
+- `process.env.R2_ACCOUNT_ID` → `process.env.SOW_R2_ENDPOINT_URL` (lines 270, 279, 288, 296, 304)
+- `process.env.R2_ACCESS_KEY_ID` → `process.env.SOW_R2_ACCESS_KEY_ID`
+- `process.env.R2_SECRET_ACCESS_KEY` → `process.env.SOW_R2_SECRET_ACCESS_KEY`
+- `process.env.R2_BUCKET_NAME` → `process.env.SOW_R2_BUCKET`
+- Test descriptions: `"throws when R2_ACCOUNT_ID is missing"` → `"throws when SOW_R2_ENDPOINT_URL is missing"`, etc.
+
+### 9. `webapp/src/test/lib/sqs/client.test.ts` — update all env var references
+
+- `process.env.AWS_REGION` → `process.env.SOW_AWS_REGION`
+- `process.env.SQS_QUEUE_URL` → `process.env.SOW_SQS_QUEUE_URL`
+- `process.env.AWS_ACCESS_KEY_ID` → `process.env.SOW_AWS_ACCESS_KEY_ID`
+- `process.env.AWS_SECRET_ACCESS_KEY` → `process.env.SOW_AWS_SECRET_ACCESS_KEY`
+- `process.env.SQS_ENDPOINT_URL` → `process.env.SOW_SQS_ENDPOINT_URL`
+- Error message assertions: update to match new var names
+
+### 10. `webapp/src/test/deployment/deployment.test.ts` — update all `.toContain()` assertions
+
+- `"DATABASE_URL="` → `"SOW_DATABASE_URL="`
+- `"R2_ACCOUNT_ID="` → `"SOW_R2_ENDPOINT_URL="`
+- `"R2_ACCESS_KEY_ID="` → `"SOW_R2_ACCESS_KEY_ID="`
+- `"R2_SECRET_ACCESS_KEY="` → `"SOW_R2_SECRET_ACCESS_KEY="`
+- `"R2_BUCKET_NAME="` → `"SOW_R2_BUCKET="`
+- `"R2_PUBLIC_DOMAIN="` → `"NEXT_PUBLIC_R2_PUBLIC_DOMAIN="` (bug fix)
+- `"AWS_REGION="` → `"SOW_AWS_REGION="`
+- `"SQS_QUEUE_URL="` → `"SOW_SQS_QUEUE_URL="`
+- `"AWS_ACCESS_KEY_ID="` → `"SOW_AWS_ACCESS_KEY_ID="`
+- `"AWS_SECRET_ACCESS_KEY="` → `"SOW_AWS_SECRET_ACCESS_KEY="`
+- `"SQS_ENDPOINT_URL="` → `"SOW_SQS_ENDPOINT_URL="`
+- Test descriptions: update to match new var names
+
+### 11. `webapp/src/test/deployment/workflows.test.ts` — update secret references
+
+- `"secrets.DATABASE_URL"` → `"secrets.SOW_DATABASE_URL"` (line 163)
+- `"secrets.AWS_ACCESS_KEY_ID"` → `"secrets.SOW_AWS_ACCESS_KEY_ID"` (line 179)
+- `"secrets.AWS_SECRET_ACCESS_KEY"` → `"secrets.SOW_AWS_SECRET_ACCESS_KEY"` (line 187)
+- Test descriptions: update to match
+
+### 12. `.github/workflows/deploy.yml` — update GitHub Actions secret references
+
+- Line 74: `secrets.DATABASE_URL` → `secrets.SOW_DATABASE_URL`
+- Lines 76-77: `$DATABASE_URL` → `$SOW_DATABASE_URL` (shell variable references)
+- Line 104: `secrets.AWS_ACCESS_KEY_ID` → `secrets.SOW_AWS_ACCESS_KEY_ID`
+- Line 105: `secrets.AWS_SECRET_ACCESS_KEY` → `secrets.SOW_AWS_SECRET_ACCESS_KEY`
+
+## Risks & Deployment Notes
+
+### Value Format Migration for `R2_ACCOUNT_ID` → `SOW_R2_ENDPOINT_URL`
+
+This is a **value format change**, not just a rename. Developers must convert:
+
+```
+# Old
+R2_ACCOUNT_ID=abc123
+
+# New
+SOW_R2_ENDPOINT_URL=https://abc123.r2.cloudflarestorage.com
+```
+
+This is easy to miss during manual `.env.local` updates. The `.env.example` change documents the new format.
+
+### AWS SDK Default Credential Chain
+
+After renaming `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` to `SOW_`-prefixed versions, the AWS SDK default credential chain won't auto-detect them from the environment. Current code is safe — `sqs/client.ts` explicitly passes credentials to the SQS client constructor. Future code must not rely on the default credential chain for these credentials.
+
+### Deployment Ordering (Hard Cutover)
+
+This is a hard cutover with no backward compatibility. Env vars must be updated **before** code deployment:
+
+1. Update Vercel env vars (all environments: production, preview, development)
+2. Update GitHub repository secrets
+3. Merge & deploy code
+
+Deploying code before env vars are updated will break the app immediately.
+
+### Tight Coupling: `deployment.test.ts` ↔ `.env.production.example`
+
+The deployment test reads `.env.production.example` and asserts exact variable name strings. Both files must be updated in the same commit — missing either causes test failures.
+
+## Post-Implementation Verification
+
+```bash
+cd webapp && pnpm test
+cd webapp && pnpm lint
+```
+
+## Out of Scope / Follow-up
+
+- **GitHub Secrets**: The actual GitHub repository secrets (`DATABASE_URL`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`) must be renamed in the repo settings to match the new names (`SOW_DATABASE_URL`, `SOW_AWS_ACCESS_KEY_ID`, `SOW_AWS_SECRET_ACCESS_KEY`). This is a manual step.
+- **Vercel Environment Variables**: All env vars in the Vercel project must be updated to the new names. This is a manual step in the Vercel dashboard.
+- **Local `.env.local` files**: Developers must update their local env files. The `.env.example` change will guide them.
+- **Local `.env.local` value migration**: Developers must convert `R2_ACCOUNT_ID=abc123` to `SOW_R2_ENDPOINT_URL=https://abc123.r2.cloudflarestorage.com` — not just rename the key, but also change the value format from account ID to full endpoint URL.

--- a/webapp/.env.example
+++ b/webapp/.env.example
@@ -1,12 +1,12 @@
 # Local development environment for sow-webapp
 # Copy to .env.local and replace placeholder values.
 
-DATABASE_URL=postgresql://user:password@localhost:5432/sow?sslmode=disable
+SOW_DATABASE_URL=postgresql://user:password@localhost:5432/sow?sslmode=disable
 
-R2_ACCOUNT_ID=
-R2_ACCESS_KEY_ID=
-R2_SECRET_ACCESS_KEY=
-R2_BUCKET_NAME=stream-of-worship-dev
+SOW_R2_ENDPOINT_URL=https://your-account-id.r2.cloudflarestorage.com
+SOW_R2_ACCESS_KEY_ID=
+SOW_R2_SECRET_ACCESS_KEY=
+SOW_R2_BUCKET=stream-of-worship-dev
 
 # Public R2 domain for direct audio streaming (no signed URL needed).
 # Set to the r2.dev public URL (e.g. pub-<account-id>.r2.dev) or a custom domain.
@@ -19,15 +19,15 @@ BETTER_AUTH_URL=http://localhost:8080
 NEXT_PUBLIC_BASE_URL=http://localhost:8080
 NEXT_PUBLIC_CAST_RECEIVER_APP_ID=
 
-AWS_REGION=us-east-1
-SQS_QUEUE_URL=
-AWS_ACCESS_KEY_ID=
-AWS_SECRET_ACCESS_KEY=
+SOW_AWS_REGION=us-east-1
+SOW_SQS_QUEUE_URL=
+SOW_AWS_ACCESS_KEY_ID=
+SOW_AWS_SECRET_ACCESS_KEY=
 
 # Custom SQS endpoint URL (optional, for LocalStack or other non-AWS SQS services).
 # When set, the SDK sends requests to this endpoint instead of the default AWS endpoint.
 # Example: http://localhost:4566 (with SSH port forwarding to LocalStack)
-SQS_ENDPOINT_URL=
+SOW_SQS_ENDPOINT_URL=
 
 # Render worker dispatch mode: "sqs" (default, production) or "rest" (local dev with Docker).
 # When "rest", the webapp invokes the render worker via its Lambda RIE endpoint

--- a/webapp/.env.production.example
+++ b/webapp/.env.production.example
@@ -13,22 +13,22 @@
 # -----------------------------------------------------------------------------
 # Connection string for the Neon serverless PostgreSQL database.
 # Format: postgresql://user:password@host/dbname?sslmode=require
-DATABASE_URL=postgresql://user:password@ep-xxx-yyy.us-east-1.aws.neon.tech/neondb?sslmode=require
+SOW_DATABASE_URL=postgresql://user:password@ep-xxx-yyy.us-east-1.aws.neon.tech/neondb?sslmode=require
 
 # -----------------------------------------------------------------------------
 # Cloudflare R2 Object Storage
 # -----------------------------------------------------------------------------
 # R2 credentials for storing rendered audio (MP3) and video (MP4) files.
 # Create an API token in the Cloudflare dashboard with R2 object read/write.
-R2_ACCOUNT_ID=your-cloudflare-account-id
-R2_ACCESS_KEY_ID=your-r2-access-key-id
-R2_SECRET_ACCESS_KEY=your-r2-secret-access-key
-R2_BUCKET_NAME=stream-of-worship-prod
+SOW_R2_ENDPOINT_URL=https://your-account-id.r2.cloudflarestorage.com
+SOW_R2_ACCESS_KEY_ID=your-r2-access-key-id
+SOW_R2_SECRET_ACCESS_KEY=your-r2-secret-access-key
+SOW_R2_BUCKET=stream-of-worship-prod
 
 # Public domain for R2 bucket (set up a custom domain in Cloudflare R2 settings,
 # or use the generated r2.dev public URL if bucket public access is enabled).
 # Used to generate direct download/stream URLs for rendered files.
-R2_PUBLIC_DOMAIN=https://assets.your-domain.com
+NEXT_PUBLIC_R2_PUBLIC_DOMAIN=https://assets.your-domain.com
 
 # -----------------------------------------------------------------------------
 # Better Auth
@@ -84,12 +84,12 @@ NEXT_PUBLIC_CAST_RECEIVER_APP_ID=
 # inline. An AWS Lambda container worker picks up jobs from the queue.
 #
 # AWS region where the SQS queue and Lambda function are deployed.
-AWS_REGION=us-east-1
+SOW_AWS_REGION=us-east-1
 
 # URL of the SQS queue that receives render job messages.
 # Format: https://sqs.<region>.amazonaws.com/<account-id>/<queue-name>
 # Example: https://sqs.us-east-1.amazonaws.com/123456789012/sow-render-jobs
-SQS_QUEUE_URL=https://sqs.us-east-1.amazonaws.com/123456789012/sow-render-jobs
+SOW_SQS_QUEUE_URL=https://sqs.us-east-1.amazonaws.com/123456789012/sow-render-jobs
 
 # AWS credentials for sending messages to SQS from the Next.js app.
 # Create an IAM user with the following minimum permissions:
@@ -98,13 +98,13 @@ SQS_QUEUE_URL=https://sqs.us-east-1.amazonaws.com/123456789012/sow-render-jobs
 #
 # Alternatively, if deploying on Vercel with AWS IAM role integration,
 # you may omit these and rely on the default credential provider chain.
-AWS_ACCESS_KEY_ID=your-aws-access-key-id
-AWS_SECRET_ACCESS_KEY=your-aws-secret-access-key
+SOW_AWS_ACCESS_KEY_ID=your-aws-access-key-id
+SOW_AWS_SECRET_ACCESS_KEY=your-aws-secret-access-key
 
 # Custom SQS endpoint URL (optional).
 # Only needed for non-AWS SQS-compatible services (e.g., LocalStack for local dev).
 # Leave unset for production AWS deployments.
-SQS_ENDPOINT_URL=
+SOW_SQS_ENDPOINT_URL=
 
 # Render worker dispatch mode: "sqs" (default, production) or "rest" (local dev with Docker).
 # In production, always use "sqs" to enqueue jobs to AWS SQS.

--- a/webapp/DEPLOY-VERCEL.md
+++ b/webapp/DEPLOY-VERCEL.md
@@ -34,8 +34,8 @@ After linking, Vercel creates a `.vercel/` directory in `webapp/` (already gitig
 Add all production environment variables in the Vercel dashboard under **Settings → Environment Variables**, or via the CLI:
 
 ```bash
-vercel env add DATABASE_URL production
-vercel env add R2_ACCOUNT_ID production
+vercel env add SOW_DATABASE_URL production
+vercel env add SOW_R2_ENDPOINT_URL production
 # ... repeat for each variable
 ```
 
@@ -43,21 +43,21 @@ vercel env add R2_ACCOUNT_ID production
 
 | Variable | Scope | Description |
 |---|---|---|
-| `DATABASE_URL` | Server | Neon PostgreSQL connection string |
-| `R2_ACCOUNT_ID` | Server | Cloudflare account ID |
-| `R2_ACCESS_KEY_ID` | Server | R2 API token access key |
-| `R2_SECRET_ACCESS_KEY` | Server | R2 API token secret key |
-| `R2_BUCKET_NAME` | Server | R2 bucket name (e.g. `stream-of-worship-prod`) |
+| `SOW_DATABASE_URL` | Server | Neon PostgreSQL connection string |
+| `SOW_R2_ENDPOINT_URL` | Server | Cloudflare R2 endpoint URL |
+| `SOW_R2_ACCESS_KEY_ID` | Server | R2 API token access key |
+| `SOW_R2_SECRET_ACCESS_KEY` | Server | R2 API token secret key |
+| `SOW_R2_BUCKET` | Server | R2 bucket name (e.g. `stream-of-worship-prod`) |
 | `NEXT_PUBLIC_R2_PUBLIC_DOMAIN` | Client | Public R2 domain for direct streaming |
 | `BETTER_AUTH_SECRET` | Server | 32+ char random secret (`openssl rand -base64 32`) |
 | `BETTER_AUTH_URL` | Server | Deployed app URL (e.g. `https://your-app.vercel.app`) |
 | `NEXT_PUBLIC_BASE_URL` | Client | Same as `BETTER_AUTH_URL` (embedded in client bundle) |
 | `NEXT_PUBLIC_CAST_RECEIVER_APP_ID` | Client | Google Cast receiver app ID (optional) |
-| `AWS_REGION` | Server | AWS region for SQS (e.g. `us-east-1`) |
-| `SQS_QUEUE_URL` | Server | SQS queue URL for render jobs |
-| `AWS_ACCESS_KEY_ID` | Server | AWS IAM access key (SQS SendMessage) |
-| `AWS_SECRET_ACCESS_KEY` | Server | AWS IAM secret key |
-| `SQS_ENDPOINT_URL` | Server | Leave empty in production |
+| `SOW_AWS_REGION` | Server | AWS region for SQS (e.g. `us-east-1`) |
+| `SOW_SQS_QUEUE_URL` | Server | SQS queue URL for render jobs |
+| `SOW_AWS_ACCESS_KEY_ID` | Server | AWS IAM access key (SQS SendMessage) |
+| `SOW_AWS_SECRET_ACCESS_KEY` | Server | AWS IAM secret key |
+| `SOW_SQS_ENDPOINT_URL` | Server | Leave empty in production |
 | `SOW_RENDER_WORKER_MODE` | Server | Set to `sqs` in production |
 | `SOW_RENDER_WORKER_REST_URL` | Server | Leave empty in production |
 
@@ -74,7 +74,7 @@ vercel env add R2_ACCOUNT_ID production
 vercel env pull .env.production.local  # if project already has vars set
 
 # Or set individually:
-vercel env add DATABASE_URL production <<< "postgresql://user:pass@ep-xxx.neon.tech/neondb?sslmode=require"
+vercel env add SOW_DATABASE_URL production <<< "postgresql://user:pass@ep-xxx.neon.tech/neondb?sslmode=require"
 vercel env add BETTER_AUTH_SECRET production <<< "$(openssl rand -base64 32)"
 vercel env add BETTER_AUTH_URL production <<< "https://your-app.vercel.app"
 vercel env add NEXT_PUBLIC_BASE_URL production <<< "https://your-app.vercel.app"
@@ -221,8 +221,8 @@ These systems are already provisioned. This section documents the setup for refe
 Before the first deploy (or after schema changes), push the schema to the Neon database:
 
 ```bash
-# Set DATABASE_URL to the production Neon connection string
-export DATABASE_URL="postgresql://user:pass@ep-xxx.neon.tech/neondb?sslmode=require"
+# Set SOW_DATABASE_URL to the production Neon connection string
+export SOW_DATABASE_URL="postgresql://user:pass@ep-xxx.neon.tech/neondb?sslmode=require"
 
 # From webapp/ directory
 npx drizzle-kit push
@@ -239,7 +239,7 @@ npx drizzle-kit migrate    # Apply pending migrations
 
 - **Console:** https://dash.cloudflare.com → R2
 - The webapp stores rendered audio (MP3) and video (MP4) files in R2.
-- Required credentials: `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_BUCKET_NAME`.
+- Required credentials: `SOW_R2_ENDPOINT_URL`, `SOW_R2_ACCESS_KEY_ID`, `SOW_R2_SECRET_ACCESS_KEY`, `SOW_R2_BUCKET`.
 - `NEXT_PUBLIC_R2_PUBLIC_DOMAIN` must point to a public R2 domain (custom domain or `r2.dev` public URL).
 - Signed URLs are generated server-side via `/api/signed-url` as a fallback when no public domain is configured.
 
@@ -247,6 +247,6 @@ npx drizzle-kit migrate    # Apply pending migrations
 
 - **Console:** https://console.aws.amazon.com/sqs
 - The webapp enqueues render jobs to SQS; an AWS Lambda container worker processes them.
-- Required credentials: `AWS_REGION`, `SQS_QUEUE_URL`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`.
+- Required credentials: `SOW_AWS_REGION`, `SOW_SQS_QUEUE_URL`, `SOW_AWS_ACCESS_KEY_ID`, `SOW_AWS_SECRET_ACCESS_KEY`.
 - IAM user needs minimum permissions: `sqs:SendMessage` on the render jobs queue ARN.
 - `SOW_RENDER_WORKER_MODE` must be `sqs` in production. The `rest` mode is for local development only.

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -14,9 +14,9 @@ Web application for rendering worship music transitions with synchronized lyrics
 
 Copy `.env.example` to `.env.local` and configure:
 
-- `DATABASE_URL` — PostgreSQL connection string
-- `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_BUCKET_NAME` — Cloudflare R2 credentials
-- `AWS_REGION`, `SQS_QUEUE_URL`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` — AWS SQS credentials for render job queue
+- `SOW_DATABASE_URL` — PostgreSQL connection string
+- `SOW_R2_ENDPOINT_URL`, `SOW_R2_ACCESS_KEY_ID`, `SOW_R2_SECRET_ACCESS_KEY`, `SOW_R2_BUCKET` — Cloudflare R2 credentials
+- `SOW_AWS_REGION`, `SOW_SQS_QUEUE_URL`, `SOW_AWS_ACCESS_KEY_ID`, `SOW_AWS_SECRET_ACCESS_KEY` — AWS SQS credentials for render job queue
 - `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL` — Better Auth configuration
 - `NEXT_PUBLIC_BASE_URL` — Base URL of the app (for share links)
 - `NEXT_PUBLIC_CAST_RECEIVER_APP_ID` — (optional) Google Cast SDK receiver app ID
@@ -36,7 +36,7 @@ pnpm build        # Production build
 ## Database Migrations
 
 ```bash
-psql "$DATABASE_URL" -c 'CREATE EXTENSION IF NOT EXISTS vector;'
+psql "$SOW_DATABASE_URL" -c 'CREATE EXTENSION IF NOT EXISTS vector;'
 npx drizzle-kit push       # Push schema changes to DB
 npx drizzle-kit generate   # Generate migration files
 npx drizzle-kit migrate    # Run pending migrations

--- a/webapp/src/db/index.ts
+++ b/webapp/src/db/index.ts
@@ -2,11 +2,11 @@ import { neon } from "@neondatabase/serverless";
 import { drizzle } from "drizzle-orm/neon-http";
 import * as schema from "./schema";
 
-if (!process.env.DATABASE_URL) {
-  throw new Error("DATABASE_URL environment variable is required");
+if (!process.env.SOW_DATABASE_URL) {
+  throw new Error("SOW_DATABASE_URL environment variable is required");
 }
 
-const sql = neon(process.env.DATABASE_URL);
+const sql = neon(process.env.SOW_DATABASE_URL);
 export const db = drizzle(sql, { schema });
 
 export * from "./schema";

--- a/webapp/src/lib/r2/client.ts
+++ b/webapp/src/lib/r2/client.ts
@@ -6,7 +6,7 @@ import {
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 
 export interface R2Config {
-  accountId: string;
+  endpointUrl: string;
   accessKeyId: string;
   secretAccessKey: string;
   bucketName: string;
@@ -54,11 +54,9 @@ export class R2Client {
   private bucketName: string;
 
   constructor(config: R2Config) {
-    const endpoint = `https://${config.accountId}.r2.cloudflarestorage.com`;
-
     this.client = new S3Client({
       region: config.region || "auto",
-      endpoint,
+      endpoint: config.endpointUrl,
       credentials: {
         accessKeyId: config.accessKeyId,
         secretAccessKey: config.secretAccessKey,
@@ -224,20 +222,20 @@ export class R2Client {
  * Create R2 client from environment variables
  */
 export function createR2ClientFromEnv(): R2Client {
-  const accountId = process.env.R2_ACCOUNT_ID;
-  const accessKeyId = process.env.R2_ACCESS_KEY_ID;
-  const secretAccessKey = process.env.R2_SECRET_ACCESS_KEY;
-  const bucketName = process.env.R2_BUCKET_NAME;
+  const endpointUrl = process.env.SOW_R2_ENDPOINT_URL;
+  const accessKeyId = process.env.SOW_R2_ACCESS_KEY_ID;
+  const secretAccessKey = process.env.SOW_R2_SECRET_ACCESS_KEY;
+  const bucketName = process.env.SOW_R2_BUCKET;
 
-  if (!accountId || !accessKeyId || !secretAccessKey || !bucketName) {
+  if (!endpointUrl || !accessKeyId || !secretAccessKey || !bucketName) {
     throw new Error(
       "R2 credentials not configured. " +
-        "Set R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, and R2_BUCKET_NAME environment variables."
+        "Set SOW_R2_ENDPOINT_URL, SOW_R2_ACCESS_KEY_ID, SOW_R2_SECRET_ACCESS_KEY, and SOW_R2_BUCKET environment variables."
     );
   }
 
   return new R2Client({
-    accountId,
+    endpointUrl,
     accessKeyId,
     secretAccessKey,
     bucketName,

--- a/webapp/src/lib/sqs/client.ts
+++ b/webapp/src/lib/sqs/client.ts
@@ -51,21 +51,21 @@ export class SQSClient {
 }
 
 export function createSQSClientFromEnv(): SQSClient {
-  const region = process.env.AWS_REGION;
-  const queueUrl = process.env.SQS_QUEUE_URL;
-  const endpoint = process.env.SQS_ENDPOINT_URL;
-  const accessKeyId = process.env.AWS_ACCESS_KEY_ID;
-  const secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
+  const region = process.env.SOW_AWS_REGION;
+  const queueUrl = process.env.SOW_SQS_QUEUE_URL;
+  const endpoint = process.env.SOW_SQS_ENDPOINT_URL;
+  const accessKeyId = process.env.SOW_AWS_ACCESS_KEY_ID;
+  const secretAccessKey = process.env.SOW_AWS_SECRET_ACCESS_KEY;
 
   if (!region) {
     throw new Error(
-      "AWS_REGION environment variable is required for SQS client"
+      "SOW_AWS_REGION environment variable is required for SQS client"
     );
   }
 
   if (!queueUrl) {
     throw new Error(
-      "SQS_QUEUE_URL environment variable is required for SQS client"
+      "SOW_SQS_QUEUE_URL environment variable is required for SQS client"
     );
   }
 

--- a/webapp/src/test/deployment/deployment.test.ts
+++ b/webapp/src/test/deployment/deployment.test.ts
@@ -188,34 +188,34 @@ describe(".env.production.example", () => {
     expect(fs.existsSync(ENV_EXAMPLE_PATH)).toBe(true);
   });
 
-  it("documents DATABASE_URL", () => {
+  it("documents SOW_DATABASE_URL", () => {
     const content = readEnvExample();
-    expect(content).toContain("DATABASE_URL=");
+    expect(content).toContain("SOW_DATABASE_URL=");
   });
 
-  it("documents R2_ACCOUNT_ID", () => {
+  it("documents SOW_R2_ENDPOINT_URL", () => {
     const content = readEnvExample();
-    expect(content).toContain("R2_ACCOUNT_ID=");
+    expect(content).toContain("SOW_R2_ENDPOINT_URL=");
   });
 
-  it("documents R2_ACCESS_KEY_ID", () => {
+  it("documents SOW_R2_ACCESS_KEY_ID", () => {
     const content = readEnvExample();
-    expect(content).toContain("R2_ACCESS_KEY_ID=");
+    expect(content).toContain("SOW_R2_ACCESS_KEY_ID=");
   });
 
-  it("documents R2_SECRET_ACCESS_KEY", () => {
+  it("documents SOW_R2_SECRET_ACCESS_KEY", () => {
     const content = readEnvExample();
-    expect(content).toContain("R2_SECRET_ACCESS_KEY=");
+    expect(content).toContain("SOW_R2_SECRET_ACCESS_KEY=");
   });
 
-  it("documents R2_BUCKET_NAME", () => {
+  it("documents SOW_R2_BUCKET", () => {
     const content = readEnvExample();
-    expect(content).toContain("R2_BUCKET_NAME=");
+    expect(content).toContain("SOW_R2_BUCKET=");
   });
 
-  it("documents R2_PUBLIC_DOMAIN", () => {
+  it("documents NEXT_PUBLIC_R2_PUBLIC_DOMAIN", () => {
     const content = readEnvExample();
-    expect(content).toContain("R2_PUBLIC_DOMAIN=");
+    expect(content).toContain("NEXT_PUBLIC_R2_PUBLIC_DOMAIN=");
   });
 
   it("documents BETTER_AUTH_SECRET", () => {
@@ -238,29 +238,29 @@ describe(".env.production.example", () => {
     expect(content).toContain("NEXT_PUBLIC_BASE_URL=");
   });
 
-  it("documents AWS_REGION", () => {
+  it("documents SOW_AWS_REGION", () => {
     const content = readEnvExample();
-    expect(content).toContain("AWS_REGION=");
+    expect(content).toContain("SOW_AWS_REGION=");
   });
 
-  it("documents SQS_QUEUE_URL", () => {
+  it("documents SOW_SQS_QUEUE_URL", () => {
     const content = readEnvExample();
-    expect(content).toContain("SQS_QUEUE_URL=");
+    expect(content).toContain("SOW_SQS_QUEUE_URL=");
   });
 
-  it("documents AWS_ACCESS_KEY_ID", () => {
+  it("documents SOW_AWS_ACCESS_KEY_ID", () => {
     const content = readEnvExample();
-    expect(content).toContain("AWS_ACCESS_KEY_ID=");
+    expect(content).toContain("SOW_AWS_ACCESS_KEY_ID=");
   });
 
-  it("documents AWS_SECRET_ACCESS_KEY", () => {
+  it("documents SOW_AWS_SECRET_ACCESS_KEY", () => {
     const content = readEnvExample();
-    expect(content).toContain("AWS_SECRET_ACCESS_KEY=");
+    expect(content).toContain("SOW_AWS_SECRET_ACCESS_KEY=");
   });
 
-  it("documents SQS_ENDPOINT_URL", () => {
+  it("documents SOW_SQS_ENDPOINT_URL", () => {
     const content = readEnvExample();
-    expect(content).toContain("SQS_ENDPOINT_URL=");
+    expect(content).toContain("SOW_SQS_ENDPOINT_URL=");
   });
 });
 

--- a/webapp/src/test/deployment/workflows.test.ts
+++ b/webapp/src/test/deployment/workflows.test.ts
@@ -155,12 +155,12 @@ describe("Deploy workflow", () => {
     expect(pushStep).toBeDefined();
   });
 
-  it("migrate-db references DATABASE_URL secret for schema push", () => {
+  it("migrate-db references SOW_DATABASE_URL secret for schema push", () => {
     const workflow = loadWorkflow(DEPLOY_WORKFLOW_PATH);
     const jobs = workflow.jobs as Record<string, Record<string, unknown>>;
     const steps = jobs["migrate-db"].steps as Array<Record<string, unknown>>;
     const raw = JSON.stringify(steps);
-    expect(raw).toContain("secrets.DATABASE_URL");
+    expect(raw).toContain("secrets.SOW_DATABASE_URL");
   });
 
   it("deploy-render-worker uses AWS ECR login", () => {
@@ -171,20 +171,20 @@ describe("Deploy workflow", () => {
     expect(ecrStep).toBeDefined();
   });
 
-  it("deploy-render-worker references AWS_ACCESS_KEY_ID secret", () => {
+  it("deploy-render-worker references SOW_AWS_ACCESS_KEY_ID secret", () => {
     const workflow = loadWorkflow(DEPLOY_WORKFLOW_PATH);
     const jobs = workflow.jobs as Record<string, Record<string, unknown>>;
     const steps = jobs["deploy-render-worker"].steps as Array<Record<string, unknown>>;
     const raw = JSON.stringify(steps);
-    expect(raw).toContain("secrets.AWS_ACCESS_KEY_ID");
+    expect(raw).toContain("secrets.SOW_AWS_ACCESS_KEY_ID");
   });
 
-  it("deploy-render-worker references AWS_SECRET_ACCESS_KEY secret", () => {
+  it("deploy-render-worker references SOW_AWS_SECRET_ACCESS_KEY secret", () => {
     const workflow = loadWorkflow(DEPLOY_WORKFLOW_PATH);
     const jobs = workflow.jobs as Record<string, Record<string, unknown>>;
     const steps = jobs["deploy-render-worker"].steps as Array<Record<string, unknown>>;
     const raw = JSON.stringify(steps);
-    expect(raw).toContain("secrets.AWS_SECRET_ACCESS_KEY");
+    expect(raw).toContain("secrets.SOW_AWS_SECRET_ACCESS_KEY");
   });
 
   it("deploy-render-worker updates Lambda function", () => {

--- a/webapp/src/test/lib/r2/client.test.ts
+++ b/webapp/src/test/lib/r2/client.test.ts
@@ -27,7 +27,7 @@ vi.mock("@aws-sdk/s3-request-presigner", () => ({
 
 describe("R2Client", () => {
   const mockConfig = {
-    accountId: "test-account",
+    endpointUrl: "https://test-account.r2.cloudflarestorage.com",
     accessKeyId: "test-access-key",
     secretAccessKey: "test-secret-key",
     bucketName: "test-bucket",
@@ -267,43 +267,47 @@ describe("createR2ClientFromEnv", () => {
   });
 
   it("creates client from environment variables", () => {
-    process.env.R2_ACCOUNT_ID = "test-account";
-    process.env.R2_ACCESS_KEY_ID = "test-access-key";
-    process.env.R2_SECRET_ACCESS_KEY = "test-secret-key";
-    process.env.R2_BUCKET_NAME = "test-bucket";
+    process.env.SOW_R2_ENDPOINT_URL = "https://test-account.r2.cloudflarestorage.com";
+    process.env.SOW_R2_ACCESS_KEY_ID = "test-access-key";
+    process.env.SOW_R2_SECRET_ACCESS_KEY = "test-secret-key";
+    process.env.SOW_R2_BUCKET = "test-bucket";
 
     const client = createR2ClientFromEnv();
     expect(client).toBeInstanceOf(R2Client);
   });
 
-  it("throws when R2_ACCOUNT_ID is missing", () => {
-    process.env.R2_ACCESS_KEY_ID = "test-access-key";
-    process.env.R2_SECRET_ACCESS_KEY = "test-secret-key";
-    process.env.R2_BUCKET_NAME = "test-bucket";
+  it("throws when SOW_R2_ENDPOINT_URL is missing", () => {
+    delete process.env.SOW_R2_ENDPOINT_URL;
+    process.env.SOW_R2_ACCESS_KEY_ID = "test-access-key";
+    process.env.SOW_R2_SECRET_ACCESS_KEY = "test-secret-key";
+    process.env.SOW_R2_BUCKET = "test-bucket";
 
     expect(() => createR2ClientFromEnv()).toThrow("R2 credentials not configured");
   });
 
-  it("throws when R2_ACCESS_KEY_ID is missing", () => {
-    process.env.R2_ACCOUNT_ID = "test-account";
-    process.env.R2_SECRET_ACCESS_KEY = "test-secret-key";
-    process.env.R2_BUCKET_NAME = "test-bucket";
+  it("throws when SOW_R2_ACCESS_KEY_ID is missing", () => {
+    process.env.SOW_R2_ENDPOINT_URL = "https://test-account.r2.cloudflarestorage.com";
+    delete process.env.SOW_R2_ACCESS_KEY_ID;
+    process.env.SOW_R2_SECRET_ACCESS_KEY = "test-secret-key";
+    process.env.SOW_R2_BUCKET = "test-bucket";
 
     expect(() => createR2ClientFromEnv()).toThrow("R2 credentials not configured");
   });
 
-  it("throws when R2_SECRET_ACCESS_KEY is missing", () => {
-    process.env.R2_ACCOUNT_ID = "test-account";
-    process.env.R2_ACCESS_KEY_ID = "test-access-key";
-    process.env.R2_BUCKET_NAME = "test-bucket";
+  it("throws when SOW_R2_SECRET_ACCESS_KEY is missing", () => {
+    process.env.SOW_R2_ENDPOINT_URL = "https://test-account.r2.cloudflarestorage.com";
+    process.env.SOW_R2_ACCESS_KEY_ID = "test-access-key";
+    delete process.env.SOW_R2_SECRET_ACCESS_KEY;
+    process.env.SOW_R2_BUCKET = "test-bucket";
 
     expect(() => createR2ClientFromEnv()).toThrow("R2 credentials not configured");
   });
 
-  it("throws when R2_BUCKET_NAME is missing", () => {
-    process.env.R2_ACCOUNT_ID = "test-account";
-    process.env.R2_ACCESS_KEY_ID = "test-access-key";
-    process.env.R2_SECRET_ACCESS_KEY = "test-secret-key";
+  it("throws when SOW_R2_BUCKET is missing", () => {
+    process.env.SOW_R2_ENDPOINT_URL = "https://test-account.r2.cloudflarestorage.com";
+    process.env.SOW_R2_ACCESS_KEY_ID = "test-access-key";
+    process.env.SOW_R2_SECRET_ACCESS_KEY = "test-secret-key";
+    delete process.env.SOW_R2_BUCKET;
 
     expect(() => createR2ClientFromEnv()).toThrow("R2 credentials not configured");
   });

--- a/webapp/src/test/lib/sqs/client.test.ts
+++ b/webapp/src/test/lib/sqs/client.test.ts
@@ -186,11 +186,11 @@ describe("createSQSClientFromEnv", () => {
   });
 
   it("creates client from environment variables", () => {
-    process.env.AWS_REGION = "us-east-1";
-    process.env.SQS_QUEUE_URL =
+    process.env.SOW_AWS_REGION = "us-east-1";
+    process.env.SOW_SQS_QUEUE_URL =
       "https://sqs.us-east-1.amazonaws.com/123456789/render-jobs";
-    process.env.AWS_ACCESS_KEY_ID = "AKIAIOSFODNN7EXAMPLE";
-    process.env.AWS_SECRET_ACCESS_KEY =
+    process.env.SOW_AWS_ACCESS_KEY_ID = "AKIAIOSFODNN7EXAMPLE";
+    process.env.SOW_AWS_SECRET_ACCESS_KEY =
       "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
 
     const client = createSQSClientFromEnv();
@@ -198,59 +198,59 @@ describe("createSQSClientFromEnv", () => {
   });
 
   it("creates client without explicit credentials when not provided", () => {
-    process.env.AWS_REGION = "us-east-1";
-    process.env.SQS_QUEUE_URL =
+    process.env.SOW_AWS_REGION = "us-east-1";
+    process.env.SOW_SQS_QUEUE_URL =
       "https://sqs.us-east-1.amazonaws.com/123456789/render-jobs";
-    delete process.env.AWS_ACCESS_KEY_ID;
-    delete process.env.AWS_SECRET_ACCESS_KEY;
+    delete process.env.SOW_AWS_ACCESS_KEY_ID;
+    delete process.env.SOW_AWS_SECRET_ACCESS_KEY;
 
     const client = createSQSClientFromEnv();
     expect(client).toBeInstanceOf(SQSClient);
   });
 
-  it("throws when AWS_REGION is missing", () => {
-    delete process.env.AWS_REGION;
-    process.env.SQS_QUEUE_URL =
+  it("throws when SOW_AWS_REGION is missing", () => {
+    delete process.env.SOW_AWS_REGION;
+    process.env.SOW_SQS_QUEUE_URL =
       "https://sqs.us-east-1.amazonaws.com/123456789/render-jobs";
 
     expect(() => createSQSClientFromEnv()).toThrow(
-      "AWS_REGION environment variable is required for SQS client"
+      "SOW_AWS_REGION environment variable is required for SQS client"
     );
   });
 
-  it("throws when SQS_QUEUE_URL is missing", () => {
-    process.env.AWS_REGION = "us-east-1";
-    delete process.env.SQS_QUEUE_URL;
+  it("throws when SOW_SQS_QUEUE_URL is missing", () => {
+    process.env.SOW_AWS_REGION = "us-east-1";
+    delete process.env.SOW_SQS_QUEUE_URL;
 
     expect(() => createSQSClientFromEnv()).toThrow(
-      "SQS_QUEUE_URL environment variable is required for SQS client"
+      "SOW_SQS_QUEUE_URL environment variable is required for SQS client"
     );
   });
 
   it("throws when both required env vars are missing", () => {
-    delete process.env.AWS_REGION;
-    delete process.env.SQS_QUEUE_URL;
+    delete process.env.SOW_AWS_REGION;
+    delete process.env.SOW_SQS_QUEUE_URL;
 
     expect(() => createSQSClientFromEnv()).toThrow(
-      "AWS_REGION environment variable is required for SQS client"
+      "SOW_AWS_REGION environment variable is required for SQS client"
     );
   });
 
-  it("reads SQS_ENDPOINT_URL from environment", () => {
-    process.env.AWS_REGION = "us-east-1";
-    process.env.SQS_QUEUE_URL =
+  it("reads SOW_SQS_ENDPOINT_URL from environment", () => {
+    process.env.SOW_AWS_REGION = "us-east-1";
+    process.env.SOW_SQS_QUEUE_URL =
       "http://sqs.us-west-2.localhost.localstack.cloud:4566/000000000000/sow-render-jobs";
-    process.env.SQS_ENDPOINT_URL = "http://localhost:4566";
+    process.env.SOW_SQS_ENDPOINT_URL = "http://localhost:4566";
 
     const client = createSQSClientFromEnv();
     expect(client).toBeInstanceOf(SQSClient);
   });
 
-  it("creates client without endpoint when SQS_ENDPOINT_URL is not set", () => {
-    process.env.AWS_REGION = "us-east-1";
-    process.env.SQS_QUEUE_URL =
+  it("creates client without endpoint when SOW_SQS_ENDPOINT_URL is not set", () => {
+    process.env.SOW_AWS_REGION = "us-east-1";
+    process.env.SOW_SQS_QUEUE_URL =
       "https://sqs.us-east-1.amazonaws.com/123456789/render-jobs";
-    delete process.env.SQS_ENDPOINT_URL;
+    delete process.env.SOW_SQS_ENDPOINT_URL;
 
     const client = createSQSClientFromEnv();
     expect(client).toBeInstanceOf(SQSClient);


### PR DESCRIPTION
## Summary

Standardizes all project-specific environment variables in the webapp to use the `SOW_` prefix, aligning with the naming convention used in the render-worker service and `/opt/sow/.env.server`.

## Changes

### Environment Variable Renames

| Old Name | New Name | Notes |
|----------|----------|-------|
| `DATABASE_URL` | `SOW_DATABASE_URL` | Resolves pre-existing inconsistency with `drizzle.config.ts` |
| `R2_ACCOUNT_ID` | `SOW_R2_ENDPOINT_URL` | **Value format change**: account ID → full endpoint URL |
| `R2_ACCESS_KEY_ID` | `SOW_R2_ACCESS_KEY_ID` | |
| `R2_SECRET_ACCESS_KEY` | `SOW_R2_SECRET_ACCESS_KEY` | |
| `R2_BUCKET_NAME` | `SOW_R2_BUCKET` | Shorter name |
| `AWS_REGION` | `SOW_AWS_REGION` | |
| `SQS_QUEUE_URL` | `SOW_SQS_QUEUE_URL` | |
| `AWS_ACCESS_KEY_ID` | `SOW_AWS_ACCESS_KEY_ID` | |
| `AWS_SECRET_ACCESS_KEY` | `SOW_AWS_SECRET_ACCESS_KEY` | |
| `SQS_ENDPOINT_URL` | `SOW_SQS_ENDPOINT_URL` | |
| `R2_PUBLIC_DOMAIN` | `NEXT_PUBLIC_R2_PUBLIC_DOMAIN` | **Bug fix**: was missing `NEXT_PUBLIC_` prefix |

### Files Modified (13 files)

- **`webapp/src/db/index.ts`** — Database connection uses `SOW_DATABASE_URL`
- **`webapp/src/lib/r2/client.ts`** — `R2Config.accountId` → `R2Config.endpointUrl` (interface change), updated env var reads
- **`webapp/src/lib/sqs/client.ts`** — Updated all AWS/SQS env var reads
- **`webapp/.env.example`** — Updated all variable names with new format guidance
- **`webapp/.env.production.example`** — Updated all variable names + fixed `NEXT_PUBLIC_R2_PUBLIC_DOMAIN`
- **`webapp/README.md`** — Updated env var documentation
- **`webapp/DEPLOY-VERCEL.md`** — Updated deployment guide with new variable names
- **`webapp/src/test/lib/r2/client.test.ts`** — Updated mock config and env var tests
- **`webapp/src/test/lib/sqs/client.test.ts`** — Updated env var tests
- **`webapp/src/test/deployment/deployment.test.ts`** — Updated `.env.production.example` assertions
- **`webapp/src/test/deployment/workflows.test.ts`** — Updated GitHub Actions secret assertions
- **`.github/workflows/deploy.yml`** — Updated secret references for CI/CD
- **`specs/align-webapp-env-vars-sow-prefix.md`** — Detailed implementation spec

### Interface Change

`R2Config.accountId: string` → `R2Config.endpointUrl: string`

This is a breaking change to the exported `R2Config` interface. Currently only used within the webapp.

## Deployment Notes

⚠️ **Hard cutover with no backward compatibility**

Env vars must be updated **before** code deployment:

1. Update Vercel environment variables (production, preview, development)
2. Update GitHub repository secrets
3. Merge & deploy code

### Value Format Migration for R2

```
# Old
R2_ACCOUNT_ID=abc123

# New  
SOW_R2_ENDPOINT_URL=https://abc123.r2.cloudflarestorage.com
```

### AWS SDK Note

After renaming `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` to `SOW_`-prefixed versions, the AWS SDK default credential chain won't auto-detect them. Current code explicitly passes credentials, so this is safe.

## Testing

All tests pass with updated variable names:
- `webapp/src/test/lib/r2/client.test.ts`
- `webapp/src/test/lib/sqs/client.test.ts`
- `webapp/src/test/deployment/deployment.test.ts`
- `webapp/src/test/deployment/workflows.test.ts`