### PR TITLE
fix(webapp): use signed URLs for offline artifact caching

### DIFF
--- a/services/render-worker/src/sow_render_worker/chapters.py
+++ b/services/render-worker/src/sow_render_worker/chapters.py
@@ -2,17 +2,40 @@ from __future__ import annotations
 
 import json
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields, is_dataclass
 from datetime import datetime, timezone
-from typing import Callable, Protocol
+from typing import Any, Callable, Protocol
 
 logger = logging.getLogger(__name__)
+
+
+def _snake_to_camel(name: str) -> str:
+    components = name.split("_")
+    return components[0] + "".join(x.title() for x in components[1:])
+
+
+def dataclass_to_camel_case_dict(obj: Any) -> dict | list | str | int | float | bool | None:
+    if is_dataclass(obj) and not isinstance(obj, type):
+        result = {}
+        for f in fields(obj):
+            value = getattr(obj, f.name)
+            result[_snake_to_camel(f.name)] = dataclass_to_camel_case_dict(value)
+        return result
+    elif isinstance(obj, tuple):
+        return [dataclass_to_camel_case_dict(item) for item in obj]
+    elif isinstance(obj, list):
+        return [dataclass_to_camel_case_dict(item) for item in obj]
+    else:
+        return obj
 
 
 @dataclass(frozen=True)
 class ChapterLine:
     text: str
     start_seconds: float
+
+    def to_camel_case_dict(self) -> dict:
+        return dataclass_to_camel_case_dict(self)
 
 
 @dataclass(frozen=True)
@@ -23,12 +46,18 @@ class Chapter:
     end_seconds: float
     lines: tuple[ChapterLine, ...] = field(default_factory=tuple)
 
+    def to_camel_case_dict(self) -> dict:
+        return dataclass_to_camel_case_dict(self)
+
 
 @dataclass(frozen=True)
 class ChaptersManifest:
     chapters: tuple[Chapter, ...] = field(default_factory=tuple)
     total_duration_seconds: float = 0.0
     generated_at: str = ""
+
+    def to_camel_case_dict(self) -> dict:
+        return dataclass_to_camel_case_dict(self)
 
 
 class SegmentInfo(Protocol):

--- a/services/render-worker/src/sow_render_worker/uploader.py
+++ b/services/render-worker/src/sow_render_worker/uploader.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 
 import json
 import logging
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
 
-
+from sow_render_worker.chapters import ChaptersManifest
 from sow_render_worker.r2_client import R2Client, create_r2_client_from_env
 
 logger = logging.getLogger(__name__)
@@ -33,7 +32,7 @@ DEFAULT_CACHE_CONTROL = "public, max-age=3600"
 class RenderArtifacts:
     mp3_path: str | None = None
     mp4_path: str | None = None
-    chapters: Any = None
+    chapters: ChaptersManifest | None = None
 
 
 @dataclass
@@ -132,7 +131,7 @@ class R2Uploader:
         if artifacts.chapters is not None:
             key = f"renders/{render_job_id}/chapters.json"
             json_content = json.dumps(
-                asdict(artifacts.chapters), indent=2, ensure_ascii=False
+                artifacts.chapters.to_camel_case_dict(), indent=2, ensure_ascii=False
             )
             buffer = json_content.encode("utf-8")
 

--- a/services/render-worker/tests/test_chapters.py
+++ b/services/render-worker/tests/test_chapters.py
@@ -1,5 +1,6 @@
 import json
-from dataclasses import dataclass
+import dataclasses
+from dataclasses import dataclass, fields as dc_fields
 
 import pytest
 
@@ -7,8 +8,10 @@ from sow_render_worker.chapters import (
     Chapter,
     ChapterLine,
     ChaptersManifest,
+    _snake_to_camel,
     build_chapters_from_segments,
     chapters_to_ffmpeg_metadata,
+    dataclass_to_camel_case_dict,
     find_chapter_at_time,
     generate_chapters_manifest,
     get_lyric_at_time,
@@ -619,3 +622,94 @@ class TestParseChaptersManifest:
         assert ffmpeg_str.startswith(";FFMETADATA1")
         assert "title=Song A" in ffmpeg_str
         assert "title=Song B" in ffmpeg_str
+
+
+class TestChaptersManifestRoundtrip:
+    def test_serialize_and_parse_roundtrip(self):
+        chapters = [
+            Chapter(
+                position=1,
+                song_title="Song A",
+                start_seconds=0.0,
+                end_seconds=30.0,
+                lines=(ChapterLine(text="Line 1", start_seconds=5.0),),
+            ),
+            Chapter(
+                position=2,
+                song_title="Song B",
+                start_seconds=30.0,
+                end_seconds=60.0,
+                lines=(),
+            ),
+        ]
+        original = ChaptersManifest(
+            chapters=tuple(chapters),
+            total_duration_seconds=60.0,
+            generated_at="2024-01-01T00:00:00Z",
+        )
+
+        json_str = json.dumps(original.to_camel_case_dict())
+        parsed = parse_chapters_manifest(json_str)
+
+        assert len(parsed.chapters) == 2
+        assert parsed.chapters[0].song_title == "Song A"
+        assert parsed.chapters[0].start_seconds == 0.0
+        assert parsed.chapters[0].end_seconds == 30.0
+        assert len(parsed.chapters[0].lines) == 1
+        assert parsed.chapters[0].lines[0].text == "Line 1"
+        assert parsed.chapters[0].lines[0].start_seconds == 5.0
+        assert parsed.chapters[1].song_title == "Song B"
+        assert parsed.total_duration_seconds == 60.0
+        assert parsed.generated_at == "2024-01-01T00:00:00Z"
+
+    def test_to_camel_case_dict_produces_camel_case_keys(self):
+        chapter = Chapter(
+            position=1,
+            song_title="Test Song",
+            start_seconds=0.0,
+            end_seconds=30.0,
+            lines=(ChapterLine(text="Hello", start_seconds=5.0),),
+        )
+        manifest = ChaptersManifest(
+            chapters=(chapter,),
+            total_duration_seconds=30.0,
+            generated_at="2024-01-01T00:00:00Z",
+        )
+
+        d = manifest.to_camel_case_dict()
+
+        assert "chapters" in d
+        assert "totalDurationSeconds" in d
+        assert "generatedAt" in d
+        assert "total_duration_seconds" not in d
+
+        chapter_dict = d["chapters"][0]
+        assert "position" in chapter_dict
+        assert "songTitle" in chapter_dict
+        assert "startSeconds" in chapter_dict
+        assert "endSeconds" in chapter_dict
+        assert "lines" in chapter_dict
+        assert "song_title" not in chapter_dict
+        assert "start_seconds" not in chapter_dict
+
+        line_dict = chapter_dict["lines"][0]
+        assert "text" in line_dict
+        assert "startSeconds" in line_dict
+        assert "start_seconds" not in line_dict
+
+    def test_to_camel_case_dict_covers_all_fields(self):
+        for cls in (ChapterLine, Chapter, ChaptersManifest):
+            instance = cls.__new__(cls)
+            for f in dc_fields(cls):
+                default = f.default if f.default is not dataclasses.MISSING else (
+                    f.default_factory() if f.default_factory is not dataclasses.MISSING else None
+                )
+                object.__setattr__(instance, f.name, default)
+
+            camel_dict = instance.to_camel_case_dict()
+            for f in dc_fields(cls):
+                expected_key = _snake_to_camel(f.name)
+                assert expected_key in camel_dict, (
+                    f"{cls.__name__}.to_camel_case_dict() is missing field "
+                    f"'{f.name}' (expected key '{expected_key}')"
+                )

--- a/services/render-worker/tests/test_uploader.py
+++ b/services/render-worker/tests/test_uploader.py
@@ -265,7 +265,7 @@ class TestUploadRenderArtifacts:
         body = call_kwargs["Body"]
         parsed = json.loads(body)
         assert parsed["chapters"] == []
-        assert parsed["total_duration_seconds"] == 0.0
+        assert parsed["totalDurationSeconds"] == 0.0
 
     def test_no_artifacts_returns_empty_result(self):
         uploader = _make_uploader()
@@ -288,27 +288,24 @@ class TestUploadRenderArtifacts:
         call_kwargs = uploader._client.put_object.call_args[1]
         body = call_kwargs["Body"]
         parsed = json.loads(body)
-        assert parsed["chapters"][0]["song_title"] == "中文標題"
+        assert parsed["chapters"][0]["songTitle"] == "中文標題"
 
     def test_chapters_dataclass_serialization(self):
-        from dataclasses import dataclass
-
-        @dataclass
-        class FakeChapter:
-            title: str
-            start: float
-
         uploader = _make_uploader()
         uploader._client.put_object.return_value = {"ETag": '"etag"'}
 
-        artifacts = RenderArtifacts(chapters=FakeChapter(title="Test", start=0.0))
+        artifacts = RenderArtifacts(chapters=ChaptersManifest(
+            chapters=(Chapter(position=1, song_title="Test", start_seconds=0.0, end_seconds=60.0),),
+            total_duration_seconds=60.0,
+            generated_at="2024-01-01",
+        ))
         uploader.upload_render_artifacts("job-dc", artifacts)
 
         call_kwargs = uploader._client.put_object.call_args[1]
         body = call_kwargs["Body"]
         parsed = json.loads(body)
-        assert parsed["title"] == "Test"
-        assert parsed["start"] == 0.0
+        assert parsed["chapters"][0]["songTitle"] == "Test"
+        assert parsed["chapters"][0]["startSeconds"] == 0.0
 
 
 class TestDeleteRenderArtifacts:

--- a/specs/fix-chapter-skip-snake-case-camelcase-mismatch-v2.md
+++ b/specs/fix-chapter-skip-snake-case-camelcase-mismatch-v2.md
@@ -1,0 +1,820 @@
+# Fix: Chapter Skip Buttons Not Working — snake_case vs camelCase Mismatch (v2)
+
+> **Status:** Implementation plan ready.
+> **Supersedes:** `fix-chapter-skip-snake-case-camelcase-mismatch.md` (v1)
+> **Updated:** 2026-05-26
+
+---
+
+## Problem
+
+The "Chapter Skip Forward/Backwards" buttons on the Worship Screen (ControllerPlayer) do nothing when clicked. Console shows:
+
+```
+ControllerPlayer.tsx:177 Uncaught TypeError: Failed to set the 'currentTime' property on 'HTMLMediaElement': The provided double value is non-finite.
+    at ControllerPlayer.useCallback[handleSeek] (ControllerPlayer.tsx:177:24)
+    at ControllerPlayer.useCallback[handleNextSong] (ControllerPlayer.tsx:201:7)
+```
+
+After adding `isFinite()` guards, the error disappears but buttons still do nothing.
+
+---
+
+## Root Cause Analysis
+
+### The Mismatch
+
+The backend serializes chapters using `dataclasses.asdict()` which preserves Python **snake_case** field names, but the frontend expects **camelCase** keys.
+
+| Python dataclass field | `asdict()` JSON key | Frontend expected key | Match? |
+|---|---|---|---|
+| `position` | `"position"` | `position` | YES |
+| `song_title` | `"song_title"` | `songTitle` | **NO** |
+| `start_seconds` | `"start_seconds"` | `startSeconds` | **NO** |
+| `end_seconds` | `"end_seconds"` | `endSeconds` | **NO** |
+| `ChapterLine.start_seconds` | `"start_seconds"` | `startSeconds` | **NO** |
+| `total_duration_seconds` | `"total_duration_seconds"` | `totalDurationSeconds` | **NO** |
+| `generated_at` | `"generated_at"` | `generatedAt` | **NO** |
+
+### Data Flow
+
+```
+Python dataclass (snake_case fields)
+    |
+    v  dataclasses.asdict()  <-- BUG: preserves snake_case
+    |
+JSON with snake_case keys: {"song_title", "start_seconds", ...}
+    |
+    v  boto3 put_object to R2
+    |
+R2: renders/{jobId}/chapters.json  (snake_case JSON)
+    |
+    v  fetch via /api/r2/artifact/{jobId}/chapters.json
+    |
+Frontend response.json()  (still snake_case keys)
+    |
+    v  setChapters(chaptersData.chapters)  <-- NO transformation
+    |
+React state: Chapter[]  (TypeScript expects camelCase, but values are snake_case)
+    |
+    v  chapter.startSeconds  --> undefined
+    |
+    v  isFinite(undefined) = false
+    |
+Skip buttons silently fail
+```
+
+### Backend Self-Inconsistency
+
+The backend's own `parse_chapters_manifest()` function in `chapters.py:149-197` expects **camelCase** keys:
+
+```python
+chapter_data.get("songTitle")     # camelCase
+chapter_data.get("startSeconds")  # camelCase
+chapter_data.get("endSeconds")    # camelCase
+```
+
+This means `generate_chapters_manifest()` → `asdict()` → `json.dumps()` → `parse_chapters_manifest()` would **fail** because the serializer produces snake_case but the parser expects camelCase.
+
+### Frontend Type Definition
+
+**File:** `webapp/src/lib/render/chapters.ts:40-46`
+
+```typescript
+export interface Chapter {
+  position: number;
+  songTitle: string;      // camelCase
+  startSeconds: number;   // camelCase
+  endSeconds: number;     // camelCase
+  lines: ChapterLine[];
+}
+```
+
+### Frontend Loading Code (No Transformation)
+
+**File:** `webapp/src/app/songsets/[id]/play/controller/page.tsx:95-103`
+
+```typescript
+if (jobData.chaptersR2Key) {
+  const chaptersProxyUrl = `/api/r2/artifact/${jobData.id}/chapters.json`;
+  const chaptersDataResponse = await fetch(chaptersProxyUrl);
+  if (chaptersDataResponse.ok) {
+    const chaptersData = await chaptersDataResponse.json();
+    if (chaptersData.chapters) {
+      setChapters(chaptersData.chapters);  // <-- Raw assignment, no key mapping!
+    }
+  }
+}
+```
+
+---
+
+## Changes from v1 Plan
+
+| Concern | v1 Approach | v2 Approach | Rationale |
+|---|---|---|---|
+| Serialization safety | Manual `to_camel_case_dict()` per class | Generic `dataclass_to_camel_case_dict()` helper | New fields are never silently dropped; auto-converts all `dataclasses.fields()` |
+| Uploader test break | Not mentioned | Update `test_uploader.py` assertions | `song_title` → `songTitle` after fix; test would fail |
+| Type safety | `RenderArtifacts.chapters: Any` | `ChaptersManifest \| None` | Calling `.to_camel_case_dict()` on `Any` is a runtime crash risk |
+| Redundant fallbacks | `raw.chapters ?? raw["chapters"]` | `raw.chapters` only | Dot and bracket notation access the same property; `??` is a no-op |
+| Duplicate Chapter type | Ambiguous (keep both or re-export) | Single source in `chapters.ts`, re-export from `LyricJumpList.tsx` | Prevents type drift |
+| R2 data migration | Not addressed | Document normalization as permanent compatibility layer | No backfill; normalization stays forever for existing R2 data |
+
+---
+
+## Implementation Plan
+
+### Fix Strategy
+
+Two-pronged approach:
+1. **Backend Fix**: Replace `asdict()` with a generic camelCase serializer so future renders produce correct JSON keys.
+2. **Frontend Fix**: Add a permanent normalization function that converts snake_case keys to camelCase when loading chapters. This handles **existing** chapters.json files already stored in R2 with snake_case keys.
+
+Both fixes are necessary because:
+- Backend fix alone won't fix existing R2 data
+- Frontend fix alone leaves the backend self-inconsistent
+
+---
+
+### Step 1: Add generic camelCase serialization helper to backend
+
+**File:** `services/render-worker/src/sow_render_worker/chapters.py`
+
+Add a generic `dataclass_to_camel_case_dict()` function that introspects `dataclasses.fields()` and auto-converts snake_case field names to camelCase. Then add `to_camel_case_dict()` methods to each dataclass that delegate to the helper, with `Chapter.to_camel_case_dict()` handling recursive `lines` conversion.
+
+```python
+import re
+
+def _snake_to_camel(name: str) -> str:
+    """Convert snake_case to camelCase. e.g. song_title -> songTitle"""
+    components = name.split("_")
+    return components[0] + "".join(x.title() for x in components[1:])
+
+def dataclass_to_camel_case_dict(obj: object) -> dict | list | str | int | float | bool | None:
+    """Recursively convert a dataclass instance to a dict with camelCase keys.
+
+    Handles nested dataclasses, tuples (converted to lists), and primitive values.
+    """
+    if is_dataclass(obj) and not isinstance(obj, type):
+        result = {}
+        for f in fields(obj):
+            value = getattr(obj, f.name)
+            result[_snake_to_camel(f.name)] = dataclass_to_camel_case_dict(value)
+        return result
+    elif isinstance(obj, tuple):
+        return [dataclass_to_camel_case_dict(item) for item in obj]
+    elif isinstance(obj, list):
+        return [dataclass_to_camel_case_dict(item) for item in obj]
+    else:
+        return obj
+```
+
+Then add `to_camel_case_dict()` methods that delegate to the helper:
+
+```python
+@dataclass(frozen=True)
+class ChapterLine:
+    text: str
+    start_seconds: float
+
+    def to_camel_case_dict(self) -> dict:
+        return dataclass_to_camel_case_dict(self)
+
+
+@dataclass(frozen=True)
+class Chapter:
+    position: int
+    song_title: str
+    start_seconds: float
+    end_seconds: float
+    lines: tuple[ChapterLine, ...] = field(default_factory=tuple)
+
+    def to_camel_case_dict(self) -> dict:
+        return dataclass_to_camel_case_dict(self)
+
+
+@dataclass(frozen=True)
+class ChaptersManifest:
+    chapters: tuple[Chapter, ...] = field(default_factory=tuple)
+    total_duration_seconds: float = 0.0
+    generated_at: str = ""
+
+    def to_camel_case_dict(self) -> dict:
+        return dataclass_to_camel_case_dict(self)
+```
+
+**Why generic helper over manual methods:** If a developer adds a new field (e.g., `key_signature: str`) to any dataclass, it automatically appears in the serialized output. No risk of silent field omission.
+
+---
+
+### Step 2: Update uploader to use camelCase serializer + tighten type
+
+**File:** `services/render-worker/src/sow_render_worker/uploader.py`
+
+Replace `asdict()` with `to_camel_case_dict()`, remove the `asdict` import, and type `chapters` as `ChaptersManifest | None`:
+
+```python
+# Line 5, remove asdict from import:
+from dataclasses import dataclass, field  # remove asdict
+
+# Line 36, tighten type:
+from sow_render_worker.chapters import ChaptersManifest
+
+@dataclass
+class RenderArtifacts:
+    mp3_path: str | None = None
+    mp4_path: str | None = None
+    chapters: ChaptersManifest | None = None
+
+# Lines 134-136, replace:
+json_content = json.dumps(
+    asdict(artifacts.chapters), indent=2, ensure_ascii=False
+)
+
+# With:
+json_content = json.dumps(
+    artifacts.chapters.to_camel_case_dict(), indent=2, ensure_ascii=False
+)
+```
+
+---
+
+### Step 3: Add backend roundtrip test
+
+**File:** `services/render-worker/tests/test_chapters.py`
+
+Add a test that proves `generate → serialize → parse` works end-to-end, plus a field-completeness test:
+
+```python
+class TestChaptersManifestRoundtrip:
+    def test_serialize_and_parse_roundtrip(self):
+        """Test that to_camel_case_dict() produces JSON that parse_chapters_manifest() can read."""
+        chapters = [
+            Chapter(
+                position=1,
+                song_title="Song A",
+                start_seconds=0.0,
+                end_seconds=30.0,
+                lines=(ChapterLine(text="Line 1", start_seconds=5.0),),
+            ),
+            Chapter(
+                position=2,
+                song_title="Song B",
+                start_seconds=30.0,
+                end_seconds=60.0,
+                lines=(),
+            ),
+        ]
+        original = ChaptersManifest(
+            chapters=tuple(chapters),
+            total_duration_seconds=60.0,
+            generated_at="2024-01-01T00:00:00Z",
+        )
+
+        # Serialize to camelCase JSON
+        json_str = json.dumps(original.to_camel_case_dict())
+
+        # Parse back
+        parsed = parse_chapters_manifest(json_str)
+
+        # Verify structure matches
+        assert len(parsed.chapters) == 2
+        assert parsed.chapters[0].song_title == "Song A"
+        assert parsed.chapters[0].start_seconds == 0.0
+        assert parsed.chapters[0].end_seconds == 30.0
+        assert len(parsed.chapters[0].lines) == 1
+        assert parsed.chapters[0].lines[0].text == "Line 1"
+        assert parsed.chapters[0].lines[0].start_seconds == 5.0
+        assert parsed.chapters[1].song_title == "Song B"
+        assert parsed.total_duration_seconds == 60.0
+        assert parsed.generated_at == "2024-01-01T00:00:00Z"
+
+    def test_to_camel_case_dict_produces_camel_case_keys(self):
+        """Verify the serialized JSON uses camelCase keys."""
+        chapter = Chapter(
+            position=1,
+            song_title="Test Song",
+            start_seconds=0.0,
+            end_seconds=30.0,
+            lines=(ChapterLine(text="Hello", start_seconds=5.0),),
+        )
+        manifest = ChaptersManifest(
+            chapters=(chapter,),
+            total_duration_seconds=30.0,
+            generated_at="2024-01-01T00:00:00Z",
+        )
+
+        d = manifest.to_camel_case_dict()
+
+        # Top-level keys
+        assert "chapters" in d
+        assert "totalDurationSeconds" in d
+        assert "generatedAt" in d
+        assert "total_duration_seconds" not in d
+
+        # Chapter keys
+        chapter_dict = d["chapters"][0]
+        assert "position" in chapter_dict
+        assert "songTitle" in chapter_dict
+        assert "startSeconds" in chapter_dict
+        assert "endSeconds" in chapter_dict
+        assert "lines" in chapter_dict
+        assert "song_title" not in chapter_dict
+        assert "start_seconds" not in chapter_dict
+
+        # Line keys
+        line_dict = chapter_dict["lines"][0]
+        assert "text" in line_dict
+        assert "startSeconds" in line_dict
+        assert "start_seconds" not in line_dict
+
+    def test_to_camel_case_dict_covers_all_fields(self):
+        """Verify that to_camel_case_dict() includes every dataclass field.
+
+        This catches the case where a new field is added to a dataclass
+        but the serialization is not updated.
+        """
+        from dataclasses import fields as dc_fields
+
+        for cls in (ChapterLine, Chapter, ChaptersManifest):
+            instance = cls.__new__(cls)
+            for f in dc_fields(cls):
+                # Set dummy values so getattr works
+                default = f.default if f.default is not dataclasses.MISSING else (
+                    f.default_factory() if f.default_factory is not dataclasses.MISSING else None
+                )
+                object.__setattr__(instance, f.name, default)
+
+            camel_dict = instance.to_camel_case_dict()
+            for f in dc_fields(cls):
+                expected_key = _snake_to_camel(f.name)
+                assert expected_key in camel_dict, (
+                    f"{cls.__name__}.to_camel_case_dict() is missing field "
+                    f"'{f.name}' (expected key '{expected_key}')"
+                )
+```
+
+---
+
+### Step 4: Update uploader tests
+
+**File:** `services/render-worker/tests/test_uploader.py`
+
+Fix the snake_case assertion and rewrite the `FakeChapter` test to use `ChaptersManifest`:
+
+```python
+# test_chapters_json_is_utf8_encoded — fix assertion:
+def test_chapters_json_is_utf8_encoded(self):
+    uploader = _make_uploader()
+    uploader._client.put_object.return_value = {"ETag": '"etag"'}
+
+    artifacts = RenderArtifacts(chapters=ChaptersManifest(
+        chapters=(Chapter(position=1, song_title="中文標題", start_seconds=0.0, end_seconds=60.0),),
+        total_duration_seconds=60.0,
+        generated_at="",
+    ))
+    uploader.upload_render_artifacts("job-cn", artifacts)
+
+    call_kwargs = uploader._client.put_object.call_args[1]
+    body = call_kwargs["Body"]
+    parsed = json.loads(body)
+    assert parsed["chapters"][0]["songTitle"] == "中文標題"  # camelCase, not snake_case
+
+# test_chapters_dataclass_serialization — rewrite to use ChaptersManifest:
+def test_chapters_dataclass_serialization(self):
+    uploader = _make_uploader()
+    uploader._client.put_object.return_value = {"ETag": '"etag"'}
+
+    artifacts = RenderArtifacts(chapters=ChaptersManifest(
+        chapters=(Chapter(position=1, song_title="Test", start_seconds=0.0, end_seconds=60.0),),
+        total_duration_seconds=60.0,
+        generated_at="2024-01-01",
+    ))
+    uploader.upload_render_artifacts("job-dc", artifacts)
+
+    call_kwargs = uploader._client.put_object.call_args[1]
+    body = call_kwargs["Body"]
+    parsed = json.loads(body)
+    assert parsed["chapters"][0]["songTitle"] == "Test"
+    assert parsed["chapters"][0]["startSeconds"] == 0.0
+```
+
+---
+
+### Step 5: Add frontend normalization utility
+
+**File:** `webapp/src/lib/render/chapters.ts`
+
+Add a `normalizeChaptersManifest()` function that converts snake_case keys to camelCase. This is a **permanent compatibility layer** for existing chapters.json files in R2 that were serialized with `dataclasses.asdict()`.
+
+```typescript
+/**
+ * Normalizes a chapters manifest from R2, converting snake_case keys to camelCase.
+ *
+ * PERMANENT COMPATIBILITY LAYER: Existing chapters.json files in R2 were
+ * serialized with dataclasses.asdict() which preserves Python snake_case field
+ * names. This function handles both formats so that old and new data work
+ * correctly. Do not remove — existing R2 data will not be re-uploaded.
+ *
+ * @param data - Raw parsed JSON from chapters.json
+ * @returns Normalized ChaptersManifest with camelCase keys
+ */
+export function normalizeChaptersManifest(data: unknown): ChaptersManifest {
+  if (!data || typeof data !== "object") {
+    throw new Error("Invalid chapters manifest: expected an object");
+  }
+
+  const raw = data as Record<string, unknown>;
+
+  const chapters = raw.chapters;
+  const totalDurationSeconds =
+    (raw.totalDurationSeconds as number) ?? (raw.total_duration_seconds as number) ?? 0;
+  const generatedAt =
+    (raw.generatedAt as string) ?? (raw.generated_at as string) ?? "";
+
+  if (!Array.isArray(chapters)) {
+    throw new Error("Invalid chapters manifest: chapters must be an array");
+  }
+
+  const normalizedChapters: Chapter[] = chapters.map((chapter, index) => {
+    if (!chapter || typeof chapter !== "object") {
+      throw new Error(`Invalid chapter at index ${index}`);
+    }
+
+    const c = chapter as Record<string, unknown>;
+
+    const position = (c.position as number) ?? index + 1;
+    const songTitle =
+      (c.songTitle as string) ?? (c.song_title as string) ?? `Song ${index + 1}`;
+    const startSeconds =
+      (c.startSeconds as number) ?? (c.start_seconds as number);
+    const endSeconds =
+      (c.endSeconds as number) ?? (c.end_seconds as number);
+    const lines = (c.lines as unknown[]) ?? [];
+
+    if (typeof startSeconds !== "number" || typeof endSeconds !== "number") {
+      throw new Error(
+        `Invalid chapter at index ${index}: missing or invalid startSeconds/endSeconds`
+      );
+    }
+
+    if (!Array.isArray(lines)) {
+      throw new Error(`Invalid chapter at index ${index}: lines must be an array`);
+    }
+
+    const normalizedLines: ChapterLine[] = lines.map((line, lineIndex) => {
+      if (!line || typeof line !== "object") {
+        throw new Error(`Invalid line at index ${lineIndex} in chapter ${index}`);
+      }
+
+      const l = line as Record<string, unknown>;
+
+      const text = l.text as string;
+      const lineStartSeconds =
+        (l.startSeconds as number) ?? (l.start_seconds as number);
+
+      if (typeof text !== "string" || typeof lineStartSeconds !== "number") {
+        throw new Error(
+          `Invalid line at index ${lineIndex} in chapter ${index}: missing text or startSeconds`
+        );
+      }
+
+      return {
+        text,
+        startSeconds: lineStartSeconds,
+      };
+    });
+
+    return {
+      position: typeof position === "number" ? position : index + 1,
+      songTitle: typeof songTitle === "string" ? songTitle : `Song ${index + 1}`,
+      startSeconds,
+      endSeconds,
+      lines: normalizedLines,
+    };
+  });
+
+  return {
+    chapters: normalizedChapters,
+    totalDurationSeconds:
+      typeof totalDurationSeconds === "number" ? totalDurationSeconds : 0,
+    generatedAt: typeof generatedAt === "string" ? generatedAt : "",
+  };
+}
+```
+
+---
+
+### Step 6: Consolidate Chapter type — single source in chapters.ts
+
+**File:** `webapp/src/components/play/LyricJumpList.tsx`
+
+Replace the inline `Chapter` interface with a re-export from `chapters.ts`:
+
+```typescript
+// Remove the inline Chapter interface (lines 7-16)
+// Add re-export:
+export type { Chapter, ChapterLine } from "@/lib/render/chapters";
+```
+
+**File:** `webapp/src/app/songsets/[id]/play/controller/page.tsx`
+
+Update the import to use the canonical source:
+
+```typescript
+// Change:
+import { Chapter } from "@/components/play/LyricJumpList";
+
+// To:
+import type { Chapter } from "@/lib/render/chapters";
+```
+
+**File:** `webapp/src/components/play/ControllerPlayer.tsx`
+
+Update the import (currently imports `Chapter` from `LyricJumpList`):
+
+```typescript
+// Change:
+import { LyricJumpList, Chapter } from "./LyricJumpList";
+
+// To:
+import { LyricJumpList } from "./LyricJumpList";
+import type { Chapter } from "@/lib/render/chapters";
+```
+
+---
+
+### Step 7: Update frontend chapter loading to use normalization
+
+**File:** `webapp/src/app/songsets/[id]/play/controller/page.tsx`
+
+Import the normalization function and use it when loading chapters:
+
+```typescript
+// Add import at top:
+import { normalizeChaptersManifest } from "@/lib/render/chapters";
+
+// Update the chapters loading code (lines 95-103):
+if (jobData.chaptersR2Key) {
+  const chaptersProxyUrl = `/api/r2/artifact/${jobData.id}/chapters.json`;
+  const chaptersDataResponse = await fetch(chaptersProxyUrl);
+  if (chaptersDataResponse.ok) {
+    const chaptersData = await chaptersDataResponse.json();
+    try {
+      const manifest = normalizeChaptersManifest(chaptersData);
+      setChapters(manifest.chapters);
+    } catch (e) {
+      console.error("Failed to parse chapters:", e);
+      // Continue without chapters rather than crashing
+    }
+  }
+}
+```
+
+---
+
+### Step 8: Add frontend tests for normalization
+
+**File:** `webapp/src/test/lib/render/chapters.test.ts`
+
+Add tests for `normalizeChaptersManifest`:
+
+```typescript
+import { normalizeChaptersManifest } from "@/lib/render/chapters";
+
+describe("normalizeChaptersManifest", () => {
+  it("normalizes snake_case keys to camelCase", () => {
+    const snakeCaseData = {
+      chapters: [
+        {
+          position: 1,
+          song_title: "Song A",
+          start_seconds: 0,
+          end_seconds: 30,
+          lines: [
+            { text: "Line 1", start_seconds: 5 },
+          ],
+        },
+      ],
+      total_duration_seconds: 30,
+      generated_at: "2024-01-01T00:00:00Z",
+    };
+
+    const manifest = normalizeChaptersManifest(snakeCaseData);
+
+    expect(manifest.chapters).toHaveLength(1);
+    expect(manifest.chapters[0].songTitle).toBe("Song A");
+    expect(manifest.chapters[0].startSeconds).toBe(0);
+    expect(manifest.chapters[0].endSeconds).toBe(30);
+    expect(manifest.chapters[0].lines[0].startSeconds).toBe(5);
+    expect(manifest.totalDurationSeconds).toBe(30);
+    expect(manifest.generatedAt).toBe("2024-01-01T00:00:00Z");
+  });
+
+  it("passes through already-camelCase data unchanged", () => {
+    const camelCaseData = {
+      chapters: [
+        {
+          position: 1,
+          songTitle: "Song A",
+          startSeconds: 0,
+          endSeconds: 30,
+          lines: [
+            { text: "Line 1", startSeconds: 5 },
+          ],
+        },
+      ],
+      totalDurationSeconds: 30,
+      generatedAt: "2024-01-01T00:00:00Z",
+    };
+
+    const manifest = normalizeChaptersManifest(camelCaseData);
+
+    expect(manifest.chapters).toHaveLength(1);
+    expect(manifest.chapters[0].songTitle).toBe("Song A");
+    expect(manifest.chapters[0].startSeconds).toBe(0);
+  });
+
+  it("handles mixed snake_case and camelCase keys", () => {
+    const mixedData = {
+      chapters: [
+        {
+          position: 1,
+          songTitle: "Song A",      // camelCase
+          start_seconds: 0,          // snake_case
+          endSeconds: 30,            // camelCase
+          lines: [
+            { text: "Line 1", start_seconds: 5 },  // snake_case
+          ],
+        },
+      ],
+      total_duration_seconds: 30,    // snake_case
+      generatedAt: "2024-01-01",     // camelCase
+    };
+
+    const manifest = normalizeChaptersManifest(mixedData);
+
+    expect(manifest.chapters[0].songTitle).toBe("Song A");
+    expect(manifest.chapters[0].startSeconds).toBe(0);
+    expect(manifest.chapters[0].lines[0].startSeconds).toBe(5);
+    expect(manifest.totalDurationSeconds).toBe(30);
+  });
+
+  it("throws on invalid chapters structure", () => {
+    expect(() => normalizeChaptersManifest({ chapters: "not an array" }))
+      .toThrow("chapters must be an array");
+  });
+
+  it("throws on missing startSeconds in chapter", () => {
+    expect(() => normalizeChaptersManifest({
+      chapters: [{ position: 1, songTitle: "Test" }],
+    })).toThrow("missing or invalid startSeconds/endSeconds");
+  });
+
+  it("handles empty chapters array", () => {
+    const manifest = normalizeChaptersManifest({
+      chapters: [],
+      totalDurationSeconds: 0,
+      generatedAt: "2024-01-01",
+    });
+
+    expect(manifest.chapters).toEqual([]);
+  });
+});
+```
+
+---
+
+### Step 9: Clean up defensive guards in ControllerPlayer
+
+**File:** `webapp/src/components/play/ControllerPlayer.tsx`
+
+The `isFinite()` guards added as a temporary fix can be simplified. Keep only the essential guard in `handleSeek` as defensive programming, but remove redundant guards in `handlePrevSong`, `handleNextSong`, `handleJumpToChapter`, and `handleJumpToLine` since the normalization ensures valid data.
+
+**After fix:**
+
+```typescript
+const handleSeek = useCallback(
+  (time: number) => {
+    const video = videoRef.current;
+    if (!video) return;
+
+    // Defensive guard against non-finite values
+    if (!isFinite(time)) {
+      console.warn("handleSeek called with non-finite time:", time);
+      return;
+    }
+
+    const clampedTime = Math.max(0, Math.min(duration, time));
+    video.currentTime = clampedTime;
+    setCurrentTime(clampedTime);
+  },
+  [duration]
+);
+
+const handlePrevSong = useCallback(() => {
+  if (currentSongIndex > 0) {
+    const prevChapter = chapters[currentSongIndex - 1];
+    if (prevChapter) {
+      handleSeek(prevChapter.startSeconds);
+    }
+  }
+}, [currentSongIndex, chapters, handleSeek]);
+
+const handleNextSong = useCallback(() => {
+  if (currentSongIndex < chapters.length - 1) {
+    const nextChapter = chapters[currentSongIndex + 1];
+    if (nextChapter) {
+      handleSeek(nextChapter.startSeconds);
+    }
+  }
+}, [currentSongIndex, chapters, handleSeek]);
+
+const handleJumpToChapter = useCallback(
+  (index: number) => {
+    if (index >= 0 && index < chapters.length) {
+      const chapter = chapters[index];
+      if (chapter) {
+        handleSeek(chapter.startSeconds);
+      }
+    }
+  },
+  [chapters, handleSeek]
+);
+
+const handleJumpToLine = useCallback(
+  (chapterIndex: number, lineIndex: number) => {
+    if (chapterIndex >= 0 && chapterIndex < chapters.length) {
+      const chapter = chapters[chapterIndex];
+      if (chapter && lineIndex >= 0 && lineIndex < chapter.lines.length) {
+        const line = chapter.lines[lineIndex];
+        if (line) {
+          handleSeek(line.startSeconds);
+        }
+      }
+    }
+  },
+  [chapters, handleSeek]
+);
+```
+
+---
+
+## Summary of Files Changed
+
+| File | Changes |
+|------|---------|
+| `services/render-worker/src/sow_render_worker/chapters.py` | Add `_snake_to_camel()`, `dataclass_to_camel_case_dict()`, and `to_camel_case_dict()` methods on `ChapterLine`, `Chapter`, `ChaptersManifest` |
+| `services/render-worker/src/sow_render_worker/uploader.py` | Replace `asdict()` with `to_camel_case_dict()`, remove `asdict` import, type `chapters` as `ChaptersManifest \| None` |
+| `services/render-worker/tests/test_chapters.py` | Add `TestChaptersManifestRoundtrip` class with roundtrip, key-format, and field-completeness tests |
+| `services/render-worker/tests/test_uploader.py` | Fix `song_title` → `songTitle` assertion; rewrite `FakeChapter` test to use `ChaptersManifest` |
+| `webapp/src/lib/render/chapters.ts` | Add `normalizeChaptersManifest()` function (permanent compatibility layer) |
+| `webapp/src/components/play/LyricJumpList.tsx` | Replace inline `Chapter` interface with re-export from `@/lib/render/chapters` |
+| `webapp/src/app/songsets/[id]/play/controller/page.tsx` | Use `normalizeChaptersManifest()` when loading chapters; update `Chapter` import |
+| `webapp/src/components/play/ControllerPlayer.tsx` | Simplify `isFinite` guards (keep only in `handleSeek`); update `Chapter` import |
+| `webapp/src/test/lib/render/chapters.test.ts` | Add tests for `normalizeChaptersManifest` |
+
+---
+
+## Implementation Order
+
+1. **Backend: Add generic helper + `to_camel_case_dict()` methods** (`chapters.py`)
+2. **Backend: Update uploader** (`uploader.py`) — replace `asdict`, tighten type
+3. **Backend: Add roundtrip + field-completeness tests** (`test_chapters.py`)
+4. **Backend: Update uploader tests** (`test_uploader.py`)
+5. **Backend: Run tests** to verify serialization works
+6. **Frontend: Add `normalizeChaptersManifest()`** (`chapters.ts`)
+7. **Frontend: Consolidate Chapter type** — re-export from `chapters.ts` in `LyricJumpList.tsx`
+8. **Frontend: Add normalization tests** (`chapters.test.ts`)
+9. **Frontend: Run tests** to verify normalization works
+10. **Frontend: Update controller page** to use normalization
+11. **Frontend: Clean up defensive guards** in ControllerPlayer
+12. **Frontend: Run tests** to verify everything works
+13. **Integration test**: Re-render a songset and verify chapter skip buttons work
+
+---
+
+## Verification Checklist
+
+- [ ] `services/render-worker/tests/test_chapters.py` passes with new roundtrip + field-completeness tests
+- [ ] `services/render-worker/tests/test_uploader.py` passes with updated assertions
+- [ ] `webapp/src/test/lib/render/chapters.test.ts` passes with normalization tests
+- [ ] `webapp/src/test/components/play/ControllerPlayer.test.tsx` passes
+- [ ] `webapp/pnpm lint` passes
+- [ ] Manual test: Load a songset with existing chapters.json (snake_case) — skip buttons work
+- [ ] Manual test: Re-render a songset — new chapters.json has camelCase keys
+- [ ] Manual test: Load newly rendered songset — skip buttons work
+
+---
+
+## Expected Impact
+
+| Metric | Before | After |
+|--------|--------|-------|
+| Chapter skip buttons | Do nothing | Jump to correct chapter |
+| `chapter.startSeconds` | `undefined` | Valid number |
+| `isFinite(chapter.startSeconds)` | `false` | `true` |
+| Backend self-consistency | Broken (`asdict` produces snake_case, parser expects camelCase) | Fixed (both use camelCase) |
+| Existing R2 chapters.json files | Broken | Fixed by frontend normalization (permanent) |
+| Future chapters.json files | Would be broken | Correct camelCase from the start |
+| New dataclass fields | Risk of silent omission from JSON | Auto-included by generic helper |

--- a/specs/fix-chapter-skip-snake-case-camelcase-mismatch.md
+++ b/specs/fix-chapter-skip-snake-case-camelcase-mismatch.md
@@ -1,0 +1,708 @@
+# Fix: Chapter Skip Buttons Not Working — snake_case vs camelCase Mismatch
+
+> **Status:** Implementation plan ready.
+> **Discovered:** 2026-05-26
+
+---
+
+## Problem
+
+The "Chapter Skip Forward/Backwards" buttons on the Worship Screen (ControllerPlayer) do nothing when clicked. Console shows:
+
+```
+ControllerPlayer.tsx:177 Uncaught TypeError: Failed to set the 'currentTime' property on 'HTMLMediaElement': The provided double value is non-finite.
+    at ControllerPlayer.useCallback[handleSeek] (ControllerPlayer.tsx:177:24)
+    at ControllerPlayer.useCallback[handleNextSong] (ControllerPlayer.tsx:201:7)
+```
+
+After adding `isFinite()` guards, the error disappears but buttons still do nothing.
+
+---
+
+## Root Cause Analysis
+
+### The Mismatch
+
+The backend serializes chapters using `dataclasses.asdict()` which preserves Python **snake_case** field names, but the frontend expects **camelCase** keys.
+
+| Python dataclass field | `asdict()` JSON key | Frontend expected key | Match? |
+|---|---|---|---|
+| `position` | `"position"` | `position` | YES |
+| `song_title` | `"song_title"` | `songTitle` | **NO** |
+| `start_seconds` | `"start_seconds"` | `startSeconds` | **NO** |
+| `end_seconds` | `"end_seconds"` | `endSeconds` | **NO** |
+| `ChapterLine.start_seconds` | `"start_seconds"` | `startSeconds` | **NO** |
+| `total_duration_seconds` | `"total_duration_seconds"` | `totalDurationSeconds` | **NO** |
+| `generated_at` | `"generated_at"` | `generatedAt` | **NO** |
+
+### Data Flow
+
+```
+Python dataclass (snake_case fields)
+    |
+    v  dataclasses.asdict()  <-- BUG: preserves snake_case
+    |
+JSON with snake_case keys: {"song_title", "start_seconds", ...}
+    |
+    v  boto3 put_object to R2
+    |
+R2: renders/{jobId}/chapters.json  (snake_case JSON)
+    |
+    v  fetch via /api/r2/artifact/{jobId}/chapters.json
+    |
+Frontend response.json()  (still snake_case keys)
+    |
+    v  setChapters(chaptersData.chapters)  <-- NO transformation
+    |
+React state: Chapter[]  (TypeScript expects camelCase, but values are snake_case)
+    |
+    v  chapter.startSeconds  --> undefined
+    |
+    v  isFinite(undefined) = false
+    |
+Skip buttons silently fail
+```
+
+### Backend Self-Inconsistency
+
+The backend's own `parse_chapters_manifest()` function in `chapters.py:149-197` expects **camelCase** keys:
+
+```python
+chapter_data.get("songTitle")     # camelCase
+chapter_data.get("startSeconds")  # camelCase
+chapter_data.get("endSeconds")    # camelCase
+```
+
+This means `generate_chapters_manifest()` → `asdict()` → `json.dumps()` → `parse_chapters_manifest()` would **fail** because the serializer produces snake_case but the parser expects camelCase.
+
+### Frontend Type Definition
+
+**File:** `webapp/src/components/play/LyricJumpList.tsx:7-16`
+
+```typescript
+export interface Chapter {
+  position: number;
+  songTitle: string;      // camelCase
+  startSeconds: number;   // camelCase
+  endSeconds: number;     // camelCase
+  lines: {
+    text: string;
+    startSeconds: number; // camelCase
+  }[];
+}
+```
+
+### Frontend Loading Code (No Transformation)
+
+**File:** `webapp/src/app/songsets/[id]/play/controller/page.tsx:95-103`
+
+```typescript
+if (jobData.chaptersR2Key) {
+  const chaptersProxyUrl = `/api/r2/artifact/${jobData.id}/chapters.json`;
+  const chaptersDataResponse = await fetch(chaptersProxyUrl);
+  if (chaptersDataResponse.ok) {
+    const chaptersData = await chaptersDataResponse.json();
+    if (chaptersData.chapters) {
+      setChapters(chaptersData.chapters);  // <-- Raw assignment, no key mapping!
+    }
+  }
+}
+```
+
+---
+
+## Implementation Plan
+
+### Fix Strategy
+
+Two-pronged approach:
+
+1. **Backend Fix**: Replace `asdict()` with a camelCase-aware serializer so future renders produce correct JSON keys.
+2. **Frontend Fix**: Add a normalization function that converts snake_case keys to camelCase when loading chapters. This handles **existing** chapters.json files already stored in R2 with snake_case keys.
+
+Both fixes are necessary because:
+- Backend fix alone won't fix existing R2 data
+- Frontend fix alone leaves the backend self-inconsistent
+
+---
+
+### Step 1: Add camelCase serialization to backend
+
+**File:** `services/render-worker/src/sow_render_worker/chapters.py`
+
+Add a `to_camel_case_dict()` method to each dataclass that produces camelCase keys:
+
+```python
+@dataclass(frozen=True)
+class ChapterLine:
+    text: str
+    start_seconds: float
+
+    def to_camel_case_dict(self) -> dict:
+        return {
+            "text": self.text,
+            "startSeconds": self.start_seconds,
+        }
+
+
+@dataclass(frozen=True)
+class Chapter:
+    position: int
+    song_title: str
+    start_seconds: float
+    end_seconds: float
+    lines: tuple[ChapterLine, ...] = field(default_factory=tuple)
+
+    def to_camel_case_dict(self) -> dict:
+        return {
+            "position": self.position,
+            "songTitle": self.song_title,
+            "startSeconds": self.start_seconds,
+            "endSeconds": self.end_seconds,
+            "lines": [line.to_camel_case_dict() for line in self.lines],
+        }
+
+
+@dataclass(frozen=True)
+class ChaptersManifest:
+    chapters: tuple[Chapter, ...] = field(default_factory=tuple)
+    total_duration_seconds: float = 0.0
+    generated_at: str = ""
+
+    def to_camel_case_dict(self) -> dict:
+        return {
+            "chapters": [chapter.to_camel_case_dict() for chapter in self.chapters],
+            "totalDurationSeconds": self.total_duration_seconds,
+            "generatedAt": self.generated_at,
+        }
+```
+
+---
+
+### Step 2: Update uploader to use camelCase serializer
+
+**File:** `services/render-worker/src/sow_render_worker/uploader.py`
+
+Replace `asdict()` with `to_camel_case_dict()`:
+
+```python
+# Line 134-136, replace:
+json_content = json.dumps(
+    asdict(artifacts.chapters), indent=2, ensure_ascii=False
+)
+
+# With:
+json_content = json.dumps(
+    artifacts.chapters.to_camel_case_dict(), indent=2, ensure_ascii=False
+)
+```
+
+Also remove the `asdict` import since it's no longer needed:
+
+```python
+# Line 5, remove asdict from import:
+from dataclasses import dataclass, field  # remove asdict
+```
+
+---
+
+### Step 3: Add backend roundtrip test
+
+**File:** `services/render-worker/tests/test_chapters.py`
+
+Add a test that proves `generate → serialize → parse` works end-to-end:
+
+```python
+class TestChaptersManifestRoundtrip:
+    def test_serialize_and_parse_roundtrip(self):
+        """Test that to_camel_case_dict() produces JSON that parse_chapters_manifest() can read."""
+        # Create a manifest with chapters
+        chapters = [
+            Chapter(
+                position=1,
+                song_title="Song A",
+                start_seconds=0.0,
+                end_seconds=30.0,
+                lines=(ChapterLine(text="Line 1", start_seconds=5.0),),
+            ),
+            Chapter(
+                position=2,
+                song_title="Song B",
+                start_seconds=30.0,
+                end_seconds=60.0,
+                lines=(),
+            ),
+        ]
+        original = ChaptersManifest(
+            chapters=tuple(chapters),
+            total_duration_seconds=60.0,
+            generated_at="2024-01-01T00:00:00Z",
+        )
+
+        # Serialize to camelCase JSON
+        json_str = json.dumps(original.to_camel_case_dict())
+
+        # Parse back
+        parsed = parse_chapters_manifest(json_str)
+
+        # Verify structure matches
+        assert len(parsed.chapters) == 2
+        assert parsed.chapters[0].song_title == "Song A"
+        assert parsed.chapters[0].start_seconds == 0.0
+        assert parsed.chapters[0].end_seconds == 30.0
+        assert len(parsed.chapters[0].lines) == 1
+        assert parsed.chapters[0].lines[0].text == "Line 1"
+        assert parsed.chapters[0].lines[0].start_seconds == 5.0
+        assert parsed.chapters[1].song_title == "Song B"
+        assert parsed.total_duration_seconds == 60.0
+        assert parsed.generated_at == "2024-01-01T00:00:00Z"
+
+    def test_to_camel_case_dict_produces_camel_case_keys(self):
+        """Verify the serialized JSON uses camelCase keys."""
+        chapter = Chapter(
+            position=1,
+            song_title="Test Song",
+            start_seconds=0.0,
+            end_seconds=30.0,
+            lines=(ChapterLine(text="Hello", start_seconds=5.0),),
+        )
+        manifest = ChaptersManifest(
+            chapters=(chapter,),
+            total_duration_seconds=30.0,
+            generated_at="2024-01-01T00:00:00Z",
+        )
+
+        d = manifest.to_camel_case_dict()
+
+        # Top-level keys
+        assert "chapters" in d
+        assert "totalDurationSeconds" in d
+        assert "generatedAt" in d
+        assert "total_duration_seconds" not in d
+
+        # Chapter keys
+        chapter_dict = d["chapters"][0]
+        assert "position" in chapter_dict
+        assert "songTitle" in chapter_dict
+        assert "startSeconds" in chapter_dict
+        assert "endSeconds" in chapter_dict
+        assert "lines" in chapter_dict
+        assert "song_title" not in chapter_dict
+        assert "start_seconds" not in chapter_dict
+
+        # Line keys
+        line_dict = chapter_dict["lines"][0]
+        assert "text" in line_dict
+        assert "startSeconds" in line_dict
+        assert "start_seconds" not in line_dict
+```
+
+---
+
+### Step 4: Add frontend normalization utility
+
+**File:** `webapp/src/lib/render/chapters.ts`
+
+Add a `normalizeChaptersManifest()` function that converts snake_case keys to camelCase:
+
+```typescript
+/**
+ * Normalizes a chapters manifest from R2, converting snake_case keys to camelCase.
+ * 
+ * This handles existing chapters.json files that were serialized with
+ * dataclasses.asdict() (which preserves Python snake_case field names).
+ * 
+ * @param data - Raw parsed JSON from chapters.json
+ * @returns Normalized ChaptersManifest with camelCase keys
+ */
+export function normalizeChaptersManifest(data: unknown): ChaptersManifest {
+  if (!data || typeof data !== "object") {
+    throw new Error("Invalid chapters manifest: expected an object");
+  }
+
+  const raw = data as Record<string, unknown>;
+
+  // Handle both camelCase and snake_case for top-level keys
+  const chapters = raw.chapters ?? raw["chapters"];
+  const totalDurationSeconds = raw.totalDurationSeconds ?? raw["total_duration_seconds"] ?? 0;
+  const generatedAt = raw.generatedAt ?? raw["generated_at"] ?? "";
+
+  if (!Array.isArray(chapters)) {
+    throw new Error("Invalid chapters manifest: chapters must be an array");
+  }
+
+  const normalizedChapters: Chapter[] = chapters.map((chapter, index) => {
+    if (!chapter || typeof chapter !== "object") {
+      throw new Error(`Invalid chapter at index ${index}`);
+    }
+
+    const c = chapter as Record<string, unknown>;
+
+    // Handle both camelCase and snake_case for chapter keys
+    const position = c.position ?? c["position"] ?? index + 1;
+    const songTitle = c.songTitle ?? c["song_title"] ?? `Song ${index + 1}`;
+    const startSeconds = c.startSeconds ?? c["start_seconds"];
+    const endSeconds = c.endSeconds ?? c["end_seconds"];
+    const lines = c.lines ?? c["lines"] ?? [];
+
+    if (typeof startSeconds !== "number" || typeof endSeconds !== "number") {
+      throw new Error(`Invalid chapter at index ${index}: missing or invalid startSeconds/endSeconds`);
+    }
+
+    if (!Array.isArray(lines)) {
+      throw new Error(`Invalid chapter at index ${index}: lines must be an array`);
+    }
+
+    const normalizedLines: ChapterLine[] = lines.map((line, lineIndex) => {
+      if (!line || typeof line !== "object") {
+        throw new Error(`Invalid line at index ${lineIndex} in chapter ${index}`);
+      }
+
+      const l = line as Record<string, unknown>;
+
+      const text = l.text ?? l["text"];
+      const lineStartSeconds = l.startSeconds ?? l["start_seconds"];
+
+      if (typeof text !== "string" || typeof lineStartSeconds !== "number") {
+        throw new Error(`Invalid line at index ${lineIndex} in chapter ${index}: missing text or startSeconds`);
+      }
+
+      return {
+        text,
+        startSeconds: lineStartSeconds,
+      };
+    });
+
+    return {
+      position: typeof position === "number" ? position : index + 1,
+      songTitle: typeof songTitle === "string" ? songTitle : `Song ${index + 1}`,
+      startSeconds,
+      endSeconds,
+      lines: normalizedLines,
+    };
+  });
+
+  return {
+    chapters: normalizedChapters,
+    totalDurationSeconds: typeof totalDurationSeconds === "number" ? totalDurationSeconds : 0,
+    generatedAt: typeof generatedAt === "string" ? generatedAt : "",
+  };
+}
+```
+
+---
+
+### Step 5: Update frontend chapter loading to use normalization
+
+**File:** `webapp/src/app/songsets/[id]/play/controller/page.tsx`
+
+Import the normalization function and use it when loading chapters:
+
+```typescript
+// Add import at top:
+import { normalizeChaptersManifest, Chapter } from "@/lib/render/chapters";
+
+// Update the chapters loading code (lines 95-103):
+if (jobData.chaptersR2Key) {
+  const chaptersProxyUrl = `/api/r2/artifact/${jobData.id}/chapters.json`;
+  const chaptersDataResponse = await fetch(chaptersProxyUrl);
+  if (chaptersDataResponse.ok) {
+    const chaptersData = await chaptersDataResponse.json();
+    try {
+      const manifest = normalizeChaptersManifest(chaptersData);
+      setChapters(manifest.chapters);
+    } catch (e) {
+      console.error("Failed to parse chapters:", e);
+      // Continue without chapters rather than crashing
+    }
+  }
+}
+```
+
+Also update the import for Chapter type — it should come from `@/lib/render/chapters` instead of `@/components/play/LyricJumpList` to avoid duplication:
+
+```typescript
+// Change:
+import { Chapter } from "@/components/play/LyricJumpList";
+
+// To:
+import type { Chapter } from "@/lib/render/chapters";
+```
+
+Then update `LyricJumpList.tsx` to re-export the type:
+
+```typescript
+// In LyricJumpList.tsx, change the interface to a re-export:
+export type { Chapter } from "@/lib/render/chapters";
+```
+
+Or keep the interface in LyricJumpList.tsx and have both locations define the same type (current approach). The key is that `normalizeChaptersManifest` returns the same shape.
+
+---
+
+### Step 6: Add frontend tests for normalization
+
+**File:** `webapp/src/test/lib/render/chapters.test.ts`
+
+Add tests for `normalizeChaptersManifest`:
+
+```typescript
+import { normalizeChaptersManifest } from "@/lib/render/chapters";
+
+describe("normalizeChaptersManifest", () => {
+  it("normalizes snake_case keys to camelCase", () => {
+    const snakeCaseData = {
+      chapters: [
+        {
+          position: 1,
+          song_title: "Song A",
+          start_seconds: 0,
+          end_seconds: 30,
+          lines: [
+            { text: "Line 1", start_seconds: 5 },
+          ],
+        },
+      ],
+      total_duration_seconds: 30,
+      generated_at: "2024-01-01T00:00:00Z",
+    };
+
+    const manifest = normalizeChaptersManifest(snakeCaseData);
+
+    expect(manifest.chapters).toHaveLength(1);
+    expect(manifest.chapters[0].songTitle).toBe("Song A");
+    expect(manifest.chapters[0].startSeconds).toBe(0);
+    expect(manifest.chapters[0].endSeconds).toBe(30);
+    expect(manifest.chapters[0].lines[0].startSeconds).toBe(5);
+    expect(manifest.totalDurationSeconds).toBe(30);
+    expect(manifest.generatedAt).toBe("2024-01-01T00:00:00Z");
+  });
+
+  it("passes through already-camelCase data unchanged", () => {
+    const camelCaseData = {
+      chapters: [
+        {
+          position: 1,
+          songTitle: "Song A",
+          startSeconds: 0,
+          endSeconds: 30,
+          lines: [
+            { text: "Line 1", startSeconds: 5 },
+          ],
+        },
+      ],
+      totalDurationSeconds: 30,
+      generatedAt: "2024-01-01T00:00:00Z",
+    };
+
+    const manifest = normalizeChaptersManifest(camelCaseData);
+
+    expect(manifest.chapters).toHaveLength(1);
+    expect(manifest.chapters[0].songTitle).toBe("Song A");
+    expect(manifest.chapters[0].startSeconds).toBe(0);
+  });
+
+  it("handles mixed snake_case and camelCase keys", () => {
+    const mixedData = {
+      chapters: [
+        {
+          position: 1,
+          songTitle: "Song A",      // camelCase
+          start_seconds: 0,          // snake_case
+          endSeconds: 30,            // camelCase
+          lines: [
+            { text: "Line 1", start_seconds: 5 },  // snake_case
+          ],
+        },
+      ],
+      total_duration_seconds: 30,    // snake_case
+      generatedAt: "2024-01-01",     // camelCase
+    };
+
+    const manifest = normalizeChaptersManifest(mixedData);
+
+    expect(manifest.chapters[0].songTitle).toBe("Song A");
+    expect(manifest.chapters[0].startSeconds).toBe(0);
+    expect(manifest.chapters[0].lines[0].startSeconds).toBe(5);
+    expect(manifest.totalDurationSeconds).toBe(30);
+  });
+
+  it("throws on invalid chapters structure", () => {
+    expect(() => normalizeChaptersManifest({ chapters: "not an array" }))
+      .toThrow("chapters must be an array");
+  });
+
+  it("throws on missing startSeconds in chapter", () => {
+    expect(() => normalizeChaptersManifest({
+      chapters: [{ position: 1, songTitle: "Test" }],
+    })).toThrow("missing or invalid startSeconds/endSeconds");
+  });
+
+  it("handles empty chapters array", () => {
+    const manifest = normalizeChaptersManifest({
+      chapters: [],
+      totalDurationSeconds: 0,
+      generatedAt: "2024-01-01",
+    });
+
+    expect(manifest.chapters).toEqual([]);
+  });
+});
+```
+
+---
+
+### Step 7: Clean up defensive guards in ControllerPlayer
+
+**File:** `webapp/src/components/play/ControllerPlayer.tsx`
+
+The `isFinite()` guards added as a temporary fix can be simplified. Keep only the essential guard in `handleSeek` as defensive programming, but remove redundant guards in `handlePrevSong`, `handleNextSong`, `handleJumpToChapter`, and `handleJumpToLine` since the normalization ensures valid data.
+
+**Current (after temporary fix):**
+
+```typescript
+const handleSeek = useCallback(
+  (time: number) => {
+    const video = videoRef.current;
+    if (!video) return;
+
+    if (!isFinite(time)) return;  // Keep this as defensive guard
+
+    const clampedTime = Math.max(0, Math.min(duration, time));
+    video.currentTime = clampedTime;
+    setCurrentTime(clampedTime);
+  },
+  [duration]
+);
+
+const handlePrevSong = useCallback(() => {
+  if (currentSongIndex > 0) {
+    const prevChapter = chapters[currentSongIndex - 1];
+    if (prevChapter && isFinite(prevChapter.startSeconds)) {  // Remove this check
+      handleSeek(prevChapter.startSeconds);
+    }
+  }
+}, [currentSongIndex, chapters, handleSeek]);
+```
+
+**After fix:**
+
+```typescript
+const handleSeek = useCallback(
+  (time: number) => {
+    const video = videoRef.current;
+    if (!video) return;
+
+    // Defensive guard against non-finite values
+    if (!isFinite(time)) {
+      console.warn("handleSeek called with non-finite time:", time);
+      return;
+    }
+
+    const clampedTime = Math.max(0, Math.min(duration, time));
+    video.currentTime = clampedTime;
+    setCurrentTime(clampedTime);
+  },
+  [duration]
+);
+
+const handlePrevSong = useCallback(() => {
+  if (currentSongIndex > 0) {
+    const prevChapter = chapters[currentSongIndex - 1];
+    if (prevChapter) {
+      handleSeek(prevChapter.startSeconds);
+    }
+  }
+}, [currentSongIndex, chapters, handleSeek]);
+
+const handleNextSong = useCallback(() => {
+  if (currentSongIndex < chapters.length - 1) {
+    const nextChapter = chapters[currentSongIndex + 1];
+    if (nextChapter) {
+      handleSeek(nextChapter.startSeconds);
+    }
+  }
+}, [currentSongIndex, chapters, handleSeek]);
+
+const handleJumpToChapter = useCallback(
+  (index: number) => {
+    if (index >= 0 && index < chapters.length) {
+      const chapter = chapters[index];
+      if (chapter) {
+        handleSeek(chapter.startSeconds);
+      }
+    }
+  },
+  [chapters, handleSeek]
+);
+
+const handleJumpToLine = useCallback(
+  (chapterIndex: number, lineIndex: number) => {
+    if (chapterIndex >= 0 && chapterIndex < chapters.length) {
+      const chapter = chapters[chapterIndex];
+      if (chapter && lineIndex >= 0 && lineIndex < chapter.lines.length) {
+        const line = chapter.lines[lineIndex];
+        if (line) {
+          handleSeek(line.startSeconds);
+        }
+      }
+    }
+  },
+  [chapters, handleSeek]
+);
+```
+
+---
+
+## Summary of Files Changed
+
+| File | Changes |
+|------|---------|
+| `services/render-worker/src/sow_render_worker/chapters.py` | Add `to_camel_case_dict()` methods to `ChapterLine`, `Chapter`, `ChaptersManifest` |
+| `services/render-worker/src/sow_render_worker/uploader.py` | Replace `asdict()` with `to_camel_case_dict()`, remove unused import |
+| `services/render-worker/tests/test_chapters.py` | Add `TestChaptersManifestRoundtrip` class with roundtrip and key-format tests |
+| `webapp/src/lib/render/chapters.ts` | Add `normalizeChaptersManifest()` function |
+| `webapp/src/app/songsets/[id]/play/controller/page.tsx` | Use `normalizeChaptersManifest()` when loading chapters |
+| `webapp/src/test/lib/render/chapters.test.ts` | Add tests for `normalizeChaptersManifest` |
+| `webapp/src/components/play/ControllerPlayer.tsx` | Simplify `isFinite` guards (keep only in `handleSeek`) |
+
+---
+
+## Implementation Order
+
+1. **Backend: Add `to_camel_case_dict()` methods** (`chapters.py`)
+2. **Backend: Update uploader** (`uploader.py`)
+3. **Backend: Add roundtrip tests** (`test_chapters.py`)
+4. **Backend: Run tests** to verify serialization works
+5. **Frontend: Add `normalizeChaptersManifest()`** (`chapters.ts`)
+6. **Frontend: Add normalization tests** (`chapters.test.ts`)
+7. **Frontend: Run tests** to verify normalization works
+8. **Frontend: Update controller page** to use normalization
+9. **Frontend: Clean up defensive guards** in ControllerPlayer
+10. **Frontend: Run tests** to verify everything works
+11. **Integration test**: Re-render a songset and verify chapter skip buttons work
+
+---
+
+## Verification Checklist
+
+- [ ] `services/render-worker/tests/test_chapters.py` passes with new roundtrip tests
+- [ ] `webapp/src/test/lib/render/chapters.test.ts` passes with normalization tests
+- [ ] `webapp/src/test/components/play/ControllerPlayer.test.tsx` passes
+- [ ] `webapp/pnpm lint` passes
+- [ ] Manual test: Load a songset with existing chapters.json (snake_case) — skip buttons work
+- [ ] Manual test: Re-render a songset — new chapters.json has camelCase keys
+- [ ] Manual test: Load newly rendered songset — skip buttons work
+
+---
+
+## Expected Impact
+
+| Metric | Before | After |
+|--------|--------|-------|
+| Chapter skip buttons | Do nothing | Jump to correct chapter |
+| `chapter.startSeconds` | `undefined` | Valid number |
+| `isFinite(chapter.startSeconds)` | `false` | `true` |
+| Backend self-consistency | Broken (`asdict` produces snake_case, parser expects camelCase) | Fixed (both use camelCase) |
+| Existing R2 chapters.json files | Broken | Fixed by frontend normalization |
+| Future chapters.json files | Would be broken | Correct camelCase from the start |

--- a/specs/fix-worship-screen-ux-issues-v2.md
+++ b/specs/fix-worship-screen-ux-issues-v2.md
@@ -1,0 +1,1046 @@
+# Fix: Worship Screen UX Issues (v2)
+
+> **Status:** Plan only — not yet implemented.
+> **Date:** 2026-05-26
+> **Supersedes:** `fix-worship-screen-ux-issues.md` (v1)
+
+---
+
+## Changes from v1
+
+| Bug | v1 Approach | v2 Change | Reason |
+|-----|-------------|-----------|--------|
+| 1 | `didDragRef` threshold 10px | Raise to 30px | 10px threshold created a dead zone: 15px drag sets `didDrag=true` but doesn't meet 100px toggle threshold, silently swallowing the interaction |
+| 3 | Fixes 3a + 3b + 3c as separate items | Keep all three, document they are compatible | `pointer-events-none` only applies when controls are hidden, so `onMouseEnter`/`onMouseLeave` work when controls are visible — no conflict |
+| 3 | No throttle on `onMouseMove` | No throttle (confirmed) | React batches state updates; `clearTimeout`/`setTimeout` is cheap |
+| 4 | No fullscreen re-entry mechanism | Add "Re-enter Fullscreen" button | If user accidentally exits fullscreen (Escape), there's no way back without navigating away |
+| 5 | Shrink mute button on mobile | Remove mute button on mobile entirely | Hardware volume buttons make mute toggle unnecessary on mobile; saves ~32px width |
+| 2 | Defense-in-depth in `normalizeChaptersManifest` only | Also harden `parseChaptersManifest` | Same `typeof`-only check exists in `parseChaptersManifest` (lines 222-232) |
+
+---
+
+## Summary
+
+Five UX bugs on the Worship screen (`/songsets/[id]/play/controller`) affecting both Desktop Chrome and Mobile browsers:
+
+| # | Bug | Platform | Severity |
+|---|-----|----------|----------|
+| 1 | Lyrics slide-up panel only slides up a tiny bit, no lyrics visible | Desktop | High |
+| 2 | Timestamps shown as "nn:nn" (NaN:NaN) | Mobile | High |
+| 3 | Playback Controls only visible on click, which pauses playback | Desktop | High |
+| 4 | Clicking toggles fullscreen unexpectedly | Desktop | Medium |
+| 5 | Playback Controls too wide, Play/Pause button cut off | Mobile | High |
+
+---
+
+## Bug 1: Desktop — Lyrics Panel Only Slides Up a Tiny Bit
+
+### Problem
+
+On Desktop Chrome, clicking the "Lyrics" handle bar at the bottom of the Worship screen causes the panel to slide up only ~10-40px, then immediately snap back down. No lyrics are visible.
+
+### Root Cause
+
+The handle bar (`LyricJumpList.tsx:118-146`) has **no `onClick` handler**. The only toggle mechanisms are:
+
+1. **Drag gesture** with a 100px minimum threshold (`line 68`)
+2. **Keyboard** Enter/Space (`line 130-134`)
+
+On desktop, a mouse click fires `onMouseDown` → `onMouseUp` without meaningful `currentY` accumulation. Since `currentY` stays at 0 and the 100px threshold isn't met, the panel never toggles. A slight mouse jitter during click causes a tiny drag (~10-38px), making the panel shift up briefly then snap back.
+
+**Trace of a desktop click:**
+
+1. `onMouseDown` fires `handleTouchStart` (`line 34-43`): sets `isDragging = true`, `startY = clientY`, `currentY = 0`
+2. `onMouseUp` fires `handleTouchEnd` (`line 63-78`): checks `currentY > threshold` (0 > 100) = **false**; `currentY < -threshold` (0 < -100) = **false** → **NO toggle occurs**
+3. After handler: `isDragging = false`, `currentY = 0`, panel snaps back
+
+### Proposed Fix
+
+**File:** `webapp/src/components/play/LyricJumpList.tsx`
+
+#### Fix 1a: Add `didDragRef` with 30px threshold
+
+Add a `didDrag` ref that tracks whether a significant drag occurred. Only toggle on `onClick` if the user did **not** drag past 30px. This threshold is high enough to avoid the dead zone between 10px (v1) and 100px (toggle threshold), while still distinguishing intentional drags from click jitter.
+
+**New code (add after line 30):**
+
+```tsx
+const didDragRef = useRef(false);
+```
+
+**Modified `handleTouchStart` (lines 34-43):**
+
+```tsx
+const handleTouchStart = useCallback(
+  (e: React.TouchEvent | React.MouseEvent) => {
+    e.stopPropagation();
+    const clientY =
+      "touches" in e ? e.touches[0].clientY : (e as React.MouseEvent).clientY;
+    setStartY(clientY);
+    setIsDragging(true);
+    didDragRef.current = false;
+  },
+  []
+);
+```
+
+**Modified `handleTouchMove` (lines 45-61):**
+
+```tsx
+const handleTouchMove = useCallback(
+  (e: React.TouchEvent | React.MouseEvent) => {
+    if (!isDragging) return;
+    e.stopPropagation();
+
+    const clientY =
+      "touches" in e ? e.touches[0].clientY : (e as React.MouseEvent).clientY;
+    const deltaY = startY - clientY;
+
+    if (Math.abs(deltaY) > 30) {
+      didDragRef.current = true;
+    }
+
+    if (!isOpen && deltaY > 0) {
+      setCurrentY(Math.min(deltaY, 300));
+    } else if (isOpen && deltaY < 0) {
+      setCurrentY(Math.max(deltaY, -300));
+    }
+  },
+  [isDragging, startY, isOpen]
+);
+```
+
+#### Fix 1b: Add `onClick` handler to handle bar
+
+**Location:** Lines 118-146 (handle bar `<div>`)
+
+**Current:**
+```tsx
+<div
+  className="flex flex-col items-center justify-center h-12 bg-black/90 backdrop-blur-sm rounded-t-2xl cursor-grab active:cursor-grabbing"
+  onTouchStart={handleTouchStart}
+  onTouchMove={handleTouchMove}
+  onTouchEnd={handleTouchEnd}
+  onMouseDown={handleTouchStart}
+  onMouseMove={handleTouchMove}
+  onMouseUp={handleTouchEnd}
+  onMouseLeave={handleTouchEnd}
+  role="button"
+  tabIndex={0}
+  aria-label={isOpen ? "Close lyric jump list" : "Open lyric jump list"}
+  onKeyDown={(e) => {
+    if (e.key === "Enter" || e.key === " ") {
+      setIsOpen(!isOpen);
+    }
+  }}
+>
+```
+
+**Proposed:**
+```tsx
+<div
+  className="flex flex-col items-center justify-center h-12 bg-black/90 backdrop-blur-sm rounded-t-2xl cursor-grab active:cursor-grabbing"
+  onClick={() => {
+    if (!didDragRef.current) {
+      setIsOpen(!isOpen);
+    }
+  }}
+  onTouchStart={handleTouchStart}
+  onTouchMove={handleTouchMove}
+  onTouchEnd={handleTouchEnd}
+  onMouseDown={handleTouchStart}
+  onMouseMove={handleTouchMove}
+  onMouseUp={handleTouchEnd}
+  onMouseLeave={handleTouchEnd}
+  role="button"
+  tabIndex={0}
+  aria-label={isOpen ? "Close lyric jump list" : "Open lyric jump list"}
+  onKeyDown={(e) => {
+    if (e.key === "Enter" || e.key === " ") {
+      setIsOpen(!isOpen);
+    }
+  }}
+>
+```
+
+**Interaction matrix:**
+
+| User action | `didDragRef.current` | `handleTouchEnd` | `onClick` | Result |
+|-------------|---------------------|-------------------|-----------|--------|
+| Simple click (no movement) | `false` | No toggle (currentY=0) | Toggles | Panel opens/closes |
+| Small drag < 30px | `false` | No toggle (currentY < threshold) | Toggles | Panel opens/closes |
+| Medium drag 30-99px | `true` | No toggle (currentY < threshold) | Skipped | Panel snaps back (user didn't commit) |
+| Full drag ≥ 100px | `true` | Toggles | Skipped | Panel opens/closes via drag |
+
+---
+
+## Bug 2: Mobile — Timestamps Shown as "nn:nn"
+
+### Problem
+
+On Mobile browsers, lyrics timestamps display as "nn:nn" (actually "NaN:NaN") or are missing entirely.
+
+### Root Cause
+
+The `formatTime` function in `LyricJumpList.tsx:81-85` lacks input validation that exists in every other `formatTime` in the codebase:
+
+```tsx
+// LyricJumpList.tsx (BUGGY — no guard)
+const formatTime = (seconds: number): string => {
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60);
+  return `${mins}:${secs.toString().padStart(2, "0")}`;
+};
+```
+
+When `seconds` is `NaN` or `undefined`, `Math.floor(NaN/60)` → `NaN`, producing `"NaN:NaN"`.
+
+**Contrast with correct implementation:**
+
+```tsx
+// PlaybackControls.tsx:54-58 (CORRECT — has guard)
+const formatTime = (seconds: number): string => {
+  if (!isFinite(seconds) || seconds < 0) return "0:00";
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60);
+  return `${mins}:${secs.toString().padStart(2, "0")}`;
+};
+```
+
+**How NaN enters the data:**
+
+The `normalizeChaptersManifest` function (`chapters.ts:335`) checks `typeof lineStartSeconds === "number"`, but `typeof NaN === "number"` is `true`, so NaN values pass validation. This can happen if the JSON data contains `null` values that get cast to `NaN` via `as number`.
+
+### Proposed Fix
+
+#### Fix 2a: Add guard to `formatTime` in LyricJumpList
+
+**File:** `webapp/src/components/play/LyricJumpList.tsx`
+
+**Location:** Lines 81-85
+
+**Current:**
+```tsx
+const formatTime = (seconds: number): string => {
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60);
+  return `${mins}:${secs.toString().padStart(2, "0")}`;
+};
+```
+
+**Proposed:**
+```tsx
+const formatTime = (seconds: number): string => {
+  if (!isFinite(seconds) || seconds < 0) return "0:00";
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60);
+  return `${mins}:${secs.toString().padStart(2, "0")}`;
+};
+```
+
+#### Fix 2b: Harden `normalizeChaptersManifest` (defense-in-depth)
+
+**File:** `webapp/src/lib/render/chapters.ts`
+
+**Location:** Lines 314-318 (chapter start/end validation)
+
+**Current:**
+```tsx
+if (typeof startSeconds !== "number" || typeof endSeconds !== "number") {
+  throw new Error(
+    `Invalid chapter at index ${index}: missing or invalid startSeconds/endSeconds`
+  );
+}
+```
+
+**Proposed:**
+```tsx
+if (
+  typeof startSeconds !== "number" ||
+  typeof endSeconds !== "number" ||
+  !Number.isFinite(startSeconds) ||
+  !Number.isFinite(endSeconds)
+) {
+  throw new Error(
+    `Invalid chapter at index ${index}: missing or invalid startSeconds/endSeconds`
+  );
+}
+```
+
+**Location:** Lines 335-338 (line startSeconds validation)
+
+**Current:**
+```tsx
+if (typeof text !== "string" || typeof lineStartSeconds !== "number") {
+  throw new Error(
+    `Invalid line at index ${lineIndex} in chapter ${index}: missing text or startSeconds`
+  );
+}
+```
+
+**Proposed:**
+```tsx
+if (
+  typeof text !== "string" ||
+  typeof lineStartSeconds !== "number" ||
+  !Number.isFinite(lineStartSeconds)
+) {
+  throw new Error(
+    `Invalid line at index ${lineIndex} in chapter ${index}: missing text or startSeconds`
+  );
+}
+```
+
+#### Fix 2c: Harden `parseChaptersManifest` (defense-in-depth)
+
+**File:** `webapp/src/lib/render/chapters.ts`
+
+**Location:** Lines 222-232 (chapter validation in `parseChaptersManifest`)
+
+**Current:**
+```tsx
+for (const chapter of parsed.chapters) {
+  if (
+    typeof chapter.position !== "number" ||
+    typeof chapter.songTitle !== "string" ||
+    typeof chapter.startSeconds !== "number" ||
+    typeof chapter.endSeconds !== "number" ||
+    !Array.isArray(chapter.lines)
+  ) {
+    throw new Error("Invalid chapter structure");
+  }
+}
+```
+
+**Proposed:**
+```tsx
+for (const chapter of parsed.chapters) {
+  if (
+    typeof chapter.position !== "number" ||
+    typeof chapter.songTitle !== "string" ||
+    typeof chapter.startSeconds !== "number" ||
+    typeof chapter.endSeconds !== "number" ||
+    !Number.isFinite(chapter.startSeconds) ||
+    !Number.isFinite(chapter.endSeconds) ||
+    !Array.isArray(chapter.lines)
+  ) {
+    throw new Error("Invalid chapter structure");
+  }
+}
+```
+
+**Rationale:** Adding `Number.isFinite()` rejects `NaN` and `Infinity` values at both normalization and parsing layers, preventing them from reaching the UI. The `formatTime` guard handles any edge cases that slip through.
+
+---
+
+## Bug 3: Desktop — Playback Controls Only Visible on Click (Which Pauses)
+
+### Problem
+
+On Desktop Chrome, the Playback Controls auto-hide after 2 seconds of playing. To reveal them, the user must click somewhere. However, clicking the video (the largest clickable area) toggles play/pause, which is not what the user wants — they just want to see the controls to scrub to a new position.
+
+### Root Cause
+
+Controls visibility is driven only by `onClick` and `onTouchStart` on the outer container (`ControllerPlayer.tsx:368-369`). There is **no `onMouseMove` handler**. On desktop, the standard video player pattern is: mouse movement reveals controls, click on video toggles play/pause.
+
+**Current flow on desktop:**
+
+1. Controls auto-hide after 2s of playing (`line 121-125`)
+2. User moves mouse → **nothing happens** (no `onMouseMove` handler)
+3. User clicks video → `handlePlayPause()` fires → **playback pauses** (`line 379-382`)
+4. User clicks background → `handleInteraction()` → controls appear, but background click area is tiny
+
+### Proposed Fix
+
+All three sub-fixes are compatible and should be applied together:
+
+- **Fix 3b** (`onMouseEnter`/`onMouseLeave`) only fires when controls are **visible** (no `pointer-events-none`)
+- **Fix 3c** (`pointer-events-none`) only applies when controls are **hidden** (no `onMouseEnter` possible)
+- These are complementary, not contradictory
+
+**Edge case:** During the 300ms fade-out transition, `pointer-events-none` is applied immediately (CSS doesn't wait for the transition). If the mouse re-enters the controls during this window, `onMouseEnter` won't fire. However, the container's `onMouseMove` (Fix 3a) would still detect movement and re-show controls. This is a very narrow window and unlikely to cause issues.
+
+#### Fix 3a: Add `onMouseMove` to reveal controls
+
+**File:** `webapp/src/components/play/ControllerPlayer.tsx`
+
+**Location:** Lines 363-370 (outer container `<div>`)
+
+**Current:**
+```tsx
+<div
+  className={cn(
+    "fixed inset-0 z-[70] bg-black flex flex-col",
+    className
+  )}
+  onClick={handleInteraction}
+  onTouchStart={handleInteraction}
+>
+```
+
+**Proposed:**
+```tsx
+<div
+  className={cn(
+    "fixed inset-0 z-[70] bg-black flex flex-col",
+    className
+  )}
+  onClick={handleInteraction}
+  onTouchStart={handleInteraction}
+  onMouseMove={handleInteraction}
+>
+```
+
+**Rationale:** Adding `onMouseMove` allows desktop users to reveal controls by simply moving the mouse, without clicking. No throttle needed — React batches state updates and `clearTimeout`/`setTimeout` is cheap.
+
+#### Fix 3b: Keep controls visible while hovering over them
+
+**File:** `webapp/src/components/play/ControllerPlayer.tsx`
+
+**Location:** Lines 466-472 (controls container `<div>`)
+
+**Current:**
+```tsx
+<div
+  ref={controlsRef}
+  className={cn(
+    "transition-opacity duration-300 pb-12",
+    controlsVisible || isPresentationActive ? "opacity-100" : "opacity-0"
+  )}
+>
+```
+
+**Proposed:**
+```tsx
+<div
+  ref={controlsRef}
+  className={cn(
+    "transition-opacity duration-300 pb-12",
+    controlsVisible || isPresentationActive ? "opacity-100" : "opacity-0"
+  )}
+  onMouseEnter={() => {
+    if (hideTimeoutRef.current) {
+      clearTimeout(hideTimeoutRef.current);
+    }
+  }}
+  onMouseLeave={startHideTimer}
+>
+```
+
+**Rationale:** When the mouse enters the controls area, cancel the auto-hide timer so controls stay visible while the user is interacting with them. When the mouse leaves, restart the timer. On mobile (touch-only), these events never fire — no impact.
+
+#### Fix 3c: Add `pointer-events-none` when controls are hidden
+
+**File:** `webapp/src/components/play/ControllerPlayer.tsx`
+
+**Location:** Lines 466-472 (controls container `<div>`)
+
+**Proposed (modify className):**
+```tsx
+className={cn(
+  "transition-opacity duration-300 pb-12",
+  controlsVisible || isPresentationActive
+    ? "opacity-100"
+    : "opacity-0 pointer-events-none"
+)}
+```
+
+**Rationale:** When controls are hidden (`opacity-0`), they should not intercept mouse events. This prevents accidental clicks on invisible buttons. Since `pointer-events-none` is only applied when controls are hidden, it does not conflict with Fix 3b's `onMouseEnter`/`onMouseLeave` (which only need to fire when controls are visible).
+
+---
+
+## Bug 4: Desktop — Clicking Toggles Fullscreen Unexpectedly
+
+### Problem
+
+On Desktop Chrome, clicking somewhere causes fullscreen to exit and re-enter, creating a visible flicker. This is annoying and disorienting.
+
+### Root Cause
+
+The fullscreen `useEffect` depends on `[showControls]` (`line 346`). The callback chain is:
+
+```
+startHideTimer → depends on [isPresentationActive, isPlaying] (line 126)
+showControls → depends on [startHideTimer] (line 131)
+handleInteraction → depends on [showControls] (line 136)
+```
+
+So every time `isPlaying` changes (e.g., user clicks video → play/pause toggles), `showControls` gets a new reference, the fullscreen effect's cleanup runs `document.exitFullscreen()`, then the effect re-runs and calls `requestFullscreen()` — causing a fullscreen flicker on every play/pause.
+
+**Additionally:** Chrome natively toggles fullscreen on **double-click** on `<video>` elements, which would exit fullscreen even after we fix the dependency issue.
+
+### Proposed Fix
+
+#### Fix 4a: Use a ref for `showControls` in fullscreen effect
+
+**File:** `webapp/src/components/play/ControllerPlayer.tsx`
+
+**Location:** Lines 319-346 (fullscreen `useEffect`)
+
+**Current:**
+```tsx
+// Request fullscreen on mount
+useEffect(() => {
+  const requestFullscreen = async () => {
+    try {
+      if (document.documentElement.requestFullscreen) {
+        await document.documentElement.requestFullscreen();
+      }
+    } catch {
+      // Fullscreen not supported or blocked
+    }
+  };
+
+  requestFullscreen();
+
+  const handleFullscreenChange = () => {
+    if (!document.fullscreenElement) {
+      showControls();
+    }
+  };
+
+  document.addEventListener("fullscreenchange", handleFullscreenChange);
+
+  return () => {
+    document.removeEventListener("fullscreenchange", handleFullscreenChange);
+    if (document.fullscreenElement) {
+      document.exitFullscreen().catch(() => {});
+    }
+  };
+}, [showControls]);
+```
+
+**Proposed:**
+```tsx
+// Ref to access showControls without triggering re-runs
+const showControlsRef = useRef(showControls);
+showControlsRef.current = showControls;
+
+// Request fullscreen on mount
+useEffect(() => {
+  const requestFullscreen = async () => {
+    try {
+      if (document.documentElement.requestFullscreen) {
+        await document.documentElement.requestFullscreen();
+      }
+    } catch {
+      // Fullscreen not supported or blocked
+    }
+  };
+
+  requestFullscreen();
+
+  const handleFullscreenChange = () => {
+    if (!document.fullscreenElement) {
+      showControlsRef.current();
+    }
+  };
+
+  document.addEventListener("fullscreenchange", handleFullscreenChange);
+
+  return () => {
+    document.removeEventListener("fullscreenchange", handleFullscreenChange);
+    if (document.fullscreenElement) {
+      document.exitFullscreen().catch(() => {});
+    }
+  };
+}, []); // Empty dependency array — only run on mount/unmount
+```
+
+**Rationale:** Using a ref for `showControls` allows the `handleFullscreenChange` callback to access the latest `showControls` function without causing the effect to re-run. The effect now only runs on mount (enter fullscreen) and unmount (exit fullscreen).
+
+#### Fix 4b: Prevent Chrome's native double-click-to-fullscreen on video
+
+**File:** `webapp/src/components/play/ControllerPlayer.tsx`
+
+**Location:** Lines 373-383 (`<video>` element)
+
+**Current:**
+```tsx
+<video
+  ref={videoRef}
+  src={videoSrc}
+  className="w-full h-full object-contain"
+  playsInline
+  muted={isPresentationActive}
+  onClick={(e) => {
+    e.stopPropagation();
+    handlePlayPause();
+  }}
+/>
+```
+
+**Proposed:**
+```tsx
+<video
+  ref={videoRef}
+  src={videoSrc}
+  className="w-full h-full object-contain"
+  playsInline
+  muted={isPresentationActive}
+  onClick={(e) => {
+    e.stopPropagation();
+    handlePlayPause();
+  }}
+  onDoubleClick={(e) => {
+    e.preventDefault();
+  }}
+/>
+```
+
+**Rationale:** Preventing the default behavior on double-click stops Chrome from toggling fullscreen when the user double-clicks the video.
+
+#### Fix 4c: Add "Re-enter Fullscreen" button
+
+**File:** `webapp/src/components/play/ControllerPlayer.tsx`
+
+When the user accidentally exits fullscreen (e.g., pressing Escape), there is currently no way to re-enter fullscreen without navigating away and back. Add a button that appears when not in fullscreen mode.
+
+**New state:**
+```tsx
+const [isFullscreen, setIsFullscreen] = useState(false);
+```
+
+**New effect (alongside existing fullscreen effect):**
+```tsx
+useEffect(() => {
+  const handleFullscreenChange = () => {
+    setIsFullscreen(!!document.fullscreenElement);
+  };
+
+  document.addEventListener("fullscreenchange", handleFullscreenChange);
+
+  return () => {
+    document.removeEventListener("fullscreenchange", handleFullscreenChange);
+  };
+}, []);
+```
+
+**New handler:**
+```tsx
+const handleReenterFullscreen = useCallback(() => {
+  document.documentElement.requestFullscreen().catch(() => {});
+}, []);
+```
+
+**New import:**
+```tsx
+import { ArrowLeft, X, Info, Maximize } from "lucide-react";
+```
+
+**Button placement:** Add to the top bar (lines 386-401), next to the existing Back button. Only visible when not in fullscreen:
+
+```tsx
+{!isFullscreen && (
+  <Button
+    variant="ghost"
+    size="icon"
+    className="size-10 text-white hover:bg-white/20"
+    onClick={handleReenterFullscreen}
+    aria-label="Re-enter fullscreen"
+  >
+    <Maximize className="size-5" />
+  </Button>
+)}
+```
+
+**Rationale:** This provides a user-initiated way to re-enter fullscreen after accidental exit. Browsers require fullscreen requests to be in response to a user gesture, so a button click satisfies this requirement. The button is only shown when not in fullscreen, so it doesn't clutter the normal UI.
+
+---
+
+## Bug 5: Mobile — Playback Controls Too Wide, Play/Pause Button Cut Off
+
+### Problem
+
+On Mobile browsers, the Playback Controls are too wide for the viewport. The Play/Pause button is partially cut off and not fully visible.
+
+### Root Cause
+
+The main controls row (`PlaybackControls.tsx:112`) uses `flex justify-between gap-4` with three groups of fixed-size buttons:
+
+| Group | Buttons | Size | Total Width |
+|-------|---------|------|-------------|
+| Song nav | 2× SkipBack/SkipForward + counter | `size-12` (48px) × 2 + `min-w-[3rem]` (48px) | ~160px |
+| Playback | 2× Skip + 1× Play/Pause | `size-14` (56px) × 2 + `size-16` (64px) | ~188px |
+| Volume | 1× Mute button | `size-10` (40px) | ~40px |
+
+**Total minimum:** ~160 + ~188 + ~40 + 2× `gap-4` (32px) = **~420px**
+
+On a 375px iPhone viewport, this overflows by ~45px. The Play/Pause button (`size-16` = 64px) is the largest single element and gets cut off.
+
+### Proposed Fix
+
+Make the layout responsive using Tailwind's `sm:` breakpoint (640px). On mobile (below `sm:`), use smaller buttons, tighter gaps, and **remove the mute button entirely** (hardware volume buttons make it unnecessary on mobile).
+
+**File:** `webapp/src/components/play/PlaybackControls.tsx`
+
+#### Fix 5a: Reduce button sizes on mobile
+
+**Song navigation (lines 114-138):**
+
+**Current:**
+```tsx
+<div className="flex items-center gap-2">
+  <Button
+    variant="ghost"
+    size="icon"
+    className="size-12 text-white hover:bg-white/20"
+    onClick={onPrevSong}
+    disabled={currentSongIndex <= 0}
+    aria-label="Previous song"
+  >
+    <SkipBack className="size-6" />
+  </Button>
+  <span className="text-sm text-white/70 min-w-[3rem] text-center">
+    {currentSongIndex + 1}/{totalSongs}
+  </span>
+  <Button
+    variant="ghost"
+    size="icon"
+    className="size-12 text-white hover:bg-white/20"
+    onClick={onNextSong}
+    disabled={currentSongIndex >= totalSongs - 1}
+    aria-label="Next song"
+  >
+    <SkipForward className="size-6" />
+  </Button>
+</div>
+```
+
+**Proposed:**
+```tsx
+<div className="flex items-center gap-1 sm:gap-2">
+  <Button
+    variant="ghost"
+    size="icon"
+    className="size-10 sm:size-12 text-white hover:bg-white/20"
+    onClick={onPrevSong}
+    disabled={currentSongIndex <= 0}
+    aria-label="Previous song"
+  >
+    <SkipBack className="size-5 sm:size-6" />
+  </Button>
+  <span className="text-xs sm:text-sm text-white/70 min-w-[2.5rem] sm:min-w-[3rem] text-center">
+    {currentSongIndex + 1}/{totalSongs}
+  </span>
+  <Button
+    variant="ghost"
+    size="icon"
+    className="size-10 sm:size-12 text-white hover:bg-white/20"
+    onClick={onNextSong}
+    disabled={currentSongIndex >= totalSongs - 1}
+    aria-label="Next song"
+  >
+    <SkipForward className="size-5 sm:size-6" />
+  </Button>
+</div>
+```
+
+#### Fix 5b: Reduce playback button sizes on mobile
+
+**Playback controls (lines 141-185):**
+
+**Current:**
+```tsx
+<div className="flex items-center gap-2">
+  <Button
+    variant="ghost"
+    size="icon"
+    className="size-14 text-white hover:bg-white/20"
+    onClick={onSkipBack}
+    aria-label="Skip back 10 seconds"
+  >
+    <div className="relative">
+      <SkipBack className="size-6" />
+      <span className="absolute -bottom-1 left-1/2 -translate-x-1/2 text-[8px] font-bold">
+        10
+      </span>
+    </div>
+  </Button>
+
+  <Button
+    variant="default"
+    size="icon"
+    className="size-16 rounded-full bg-white text-black hover:bg-white/90"
+    onClick={onPlayPause}
+    aria-label={isPlaying ? "Pause" : "Play"}
+  >
+    {isPlaying ? (
+      <Pause className="size-8" />
+    ) : (
+      <Play className="size-8 ml-1" />
+    )}
+  </Button>
+
+  <Button
+    variant="ghost"
+    size="icon"
+    className="size-14 text-white hover:bg-white/20"
+    onClick={onSkipForward}
+    aria-label="Skip forward 10 seconds"
+  >
+    <div className="relative">
+      <SkipForward className="size-6" />
+      <span className="absolute -bottom-1 left-1/2 -translate-x-1/2 text-[8px] font-bold">
+        10
+      </span>
+    </div>
+  </Button>
+</div>
+```
+
+**Proposed:**
+```tsx
+<div className="flex items-center gap-1 sm:gap-2">
+  <Button
+    variant="ghost"
+    size="icon"
+    className="size-10 sm:size-14 text-white hover:bg-white/20"
+    onClick={onSkipBack}
+    aria-label="Skip back 10 seconds"
+  >
+    <div className="relative">
+      <SkipBack className="size-5 sm:size-6" />
+      <span className="absolute -bottom-1 left-1/2 -translate-x-1/2 text-[7px] sm:text-[8px] font-bold">
+        10
+      </span>
+    </div>
+  </Button>
+
+  <Button
+    variant="default"
+    size="icon"
+    className="size-12 sm:size-16 rounded-full bg-white text-black hover:bg-white/90"
+    onClick={onPlayPause}
+    aria-label={isPlaying ? "Pause" : "Play"}
+  >
+    {isPlaying ? (
+      <Pause className="size-6 sm:size-8" />
+    ) : (
+      <Play className="size-6 sm:size-8 ml-1" />
+    )}
+  </Button>
+
+  <Button
+    variant="ghost"
+    size="icon"
+    className="size-10 sm:size-14 text-white hover:bg-white/20"
+    onClick={onSkipForward}
+    aria-label="Skip forward 10 seconds"
+  >
+    <div className="relative">
+      <SkipForward className="size-5 sm:size-6" />
+      <span className="absolute -bottom-1 left-1/2 -translate-x-1/2 text-[7px] sm:text-[8px] font-bold">
+        10
+      </span>
+    </div>
+  </Button>
+</div>
+```
+
+#### Fix 5c: Remove mute button on mobile, keep on desktop
+
+**Volume controls (lines 188-224):**
+
+**Current:**
+```tsx
+<div className="flex items-center gap-2">
+  <Button
+    variant="ghost"
+    size="icon"
+    className="size-10 text-white hover:bg-white/20"
+    onClick={onToggleMute}
+    aria-label={isMuted ? "Unmute" : "Mute"}
+  >
+    {isMuted || volume === 0 ? (
+      <VolumeX className="size-5" />
+    ) : (
+      <Volume2 className="size-5" />
+    )}
+  </Button>
+
+  {/* Volume slider */}
+  <div className="w-20 hidden sm:block">
+    <input
+      type="range"
+      min={0}
+      max={1}
+      step={0.01}
+      value={isMuted ? 0 : volume}
+      onChange={(e) => onVolumeChange(parseFloat(e.target.value))}
+      className="w-full h-1 bg-white/30 rounded-full appearance-none cursor-pointer [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-3 [&::-webkit-slider-thumb]:h-3 [&::-webkit-slider-thumb]:bg-white [&::-webkit-slider-thumb]:rounded-full"
+      aria-label="Volume"
+    />
+  </div>
+
+  {/* Presentation status indicator */}
+  {isPresentationActive && (
+    <div className="flex items-center gap-1 px-2 py-1 bg-green-500/20 text-green-400 rounded-full text-xs">
+      <Monitor className="size-3" />
+      <span className="hidden sm:inline">Connected</span>
+    </div>
+  )}
+</div>
+```
+
+**Proposed:**
+```tsx
+<div className="flex items-center gap-1 sm:gap-2">
+  <Button
+    variant="ghost"
+    size="icon"
+    className="hidden sm:flex size-10 text-white hover:bg-white/20"
+    onClick={onToggleMute}
+    aria-label={isMuted ? "Unmute" : "Mute"}
+  >
+    {isMuted || volume === 0 ? (
+      <VolumeX className="size-5" />
+    ) : (
+      <Volume2 className="size-5" />
+    )}
+  </Button>
+
+  {/* Volume slider */}
+  <div className="w-20 hidden sm:block">
+    <input
+      type="range"
+      min={0}
+      max={1}
+      step={0.01}
+      value={isMuted ? 0 : volume}
+      onChange={(e) => onVolumeChange(parseFloat(e.target.value))}
+      className="w-full h-1 bg-white/30 rounded-full appearance-none cursor-pointer [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-3 [&::-webkit-slider-thumb]:h-3 [&::-webkit-slider-thumb]:bg-white [&::-webkit-slider-thumb]:rounded-full"
+      aria-label="Volume"
+    />
+  </div>
+
+  {/* Presentation status indicator */}
+  {isPresentationActive && (
+    <div className="flex items-center gap-1 px-2 py-1 bg-green-500/20 text-green-400 rounded-full text-xs">
+      <Monitor className="size-3" />
+      <span className="hidden sm:inline">Connected</span>
+    </div>
+  )}
+</div>
+```
+
+**Rationale:** On mobile, hardware volume buttons control system audio — there is no use case for a mute toggle. Hiding the mute button on mobile (`hidden sm:flex`) saves ~40px of width. The volume slider was already hidden on mobile (`hidden sm:block`), so this makes the mute button consistent with the slider.
+
+#### Fix 5d: Reduce main container gap on mobile
+
+**Location:** Line 112
+
+**Current:**
+```tsx
+<div className="flex items-center justify-between gap-4">
+```
+
+**Proposed:**
+```tsx
+<div className="flex items-center justify-between gap-1 sm:gap-4">
+```
+
+### Width Calculation After Fix
+
+| Group | Mobile Size | Desktop Size |
+|-------|-------------|--------------|
+| Song nav | 2×40 + 40 + gaps = ~128px | 2×48 + 48 + gaps = ~160px |
+| Playback | 2×40 + 48 + gaps = ~136px | 2×56 + 64 + gaps = ~188px |
+| Volume | 0px (hidden) | 40px |
+| Gaps | 2×4 = 8px | 2×16 = 32px |
+| **Total** | **~272px** | **~420px** |
+
+Mobile total (~272px) fits comfortably within 375px viewport with ~103px to spare.
+
+---
+
+## Summary of Changes
+
+| File | Change | Bug(s) Fixed |
+|------|--------|--------------|
+| `LyricJumpList.tsx` | Add `didDragRef` (30px threshold) + `onClick` toggle | 1 |
+| `LyricJumpList.tsx` | Add `isFinite` guard to `formatTime` | 2 |
+| `chapters.ts` | Add `Number.isFinite()` checks in `normalizeChaptersManifest` | 2 (defense-in-depth) |
+| `chapters.ts` | Add `Number.isFinite()` checks in `parseChaptersManifest` | 2 (defense-in-depth) |
+| `ControllerPlayer.tsx` | Add `onMouseMove` to container | 3 |
+| `ControllerPlayer.tsx` | Add `onMouseEnter`/`onMouseLeave` to controls | 3 |
+| `ControllerPlayer.tsx` | Add `pointer-events-none` when hidden | 3 |
+| `ControllerPlayer.tsx` | Use ref for `showControls` in fullscreen effect | 4 |
+| `ControllerPlayer.tsx` | Add `onDoubleClick` preventDefault on video | 4 |
+| `ControllerPlayer.tsx` | Add `isFullscreen` state + "Re-enter Fullscreen" button | 4 |
+| `PlaybackControls.tsx` | Responsive button sizes with `sm:` variants | 5 |
+| `PlaybackControls.tsx` | Hide mute button on mobile (`hidden sm:flex`) | 5 |
+
+---
+
+## Verification
+
+### Bug 1: Lyrics Panel
+
+1. Open Worship screen on Desktop Chrome
+2. Click the "Lyrics" handle bar at the bottom
+3. Confirm the panel slides up fully and lyrics are visible
+4. Click the handle bar again
+5. Confirm the panel slides down and closes
+6. Drag the handle bar upward past 100px
+7. Confirm the panel opens via drag gesture
+8. Drag the handle bar slightly (< 30px) and release
+9. Confirm the panel still toggles (onClick fires because didDragRef stays false)
+10. Drag the handle bar 50px and release (without reaching 100px threshold)
+11. Confirm the panel snaps back (intentional drag that didn't commit)
+
+### Bug 2: Timestamps
+
+1. Open Worship screen on Mobile browser
+2. Open the Lyrics panel
+3. Confirm all timestamps display correctly (e.g., "0:10", "3:00")
+4. Confirm no "nn:nn" or "NaN:NaN" appears
+
+### Bug 3: Controls Visibility
+
+1. Open Worship screen on Desktop Chrome
+2. Start playback
+3. Wait 2+ seconds for controls to auto-hide
+4. Move the mouse (without clicking)
+5. Confirm controls appear without pausing playback
+6. Hover over the controls area
+7. Confirm controls stay visible while hovering
+8. Move mouse away from controls
+9. Confirm controls auto-hide after 2 seconds
+10. While controls are hidden, click in the area where controls would be
+11. Confirm no accidental button clicks occur (pointer-events-none)
+
+### Bug 4: Fullscreen
+
+1. Open Worship screen on Desktop Chrome
+2. Confirm fullscreen is entered automatically
+3. Click the video to pause/play
+4. Confirm fullscreen does NOT flicker or exit
+5. Double-click the video
+6. Confirm fullscreen does NOT exit
+7. Press Escape to exit fullscreen
+8. Confirm a "Re-enter Fullscreen" button appears
+9. Click the "Re-enter Fullscreen" button
+10. Confirm fullscreen is re-entered
+11. Press the Back button
+12. Confirm fullscreen exits and navigation occurs
+
+### Bug 5: Mobile Layout
+
+1. Open Worship screen on Mobile browser (375px viewport)
+2. Confirm all Playback Controls are fully visible
+3. Confirm the Play/Pause button is not cut off
+4. Confirm the mute button is NOT visible on mobile
+5. Confirm all buttons are tappable
+6. Test on tablet viewport (768px)
+7. Confirm controls use larger sizes appropriate for tablet
+8. Confirm mute button IS visible on tablet/desktop
+
+---
+
+## Out of Scope
+
+- Refactoring `formatTime` into a shared utility (could be future improvement)
+- Using `dvh` units for the lyrics panel `max-h-[60vh]` (minor mobile improvement, not critical)
+- Restructuring the controls layout for landscape mobile orientation
+- Auto-re-request fullscreen on Escape (browsers block non-user-initiated fullscreen requests)

--- a/specs/fix-worship-screen-ux-issues-v3.md
+++ b/specs/fix-worship-screen-ux-issues-v3.md
@@ -1,0 +1,1051 @@
+# Fix: Worship Screen UX Issues (v3)
+
+> **Status:** Implemented — 2026-05-26
+> **Date:** 2026-05-26
+> **Supersedes:** `fix-worship-screen-ux-issues-v2.md` (v2)
+
+---
+
+## Changes from v2
+
+| Bug | v2 Approach | v3 Change | Reason |
+|-----|-------------|-----------|--------|
+| 1 | `didDragRef` (30px) + `onClick` handler | Modify `handleTouchEnd` with 3-branch logic; remove `didDragRef` and `onClick` | v2's `onClick` + `didDragRef` causes double-toggle on mobile: after a successful drag, browser fires synthetic `mousedown` (resets `didDragRef=false`) → `mouseup` → `click` → `onClick` toggles again, undoing the drag. The `handleTouchEnd` approach avoids synthetic events entirely. |
+| 4 | "Re-enter Fullscreen" button in auto-hiding top bar | Place button outside the auto-hiding controls container, always visible when not in fullscreen | If button is inside the auto-hiding top bar, user who exits fullscreen via Escape won't see it after 2s of inactivity. Defeats the purpose of the button. |
+| 5 | Skip buttons `size-10` (40px) on mobile | Skip buttons `size-12` (48px) on mobile | 40px is below Apple's 44px and Material Design's 48px minimum touch target. `size-12` meets Material Design minimum; mobile total ~280px still fits 375px viewport. |
+
+---
+
+## Summary
+
+Five UX bugs on the Worship screen (`/songsets/[id]/play/controller`) affecting both Desktop Chrome and Mobile browsers:
+
+| # | Bug | Platform | Severity |
+|---|-----|----------|----------|
+| 1 | Lyrics slide-up panel only slides up a tiny bit, no lyrics visible | Desktop | High |
+| 2 | Timestamps shown as "nn:nn" (NaN:NaN) | Mobile | High |
+| 3 | Playback Controls only visible on click, which pauses playback | Desktop | High |
+| 4 | Clicking toggles fullscreen unexpectedly | Desktop | Medium |
+| 5 | Playback Controls too wide, Play/Pause button cut off | Mobile | High |
+
+---
+
+## Bug 1: Desktop — Lyrics Panel Only Slides Up a Tiny Bit
+
+### Problem
+
+On Desktop Chrome, clicking the "Lyrics" handle bar at the bottom of the Worship screen causes the panel to slide up only ~10-40px, then immediately snap back down. No lyrics are visible.
+
+### Root Cause
+
+The handle bar (`LyricJumpList.tsx:118-146`) has **no `onClick` handler**. The only toggle mechanisms are:
+
+1. **Drag gesture** with a 100px minimum threshold (`line 68`)
+2. **Keyboard** Enter/Space (`line 130-134`)
+
+On desktop, a mouse click fires `onMouseDown` → `onMouseUp` without meaningful `currentY` accumulation. Since `currentY` stays at 0 and the 100px threshold isn't met, the panel never toggles. A slight mouse jitter during click causes a tiny drag (~10-38px), making the panel shift up briefly then snap back.
+
+**Trace of a desktop click:**
+
+1. `onMouseDown` fires `handleTouchStart` (`line 34-43`): sets `isDragging = true`, `startY = clientY`, `currentY = 0`
+2. `onMouseUp` fires `handleTouchEnd` (`line 63-78`): checks `currentY > threshold` (0 > 100) = **false**; `currentY < -threshold` (0 < -100) = **false** → **NO toggle occurs**
+3. After handler: `isDragging = false`, `currentY = 0`, panel snaps back
+
+### Proposed Fix
+
+**File:** `webapp/src/components/play/LyricJumpList.tsx`
+
+Modify `handleTouchEnd` to toggle on both:
+1. **Drag gesture**: `|currentY| ≥ 100px` (existing behavior)
+2. **Click-like interaction**: `|currentY| < 30px` (new — handles desktop clicks and mobile taps)
+
+This eliminates the need for `didDragRef` and `onClick`, avoiding the mobile double-toggle issue entirely.
+
+**Modified `handleTouchEnd` (lines 61-75):**
+
+**Current:**
+```tsx
+const handleTouchEnd = useCallback(
+  (e: React.TouchEvent | React.MouseEvent) => {
+    if (!isDragging) return;
+    e.stopPropagation();
+    const threshold = 100;
+    if (!isOpen && currentY > threshold) {
+      setIsOpen(true);
+    } else if (isOpen && currentY < -threshold) {
+      setIsOpen(false);
+    }
+    setIsDragging(false);
+    setCurrentY(0);
+  },
+  [isDragging, currentY, isOpen]
+);
+```
+
+**Proposed:**
+```tsx
+const handleTouchEnd = useCallback(
+  (e: React.TouchEvent | React.MouseEvent) => {
+    if (!isDragging) return;
+    e.stopPropagation();
+
+    const threshold = 100;
+    const absY = Math.abs(currentY);
+
+    if (!isOpen && (currentY > threshold || absY < 30)) {
+      setIsOpen(true);
+    } else if (isOpen && (currentY < -threshold || absY < 30)) {
+      setIsOpen(false);
+    }
+
+    setIsDragging(false);
+    setCurrentY(0);
+  },
+  [isDragging, currentY, isOpen]
+);
+```
+
+**Interaction matrix:**
+
+| User action | `currentY` | `absY < 30` | `currentY > threshold` | Result |
+|-------------|------------|-------------|------------------------|--------|
+| Simple click (no movement) | 0 | `true` | `false` | Toggles via click-like branch |
+| Small drag < 30px | < 30 | `true` | `false` | Toggles via click-like branch |
+| Medium drag 30-99px | 30-99 | `false` | `false` | No toggle — panel snaps back |
+| Full drag ≥ 100px | ≥ 100 | `false` | `true` | Toggles via drag branch |
+
+**Why this avoids the mobile double-toggle issue:**
+
+On mobile, after a successful drag (≥100px):
+1. `touchend` → `handleTouchEnd` → toggles panel, sets `isDragging=false`
+2. Synthetic `mousedown` → `handleTouchStart` → sets `isDragging=true`
+3. Synthetic `mouseup` → `handleTouchEnd` → `isDragging=true`, but `currentY=0` (no move happened) → `absY < 30` → **toggles again!**
+
+Wait — this still has the issue. The synthetic `mousedown` resets `isDragging=true`, and the synthetic `mouseup` calls `handleTouchEnd` with `currentY=0`, which triggers the click-like toggle.
+
+**Revised approach:** Add a flag to prevent synthetic event double-toggle:
+
+```tsx
+const lastToggleTimeRef = useRef(0);
+
+const handleTouchEnd = useCallback(
+  (e: React.TouchEvent | React.MouseEvent) => {
+    if (!isDragging) return;
+    e.stopPropagation();
+
+    const now = Date.now();
+    const threshold = 100;
+    const absY = Math.abs(currentY);
+
+    const shouldToggle =
+      (currentY > threshold || absY < 30) && now - lastToggleTimeRef.current > 100;
+
+    if (!isOpen && shouldToggle) {
+      setIsOpen(true);
+      lastToggleTimeRef.current = now;
+    } else if (isOpen && shouldToggle) {
+      setIsOpen(false);
+      lastToggleTimeRef.current = now;
+    }
+
+    setIsDragging(false);
+    setCurrentY(0);
+  },
+  [isDragging, currentY, isOpen]
+);
+```
+
+The `lastToggleTimeRef` debounce (100ms) prevents the synthetic `mouseup` from toggling again after a real `touchend` toggle.
+
+**Interaction matrix (with debounce):**
+
+| User action | First event | Second event (synthetic) | Result |
+|-------------|-------------|--------------------------|--------|
+| Tap (mobile) | `touchend`: `absY=0 < 30` → toggles, sets timestamp | `mouseup`: `now - timestamp < 100` → skipped | Single toggle ✓ |
+| Drag ≥100px (mobile) | `touchend`: `currentY > threshold` → toggles, sets timestamp | `mouseup`: `now - timestamp < 100` → skipped | Single toggle ✓ |
+| Click (desktop) | `mouseup`: `absY=0 < 30` → toggles | (no synthetic events) | Single toggle ✓ |
+| Drag ≥100px (desktop) | `mouseup`: `currentY > threshold` → toggles | (no synthetic events) | Single toggle ✓ |
+
+---
+
+## Bug 2: Mobile — Timestamps Shown as "nn:nn"
+
+### Problem
+
+On Mobile browsers, lyrics timestamps display as "nn:nn" (actually "NaN:NaN") or are missing entirely.
+
+### Root Cause
+
+The `formatTime` function in `LyricJumpList.tsx:81-85` lacks input validation that exists in every other `formatTime` in the codebase:
+
+```tsx
+// LyricJumpList.tsx (BUGGY — no guard)
+const formatTime = (seconds: number): string => {
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60);
+  return `${mins}:${secs.toString().padStart(2, "0")}`;
+};
+```
+
+When `seconds` is `NaN` or `undefined`, `Math.floor(NaN/60)` → `NaN`, producing `"NaN:NaN"`.
+
+**Contrast with correct implementation:**
+
+```tsx
+// PlaybackControls.tsx:54-58 (CORRECT — has guard)
+const formatTime = (seconds: number): string => {
+  if (!isFinite(seconds) || seconds < 0) return "0:00";
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60);
+  return `${mins}:${secs.toString().padStart(2, "0")}`;
+};
+```
+
+**How NaN enters the data:**
+
+The `normalizeChaptersManifest` function (`chapters.ts:335`) checks `typeof lineStartSeconds === "number"`, but `typeof NaN === "number"` is `true`, so NaN values pass validation. This can happen if the JSON data contains `null` values that get cast to `NaN` via `as number`.
+
+### Proposed Fix
+
+#### Fix 2a: Add guard to `formatTime` in LyricJumpList
+
+**File:** `webapp/src/components/play/LyricJumpList.tsx`
+
+**Location:** Lines 81-85
+
+**Current:**
+```tsx
+const formatTime = (seconds: number): string => {
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60);
+  return `${mins}:${secs.toString().padStart(2, "0")}`;
+};
+```
+
+**Proposed:**
+```tsx
+const formatTime = (seconds: number): string => {
+  if (!isFinite(seconds) || seconds < 0) return "0:00";
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60);
+  return `${mins}:${secs.toString().padStart(2, "0")}`;
+};
+```
+
+#### Fix 2b: Harden `normalizeChaptersManifest` (defense-in-depth)
+
+**File:** `webapp/src/lib/render/chapters.ts`
+
+**Location:** Lines 314-318 (chapter start/end validation)
+
+**Current:**
+```tsx
+if (typeof startSeconds !== "number" || typeof endSeconds !== "number") {
+  throw new Error(
+    `Invalid chapter at index ${index}: missing or invalid startSeconds/endSeconds`
+  );
+}
+```
+
+**Proposed:**
+```tsx
+if (
+  typeof startSeconds !== "number" ||
+  typeof endSeconds !== "number" ||
+  !Number.isFinite(startSeconds) ||
+  !Number.isFinite(endSeconds)
+) {
+  throw new Error(
+    `Invalid chapter at index ${index}: missing or invalid startSeconds/endSeconds`
+  );
+}
+```
+
+**Location:** Lines 335-338 (line startSeconds validation)
+
+**Current:**
+```tsx
+if (typeof text !== "string" || typeof lineStartSeconds !== "number") {
+  throw new Error(
+    `Invalid line at index ${lineIndex} in chapter ${index}: missing text or startSeconds`
+  );
+}
+```
+
+**Proposed:**
+```tsx
+if (
+  typeof text !== "string" ||
+  typeof lineStartSeconds !== "number" ||
+  !Number.isFinite(lineStartSeconds)
+) {
+  throw new Error(
+    `Invalid line at index ${lineIndex} in chapter ${index}: missing text or startSeconds`
+  );
+}
+```
+
+#### Fix 2c: Harden `parseChaptersManifest` (defense-in-depth)
+
+**File:** `webapp/src/lib/render/chapters.ts`
+
+**Location:** Lines 222-232 (chapter validation in `parseChaptersManifest`)
+
+**Current:**
+```tsx
+for (const chapter of parsed.chapters) {
+  if (
+    typeof chapter.position !== "number" ||
+    typeof chapter.songTitle !== "string" ||
+    typeof chapter.startSeconds !== "number" ||
+    typeof chapter.endSeconds !== "number" ||
+    !Array.isArray(chapter.lines)
+  ) {
+    throw new Error("Invalid chapter structure");
+  }
+}
+```
+
+**Proposed:**
+```tsx
+for (const chapter of parsed.chapters) {
+  if (
+    typeof chapter.position !== "number" ||
+    typeof chapter.songTitle !== "string" ||
+    typeof chapter.startSeconds !== "number" ||
+    typeof chapter.endSeconds !== "number" ||
+    !Number.isFinite(chapter.startSeconds) ||
+    !Number.isFinite(chapter.endSeconds) ||
+    !Array.isArray(chapter.lines)
+  ) {
+    throw new Error("Invalid chapter structure");
+  }
+}
+```
+
+**Rationale:** Adding `Number.isFinite()` rejects `NaN` and `Infinity` values at both normalization and parsing layers, preventing them from reaching the UI. The `formatTime` guard handles any edge cases that slip through.
+
+---
+
+## Bug 3: Desktop — Playback Controls Only Visible on Click (Which Pauses)
+
+### Problem
+
+On Desktop Chrome, the Playback Controls auto-hide after 2 seconds of playing. To reveal them, the user must click somewhere. However, clicking the video (the largest clickable area) toggles play/pause, which is not what the user wants — they just want to see the controls to scrub to a new position.
+
+### Root Cause
+
+Controls visibility is driven only by `onClick` and `onTouchStart` on the outer container (`ControllerPlayer.tsx:368-369`). There is **no `onMouseMove` handler**. On desktop, the standard video player pattern is: mouse movement reveals controls, click on video toggles play/pause.
+
+**Current flow on desktop:**
+
+1. Controls auto-hide after 2s of playing (`line 121-125`)
+2. User moves mouse → **nothing happens** (no `onMouseMove` handler)
+3. User clicks video → `handlePlayPause()` fires → **playback pauses** (`line 379-382`)
+4. User clicks background → `handleInteraction()` → controls appear, but background click area is tiny
+
+### Proposed Fix
+
+All three sub-fixes are compatible and should be applied together:
+
+- **Fix 3b** (`onMouseEnter`/`onMouseLeave`) only fires when controls are **visible** (no `pointer-events-none`)
+- **Fix 3c** (`pointer-events-none`) only applies when controls are **hidden** (no `onMouseEnter` possible)
+- These are complementary, not contradictory
+
+**Edge case:** During the 300ms fade-out transition, `pointer-events-none` is applied immediately (CSS doesn't wait for the transition). If the mouse re-enters the controls during this window, `onMouseEnter` won't fire. However, the container's `onMouseMove` (Fix 3a) would still detect movement and re-show controls. This is a very narrow window and unlikely to cause issues.
+
+#### Fix 3a: Add `onMouseMove` to reveal controls
+
+**File:** `webapp/src/components/play/ControllerPlayer.tsx`
+
+**Location:** Lines 363-370 (outer container `<div>`)
+
+**Current:**
+```tsx
+<div
+  className={cn(
+    "fixed inset-0 z-[70] bg-black flex flex-col",
+    className
+  )}
+  onClick={handleInteraction}
+  onTouchStart={handleInteraction}
+>
+```
+
+**Proposed:**
+```tsx
+<div
+  className={cn(
+    "fixed inset-0 z-[70] bg-black flex flex-col",
+    className
+  )}
+  onClick={handleInteraction}
+  onTouchStart={handleInteraction}
+  onMouseMove={handleInteraction}
+>
+```
+
+**Rationale:** Adding `onMouseMove` allows desktop users to reveal controls by simply moving the mouse, without clicking. No throttle needed — React batches state updates and `clearTimeout`/`setTimeout` is cheap.
+
+#### Fix 3b: Keep controls visible while hovering over them
+
+**File:** `webapp/src/components/play/ControllerPlayer.tsx`
+
+**Location:** Lines 466-472 (controls container `<div>`)
+
+**Current:**
+```tsx
+<div
+  ref={controlsRef}
+  className={cn(
+    "transition-opacity duration-300 pb-12",
+    controlsVisible || isPresentationActive ? "opacity-100" : "opacity-0"
+  )}
+>
+```
+
+**Proposed:**
+```tsx
+<div
+  ref={controlsRef}
+  className={cn(
+    "transition-opacity duration-300 pb-12",
+    controlsVisible || isPresentationActive ? "opacity-100" : "opacity-0"
+  )}
+  onMouseEnter={() => {
+    if (hideTimeoutRef.current) {
+      clearTimeout(hideTimeoutRef.current);
+    }
+  }}
+  onMouseLeave={startHideTimer}
+>
+```
+
+**Rationale:** When the mouse enters the controls area, cancel the auto-hide timer so controls stay visible while the user is interacting with them. When the mouse leaves, restart the timer. On mobile (touch-only), these events never fire — no impact.
+
+#### Fix 3c: Add `pointer-events-none` when controls are hidden
+
+**File:** `webapp/src/components/play/ControllerPlayer.tsx`
+
+**Location:** Lines 466-472 (controls container `<div>`)
+
+**Proposed (modify className):**
+```tsx
+className={cn(
+  "transition-opacity duration-300 pb-12",
+  controlsVisible || isPresentationActive
+    ? "opacity-100"
+    : "opacity-0 pointer-events-none"
+)}
+```
+
+**Rationale:** When controls are hidden (`opacity-0`), they should not intercept mouse events. This prevents accidental clicks on invisible buttons. Since `pointer-events-none` is only applied when controls are hidden, it does not conflict with Fix 3b's `onMouseEnter`/`onMouseLeave` (which only need to fire when controls are visible).
+
+---
+
+## Bug 4: Desktop — Clicking Toggles Fullscreen Unexpectedly
+
+### Problem
+
+On Desktop Chrome, clicking somewhere causes fullscreen to exit and re-enter, creating a visible flicker. This is annoying and disorienting.
+
+### Root Cause
+
+The fullscreen `useEffect` depends on `[showControls]` (`line 346`). The callback chain is:
+
+```
+startHideTimer → depends on [isPresentationActive, isPlaying] (line 126)
+showControls → depends on [startHideTimer] (line 131)
+handleInteraction → depends on [showControls] (line 136)
+```
+
+So every time `isPlaying` changes (e.g., user clicks video → play/pause toggles), `showControls` gets a new reference, the fullscreen effect's cleanup runs `document.exitFullscreen()`, then the effect re-runs and calls `requestFullscreen()` — causing a fullscreen flicker on every play/pause.
+
+**Additionally:** Chrome natively toggles fullscreen on **double-click** on `<video>` elements, which would exit fullscreen even after we fix the dependency issue.
+
+### Proposed Fix
+
+#### Fix 4a: Use a ref for `showControls` in fullscreen effect
+
+**File:** `webapp/src/components/play/ControllerPlayer.tsx`
+
+**Location:** Lines 319-346 (fullscreen `useEffect`)
+
+**Current:**
+```tsx
+// Request fullscreen on mount
+useEffect(() => {
+  const requestFullscreen = async () => {
+    try {
+      if (document.documentElement.requestFullscreen) {
+        await document.documentElement.requestFullscreen();
+      }
+    } catch {
+      // Fullscreen not supported or blocked
+    }
+  };
+
+  requestFullscreen();
+
+  const handleFullscreenChange = () => {
+    if (!document.fullscreenElement) {
+      showControls();
+    }
+  };
+
+  document.addEventListener("fullscreenchange", handleFullscreenChange);
+
+  return () => {
+    document.removeEventListener("fullscreenchange", handleFullscreenChange);
+    if (document.fullscreenElement) {
+      document.exitFullscreen().catch(() => {});
+    }
+  };
+}, [showControls]);
+```
+
+**Proposed:**
+```tsx
+// Ref to access showControls without triggering re-runs
+const showControlsRef = useRef(showControls);
+showControlsRef.current = showControls;
+
+// Request fullscreen on mount
+useEffect(() => {
+  const requestFullscreen = async () => {
+    try {
+      if (document.documentElement.requestFullscreen) {
+        await document.documentElement.requestFullscreen();
+      }
+    } catch {
+      // Fullscreen not supported or blocked
+    }
+  };
+
+  requestFullscreen();
+
+  const handleFullscreenChange = () => {
+    if (!document.fullscreenElement) {
+      showControlsRef.current();
+    }
+  };
+
+  document.addEventListener("fullscreenchange", handleFullscreenChange);
+
+  return () => {
+    document.removeEventListener("fullscreenchange", handleFullscreenChange);
+    if (document.fullscreenElement) {
+      document.exitFullscreen().catch(() => {});
+    }
+  };
+}, []); // Empty dependency array — only run on mount/unmount
+```
+
+**Rationale:** Using a ref for `showControls` allows the `handleFullscreenChange` callback to access the latest `showControls` function without causing the effect to re-run. The effect now only runs on mount (enter fullscreen) and unmount (exit fullscreen).
+
+#### Fix 4b: Prevent Chrome's native double-click-to-fullscreen on video
+
+**File:** `webapp/src/components/play/ControllerPlayer.tsx`
+
+**Location:** Lines 373-383 (`<video>` element)
+
+**Current:**
+```tsx
+<video
+  ref={videoRef}
+  src={videoSrc}
+  className="w-full h-full object-contain"
+  playsInline
+  muted={isPresentationActive}
+  onClick={(e) => {
+    e.stopPropagation();
+    handlePlayPause();
+  }}
+/>
+```
+
+**Proposed:**
+```tsx
+<video
+  ref={videoRef}
+  src={videoSrc}
+  className="w-full h-full object-contain"
+  playsInline
+  muted={isPresentationActive}
+  onClick={(e) => {
+    e.stopPropagation();
+    handlePlayPause();
+  }}
+  onDoubleClick={(e) => {
+    e.preventDefault();
+  }}
+/>
+```
+
+**Rationale:** Preventing the default behavior on double-click stops Chrome from toggling fullscreen when the user double-clicks the video.
+
+#### Fix 4c: Add "Re-enter Fullscreen" button (always visible when not fullscreen)
+
+**File:** `webapp/src/components/play/ControllerPlayer.tsx`
+
+When the user accidentally exits fullscreen (e.g., pressing Escape), there is currently no way to re-enter fullscreen without navigating away and back. Add a button that appears when not in fullscreen mode.
+
+**Important:** The button must be placed **outside** the auto-hiding controls container so it remains visible even when controls are hidden.
+
+**New state:**
+```tsx
+const [isFullscreen, setIsFullscreen] = useState(false);
+```
+
+**New effect (alongside existing fullscreen effect):**
+```tsx
+useEffect(() => {
+  const handleFullscreenChange = () => {
+    setIsFullscreen(!!document.fullscreenElement);
+  };
+
+  document.addEventListener("fullscreenchange", handleFullscreenChange);
+
+  return () => {
+    document.removeEventListener("fullscreenchange", handleFullscreenChange);
+  };
+}, []);
+```
+
+**New handler:**
+```tsx
+const handleReenterFullscreen = useCallback(() => {
+  document.documentElement.requestFullscreen().catch(() => {});
+}, []);
+```
+
+**New import:**
+```tsx
+import { ArrowLeft, X, Info, Maximize } from "lucide-react";
+```
+
+**Button placement:** Add as a **sibling** to the controls container, positioned fixed in the top-left corner. Only visible when not in fullscreen:
+
+```tsx
+{/* Re-enter Fullscreen button — outside auto-hiding controls */}
+{!isFullscreen && (
+  <Button
+    variant="ghost"
+    size="icon"
+    className="fixed top-4 left-4 z-[80] size-10 text-white hover:bg-white/20"
+    onClick={handleReenterFullscreen}
+    aria-label="Re-enter fullscreen"
+  >
+    <Maximize className="size-5" />
+  </Button>
+)}
+```
+
+**Rationale:** This provides a user-initiated way to re-enter fullscreen after accidental exit. Browsers require fullscreen requests to be in response to a user gesture, so a button click satisfies this requirement. By placing the button outside the auto-hiding controls container with `fixed` positioning and `z-[80]`, it remains visible even when controls are hidden, ensuring the user can always find it after exiting fullscreen.
+
+---
+
+## Bug 5: Mobile — Playback Controls Too Wide, Play/Pause Button Cut Off
+
+### Problem
+
+On Mobile browsers, the Playback Controls are too wide for the viewport. The Play/Pause button is partially cut off and not fully visible.
+
+### Root Cause
+
+The main controls row (`PlaybackControls.tsx:112`) uses `flex justify-between gap-4` with three groups of fixed-size buttons:
+
+| Group | Buttons | Size | Total Width |
+|-------|---------|------|-------------|
+| Song nav | 2× SkipBack/SkipForward + counter | `size-12` (48px) × 2 + `min-w-[3rem]` (48px) | ~160px |
+| Playback | 2× Skip + 1× Play/Pause | `size-14` (56px) × 2 + `size-16` (64px) | ~188px |
+| Volume | 1× Mute button | `size-10` (40px) | ~40px |
+
+**Total minimum:** ~160 + ~188 + ~40 + 2× `gap-4` (32px) = **~420px**
+
+On a 375px iPhone viewport, this overflows by ~45px. The Play/Pause button (`size-16` = 64px) is the largest single element and gets cut off.
+
+### Proposed Fix
+
+Make the layout responsive using Tailwind's `sm:` breakpoint (640px). On mobile (below `sm:`), use smaller buttons, tighter gaps, and **remove the mute button entirely** (hardware volume buttons make it unnecessary on mobile).
+
+**File:** `webapp/src/components/play/PlaybackControls.tsx`
+
+#### Fix 5a: Reduce button sizes on mobile
+
+**Song navigation (lines 114-138):**
+
+**Current:**
+```tsx
+<div className="flex items-center gap-2">
+  <Button
+    variant="ghost"
+    size="icon"
+    className="size-12 text-white hover:bg-white/20"
+    onClick={onPrevSong}
+    disabled={currentSongIndex <= 0}
+    aria-label="Previous song"
+  >
+    <SkipBack className="size-6" />
+  </Button>
+  <span className="text-sm text-white/70 min-w-[3rem] text-center">
+    {currentSongIndex + 1}/{totalSongs}
+  </span>
+  <Button
+    variant="ghost"
+    size="icon"
+    className="size-12 text-white hover:bg-white/20"
+    onClick={onNextSong}
+    disabled={currentSongIndex >= totalSongs - 1}
+    aria-label="Next song"
+  >
+    <SkipForward className="size-6" />
+  </Button>
+</div>
+```
+
+**Proposed:**
+```tsx
+<div className="flex items-center gap-1 sm:gap-2">
+  <Button
+    variant="ghost"
+    size="icon"
+    className="size-10 sm:size-12 text-white hover:bg-white/20"
+    onClick={onPrevSong}
+    disabled={currentSongIndex <= 0}
+    aria-label="Previous song"
+  >
+    <SkipBack className="size-5 sm:size-6" />
+  </Button>
+  <span className="text-xs sm:text-sm text-white/70 min-w-[2.5rem] sm:min-w-[3rem] text-center">
+    {currentSongIndex + 1}/{totalSongs}
+  </span>
+  <Button
+    variant="ghost"
+    size="icon"
+    className="size-10 sm:size-12 text-white hover:bg-white/20"
+    onClick={onNextSong}
+    disabled={currentSongIndex >= totalSongs - 1}
+    aria-label="Next song"
+  >
+    <SkipForward className="size-5 sm:size-6" />
+  </Button>
+</div>
+```
+
+#### Fix 5b: Reduce playback button sizes on mobile (with 48px minimum touch target)
+
+**Playback controls (lines 141-185):**
+
+**Current:**
+```tsx
+<div className="flex items-center gap-2">
+  <Button
+    variant="ghost"
+    size="icon"
+    className="size-14 text-white hover:bg-white/20"
+    onClick={onSkipBack}
+    aria-label="Skip back 10 seconds"
+  >
+    <div className="relative">
+      <SkipBack className="size-6" />
+      <span className="absolute -bottom-1 left-1/2 -translate-x-1/2 text-[8px] font-bold">
+        10
+      </span>
+    </div>
+  </Button>
+
+  <Button
+    variant="default"
+    size="icon"
+    className="size-16 rounded-full bg-white text-black hover:bg-white/90"
+    onClick={onPlayPause}
+    aria-label={isPlaying ? "Pause" : "Play"}
+  >
+    {isPlaying ? (
+      <Pause className="size-8" />
+    ) : (
+      <Play className="size-8 ml-1" />
+    )}
+  </Button>
+
+  <Button
+    variant="ghost"
+    size="icon"
+    className="size-14 text-white hover:bg-white/20"
+    onClick={onSkipForward}
+    aria-label="Skip forward 10 seconds"
+  >
+    <div className="relative">
+      <SkipForward className="size-6" />
+      <span className="absolute -bottom-1 left-1/2 -translate-x-1/2 text-[8px] font-bold">
+        10
+      </span>
+    </div>
+  </Button>
+</div>
+```
+
+**Proposed:**
+```tsx
+<div className="flex items-center gap-1 sm:gap-2">
+  <Button
+    variant="ghost"
+    size="icon"
+    className="size-12 sm:size-14 text-white hover:bg-white/20"
+    onClick={onSkipBack}
+    aria-label="Skip back 10 seconds"
+  >
+    <div className="relative">
+      <SkipBack className="size-5 sm:size-6" />
+      <span className="absolute -bottom-1 left-1/2 -translate-x-1/2 text-[7px] sm:text-[8px] font-bold">
+        10
+      </span>
+    </div>
+  </Button>
+
+  <Button
+    variant="default"
+    size="icon"
+    className="size-12 sm:size-16 rounded-full bg-white text-black hover:bg-white/90"
+    onClick={onPlayPause}
+    aria-label={isPlaying ? "Pause" : "Play"}
+  >
+    {isPlaying ? (
+      <Pause className="size-6 sm:size-8" />
+    ) : (
+      <Play className="size-6 sm:size-8 ml-1" />
+    )}
+  </Button>
+
+  <Button
+    variant="ghost"
+    size="icon"
+    className="size-12 sm:size-14 text-white hover:bg-white/20"
+    onClick={onSkipForward}
+    aria-label="Skip forward 10 seconds"
+  >
+    <div className="relative">
+      <SkipForward className="size-5 sm:size-6" />
+      <span className="absolute -bottom-1 left-1/2 -translate-x-1/2 text-[7px] sm:text-[8px] font-bold">
+        10
+      </span>
+    </div>
+  </Button>
+</div>
+```
+
+**Note:** Skip buttons are `size-12` (48px) on mobile, meeting Material Design's minimum touch target. This is larger than v2's `size-10` (40px) which was below the recommended minimum.
+
+#### Fix 5c: Remove mute button on mobile, keep on desktop
+
+**Volume controls (lines 188-224):**
+
+**Current:**
+```tsx
+<div className="flex items-center gap-2">
+  <Button
+    variant="ghost"
+    size="icon"
+    className="size-10 text-white hover:bg-white/20"
+    onClick={onToggleMute}
+    aria-label={isMuted ? "Unmute" : "Mute"}
+  >
+    {isMuted || volume === 0 ? (
+      <VolumeX className="size-5" />
+    ) : (
+      <Volume2 className="size-5" />
+    )}
+  </Button>
+
+  {/* Volume slider */}
+  <div className="w-20 hidden sm:block">
+    <input
+      type="range"
+      min={0}
+      max={1}
+      step={0.01}
+      value={isMuted ? 0 : volume}
+      onChange={(e) => onVolumeChange(parseFloat(e.target.value))}
+      className="w-full h-1 bg-white/30 rounded-full appearance-none cursor-pointer [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-3 [&::-webkit-slider-thumb]:h-3 [&::-webkit-slider-thumb]:bg-white [&::-webkit-slider-thumb]:rounded-full"
+      aria-label="Volume"
+    />
+  </div>
+
+  {/* Presentation status indicator */}
+  {isPresentationActive && (
+    <div className="flex items-center gap-1 px-2 py-1 bg-green-500/20 text-green-400 rounded-full text-xs">
+      <Monitor className="size-3" />
+      <span className="hidden sm:inline">Connected</span>
+    </div>
+  )}
+</div>
+```
+
+**Proposed:**
+```tsx
+<div className="flex items-center gap-1 sm:gap-2">
+  <Button
+    variant="ghost"
+    size="icon"
+    className="hidden sm:flex size-10 text-white hover:bg-white/20"
+    onClick={onToggleMute}
+    aria-label={isMuted ? "Unmute" : "Mute"}
+  >
+    {isMuted || volume === 0 ? (
+      <VolumeX className="size-5" />
+    ) : (
+      <Volume2 className="size-5" />
+    )}
+  </Button>
+
+  {/* Volume slider */}
+  <div className="w-20 hidden sm:block">
+    <input
+      type="range"
+      min={0}
+      max={1}
+      step={0.01}
+      value={isMuted ? 0 : volume}
+      onChange={(e) => onVolumeChange(parseFloat(e.target.value))}
+      className="w-full h-1 bg-white/30 rounded-full appearance-none cursor-pointer [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-3 [&::-webkit-slider-thumb]:h-3 [&::-webkit-slider-thumb]:bg-white [&::-webkit-slider-thumb]:rounded-full"
+      aria-label="Volume"
+    />
+  </div>
+
+  {/* Presentation status indicator */}
+  {isPresentationActive && (
+    <div className="flex items-center gap-1 px-2 py-1 bg-green-500/20 text-green-400 rounded-full text-xs">
+      <Monitor className="size-3" />
+      <span className="hidden sm:inline">Connected</span>
+    </div>
+  )}
+</div>
+```
+
+**Rationale:** On mobile, hardware volume buttons control system audio — there is no use case for a mute toggle. Hiding the mute button on mobile (`hidden sm:flex`) saves ~40px of width. The volume slider was already hidden on mobile (`hidden sm:block`), so this makes the mute button consistent with the slider.
+
+#### Fix 5d: Reduce main container gap on mobile
+
+**Location:** Line 112
+
+**Current:**
+```tsx
+<div className="flex items-center justify-between gap-4">
+```
+
+**Proposed:**
+```tsx
+<div className="flex items-center justify-between gap-1 sm:gap-4">
+```
+
+### Width Calculation After Fix
+
+| Group | Mobile Size | Desktop Size |
+|-------|-------------|--------------|
+| Song nav | 2×40 + 40 + gaps = ~128px | 2×48 + 48 + gaps = ~160px |
+| Playback | 2×48 + 48 + gaps = ~152px | 2×56 + 64 + gaps = ~188px |
+| Volume | 0px (hidden) | 40px |
+| Gaps | 2×4 = 8px | 2×16 = 32px |
+| **Total** | **~288px** | **~420px** |
+
+Mobile total (~288px) fits comfortably within 375px viewport with ~87px to spare.
+
+---
+
+## Summary of Changes
+
+| File | Change | Bug(s) Fixed |
+|------|--------|--------------|
+| `LyricJumpList.tsx` | Modify `handleTouchEnd` with 3-branch logic + `lastToggleTimeRef` debounce | 1 |
+| `LyricJumpList.tsx` | Add `isFinite` guard to `formatTime` | 2 |
+| `chapters.ts` | Add `Number.isFinite()` checks in `normalizeChaptersManifest` | 2 (defense-in-depth) |
+| `chapters.ts` | Add `Number.isFinite()` checks in `parseChaptersManifest` | 2 (defense-in-depth) |
+| `ControllerPlayer.tsx` | Add `onMouseMove` to container | 3 |
+| `ControllerPlayer.tsx` | Add `onMouseEnter`/`onMouseLeave` to controls | 3 |
+| `ControllerPlayer.tsx` | Add `pointer-events-none` when hidden | 3 |
+| `ControllerPlayer.tsx` | Use ref for `showControls` in fullscreen effect | 4 |
+| `ControllerPlayer.tsx` | Add `onDoubleClick` preventDefault on video | 4 |
+| `ControllerPlayer.tsx` | Add `isFullscreen` state + "Re-enter Fullscreen" button (outside auto-hiding controls) | 4 |
+| `PlaybackControls.tsx` | Responsive button sizes with `sm:` variants | 5 |
+| `PlaybackControls.tsx` | Skip buttons `size-12` (48px) on mobile for touch target minimum | 5 |
+| `PlaybackControls.tsx` | Hide mute button on mobile (`hidden sm:flex`) | 5 |
+
+---
+
+## Verification
+
+### Bug 1: Lyrics Panel
+
+1. Open Worship screen on Desktop Chrome
+2. Click the "Lyrics" handle bar at the bottom
+3. Confirm the panel slides up fully and lyrics are visible
+4. Click the handle bar again
+5. Confirm the panel slides down and closes
+6. Drag the handle bar upward past 100px
+7. Confirm the panel opens via drag gesture
+8. Drag the handle bar slightly (< 30px) and release
+9. Confirm the panel still toggles (click-like branch fires)
+10. Drag the handle bar 50px and release (without reaching 100px threshold)
+11. Confirm the panel snaps back (intentional drag that didn't commit)
+12. On Mobile: drag ≥ 100px and release
+13. Confirm panel toggles once (no double-toggle from synthetic events)
+
+### Bug 2: Timestamps
+
+1. Open Worship screen on Mobile browser
+2. Open the Lyrics panel
+3. Confirm all timestamps display correctly (e.g., "0:10", "3:00")
+4. Confirm no "nn:nn" or "NaN:NaN" appears
+
+### Bug 3: Controls Visibility
+
+1. Open Worship screen on Desktop Chrome
+2. Start playback
+3. Wait 2+ seconds for controls to auto-hide
+4. Move the mouse (without clicking)
+5. Confirm controls appear without pausing playback
+6. Hover over the controls area
+7. Confirm controls stay visible while hovering
+8. Move mouse away from controls
+9. Confirm controls auto-hide after 2 seconds
+10. While controls are hidden, click in the area where controls would be
+11. Confirm no accidental button clicks occur (pointer-events-none)
+
+### Bug 4: Fullscreen
+
+1. Open Worship screen on Desktop Chrome
+2. Confirm fullscreen is entered automatically
+3. Click the video to pause/play
+4. Confirm fullscreen does NOT flicker or exit
+5. Double-click the video
+6. Confirm fullscreen does NOT exit
+7. Press Escape to exit fullscreen
+8. Confirm a "Re-enter Fullscreen" button appears (even if controls are hidden)
+9. Wait 2+ seconds for controls to auto-hide
+10. Confirm the "Re-enter Fullscreen" button is still visible
+11. Click the "Re-enter Fullscreen" button
+12. Confirm fullscreen is re-entered
+13. Press the Back button
+14. Confirm fullscreen exits and navigation occurs
+
+### Bug 5: Mobile Layout
+
+1. Open Worship screen on Mobile browser (375px viewport)
+2. Confirm all Playback Controls are fully visible
+3. Confirm the Play/Pause button is not cut off
+4. Confirm the mute button is NOT visible on mobile
+5. Confirm all buttons are tappable
+6. Confirm skip buttons are at least 48px (size-12) for touch target
+7. Test on tablet viewport (768px)
+8. Confirm controls use larger sizes appropriate for tablet
+9. Confirm mute button IS visible on tablet/desktop
+
+---
+
+## Out of Scope
+
+- Refactoring `formatTime` into a shared utility (could be future improvement)
+- Using `dvh` units for the lyrics panel `max-h-[60vh]` (minor mobile improvement, not critical)
+- Restructuring the controls layout for landscape mobile orientation
+- Auto-re-request fullscreen on Escape (browsers block non-user-initiated fullscreen requests)

--- a/specs/fix-worship-screen-ux-issues.md
+++ b/specs/fix-worship-screen-ux-issues.md
@@ -1,0 +1,856 @@
+# Fix: Worship Screen UX Issues
+
+> **Status:** Plan only — not yet implemented.
+> **Date:** 2026-05-26
+
+---
+
+## Summary
+
+Five UX bugs on the Worship screen (`/songsets/[id]/play/controller`) affecting both Desktop Chrome and Mobile browsers:
+
+| # | Bug | Platform | Severity |
+|---|-----|----------|----------|
+| 1 | Lyrics slide-up panel only slides up a tiny bit, no lyrics visible | Desktop | High |
+| 2 | Timestamps shown as "nn:nn" (NaN:NaN) | Mobile | High |
+| 3 | Playback Controls only visible on click, which pauses playback | Desktop | High |
+| 4 | Clicking toggles fullscreen unexpectedly | Desktop | Medium |
+| 5 | Playback Controls too wide, Play/Pause button cut off | Mobile | High |
+
+---
+
+## Bug 1: Desktop — Lyrics Panel Only Slides Up a Tiny Bit
+
+### Problem
+
+On Desktop Chrome, clicking the "Lyrics" handle bar at the bottom of the Worship screen causes the panel to slide up only ~10-40px, then immediately snap back down. No lyrics are visible.
+
+### Root Cause
+
+The handle bar (`LyricJumpList.tsx:118-146`) has **no `onClick` handler**. The only toggle mechanisms are:
+
+1. **Drag gesture** with a 100px minimum threshold (`line 68`)
+2. **Keyboard** Enter/Space (`line 130-134`)
+
+On desktop, a mouse click fires `onMouseDown` → `onMouseUp` without meaningful `currentY` accumulation. Since `currentY` stays at 0 and the 100px threshold isn't met, the panel never toggles. A slight mouse jitter during click causes a tiny drag (~10-38px), making the panel shift up briefly then snap back.
+
+**Trace of a desktop click:**
+
+1. `onMouseDown` fires `handleTouchStart` (`line 34-43`): sets `isDragging = true`, `startY = clientY`, `currentY = 0`
+2. `onMouseUp` fires `handleTouchEnd` (`line 63-78`): checks `currentY > threshold` (0 > 100) = **false**; `currentY < -threshold` (0 < -100) = **false** → **NO toggle occurs**
+3. After handler: `isDragging = false`, `currentY = 0`, panel snaps back
+
+### Proposed Fix
+
+**File:** `webapp/src/components/play/LyricJumpList.tsx`
+
+**Location:** Line 118-146 (handle bar `<div>`)
+
+**Current:**
+```tsx
+<div
+  className="flex flex-col items-center justify-center h-12 bg-black/90 backdrop-blur-sm rounded-t-2xl cursor-grab active:cursor-grabbing"
+  onTouchStart={handleTouchStart}
+  onTouchMove={handleTouchMove}
+  onTouchEnd={handleTouchEnd}
+  onMouseDown={handleTouchStart}
+  onMouseMove={handleTouchMove}
+  onMouseUp={handleTouchEnd}
+  onMouseLeave={handleTouchEnd}
+  role="button"
+  tabIndex={0}
+  aria-label={isOpen ? "Close lyric jump list" : "Open lyric jump list"}
+  onKeyDown={(e) => {
+    if (e.key === "Enter" || e.key === " ") {
+      setIsOpen(!isOpen);
+    }
+  }}
+>
+```
+
+**Proposed:**
+```tsx
+<div
+  className="flex flex-col items-center justify-center h-12 bg-black/90 backdrop-blur-sm rounded-t-2xl cursor-grab active:cursor-grabbing"
+  onClick={() => setIsOpen(!isOpen)}
+  onTouchStart={handleTouchStart}
+  onTouchMove={handleTouchMove}
+  onTouchEnd={handleTouchEnd}
+  onMouseDown={handleTouchStart}
+  onMouseMove={handleTouchMove}
+  onMouseUp={handleTouchEnd}
+  onMouseLeave={handleTouchEnd}
+  role="button"
+  tabIndex={0}
+  aria-label={isOpen ? "Close lyric jump list" : "Open lyric jump list"}
+  onKeyDown={(e) => {
+    if (e.key === "Enter" || e.key === " ") {
+      setIsOpen(!isOpen);
+    }
+  }}
+>
+```
+
+**Rationale:** Adding `onClick={() => setIsOpen(!isOpen)}` allows desktop users to click the handle to toggle the panel. The existing drag gesture handlers remain for touch/swipe interactions. The `onClick` fires after `onMouseUp`, so the drag gesture still works — if the user drags past the threshold, `setIsOpen` is called in `handleTouchEnd`, and the subsequent `onClick` toggles it back, but since the state is already correct, it's a no-op. Actually, we should prevent the `onClick` from firing if a drag occurred.
+
+**Refined approach:** Add a `didDrag` ref that tracks if significant drag occurred, and only toggle on `onClick` if `!didDrag`:
+
+```tsx
+const didDragRef = useRef(false);
+
+const handleTouchStart = useCallback(
+  (e: React.TouchEvent | React.MouseEvent) => {
+    e.stopPropagation();
+    const clientY =
+      "touches" in e ? e.touches[0].clientY : (e as React.MouseEvent).clientY;
+    setStartY(clientY);
+    setIsDragging(true);
+    didDragRef.current = false;
+  },
+  []
+);
+
+const handleTouchMove = useCallback(
+  (e: React.TouchEvent | React.MouseEvent) => {
+    if (!isDragging) return;
+    e.stopPropagation();
+
+    const clientY =
+      "touches" in e ? e.touches[0].clientY : (e as React.MouseEvent).clientY;
+    const deltaY = startY - clientY;
+
+    if (Math.abs(deltaY) > 10) {
+      didDragRef.current = true;
+    }
+
+    if (!isOpen && deltaY > 0) {
+      setCurrentY(Math.min(deltaY, 300));
+    } else if (isOpen && deltaY < 0) {
+      setCurrentY(Math.max(deltaY, -300));
+    }
+  },
+  [isDragging, startY, isOpen]
+);
+
+// In handle bar div:
+onClick={() => {
+  if (!didDragRef.current) {
+    setIsOpen(!isOpen);
+  }
+}}
+```
+
+This ensures:
+- Simple click → `didDragRef.current` stays `false` → toggle occurs
+- Drag gesture → `didDragRef.current` becomes `true` → `onClick` does nothing, `handleTouchEnd` handles the toggle
+
+---
+
+## Bug 2: Mobile — Timestamps Shown as "nn:nn"
+
+### Problem
+
+On Mobile browsers, lyrics timestamps display as "nn:nn" (actually "NaN:NaN") or are missing entirely.
+
+### Root Cause
+
+The `formatTime` function in `LyricJumpList.tsx:81-85` lacks input validation that exists in every other `formatTime` in the codebase:
+
+```tsx
+// LyricJumpList.tsx (BUGGY — no guard)
+const formatTime = (seconds: number): string => {
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60);
+  return `${mins}:${secs.toString().padStart(2, "0")}`;
+};
+```
+
+When `seconds` is `NaN` or `undefined`, `Math.floor(NaN/60)` → `NaN`, producing `"NaN:NaN"`.
+
+**Contrast with correct implementations:**
+
+```tsx
+// PlaybackControls.tsx:54-58 (CORRECT — has guard)
+const formatTime = (seconds: number): string => {
+  if (!isFinite(seconds) || seconds < 0) return "0:00";
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60);
+  return `${mins}:${secs.toString().padStart(2, "0")}`;
+};
+```
+
+**How NaN enters the data:**
+
+The `normalizeChaptersManifest` function (`chapters.ts:335`) checks `typeof lineStartSeconds === "number"`, but `typeof NaN === "number"` is `true`, so NaN values pass validation. This can happen if the JSON data contains `null` values that get cast to `NaN` via `as number`.
+
+### Proposed Fix
+
+#### Fix 2a: Add guard to `formatTime` in LyricJumpList
+
+**File:** `webapp/src/components/play/LyricJumpList.tsx`
+
+**Location:** Lines 81-85
+
+**Current:**
+```tsx
+const formatTime = (seconds: number): string => {
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60);
+  return `${mins}:${secs.toString().padStart(2, "0")}`;
+};
+```
+
+**Proposed:**
+```tsx
+const formatTime = (seconds: number): string => {
+  if (!isFinite(seconds) || seconds < 0) return "0:00";
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60);
+  return `${mins}:${secs.toString().padStart(2, "0")}`;
+};
+```
+
+#### Fix 2b: Harden `normalizeChaptersManifest` (defense-in-depth)
+
+**File:** `webapp/src/lib/render/chapters.ts`
+
+**Location:** Lines 314-318 (chapter start/end validation) and 335-338 (line startSeconds validation)
+
+**Current (line 314-318):**
+```tsx
+if (typeof startSeconds !== "number" || typeof endSeconds !== "number") {
+  throw new Error(
+    `Invalid chapter at index ${index}: missing or invalid startSeconds/endSeconds`
+  );
+}
+```
+
+**Proposed:**
+```tsx
+if (
+  typeof startSeconds !== "number" ||
+  typeof endSeconds !== "number" ||
+  !Number.isFinite(startSeconds) ||
+  !Number.isFinite(endSeconds)
+) {
+  throw new Error(
+    `Invalid chapter at index ${index}: missing or invalid startSeconds/endSeconds`
+  );
+}
+```
+
+**Current (line 335-338):**
+```tsx
+if (typeof text !== "string" || typeof lineStartSeconds !== "number") {
+  throw new Error(
+    `Invalid line at index ${lineIndex} in chapter ${index}: missing text or startSeconds`
+  );
+}
+```
+
+**Proposed:**
+```tsx
+if (
+  typeof text !== "string" ||
+  typeof lineStartSeconds !== "number" ||
+  !Number.isFinite(lineStartSeconds)
+) {
+  throw new Error(
+    `Invalid line at index ${lineIndex} in chapter ${index}: missing text or startSeconds`
+  );
+}
+```
+
+**Rationale:** Adding `Number.isFinite()` rejects `NaN` and `Infinity` values at the data normalization layer, preventing them from reaching the UI. This is defense-in-depth; the `formatTime` guard handles any edge cases that slip through.
+
+---
+
+## Bug 3: Desktop — Playback Controls Only Visible on Click (Which Pauses)
+
+### Problem
+
+On Desktop Chrome, the Playback Controls auto-hide after 2 seconds of playing. To reveal them, the user must click somewhere. However, clicking the video (the largest clickable area) toggles play/pause, which is not what the user wants — they just want to see the controls to scrub to a new position.
+
+### Root Cause
+
+Controls visibility is driven only by `onClick` and `onTouchStart` on the outer container (`ControllerPlayer.tsx:368-369`). There is **no `onMouseMove` handler**. On desktop, the standard video player pattern is: mouse movement reveals controls, click on video toggles play/pause.
+
+**Current flow on desktop:**
+
+1. Controls auto-hide after 2s of playing (`line 121-125`)
+2. User moves mouse → **nothing happens** (no `onMouseMove` handler)
+3. User clicks video → `handlePlayPause()` fires → **playback pauses** (`line 379-382`)
+4. User clicks background → `handleInteraction()` → controls appear, but background click area is tiny
+
+### Proposed Fix
+
+#### Fix 3a: Add `onMouseMove` to reveal controls
+
+**File:** `webapp/src/components/play/ControllerPlayer.tsx`
+
+**Location:** Lines 363-370 (outer container `<div>`)
+
+**Current:**
+```tsx
+<div
+  className={cn(
+    "fixed inset-0 z-[70] bg-black flex flex-col",
+    className
+  )}
+  onClick={handleInteraction}
+  onTouchStart={handleInteraction}
+>
+```
+
+**Proposed:**
+```tsx
+<div
+  className={cn(
+    "fixed inset-0 z-[70] bg-black flex flex-col",
+    className
+  )}
+  onClick={handleInteraction}
+  onTouchStart={handleInteraction}
+  onMouseMove={handleInteraction}
+>
+```
+
+**Rationale:** Adding `onMouseMove` allows desktop users to reveal controls by simply moving the mouse, without clicking. The existing `onClick` on the video for play/pause remains standard behavior.
+
+#### Fix 3b: Keep controls visible while hovering over them
+
+**File:** `webapp/src/components/play/ControllerPlayer.tsx`
+
+**Location:** Lines 466-471 (controls container `<div>`)
+
+**Current:**
+```tsx
+<div
+  ref={controlsRef}
+  className={cn(
+    "transition-opacity duration-300 pb-12",
+    controlsVisible || isPresentationActive ? "opacity-100" : "opacity-0"
+  )}
+>
+```
+
+**Proposed:**
+```tsx
+<div
+  ref={controlsRef}
+  className={cn(
+    "transition-opacity duration-300 pb-12",
+    controlsVisible || isPresentationActive ? "opacity-100" : "opacity-0"
+  )}
+  onMouseEnter={() => {
+    if (hideTimeoutRef.current) {
+      clearTimeout(hideTimeoutRef.current);
+    }
+  }}
+  onMouseLeave={startHideTimer}
+>
+```
+
+**Rationale:** When the mouse enters the controls area, cancel the auto-hide timer so controls stay visible while the user is interacting with them. When the mouse leaves, restart the timer.
+
+#### Fix 3c: Add `pointer-events-none` when controls are hidden
+
+**File:** `webapp/src/components/play/ControllerPlayer.tsx`
+
+**Location:** Lines 466-471 (controls container `<div>`)
+
+**Proposed (add to className):**
+```tsx
+className={cn(
+  "transition-opacity duration-300 pb-12",
+  controlsVisible || isPresentationActive
+    ? "opacity-100"
+    : "opacity-0 pointer-events-none",
+  className
+)}
+```
+
+**Rationale:** When controls are hidden (`opacity-0`), they should not intercept mouse events. This prevents accidental clicks on invisible buttons.
+
+---
+
+## Bug 4: Desktop — Clicking Toggles Fullscreen Unexpectedly
+
+### Problem
+
+On Desktop Chrome, clicking somewhere causes fullscreen to exit and re-enter, creating a visible flicker. This is annoying and disorienting.
+
+### Root Cause
+
+The fullscreen `useEffect` depends on `[showControls]` (`line 346`). The callback chain is:
+
+```
+startHideTimer → depends on [isPresentationActive, isPlaying] (line 126)
+showControls → depends on [startHideTimer] (line 131)
+handleInteraction → depends on [showControls] (line 136)
+```
+
+So every time `isPlaying` changes (e.g., user clicks video → play/pause toggles), `showControls` gets a new reference, the fullscreen effect's cleanup runs `document.exitFullscreen()`, then the effect re-runs and calls `requestFullscreen()` — causing a fullscreen flicker on every play/pause.
+
+**Additionally:** Chrome natively toggles fullscreen on **double-click** on `<video>` elements, which would exit fullscreen even after we fix the dependency issue.
+
+### Proposed Fix
+
+#### Fix 4a: Use a ref for `showControls` in fullscreen effect
+
+**File:** `webapp/src/components/play/ControllerPlayer.tsx`
+
+**Location:** Lines 318-346 (fullscreen `useEffect`)
+
+**Current:**
+```tsx
+// Request fullscreen on mount
+useEffect(() => {
+  const requestFullscreen = async () => {
+    try {
+      if (document.documentElement.requestFullscreen) {
+        await document.documentElement.requestFullscreen();
+      }
+    } catch {
+      // Fullscreen not supported or blocked
+    }
+  };
+
+  requestFullscreen();
+
+  const handleFullscreenChange = () => {
+    if (!document.fullscreenElement) {
+      showControls();
+    }
+  };
+
+  document.addEventListener("fullscreenchange", handleFullscreenChange);
+
+  return () => {
+    document.removeEventListener("fullscreenchange", handleFullscreenChange);
+    if (document.fullscreenElement) {
+      document.exitFullscreen().catch(() => {});
+    }
+  };
+}, [showControls]);
+```
+
+**Proposed:**
+```tsx
+// Ref to access showControls without triggering re-runs
+const showControlsRef = useRef(showControls);
+showControlsRef.current = showControls;
+
+// Request fullscreen on mount
+useEffect(() => {
+  const requestFullscreen = async () => {
+    try {
+      if (document.documentElement.requestFullscreen) {
+        await document.documentElement.requestFullscreen();
+      }
+    } catch {
+      // Fullscreen not supported or blocked
+    }
+  };
+
+  requestFullscreen();
+
+  const handleFullscreenChange = () => {
+    if (!document.fullscreenElement) {
+      showControlsRef.current();
+    }
+  };
+
+  document.addEventListener("fullscreenchange", handleFullscreenChange);
+
+  return () => {
+    document.removeEventListener("fullscreenchange", handleFullscreenChange);
+    if (document.fullscreenElement) {
+      document.exitFullscreen().catch(() => {});
+    }
+  };
+}, []); // Empty dependency array — only run on mount/unmount
+```
+
+**Rationale:** Using a ref for `showControls` allows the `handleFullscreenChange` callback to access the latest `showControls` function without causing the effect to re-run. The effect now only runs on mount (enter fullscreen) and unmount (exit fullscreen).
+
+#### Fix 4b: Prevent Chrome's native double-click-to-fullscreen on video
+
+**File:** `webapp/src/components/play/ControllerPlayer.tsx`
+
+**Location:** Lines 373-383 (`<video>` element)
+
+**Current:**
+```tsx
+<video
+  ref={videoRef}
+  src={videoSrc}
+  className="w-full h-full object-contain"
+  playsInline
+  muted={isPresentationActive}
+  onClick={(e) => {
+    e.stopPropagation();
+    handlePlayPause();
+  }}
+/>
+```
+
+**Proposed:**
+```tsx
+<video
+  ref={videoRef}
+  src={videoSrc}
+  className="w-full h-full object-contain"
+  playsInline
+  muted={isPresentationActive}
+  onClick={(e) => {
+    e.stopPropagation();
+    handlePlayPause();
+  }}
+  onDoubleClick={(e) => {
+    e.preventDefault();
+  }}
+/>
+```
+
+**Rationale:** Preventing the default behavior on double-click stops Chrome from toggling fullscreen when the user double-clicks the video. The Worship screen should always be in fullscreen mode; users can exit by pressing the Back button.
+
+---
+
+## Bug 5: Mobile — Playback Controls Too Wide, Play/Pause Button Cut Off
+
+### Problem
+
+On Mobile browsers, the Playback Controls are too wide for the viewport. The Play/Pause button is partially cut off and not fully visible.
+
+### Root Cause
+
+The main controls row (`PlaybackControls.tsx:112`) uses `flex justify-between gap-4` with three groups of fixed-size buttons:
+
+| Group | Buttons | Size | Total Width |
+|-------|---------|------|-------------|
+| Song nav | 2× SkipBack/SkipForward + counter | `size-12` (48px) × 2 + `min-w-[3rem]` (48px) | ~160px |
+| Playback | 2× Skip + 1× Play/Pause | `size-14` (56px) × 2 + `size-16` (64px) | ~188px |
+| Volume | 1× Mute button | `size-10` (40px) | ~40px |
+
+**Total minimum:** ~160 + ~188 + ~40 + 2× `gap-4` (32px) = **~420px**
+
+On a 375px iPhone viewport, this overflows by ~45px. The Play/Pause button (`size-16` = 64px) is the largest single element and gets cut off.
+
+### Proposed Fix
+
+Make the layout responsive using Tailwind's `sm:` breakpoint (640px). On mobile (below `sm:`), use smaller buttons and tighter gaps.
+
+**File:** `webapp/src/components/play/PlaybackControls.tsx`
+
+**Location:** Lines 112-225 (main controls)
+
+#### Fix 5a: Reduce button sizes on mobile
+
+**Song navigation (lines 114-138):**
+
+**Current:**
+```tsx
+<div className="flex items-center gap-2">
+  <Button
+    variant="ghost"
+    size="icon"
+    className="size-12 text-white hover:bg-white/20"
+    onClick={onPrevSong}
+    disabled={currentSongIndex <= 0}
+    aria-label="Previous song"
+  >
+    <SkipBack className="size-6" />
+  </Button>
+  <span className="text-sm text-white/70 min-w-[3rem] text-center">
+    {currentSongIndex + 1}/{totalSongs}
+  </span>
+  <Button
+    variant="ghost"
+    size="icon"
+    className="size-12 text-white hover:bg-white/20"
+    onClick={onNextSong}
+    disabled={currentSongIndex >= totalSongs - 1}
+    aria-label="Next song"
+  >
+    <SkipForward className="size-6" />
+  </Button>
+</div>
+```
+
+**Proposed:**
+```tsx
+<div className="flex items-center gap-1 sm:gap-2">
+  <Button
+    variant="ghost"
+    size="icon"
+    className="size-10 sm:size-12 text-white hover:bg-white/20"
+    onClick={onPrevSong}
+    disabled={currentSongIndex <= 0}
+    aria-label="Previous song"
+  >
+    <SkipBack className="size-5 sm:size-6" />
+  </Button>
+  <span className="text-xs sm:text-sm text-white/70 min-w-[2.5rem] sm:min-w-[3rem] text-center">
+    {currentSongIndex + 1}/{totalSongs}
+  </span>
+  <Button
+    variant="ghost"
+    size="icon"
+    className="size-10 sm:size-12 text-white hover:bg-white/20"
+    onClick={onNextSong}
+    disabled={currentSongIndex >= totalSongs - 1}
+    aria-label="Next song"
+  >
+    <SkipForward className="size-5 sm:size-6" />
+  </Button>
+</div>
+```
+
+#### Fix 5b: Reduce playback button sizes on mobile
+
+**Playback controls (lines 140-185):**
+
+**Current:**
+```tsx
+<div className="flex items-center gap-2">
+  <Button
+    variant="ghost"
+    size="icon"
+    className="size-14 text-white hover:bg-white/20"
+    onClick={onSkipBack}
+    aria-label="Skip back 10 seconds"
+  >
+    <div className="relative">
+      <SkipBack className="size-6" />
+      <span className="absolute -bottom-1 left-1/2 -translate-x-1/2 text-[8px] font-bold">
+        10
+      </span>
+    </div>
+  </Button>
+
+  <Button
+    variant="default"
+    size="icon"
+    className="size-16 rounded-full bg-white text-black hover:bg-white/90"
+    onClick={onPlayPause}
+    aria-label={isPlaying ? "Pause" : "Play"}
+  >
+    {isPlaying ? (
+      <Pause className="size-8" />
+    ) : (
+      <Play className="size-8 ml-1" />
+    )}
+  </Button>
+
+  <Button
+    variant="ghost"
+    size="icon"
+    className="size-14 text-white hover:bg-white/20"
+    onClick={onSkipForward}
+    aria-label="Skip forward 10 seconds"
+  >
+    <div className="relative">
+      <SkipForward className="size-6" />
+      <span className="absolute -bottom-1 left-1/2 -translate-x-1/2 text-[8px] font-bold">
+        10
+      </span>
+    </div>
+  </Button>
+</div>
+```
+
+**Proposed:**
+```tsx
+<div className="flex items-center gap-1 sm:gap-2">
+  <Button
+    variant="ghost"
+    size="icon"
+    className="size-10 sm:size-14 text-white hover:bg-white/20"
+    onClick={onSkipBack}
+    aria-label="Skip back 10 seconds"
+  >
+    <div className="relative">
+      <SkipBack className="size-5 sm:size-6" />
+      <span className="absolute -bottom-1 left-1/2 -translate-x-1/2 text-[7px] sm:text-[8px] font-bold">
+        10
+      </span>
+    </div>
+  </Button>
+
+  <Button
+    variant="default"
+    size="icon"
+    className="size-12 sm:size-16 rounded-full bg-white text-black hover:bg-white/90"
+    onClick={onPlayPause}
+    aria-label={isPlaying ? "Pause" : "Play"}
+  >
+    {isPlaying ? (
+      <Pause className="size-6 sm:size-8" />
+    ) : (
+      <Play className="size-6 sm:size-8 ml-1" />
+    )}
+  </Button>
+
+  <Button
+    variant="ghost"
+    size="icon"
+    className="size-10 sm:size-14 text-white hover:bg-white/20"
+    onClick={onSkipForward}
+    aria-label="Skip forward 10 seconds"
+  >
+    <div className="relative">
+      <SkipForward className="size-5 sm:size-6" />
+      <span className="absolute -bottom-1 left-1/2 -translate-x-1/2 text-[7px] sm:text-[8px] font-bold">
+        10
+      </span>
+    </div>
+  </Button>
+</div>
+```
+
+#### Fix 5c: Reduce volume button size on mobile
+
+**Volume controls (lines 187-224):**
+
+**Current:**
+```tsx
+<div className="flex items-center gap-2">
+  <Button
+    variant="ghost"
+    size="icon"
+    className="size-10 text-white hover:bg-white/20"
+    onClick={onToggleMute}
+    aria-label={isMuted ? "Unmute" : "Mute"}
+  >
+    {isMuted || volume === 0 ? (
+      <VolumeX className="size-5" />
+    ) : (
+      <Volume2 className="size-5" />
+    )}
+  </Button>
+  {/* ... volume slider ... */}
+</div>
+```
+
+**Proposed:**
+```tsx
+<div className="flex items-center gap-1 sm:gap-2">
+  <Button
+    variant="ghost"
+    size="icon"
+    className="size-8 sm:size-10 text-white hover:bg-white/20"
+    onClick={onToggleMute}
+    aria-label={isMuted ? "Unmute" : "Mute"}
+  >
+    {isMuted || volume === 0 ? (
+      <VolumeX className="size-4 sm:size-5" />
+    ) : (
+      <Volume2 className="size-4 sm:size-5" />
+    )}
+  </Button>
+  {/* ... volume slider (already hidden on mobile via hidden sm:block) ... */}
+</div>
+```
+
+#### Fix 5d: Reduce main container gap on mobile
+
+**Location:** Line 112
+
+**Current:**
+```tsx
+<div className="flex items-center justify-between gap-4">
+```
+
+**Proposed:**
+```tsx
+<div className="flex items-center justify-between gap-1 sm:gap-4">
+```
+
+### Width Calculation After Fix
+
+| Group | Mobile Size | Desktop Size |
+|-------|-------------|--------------|
+| Song nav | 2×40 + 40 + gaps = ~130px | 2×48 + 48 + gaps = ~160px |
+| Playback | 2×40 + 48 + gaps = ~140px | 2×56 + 64 + gaps = ~188px |
+| Volume | 32px | 40px |
+| Gaps | 2×4 = 8px | 2×16 = 32px |
+| **Total** | **~310px** | **~420px** |
+
+Mobile total (~310px) fits comfortably within 375px viewport.
+
+---
+
+## Summary of Changes
+
+| File | Change | Bug(s) Fixed |
+|------|--------|--------------|
+| `LyricJumpList.tsx` | Add `onClick` toggle + `didDragRef` | 1 |
+| `LyricJumpList.tsx` | Add `isFinite` guard to `formatTime` | 2 |
+| `chapters.ts` | Add `Number.isFinite()` checks | 2 (defense-in-depth) |
+| `ControllerPlayer.tsx` | Add `onMouseMove` to container | 3 |
+| `ControllerPlayer.tsx` | Add `onMouseEnter`/`onMouseLeave` to controls | 3 |
+| `ControllerPlayer.tsx` | Add `pointer-events-none` when hidden | 3 |
+| `ControllerPlayer.tsx` | Use ref for `showControls` in fullscreen effect | 4 |
+| `ControllerPlayer.tsx` | Add `onDoubleClick` preventDefault on video | 4 |
+| `PlaybackControls.tsx` | Responsive button sizes with `sm:` variants | 5 |
+
+---
+
+## Verification
+
+### Bug 1: Lyrics Panel
+
+1. Open Worship screen on Desktop Chrome
+2. Click the "Lyrics" handle bar at the bottom
+3. Confirm the panel slides up fully and lyrics are visible
+4. Click the handle bar again
+5. Confirm the panel slides down and closes
+
+### Bug 2: Timestamps
+
+1. Open Worship screen on Mobile browser
+2. Open the Lyrics panel
+3. Confirm all timestamps display correctly (e.g., "0:10", "3:00")
+4. Confirm no "nn:nn" or "NaN:NaN" appears
+
+### Bug 3: Controls Visibility
+
+1. Open Worship screen on Desktop Chrome
+2. Start playback
+3. Wait 2+ seconds for controls to auto-hide
+4. Move the mouse (without clicking)
+5. Confirm controls appear without pausing playback
+6. Hover over the controls area
+7. Confirm controls stay visible while hovering
+8. Move mouse away from controls
+9. Confirm controls auto-hide after 2 seconds
+
+### Bug 4: Fullscreen
+
+1. Open Worship screen on Desktop Chrome
+2. Confirm fullscreen is entered automatically
+3. Click the video to pause/play
+4. Confirm fullscreen does NOT flicker or exit
+5. Double-click the video
+6. Confirm fullscreen does NOT exit
+7. Press the Back button
+8. Confirm fullscreen exits and navigation occurs
+
+### Bug 5: Mobile Layout
+
+1. Open Worship screen on Mobile browser (375px viewport)
+2. Confirm all Playback Controls are fully visible
+3. Confirm the Play/Pause button is not cut off
+4. Confirm all buttons are tappable
+5. Test on tablet viewport (768px)
+6. Confirm controls use larger sizes appropriate for tablet
+
+---
+
+## Out of Scope
+
+- Refactoring `formatTime` into a shared utility (could be future improvement)
+- Adding a dedicated fullscreen toggle button (user wants always-fullscreen behavior)
+- Using `dvh` units for the lyrics panel `max-h-[60vh]` (minor mobile improvement, not critical)
+- Restructuring the controls layout for landscape mobile orientation

--- a/specs/r2-download-proxy.md
+++ b/specs/r2-download-proxy.md
@@ -1,0 +1,362 @@
+# R2 Download Proxy API Route
+
+## Problem
+
+The "Download for offline" button in `OfflineStatus.tsx` fails because:
+
+1. **CORS**: The browser's `fetch()` to R2 signed URLs (`*.r2.cloudflarestorage.com`) is blocked by CORS — R2 doesn't return `Access-Control-Allow-Origin` headers for cross-origin requests.
+2. **Stale cache entries**: Previous buggy code stored entries with relative URL keys (e.g., `http://localhost:8080/songsets/.../renders/.../output.mp3`) that are orphaned in the `"sow-artifacts"` cache.
+3. **Dual cache key schemes**: `OfflineStatus.tsx` uses raw R2 keys while `artifact-cache.ts` uses synthetic keys (`/sow-artifact-cache/{jobId}/{type}`), both writing to the same cache.
+
+## Solution: Server-side proxy route
+
+Add a Next.js API route that streams R2 content through the app's own origin, eliminating CORS. The browser fetches from same-origin `/api/r2/artifact/...` instead of directly from R2.
+
+## Files to Create/Modify
+
+| # | File | Action | Purpose |
+|---|------|--------|---------|
+| 1 | `webapp/src/app/api/r2/artifact/[...path]/route.ts` | **Create** | Proxy route: streams R2 object to client |
+| 2 | `webapp/src/components/play/OfflineStatus.tsx` | **Modify** | Use proxy URLs instead of signed URLs for caching |
+| 3 | `webapp/src/lib/offline/artifact-cache.ts` | **Modify** | Use proxy URLs as fetch source; unify cache key scheme |
+| 4 | `webapp/src/app/songsets/[id]/play/controller/page.tsx` | **Modify** | Use proxy URL for chapters JSON fetch |
+| 5 | `webapp/src/lib/download.ts` | **Modify** | Use proxy URL for file downloads |
+| 6 | `webapp/public/sw.js` | **Modify** | Add NetworkOnly rule for `/api/r2/` |
+| 7 | `webapp/src/app/api/offline/cache/route.ts` | **Modify** | Return proxy URLs instead of signed R2 URLs |
+
+## Step 1: Create proxy route
+
+**File:** `webapp/src/app/api/r2/artifact/[...path]/route.ts`
+
+**Endpoint:** `GET /api/r2/artifact/{renderJobId}/{filename}`
+
+Examples:
+- `/api/r2/artifact/Rlw5W9GMBjQ6fQ8QY5C-x/output.mp3`
+- `/api/r2/artifact/Rlw5W9GMBjQ6fQ8QY5C-x/output.mp4`
+- `/api/r2/artifact/Rlw5W9GMBjQ6fQ8QY5C-x/chapters.json`
+
+**Logic:**
+
+1. Auth check via `auth.api.getSession()`
+2. Parse `renderJobId` and `filename` from the catch-all `[...path]` segments
+3. Validate `filename` is one of: `output.mp3`, `output.mp4`, `chapters.json`
+4. DB lookup: verify the render job exists and belongs to the authenticated user (`renderJobs.userId`)
+5. Verify render job status is `completed`
+6. Construct the R2 key: `renders/{renderJobId}/{filename}`
+7. Generate a short-lived signed URL (60s expiry — only used server-side)
+8. Fetch the object from R2 via the signed URL
+9. Stream the response to the client with proper headers:
+   - `Content-Type`: derived from filename (audio/mpeg, video/mp4, application/json)
+   - `Content-Length`: from R2 response
+   - `Accept-Ranges: bytes`: for video seeking
+   - `Cache-Control: private, max-age=3600`
+   - If `Range` header present, pass through to R2 and return `206 Partial Content`
+   - If `download=1` query param present, add `Content-Disposition: attachment`
+
+**Range request support** is critical for video playback seeking. The route must:
+- Pass the `Range` header from the client request to the R2 signed URL fetch
+- Return `206 Partial Content` with `Content-Range` header when R2 responds with a partial response
+- Return `200` for full responses
+
+**Streaming:** Use `ReadableStream` to pipe the R2 response body to the client without buffering the entire file in memory. This is important for large video files.
+
+**Pseudocode:**
+
+```typescript
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/db";
+import { renderJobs } from "@/db/schema";
+import { eq, and } from "drizzle-orm";
+import { createR2ClientFromEnv } from "@/lib/r2/client";
+
+const ALLOWED_FILES = ["output.mp3", "output.mp4", "chapters.json"] as const;
+const CONTENT_TYPES: Record<string, string> = {
+  "output.mp3": "audio/mpeg",
+  "output.mp4": "video/mp4",
+  "chapters.json": "application/json",
+};
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> }
+) {
+  // 1. Auth check
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // 2. Parse path segments
+  const { path } = await params;
+  if (path.length !== 2) {
+    return NextResponse.json({ error: "Invalid path" }, { status: 400 });
+  }
+  const [renderJobId, filename] = path;
+
+  // 3. Validate filename
+  if (!ALLOWED_FILES.includes(filename as typeof ALLOWED_FILES[number])) {
+    return NextResponse.json({ error: "Invalid file" }, { status: 400 });
+  }
+
+  // 4. DB lookup: verify ownership
+  const job = await db.query.renderJobs.findFirst({
+    where: and(
+      eq(renderJobs.id, renderJobId),
+      eq(renderJobs.userId, Number(session.user.id))
+    ),
+  });
+  if (!job) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  // 5. Verify completed status
+  if (job.status !== "completed") {
+    return NextResponse.json({ error: "Render not complete" }, { status: 409 });
+  }
+
+  // 6. Construct R2 key
+  const r2Key = `renders/${renderJobId}/${filename}`;
+
+  // 7. Generate short-lived signed URL
+  const r2Client = createR2ClientFromEnv();
+  const { url: signedUrl } = await r2Client.generateSignedUrl(r2Key, "audio", {
+    expiresInSeconds: 60,
+  });
+
+  // 8. Fetch from R2 with range support
+  const rangeHeader = request.headers.get("range");
+  const r2Headers: HeadersInit = {};
+  if (rangeHeader) {
+    r2Headers["Range"] = rangeHeader;
+  }
+
+  const r2Response = await fetch(signedUrl, { headers: r2Headers });
+
+  if (!r2Response.ok && r2Response.status !== 206) {
+    return NextResponse.json({ error: "Failed to fetch from storage" }, { status: 502 });
+  }
+
+  // 9. Build response headers
+  const responseHeaders = new Headers();
+  responseHeaders.set("Content-Type", CONTENT_TYPES[filename]);
+  responseHeaders.set("Accept-Ranges", "bytes");
+  responseHeaders.set("Cache-Control", "private, max-age=3600");
+
+  const contentLength = r2Response.headers.get("content-length");
+  if (contentLength) {
+    responseHeaders.set("Content-Length", contentLength);
+  }
+
+  const contentRange = r2Response.headers.get("content-range");
+  if (contentRange) {
+    responseHeaders.set("Content-Range", contentRange);
+  }
+
+  // Download disposition
+  const searchParams = request.nextUrl.searchParams;
+  if (searchParams.get("download") === "1") {
+    const songsetName = job.songsetName || "worship";
+    const ext = filename.split(".").pop();
+    const safeName = songsetName.toLowerCase().replace(/[^a-z0-9]/g, "-");
+    responseHeaders.set(
+      "Content-Disposition",
+      `attachment; filename="${safeName}.${ext}"`
+    );
+  }
+
+  // 10. Stream response
+  const status = r2Response.status === 206 ? 206 : 200;
+  return new NextResponse(r2Response.body, {
+    status,
+    headers: responseHeaders,
+  });
+}
+```
+
+## Step 2: Update OfflineStatus to use proxy URLs
+
+**File:** `webapp/src/components/play/OfflineStatus.tsx`
+
+Replace the current flow:
+1. ~~Call `/api/offline/cache` to get signed URLs~~
+2. ~~`fetch(signedUrl)` from R2~~
+
+With:
+1. Call `/api/offline/cache` to get **proxy URLs** (see Step 7)
+2. `fetch(proxyUrl)` from same origin (no CORS)
+3. Cache using the `artifact-cache.ts` key scheme: `/sow-artifact-cache/{renderJobId}/{type}`
+
+Also:
+- Remove debug `console.log` statements
+- Add stale cache cleanup on mount: iterate cache keys, delete any that start with `http://localhost` or the app domain (leftover from the old buggy code)
+- Use `artifact-cache.ts` functions (`cacheArtifacts`, `getArtifactCacheStatus`) instead of inline cache logic to unify the cache key scheme
+
+**Stale cache cleanup (add to useEffect):**
+
+```typescript
+useEffect(() => {
+  const cleanupStaleEntries = async () => {
+    if (!("caches" in window)) return;
+    try {
+      const cache = await caches.open("sow-artifacts");
+      const keys = await cache.keys();
+      for (const key of keys) {
+        // Delete entries keyed by relative URLs or app-domain URLs (old buggy format)
+        if (key.url.includes("/songsets/") && key.url.includes("/renders/")) {
+          await cache.delete(key);
+        }
+      }
+    } catch {}
+  };
+  cleanupStaleEntries();
+}, []);
+```
+
+## Step 3: Unify cache key scheme in artifact-cache.ts
+
+**File:** `webapp/src/lib/offline/artifact-cache.ts`
+
+The library already uses stable synthetic keys (`/sow-artifact-cache/{renderJobId}/{type}`). Update `cacheArtifacts()` to accept proxy URLs as the fetch source instead of signed R2 URLs. The `url` field in `CacheableArtifacts` will now be a proxy URL like `/api/r2/artifact/{renderJobId}/output.mp3`.
+
+No change to the cache key scheme itself — it's already correct.
+
+## Step 4: Update controller page chapters fetch
+
+**File:** `webapp/src/app/songsets/[id]/play/controller/page.tsx`
+
+Currently at line 101: `fetch(chaptersUrl)` where `chaptersUrl` is a signed R2 URL. This also has a CORS issue (though it may work incidentally if R2 has permissive CORS for GET). Change to use the proxy URL:
+
+```
+/api/r2/artifact/{renderJobId}/chapters.json
+```
+
+This eliminates the need to call `/api/signed-url?fileType=json` separately — the proxy route handles auth + R2 fetch internally.
+
+## Step 5: Update download.ts
+
+**File:** `webapp/src/lib/download.ts`
+
+Currently `fetchSignedUrlAndDownload()` calls `/api/signed-url` to get a signed URL, then creates an `<a href={signedUrl}>` to trigger a browser download. The browser navigates directly to the R2 signed URL.
+
+Change to use the proxy URL with `Content-Disposition: attachment`:
+- `/api/r2/artifact/{renderJobId}/output.mp3?download=1`
+- The proxy route adds `Content-Disposition: attachment; filename="..."` when `download=1` is present
+
+This eliminates the need for the `/api/signed-url` call for downloads.
+
+**New function:**
+
+```typescript
+export async function downloadArtifactViaProxy(
+  renderJobId: string,
+  fileType: "audio" | "video" | "json",
+  filename: string,
+  extension: string
+): Promise<void> {
+  const artifactFile =
+    fileType === "audio" ? "output.mp3" :
+    fileType === "video" ? "output.mp4" : "chapters.json";
+  
+  const proxyUrl = `/api/r2/artifact/${renderJobId}/${artifactFile}?download=1`;
+  downloadArtifact(proxyUrl);
+}
+```
+
+## Step 6: Service worker exclusion
+
+**File:** `webapp/public/sw.js`
+
+Add a `NetworkOnly` route for `/api/r2/` to prevent the service worker from caching large binary artifacts:
+
+```js
+// R2 proxy endpoint serves large binary files – never cache.
+workbox.routing.registerRoute(
+  ({ url }) => url.pathname.startsWith("/api/r2/"),
+  new workbox.strategies.NetworkOnly()
+);
+```
+
+Add this after the existing `/api/signed-url` NetworkOnly rule (around line 69).
+
+## Step 7: Update /api/offline/cache to return proxy URLs
+
+**File:** `webapp/src/app/api/offline/cache/route.ts`
+
+Instead of generating signed R2 URLs and returning them, return proxy URLs:
+
+```json
+{
+  "renderJobId": "Rlw5W9GMBjQ6fQ8QY5C-x",
+  "mp3Url": "/api/r2/artifact/Rlw5W9GMBjQ6fQ8QY5C-x/output.mp3",
+  "mp4Url": "/api/r2/artifact/Rlw5W9GMBjQ6fQ8QY5C-x/output.mp4",
+  "chaptersUrl": "/api/r2/artifact/Rlw5W9GMBjQ6fQ8QY5C-x/chapters.json"
+}
+```
+
+This eliminates the need to call `r2Client.generateSignedUrl()` in this route at all — the proxy route handles R2 access. The route still verifies auth and ownership, but no longer needs R2 credentials.
+
+**Simplified route:**
+
+```typescript
+export async function GET(request: NextRequest) {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const renderJobId = request.nextUrl.searchParams.get("renderJobId");
+  if (!renderJobId) {
+    return NextResponse.json({ error: "renderJobId required" }, { status: 400 });
+  }
+
+  const job = await db.query.renderJobs.findFirst({
+    where: and(
+      eq(renderJobs.id, renderJobId),
+      eq(renderJobs.userId, Number(session.user.id))
+    ),
+  });
+
+  if (!job) {
+    return NextResponse.json({ error: "Render job not found" }, { status: 404 });
+  }
+
+  if (job.status !== "completed") {
+    return NextResponse.json({ error: "Render job not complete" }, { status: 409 });
+  }
+
+  // Return proxy URLs instead of signed R2 URLs
+  return NextResponse.json({
+    renderJobId: job.id,
+    mp3Url: job.mp3R2Key ? `/api/r2/artifact/${renderJobId}/output.mp3` : null,
+    mp4Url: job.mp4R2Key ? `/api/r2/artifact/${renderJobId}/output.mp4` : null,
+    chaptersUrl: job.chaptersR2Key ? `/api/r2/artifact/${renderJobId}/chapters.json` : null,
+  });
+}
+```
+
+## What NOT to change
+
+- **Video/audio `src` attributes** in `ControllerPlayer`, `ProjectionPlayer`, and share pages: These use `<video src={signedUrl}>` and `<audio src={signedUrl}>`. Media elements are not subject to CORS restrictions for simple playback — they work fine with signed R2 URLs. Changing these to proxy URLs would add latency and server load for no benefit. Only change if we want to hide the R2 endpoint URL from the client (optional future enhancement).
+- **`/api/signed-url` route**: Keep as-is. It's still used by the video/audio player pages for `<video src>` and `<audio src>`. The proxy route is specifically for `fetch()`-based access where CORS matters.
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| Proxy adds latency for large files | Stream response (don't buffer); R2 signed URL is generated server-side with 60s expiry |
+| Serverless function timeout on Vercel (10s for hobby, 60s for pro) | Vercel supports streaming responses; for hobby plan, large video files may timeout — consider keeping direct signed URLs for `<video src>` playback |
+| Double bandwidth cost (R2 → server → client) | Only use proxy for `fetch()`-based access (offline caching, chapters JSON, downloads); keep direct signed URLs for media `src` attributes |
+| Range request complexity | R2 supports range requests natively; pass through `Range` header and `Content-Range` response header |
+
+## Testing Checklist
+
+- [ ] Offline download button works without CORS errors
+- [ ] Cached artifacts can be played offline
+- [ ] Stale cache entries are cleaned up on mount
+- [ ] Chapters JSON loads in controller page
+- [ ] File downloads trigger browser save dialog with correct filename
+- [ ] Video seeking works (range requests)
+- [ ] Service worker doesn't cache `/api/r2/` responses
+- [ ] Auth required for all proxy requests
+- [ ] Ownership verified (can't access another user's artifacts)

--- a/webapp/public/sw.js
+++ b/webapp/public/sw.js
@@ -68,6 +68,12 @@ workbox.routing.registerRoute(
   new workbox.strategies.NetworkOnly()
 );
 
+// R2 proxy endpoint serves large binary files – never cache.
+workbox.routing.registerRoute(
+  ({ url }) => url.pathname.startsWith("/api/r2/"),
+  new workbox.strategies.NetworkOnly()
+);
+
 // Offline fallback: return a minimal JSON error for uncached API requests.
 workbox.routing.setCatchHandler(async ({ event }) => {
   if (event.request.destination === "document") {

--- a/webapp/src/app/api/offline/cache/route.ts
+++ b/webapp/src/app/api/offline/cache/route.ts
@@ -3,12 +3,11 @@ import { auth } from "@/lib/auth";
 import { db } from "@/db";
 import { renderJobs } from "@/db/schema";
 import { eq, and } from "drizzle-orm";
-import { createR2ClientFromEnv } from "@/lib/r2/client";
 
 /**
  * GET /api/offline/cache?renderJobId=<id>
  *
- * Returns signed download URLs for a completed render job's artifacts so the
+ * Returns proxy URLs for a completed render job's artifacts so the
  * client can fetch and store them in Cache Storage for offline playback.
  *
  * Requires authentication; verifies the caller owns the render job.
@@ -58,37 +57,11 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    let r2Client: ReturnType<typeof createR2ClientFromEnv>;
-    try {
-      r2Client = createR2ClientFromEnv();
-    } catch {
-      return NextResponse.json(
-        { error: "R2 storage not configured" },
-        { status: 503 }
-      );
-    }
-
-    // Generate signed URLs for each available artifact (1-hour expiry for caching).
-    const expiresInSeconds = 3600;
-
-    const [mp3Result, mp4Result, chaptersResult] = await Promise.all([
-      job.mp3R2Key
-        ? r2Client.generateSignedUrl(job.mp3R2Key, "audio", { expiresInSeconds })
-        : null,
-      job.mp4R2Key
-        ? r2Client.generateSignedUrl(job.mp4R2Key, "video", { expiresInSeconds })
-        : null,
-      job.chaptersR2Key
-        ? r2Client.generateSignedUrl(job.chaptersR2Key, "json", { expiresInSeconds })
-        : null,
-    ]);
-
     return NextResponse.json({
       renderJobId: job.id,
-      mp3Url: mp3Result?.url ?? null,
-      mp4Url: mp4Result?.url ?? null,
-      chaptersUrl: chaptersResult?.url ?? null,
-      expiresAt: (mp3Result ?? mp4Result)?.expiresAt ?? null,
+      mp3Url: job.mp3R2Key ? `/api/r2/artifact/${renderJobId}/output.mp3` : null,
+      mp4Url: job.mp4R2Key ? `/api/r2/artifact/${renderJobId}/output.mp4` : null,
+      chaptersUrl: job.chaptersR2Key ? `/api/r2/artifact/${renderJobId}/chapters.json` : null,
     });
   } catch (error) {
     console.error("Error generating offline cache URLs:", error);

--- a/webapp/src/app/api/r2/artifact/[...path]/route.ts
+++ b/webapp/src/app/api/r2/artifact/[...path]/route.ts
@@ -1,0 +1,118 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/db";
+import { renderJobs } from "@/db/schema";
+import { eq, and } from "drizzle-orm";
+import { createR2ClientFromEnv } from "@/lib/r2/client";
+
+const ALLOWED_FILES = ["output.mp3", "output.mp4", "chapters.json"] as const;
+const CONTENT_TYPES: Record<string, string> = {
+  "output.mp3": "audio/mpeg",
+  "output.mp4": "video/mp4",
+  "chapters.json": "application/json",
+};
+
+const FILE_TYPES: Record<string, "audio" | "video" | "json"> = {
+  "output.mp3": "audio",
+  "output.mp4": "video",
+  "chapters.json": "json",
+};
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> }
+) {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { path } = await params;
+  if (path.length !== 2) {
+    return NextResponse.json({ error: "Invalid path" }, { status: 400 });
+  }
+  const [renderJobId, filename] = path;
+
+  if (!ALLOWED_FILES.includes(filename as (typeof ALLOWED_FILES)[number])) {
+    return NextResponse.json({ error: "Invalid file" }, { status: 400 });
+  }
+
+  const job = await db.query.renderJobs.findFirst({
+    where: and(
+      eq(renderJobs.id, renderJobId),
+      eq(renderJobs.userId, Number(session.user.id))
+    ),
+    with: {
+      songset: {
+        columns: {
+          name: true,
+        },
+      },
+    },
+  });
+  if (!job) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  if (job.status !== "completed") {
+    return NextResponse.json({ error: "Render not complete" }, { status: 409 });
+  }
+
+  const r2Key = `renders/${renderJobId}/${filename}`;
+
+  let r2Client: ReturnType<typeof createR2ClientFromEnv>;
+  try {
+    r2Client = createR2ClientFromEnv();
+  } catch {
+    return NextResponse.json({ error: "R2 storage not configured" }, { status: 503 });
+  }
+
+  const fileType = FILE_TYPES[filename];
+  const { url: signedUrl } = await r2Client.generateSignedUrl(r2Key, fileType, {
+    expiresInSeconds: 60,
+  });
+
+  const rangeHeader = request.headers.get("range");
+  const r2Headers: HeadersInit = {};
+  if (rangeHeader) {
+    r2Headers["Range"] = rangeHeader;
+  }
+
+  const r2Response = await fetch(signedUrl, { headers: r2Headers });
+
+  if (!r2Response.ok && r2Response.status !== 206) {
+    return NextResponse.json({ error: "Failed to fetch from storage" }, { status: 502 });
+  }
+
+  const responseHeaders = new Headers();
+  responseHeaders.set("Content-Type", CONTENT_TYPES[filename]);
+  responseHeaders.set("Accept-Ranges", "bytes");
+  responseHeaders.set("Cache-Control", "private, max-age=3600");
+
+  const contentLength = r2Response.headers.get("content-length");
+  if (contentLength) {
+    responseHeaders.set("Content-Length", contentLength);
+  }
+
+  const contentRange = r2Response.headers.get("content-range");
+  if (contentRange) {
+    responseHeaders.set("Content-Range", contentRange);
+  }
+
+  const searchParams = request.nextUrl.searchParams;
+  if (searchParams.get("download") === "1") {
+    const songsetName = job.songset?.name || "worship";
+    const ext = filename.split(".").pop();
+    const safeName = songsetName.toLowerCase().replace(/[^a-z0-9]/g, "-");
+    responseHeaders.set(
+      "Content-Disposition",
+      `attachment; filename="${safeName}.${ext}"`
+    );
+  }
+
+  const status = r2Response.status === 206 ? 206 : 200;
+  return new NextResponse(r2Response.body, {
+    status,
+    headers: responseHeaders,
+  });
+}

--- a/webapp/src/app/songsets/[id]/play/controller/page.tsx
+++ b/webapp/src/app/songsets/[id]/play/controller/page.tsx
@@ -3,7 +3,8 @@
 import { useState, useEffect, useCallback } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { ControllerPlayer } from "@/components/play/ControllerPlayer";
-import { Chapter } from "@/components/play/LyricJumpList";
+import type { Chapter } from "@/lib/render/chapters";
+import { normalizeChaptersManifest } from "@/lib/render/chapters";
 import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
 
@@ -97,8 +98,11 @@ export default function ControllerPage() {
           const chaptersDataResponse = await fetch(chaptersProxyUrl);
           if (chaptersDataResponse.ok) {
             const chaptersData = await chaptersDataResponse.json();
-            if (chaptersData.chapters) {
-              setChapters(chaptersData.chapters);
+            try {
+              const manifest = normalizeChaptersManifest(chaptersData);
+              setChapters(manifest.chapters);
+            } catch (e) {
+              console.error("Failed to parse chapters:", e);
             }
           }
         }

--- a/webapp/src/app/songsets/[id]/play/controller/page.tsx
+++ b/webapp/src/app/songsets/[id]/play/controller/page.tsx
@@ -91,19 +91,14 @@ export default function ControllerPage() {
 
         setVideoUrl(url);
 
-        // Load chapters if available
+        // Load chapters if available via proxy URL
         if (jobData.chaptersR2Key) {
-          const chaptersResponse = await fetch(
-            `/api/signed-url?renderJobId=${encodeURIComponent(jobData.id)}&fileType=json`
-          );
-          if (chaptersResponse.ok) {
-            const { url: chaptersUrl } = await chaptersResponse.json();
-            const chaptersDataResponse = await fetch(chaptersUrl);
-            if (chaptersDataResponse.ok) {
-              const chaptersData = await chaptersDataResponse.json();
-              if (chaptersData.chapters) {
-                setChapters(chaptersData.chapters);
-              }
+          const chaptersProxyUrl = `/api/r2/artifact/${jobData.id}/chapters.json`;
+          const chaptersDataResponse = await fetch(chaptersProxyUrl);
+          if (chaptersDataResponse.ok) {
+            const chaptersData = await chaptersDataResponse.json();
+            if (chaptersData.chapters) {
+              setChapters(chaptersData.chapters);
             }
           }
         }

--- a/webapp/src/components/play/ControllerPlayer.tsx
+++ b/webapp/src/components/play/ControllerPlayer.tsx
@@ -4,7 +4,8 @@ import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { PlaybackControls } from "./PlaybackControls";
-import { LyricJumpList, Chapter } from "./LyricJumpList";
+import { LyricJumpList } from "./LyricJumpList";
+import type { Chapter } from "@/lib/render/chapters";
 import { useWakeLock } from "@/hooks/useWakeLock";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useMediaSession } from "@/hooks/useMediaSession";
@@ -173,6 +174,11 @@ export function ControllerPlayer({
       const video = videoRef.current;
       if (!video) return;
 
+      if (!isFinite(time)) {
+        console.warn("handleSeek called with non-finite time:", time);
+        return;
+      }
+
       const clampedTime = Math.max(0, Math.min(duration, time));
       video.currentTime = clampedTime;
       setCurrentTime(clampedTime);
@@ -191,14 +197,18 @@ export function ControllerPlayer({
   const handlePrevSong = useCallback(() => {
     if (currentSongIndex > 0) {
       const prevChapter = chapters[currentSongIndex - 1];
-      handleSeek(prevChapter.startSeconds);
+      if (prevChapter) {
+        handleSeek(prevChapter.startSeconds);
+      }
     }
   }, [currentSongIndex, chapters, handleSeek]);
 
   const handleNextSong = useCallback(() => {
     if (currentSongIndex < chapters.length - 1) {
       const nextChapter = chapters[currentSongIndex + 1];
-      handleSeek(nextChapter.startSeconds);
+      if (nextChapter) {
+        handleSeek(nextChapter.startSeconds);
+      }
     }
   }, [currentSongIndex, chapters, handleSeek]);
 
@@ -220,7 +230,10 @@ export function ControllerPlayer({
   const handleJumpToChapter = useCallback(
     (index: number) => {
       if (index >= 0 && index < chapters.length) {
-        handleSeek(chapters[index].startSeconds);
+        const chapter = chapters[index];
+        if (chapter) {
+          handleSeek(chapter.startSeconds);
+        }
       }
     },
     [chapters, handleSeek]
@@ -230,8 +243,11 @@ export function ControllerPlayer({
     (chapterIndex: number, lineIndex: number) => {
       if (chapterIndex >= 0 && chapterIndex < chapters.length) {
         const chapter = chapters[chapterIndex];
-        if (lineIndex >= 0 && lineIndex < chapter.lines.length) {
-          handleSeek(chapter.lines[lineIndex].startSeconds);
+        if (chapter && lineIndex >= 0 && lineIndex < chapter.lines.length) {
+          const line = chapter.lines[lineIndex];
+          if (line) {
+            handleSeek(line.startSeconds);
+          }
         }
       }
     },

--- a/webapp/src/components/play/ControllerPlayer.tsx
+++ b/webapp/src/components/play/ControllerPlayer.tsx
@@ -11,7 +11,7 @@ import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useMediaSession } from "@/hooks/useMediaSession";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
-import { ArrowLeft, X, Info } from "lucide-react";
+import { ArrowLeft, X, Info, Maximize } from "lucide-react";
 
 export interface ControllerPlayerProps {
   songsetId: string;
@@ -45,6 +45,7 @@ export function ControllerPlayer({
   const [currentSongIndex, setCurrentSongIndex] = useState(0);
   const [controlsVisible, setControlsVisible] = useState(true);
   const [showIosInfo, setShowIosInfo] = useState(false);
+  const [isFullscreen, setIsFullscreen] = useState(false);
 
   // Wake lock hook
   const { isSupported: wakeLockSupported } = useWakeLock();
@@ -129,6 +130,11 @@ export function ControllerPlayer({
     setControlsVisible(true);
     startHideTimer();
   }, [startHideTimer]);
+
+  const showControlsRef = useRef(showControls);
+  useEffect(() => {
+    showControlsRef.current = showControls;
+  }, [showControls]);
 
   // Handle user interaction
   const handleInteraction = useCallback(() => {
@@ -255,7 +261,6 @@ export function ControllerPlayer({
   );
 
   const handleExit = useCallback(() => {
-    // Exit fullscreen if active
     if (document.fullscreenElement) {
       document.exitFullscreen().catch(() => {
         // Ignore errors
@@ -263,6 +268,10 @@ export function ControllerPlayer({
     }
     router.push(`/songsets/${songsetId}/play`);
   }, [router, songsetId]);
+
+  const handleReenterFullscreen = useCallback(() => {
+    document.documentElement.requestFullscreen().catch(() => {});
+  }, []);
 
   // Keyboard shortcuts
   useKeyboardShortcuts({
@@ -315,7 +324,18 @@ export function ControllerPlayer({
     }
   }, [duration, currentTime, updatePositionState]);
 
-  // Request fullscreen on mount
+  useEffect(() => {
+    const handleFullscreenChange = () => {
+      setIsFullscreen(!!document.fullscreenElement);
+    };
+
+    document.addEventListener("fullscreenchange", handleFullscreenChange);
+
+    return () => {
+      document.removeEventListener("fullscreenchange", handleFullscreenChange);
+    };
+  }, []);
+
   useEffect(() => {
     const requestFullscreen = async () => {
       try {
@@ -331,7 +351,7 @@ export function ControllerPlayer({
 
     const handleFullscreenChange = () => {
       if (!document.fullscreenElement) {
-        showControls();
+        showControlsRef.current();
       }
     };
 
@@ -343,7 +363,7 @@ export function ControllerPlayer({
         document.exitFullscreen().catch(() => {});
       }
     };
-  }, [showControls]);
+  }, []);
 
   // Mute video when presentation is active (audio plays on receiver)
   useEffect(() => {
@@ -367,6 +387,7 @@ export function ControllerPlayer({
       )}
       onClick={handleInteraction}
       onTouchStart={handleInteraction}
+      onMouseMove={handleInteraction}
     >
       {/* Video */}
       <div className="flex-1 relative">
@@ -380,7 +401,22 @@ export function ControllerPlayer({
             e.stopPropagation();
             handlePlayPause();
           }}
+          onDoubleClick={(e) => {
+            e.preventDefault();
+          }}
         />
+
+        {!isFullscreen && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="fixed top-4 left-4 z-[80] size-10 text-white hover:bg-white/20"
+            onClick={handleReenterFullscreen}
+            aria-label="Re-enter fullscreen"
+          >
+            <Maximize className="size-5" />
+          </Button>
+        )}
 
         {/* Top bar */}
         <div
@@ -467,8 +503,16 @@ export function ControllerPlayer({
         ref={controlsRef}
         className={cn(
           "transition-opacity duration-300 pb-12",
-          controlsVisible || isPresentationActive ? "opacity-100" : "opacity-0"
+          controlsVisible || isPresentationActive
+            ? "opacity-100"
+            : "opacity-0 pointer-events-none"
         )}
+        onMouseEnter={() => {
+          if (hideTimeoutRef.current) {
+            clearTimeout(hideTimeoutRef.current);
+          }
+        }}
+        onMouseLeave={startHideTimer}
       >
         <PlaybackControls
           isPlaying={isPlaying}

--- a/webapp/src/components/play/LyricJumpList.tsx
+++ b/webapp/src/components/play/LyricJumpList.tsx
@@ -3,17 +3,9 @@
 import { useState, useRef, useCallback } from "react";
 import { cn } from "@/lib/utils";
 import { ChevronUp, Music } from "lucide-react";
+import type { Chapter } from "@/lib/render/chapters";
 
-export interface Chapter {
-  position: number;
-  songTitle: string;
-  startSeconds: number;
-  endSeconds: number;
-  lines: {
-    text: string;
-    startSeconds: number;
-  }[];
-}
+export type { Chapter, ChapterLine } from "@/lib/render/chapters";
 
 export interface LyricJumpListProps {
   chapters: Chapter[];

--- a/webapp/src/components/play/LyricJumpList.tsx
+++ b/webapp/src/components/play/LyricJumpList.tsx
@@ -30,6 +30,7 @@ export function LyricJumpList({
   const [currentY, setCurrentY] = useState(0);
   const sheetRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
+  const lastToggleTimeRef = useRef(0);
 
   const handleTouchStart = useCallback(
     (e: React.TouchEvent | React.MouseEvent) => {
@@ -65,11 +66,19 @@ export function LyricJumpList({
       if (!isDragging) return;
       e.stopPropagation();
 
+      const now = Date.now();
       const threshold = 100;
-      if (!isOpen && currentY > threshold) {
+      const absY = Math.abs(currentY);
+
+      const shouldToggle =
+        (currentY > threshold || absY < 30) && now - lastToggleTimeRef.current > 100;
+
+      if (!isOpen && shouldToggle) {
         setIsOpen(true);
-      } else if (isOpen && currentY < -threshold) {
+        lastToggleTimeRef.current = now;
+      } else if (isOpen && shouldToggle) {
         setIsOpen(false);
+        lastToggleTimeRef.current = now;
       }
 
       setIsDragging(false);
@@ -79,6 +88,7 @@ export function LyricJumpList({
   );
 
   const formatTime = (seconds: number): string => {
+    if (!isFinite(seconds) || seconds < 0) return "0:00";
     const mins = Math.floor(seconds / 60);
     const secs = Math.floor(seconds % 60);
     return `${mins}:${secs.toString().padStart(2, "0")}`;

--- a/webapp/src/components/play/OfflineStatus.tsx
+++ b/webapp/src/components/play/OfflineStatus.tsx
@@ -12,6 +12,14 @@ import {
 import { Download, Check, WifiOff, Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
+import {
+  ARTIFACT_CACHE_NAME,
+  cacheArtifacts,
+  getArtifactCacheStatus,
+  isOfflineSupportedOnCurrentDevice,
+  requestPersistentStorage,
+  type CacheableArtifacts,
+} from "@/lib/offline/artifact-cache";
 
 export interface OfflineStatusProps {
   renderJobId: string | null;
@@ -31,9 +39,24 @@ export function OfflineStatus({
   const [isCached, setIsCached] = useState(false);
   const [isDownloading, setIsDownloading] = useState(false);
   const [cacheProgress, setCacheProgress] = useState(0);
-  const [isIOS174Plus, setIsIOS174Plus] = useState(true);
+  const [isSupported] = useState(isOfflineSupportedOnCurrentDevice);
 
-  // Check if artifacts are already cached
+  useEffect(() => {
+    const cleanupStaleEntries = async () => {
+      if (!("caches" in window)) return;
+      try {
+        const cache = await caches.open(ARTIFACT_CACHE_NAME);
+        const keys = await cache.keys();
+        for (const key of keys) {
+          if (key.url.includes("/songsets/") && key.url.includes("/renders/")) {
+            await cache.delete(key);
+          }
+        }
+      } catch {}
+    };
+    cleanupStaleEntries();
+  }, []);
+
   useEffect(() => {
     const checkCacheStatus = async () => {
       if (!renderJobId || !("caches" in window)) {
@@ -42,14 +65,13 @@ export function OfflineStatus({
       }
 
       try {
-        const cache = await caches.open("sow-artifacts");
-        const mp3Cached = mp3R2Key ? await cache.match(mp3R2Key) : null;
-        // Check other artifacts but only mp3 is required for "cached" status
-        if (mp4R2Key) await cache.match(mp4R2Key);
-        if (chaptersR2Key) await cache.match(chaptersR2Key);
-
-        // Consider cached if at least the audio is cached
-        setIsCached(!!mp3Cached);
+        const artifacts: CacheableArtifacts = {
+          mp3Url: mp3R2Key ? `/api/r2/artifact/${renderJobId}/output.mp3` : null,
+          mp4Url: mp4R2Key ? `/api/r2/artifact/${renderJobId}/output.mp4` : null,
+          chaptersUrl: chaptersR2Key ? `/api/r2/artifact/${renderJobId}/chapters.json` : null,
+        };
+        const status = await getArtifactCacheStatus(renderJobId, artifacts);
+        setIsCached(status.isCached);
       } catch {
         setIsCached(false);
       }
@@ -58,96 +80,42 @@ export function OfflineStatus({
     checkCacheStatus();
   }, [renderJobId, mp3R2Key, mp4R2Key, chaptersR2Key]);
 
-  // Check iOS version for offline support
-  useEffect(() => {
-    const checkIOSVersion = () => {
-      const userAgent = navigator.userAgent;
-      const isIOS = /iPad|iPhone|iPod/.test(userAgent);
-
-      if (!isIOS) {
-        setIsIOS174Plus(true);
-        return;
-      }
-
-      // Extract iOS version
-      const match = userAgent.match(/OS (\d+)_(\d+)/);
-      if (match) {
-        const major = parseInt(match[1], 10);
-        const minor = parseInt(match[2], 10);
-        setIsIOS174Plus(major > 17 || (major === 17 && minor >= 4));
-      }
-    };
-
-    checkIOSVersion();
-  }, []);
-
   const handleDownloadOffline = useCallback(async () => {
     if (!renderJobId || !("caches" in window)) {
       toast.error("Offline caching not available");
       return;
     }
 
-    // Request persistent storage on first cache action (iOS 17.4+)
-    if ("storage" in navigator && "persist" in navigator.storage) {
-      try {
-        await navigator.storage.persist();
-      } catch {
-        // Continue even if persist fails
-      }
-    }
+    await requestPersistentStorage();
 
     setIsDownloading(true);
     setCacheProgress(0);
 
     try {
-      // Fetch signed URLs from the API
       const apiUrl = `/api/offline/cache?renderJobId=${renderJobId}`;
-      console.log("Fetching signed URLs from:", apiUrl);
-      
-      const signedUrlsResponse = await fetch(apiUrl);
-      console.log("API response status:", signedUrlsResponse.status);
+      const response = await fetch(apiUrl);
 
-      if (!signedUrlsResponse.ok) {
-        const errorData = await signedUrlsResponse.json().catch(() => ({}));
-        console.error("API error response:", errorData);
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
         throw new Error(errorData.error || "Failed to get download URLs");
       }
 
-      const signedUrls = await signedUrlsResponse.json();
-      console.log("API response:", JSON.stringify(signedUrls, null, 2));
-      const artifactsToCache: { r2Key: string; signedUrl: string }[] = [];
+      const proxyUrls = await response.json();
+      const artifacts: CacheableArtifacts = {
+        mp3Url: proxyUrls.mp3Url,
+        mp4Url: proxyUrls.mp4Url,
+        chaptersUrl: proxyUrls.chaptersUrl,
+      };
 
-      if (mp3R2Key && signedUrls.mp3Url) {
-        artifactsToCache.push({ r2Key: mp3R2Key, signedUrl: signedUrls.mp3Url });
-      }
-      if (mp4R2Key && signedUrls.mp4Url) {
-        artifactsToCache.push({ r2Key: mp4R2Key, signedUrl: signedUrls.mp4Url });
-      }
-      if (chaptersR2Key && signedUrls.chaptersUrl) {
-        artifactsToCache.push({ r2Key: chaptersR2Key, signedUrl: signedUrls.chaptersUrl });
-      }
-
-      if (artifactsToCache.length === 0) {
+      if (!artifacts.mp3Url && !artifacts.mp4Url && !artifacts.chaptersUrl) {
         toast.error("No artifacts available to cache");
         setIsDownloading(false);
         return;
       }
 
-      const cache = await caches.open("sow-artifacts");
-
-      // Cache each artifact using signed URL, but store with R2 key as cache key
-      for (let i = 0; i < artifactsToCache.length; i++) {
-        const { r2Key, signedUrl } = artifactsToCache[i];
-        const response = await fetch(signedUrl);
-
-        if (!response.ok) {
-          throw new Error(`Failed to fetch ${r2Key}`);
-        }
-
-        // Store in cache with R2 key as the cache key for consistent lookups
-        await cache.put(r2Key, response.clone());
-        setCacheProgress(Math.round(((i + 1) / artifactsToCache.length) * 100));
-      }
+      await cacheArtifacts(renderJobId, artifacts, (percent) => {
+        setCacheProgress(percent);
+      });
 
       setIsCached(true);
       toast.success("Downloaded for offline playback");
@@ -158,7 +126,7 @@ export function OfflineStatus({
       setIsDownloading(false);
       setCacheProgress(0);
     }
-  }, [renderJobId, mp3R2Key, mp4R2Key, chaptersR2Key]);
+  }, [renderJobId]);
 
   const hasArtifacts = !!(mp3R2Key || mp4R2Key);
 
@@ -166,8 +134,7 @@ export function OfflineStatus({
     return null;
   }
 
-  // iOS < 17.4 warning
-  if (!isIOS174Plus) {
+  if (!isSupported) {
     return (
       <TooltipProvider>
         <Tooltip>

--- a/webapp/src/components/play/OfflineStatus.tsx
+++ b/webapp/src/components/play/OfflineStatus.tsx
@@ -100,12 +100,32 @@ export function OfflineStatus({
     setCacheProgress(0);
 
     try {
-      const cache = await caches.open("sow-artifacts");
-      const artifactsToCache: string[] = [];
+      // Fetch signed URLs from the API
+      const apiUrl = `/api/offline/cache?renderJobId=${renderJobId}`;
+      console.log("Fetching signed URLs from:", apiUrl);
+      
+      const signedUrlsResponse = await fetch(apiUrl);
+      console.log("API response status:", signedUrlsResponse.status);
 
-      if (mp3R2Key) artifactsToCache.push(mp3R2Key);
-      if (mp4R2Key) artifactsToCache.push(mp4R2Key);
-      if (chaptersR2Key) artifactsToCache.push(chaptersR2Key);
+      if (!signedUrlsResponse.ok) {
+        const errorData = await signedUrlsResponse.json().catch(() => ({}));
+        console.error("API error response:", errorData);
+        throw new Error(errorData.error || "Failed to get download URLs");
+      }
+
+      const signedUrls = await signedUrlsResponse.json();
+      console.log("API response:", JSON.stringify(signedUrls, null, 2));
+      const artifactsToCache: { r2Key: string; signedUrl: string }[] = [];
+
+      if (mp3R2Key && signedUrls.mp3Url) {
+        artifactsToCache.push({ r2Key: mp3R2Key, signedUrl: signedUrls.mp3Url });
+      }
+      if (mp4R2Key && signedUrls.mp4Url) {
+        artifactsToCache.push({ r2Key: mp4R2Key, signedUrl: signedUrls.mp4Url });
+      }
+      if (chaptersR2Key && signedUrls.chaptersUrl) {
+        artifactsToCache.push({ r2Key: chaptersR2Key, signedUrl: signedUrls.chaptersUrl });
+      }
 
       if (artifactsToCache.length === 0) {
         toast.error("No artifacts available to cache");
@@ -113,16 +133,19 @@ export function OfflineStatus({
         return;
       }
 
-      // Cache each artifact
+      const cache = await caches.open("sow-artifacts");
+
+      // Cache each artifact using signed URL, but store with R2 key as cache key
       for (let i = 0; i < artifactsToCache.length; i++) {
-        const url = artifactsToCache[i];
-        const response = await fetch(url);
+        const { r2Key, signedUrl } = artifactsToCache[i];
+        const response = await fetch(signedUrl);
 
         if (!response.ok) {
-          throw new Error(`Failed to fetch ${url}`);
+          throw new Error(`Failed to fetch ${r2Key}`);
         }
 
-        await cache.put(url, response.clone());
+        // Store in cache with R2 key as the cache key for consistent lookups
+        await cache.put(r2Key, response.clone());
         setCacheProgress(Math.round(((i + 1) / artifactsToCache.length) * 100));
       }
 

--- a/webapp/src/components/play/OfflineStatus.tsx
+++ b/webapp/src/components/play/OfflineStatus.tsx
@@ -92,7 +92,7 @@ export function OfflineStatus({
     setCacheProgress(0);
 
     try {
-      const apiUrl = `/api/offline/cache?renderJobId=${renderJobId}`;
+      const apiUrl = `/api/offline/cache?renderJobId=${encodeURIComponent(renderJobId)}`;
       const response = await fetch(apiUrl);
 
       if (!response.ok) {

--- a/webapp/src/components/play/PlaybackControls.tsx
+++ b/webapp/src/components/play/PlaybackControls.tsx
@@ -109,46 +109,46 @@ export function PlaybackControls({
       </div>
 
       {/* Main controls */}
-      <div className="flex items-center justify-between gap-4">
+      <div className="flex items-center justify-between gap-1 sm:gap-4">
         {/* Song navigation */}
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-1 sm:gap-2">
           <Button
             variant="ghost"
             size="icon"
-            className="size-12 text-white hover:bg-white/20"
+            className="size-10 sm:size-12 text-white hover:bg-white/20"
             onClick={onPrevSong}
             disabled={currentSongIndex <= 0}
             aria-label="Previous song"
           >
-            <SkipBack className="size-6" />
+            <SkipBack className="size-5 sm:size-6" />
           </Button>
-          <span className="text-sm text-white/70 min-w-[3rem] text-center">
+          <span className="text-xs sm:text-sm text-white/70 min-w-[2.5rem] sm:min-w-[3rem] text-center">
             {currentSongIndex + 1}/{totalSongs}
           </span>
           <Button
             variant="ghost"
             size="icon"
-            className="size-12 text-white hover:bg-white/20"
+            className="size-10 sm:size-12 text-white hover:bg-white/20"
             onClick={onNextSong}
             disabled={currentSongIndex >= totalSongs - 1}
             aria-label="Next song"
           >
-            <SkipForward className="size-6" />
+            <SkipForward className="size-5 sm:size-6" />
           </Button>
         </div>
 
         {/* Playback controls */}
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-1 sm:gap-2">
           <Button
             variant="ghost"
             size="icon"
-            className="size-14 text-white hover:bg-white/20"
+            className="size-12 sm:size-14 text-white hover:bg-white/20"
             onClick={onSkipBack}
             aria-label="Skip back 10 seconds"
           >
             <div className="relative">
-              <SkipBack className="size-6" />
-              <span className="absolute -bottom-1 left-1/2 -translate-x-1/2 text-[8px] font-bold">
+              <SkipBack className="size-5 sm:size-6" />
+              <span className="absolute -bottom-1 left-1/2 -translate-x-1/2 text-[7px] sm:text-[8px] font-bold">
                 10
               </span>
             </div>
@@ -157,27 +157,27 @@ export function PlaybackControls({
           <Button
             variant="default"
             size="icon"
-            className="size-16 rounded-full bg-white text-black hover:bg-white/90"
+            className="size-12 sm:size-16 rounded-full bg-white text-black hover:bg-white/90"
             onClick={onPlayPause}
             aria-label={isPlaying ? "Pause" : "Play"}
           >
             {isPlaying ? (
-              <Pause className="size-8" />
+              <Pause className="size-6 sm:size-8" />
             ) : (
-              <Play className="size-8 ml-1" />
+              <Play className="size-6 sm:size-8 ml-1" />
             )}
           </Button>
 
           <Button
             variant="ghost"
             size="icon"
-            className="size-14 text-white hover:bg-white/20"
+            className="size-12 sm:size-14 text-white hover:bg-white/20"
             onClick={onSkipForward}
             aria-label="Skip forward 10 seconds"
           >
             <div className="relative">
-              <SkipForward className="size-6" />
-              <span className="absolute -bottom-1 left-1/2 -translate-x-1/2 text-[8px] font-bold">
+              <SkipForward className="size-5 sm:size-6" />
+              <span className="absolute -bottom-1 left-1/2 -translate-x-1/2 text-[7px] sm:text-[8px] font-bold">
                 10
               </span>
             </div>
@@ -185,11 +185,11 @@ export function PlaybackControls({
         </div>
 
         {/* Volume and presentation status */}
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-1 sm:gap-2">
           <Button
             variant="ghost"
             size="icon"
-            className="size-10 text-white hover:bg-white/20"
+            className="hidden sm:flex size-10 text-white hover:bg-white/20"
             onClick={onToggleMute}
             aria-label={isMuted ? "Unmute" : "Mute"}
           >

--- a/webapp/src/lib/download.ts
+++ b/webapp/src/lib/download.ts
@@ -49,3 +49,15 @@ export async function fetchSignedUrlAndDownload(
   const { url } = await res.json();
   downloadArtifact(url);
 }
+
+export function downloadArtifactViaProxy(
+  renderJobId: string,
+  fileType: "audio" | "video" | "json",
+): void {
+  const artifactFile =
+    fileType === "audio" ? "output.mp3" :
+    fileType === "video" ? "output.mp4" : "chapters.json";
+
+  const proxyUrl = `/api/r2/artifact/${renderJobId}/${artifactFile}?download=1`;
+  downloadArtifact(proxyUrl);
+}

--- a/webapp/src/lib/render/chapters.ts
+++ b/webapp/src/lib/render/chapters.ts
@@ -225,6 +225,8 @@ export function parseChaptersManifest(json: string): ChaptersManifest {
       typeof chapter.songTitle !== "string" ||
       typeof chapter.startSeconds !== "number" ||
       typeof chapter.endSeconds !== "number" ||
+      !Number.isFinite(chapter.startSeconds) ||
+      !Number.isFinite(chapter.endSeconds) ||
       !Array.isArray(chapter.lines)
     ) {
       throw new Error("Invalid chapter structure");
@@ -311,7 +313,12 @@ export function normalizeChaptersManifest(data: unknown): ChaptersManifest {
       (c.endSeconds as number) ?? (c.end_seconds as number);
     const lines = (c.lines as unknown[]) ?? [];
 
-    if (typeof startSeconds !== "number" || typeof endSeconds !== "number") {
+    if (
+      typeof startSeconds !== "number" ||
+      typeof endSeconds !== "number" ||
+      !Number.isFinite(startSeconds) ||
+      !Number.isFinite(endSeconds)
+    ) {
       throw new Error(
         `Invalid chapter at index ${index}: missing or invalid startSeconds/endSeconds`
       );
@@ -332,7 +339,11 @@ export function normalizeChaptersManifest(data: unknown): ChaptersManifest {
       const lineStartSeconds =
         (l.startSeconds as number) ?? (l.start_seconds as number);
 
-      if (typeof text !== "string" || typeof lineStartSeconds !== "number") {
+      if (
+        typeof text !== "string" ||
+        typeof lineStartSeconds !== "number" ||
+        !Number.isFinite(lineStartSeconds)
+      ) {
         throw new Error(
           `Invalid line at index ${lineIndex} in chapter ${index}: missing text or startSeconds`
         );

--- a/webapp/src/lib/render/chapters.ts
+++ b/webapp/src/lib/render/chapters.ts
@@ -277,3 +277,86 @@ export function getChapterProgress(
 
   return { chapterIndex, progressPercent };
 }
+
+export function normalizeChaptersManifest(data: unknown): ChaptersManifest {
+  if (!data || typeof data !== "object") {
+    throw new Error("Invalid chapters manifest: expected an object");
+  }
+
+  const raw = data as Record<string, unknown>;
+
+  const chapters = raw.chapters;
+  const totalDurationSeconds =
+    (raw.totalDurationSeconds as number) ?? (raw.total_duration_seconds as number) ?? 0;
+  const generatedAt =
+    (raw.generatedAt as string) ?? (raw.generated_at as string) ?? "";
+
+  if (!Array.isArray(chapters)) {
+    throw new Error("Invalid chapters manifest: chapters must be an array");
+  }
+
+  const normalizedChapters: Chapter[] = chapters.map((chapter, index) => {
+    if (!chapter || typeof chapter !== "object") {
+      throw new Error(`Invalid chapter at index ${index}`);
+    }
+
+    const c = chapter as Record<string, unknown>;
+
+    const position = (c.position as number) ?? index + 1;
+    const songTitle =
+      (c.songTitle as string) ?? (c.song_title as string) ?? `Song ${index + 1}`;
+    const startSeconds =
+      (c.startSeconds as number) ?? (c.start_seconds as number);
+    const endSeconds =
+      (c.endSeconds as number) ?? (c.end_seconds as number);
+    const lines = (c.lines as unknown[]) ?? [];
+
+    if (typeof startSeconds !== "number" || typeof endSeconds !== "number") {
+      throw new Error(
+        `Invalid chapter at index ${index}: missing or invalid startSeconds/endSeconds`
+      );
+    }
+
+    if (!Array.isArray(lines)) {
+      throw new Error(`Invalid chapter at index ${index}: lines must be an array`);
+    }
+
+    const normalizedLines: ChapterLine[] = lines.map((line, lineIndex) => {
+      if (!line || typeof line !== "object") {
+        throw new Error(`Invalid line at index ${lineIndex} in chapter ${index}`);
+      }
+
+      const l = line as Record<string, unknown>;
+
+      const text = l.text as string;
+      const lineStartSeconds =
+        (l.startSeconds as number) ?? (l.start_seconds as number);
+
+      if (typeof text !== "string" || typeof lineStartSeconds !== "number") {
+        throw new Error(
+          `Invalid line at index ${lineIndex} in chapter ${index}: missing text or startSeconds`
+        );
+      }
+
+      return {
+        text,
+        startSeconds: lineStartSeconds,
+      };
+    });
+
+    return {
+      position: typeof position === "number" ? position : index + 1,
+      songTitle: typeof songTitle === "string" ? songTitle : `Song ${index + 1}`,
+      startSeconds,
+      endSeconds,
+      lines: normalizedLines,
+    };
+  });
+
+  return {
+    chapters: normalizedChapters,
+    totalDurationSeconds:
+      typeof totalDurationSeconds === "number" ? totalDurationSeconds : 0,
+    generatedAt: typeof generatedAt === "string" ? generatedAt : "",
+  };
+}

--- a/webapp/src/test/api/offline/cache.test.ts
+++ b/webapp/src/test/api/offline/cache.test.ts
@@ -5,10 +5,6 @@ import { NextRequest } from "next/server";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-// --------------------------------------------------------------------------
-// Mocks
-// --------------------------------------------------------------------------
-
 vi.mock("@/lib/auth", () => ({
   auth: {
     api: { getSession: vi.fn() },
@@ -26,20 +22,6 @@ vi.mock("@/db", () => ({
     },
   },
 }));
-
-const mockGenerateSignedUrl = vi.fn();
-
-vi.mock("@/lib/r2/client", () => ({
-  createR2ClientFromEnv: vi.fn().mockReturnValue({
-    generateSignedUrl: (...args: unknown[]) => mockGenerateSignedUrl(...args),
-  }),
-}));
-
-import { createR2ClientFromEnv } from "@/lib/r2/client";
-
-// --------------------------------------------------------------------------
-// Helpers
-// --------------------------------------------------------------------------
 
 function makeRequest(url: string, method = "GET"): NextRequest {
   const request = new Request(url, { method }) as unknown as NextRequest;
@@ -59,22 +41,9 @@ const completedJob = {
   chaptersR2Key: "renders/job-123/chapters.json",
 };
 
-const signedUrlResult = (suffix: string) => ({
-  url: `https://r2.example.com/${suffix}?sig=abc`,
-  expiresAt: new Date("2026-01-01T02:00:00Z"),
-  cacheControl: "public, max-age=3600",
-});
-
-// --------------------------------------------------------------------------
-// GET /api/offline/cache
-// --------------------------------------------------------------------------
-
 describe("GET /api/offline/cache", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGenerateSignedUrl.mockImplementation((_key: string, fileType: string) =>
-      Promise.resolve(signedUrlResult(fileType))
-    );
   });
 
   it("returns 401 when not authenticated", async () => {
@@ -127,18 +96,7 @@ describe("GET /api/offline/cache", () => {
     expect(data.error).toMatch(/no artifacts/i);
   });
 
-  it("returns 503 when R2 is not configured", async () => {
-    vi.mocked(auth.api.getSession).mockResolvedValue(sessionUser as any);
-    mockFindFirst.mockResolvedValue(completedJob);
-    vi.mocked(createR2ClientFromEnv).mockImplementationOnce(() => {
-      throw new Error("R2 credentials not configured");
-    });
-
-    const res = await GET(makeRequest("http://localhost/api/offline/cache?renderJobId=job-123"));
-    expect(res.status).toBe(503);
-  });
-
-  it("returns signed URLs for all three artifacts", async () => {
+  it("returns proxy URLs for all three artifacts", async () => {
     vi.mocked(auth.api.getSession).mockResolvedValue(sessionUser as any);
     mockFindFirst.mockResolvedValue(completedJob);
 
@@ -147,10 +105,9 @@ describe("GET /api/offline/cache", () => {
 
     const data = await res.json();
     expect(data.renderJobId).toBe("job-123");
-    expect(data.mp3Url).toContain("r2.example.com");
-    expect(data.mp4Url).toContain("r2.example.com");
-    expect(data.chaptersUrl).toContain("r2.example.com");
-    expect(data.expiresAt).toBeDefined();
+    expect(data.mp3Url).toBe("/api/r2/artifact/job-123/output.mp3");
+    expect(data.mp4Url).toBe("/api/r2/artifact/job-123/output.mp4");
+    expect(data.chaptersUrl).toBe("/api/r2/artifact/job-123/chapters.json");
   });
 
   it("returns null chaptersUrl when job has no chapters key", async () => {
@@ -172,10 +129,6 @@ describe("GET /api/offline/cache", () => {
     expect(res.status).toBe(500);
   });
 });
-
-// --------------------------------------------------------------------------
-// DELETE /api/offline/cache
-// --------------------------------------------------------------------------
 
 describe("DELETE /api/offline/cache", () => {
   beforeEach(() => {

--- a/webapp/src/test/app/controller-page.test.tsx
+++ b/webapp/src/test/app/controller-page.test.tsx
@@ -254,13 +254,6 @@ describe("ControllerPage", () => {
           ok: true,
           json: () =>
             Promise.resolve({
-              url: "https://r2.example.com/chapters/test.json",
-            }),
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () =>
-            Promise.resolve({
               chapters: [
                 {
                   position: 0,

--- a/webapp/src/test/components/play/OfflineStatus.test.tsx
+++ b/webapp/src/test/components/play/OfflineStatus.test.tsx
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { OfflineStatus } from "@/components/play/OfflineStatus";
 
-// Mock sonner toast
 vi.mock("sonner", () => ({
   toast: {
     success: vi.fn(),
@@ -10,22 +9,31 @@ vi.mock("sonner", () => ({
   },
 }));
 
+vi.mock("@/lib/offline/artifact-cache", () => ({
+  ARTIFACT_CACHE_NAME: "sow-artifacts",
+  cacheArtifacts: vi.fn().mockResolvedValue(undefined),
+  getArtifactCacheStatus: vi.fn().mockResolvedValue({ isCached: false, renderJobId: "test-job" }),
+  isOfflineSupportedOnCurrentDevice: vi.fn().mockReturnValue(true),
+  requestPersistentStorage: vi.fn().mockResolvedValue(true),
+}));
+
 describe("OfflineStatus", () => {
   const mockProps = {
     songsetId: "test-songset",
     renderJobId: "test-job",
-    mp3R2Key: "https://r2.example.com/audio.mp3",
-    mp4R2Key: "https://r2.example.com/video.mp4",
-    chaptersR2Key: "https://r2.example.com/chapters.json",
+    mp3R2Key: "renders/test-job/output.mp3",
+    mp4R2Key: "renders/test-job/output.mp4",
+    chaptersR2Key: "renders/test-job/chapters.json",
   };
 
   beforeEach(() => {
     vi.clearAllMocks();
 
-    // Mock caches API
     const mockCache = {
       match: vi.fn().mockResolvedValue(null),
       put: vi.fn().mockResolvedValue(undefined),
+      keys: vi.fn().mockResolvedValue([]),
+      delete: vi.fn().mockResolvedValue(true),
     };
 
     Object.defineProperty(global, "caches", {
@@ -36,15 +44,16 @@ describe("OfflineStatus", () => {
       configurable: true,
     });
 
-    // Mock fetch
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
-      clone: vi.fn().mockReturnValue({
-        ok: true,
+      json: vi.fn().mockResolvedValue({
+        renderJobId: "test-job",
+        mp3Url: "/api/r2/artifact/test-job/output.mp3",
+        mp4Url: "/api/r2/artifact/test-job/output.mp4",
+        chaptersUrl: "/api/r2/artifact/test-job/chapters.json",
       }),
     });
 
-    // Mock navigator.userAgent
     Object.defineProperty(navigator, "userAgent", {
       value: "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
       writable: true,
@@ -66,18 +75,8 @@ describe("OfflineStatus", () => {
     });
 
     it("renders offline ready badge when cached", async () => {
-      const mockCache = {
-        match: vi.fn().mockResolvedValue({ ok: true }),
-        put: vi.fn().mockResolvedValue(undefined),
-      };
-
-      Object.defineProperty(global, "caches", {
-        value: {
-          open: vi.fn().mockResolvedValue(mockCache),
-        },
-        writable: true,
-        configurable: true,
-      });
+      const { getArtifactCacheStatus } = await import("@/lib/offline/artifact-cache");
+      vi.mocked(getArtifactCacheStatus).mockResolvedValueOnce({ isCached: true, renderJobId: "test-job" });
 
       render(<OfflineStatus {...mockProps} />);
 
@@ -95,8 +94,9 @@ describe("OfflineStatus", () => {
   });
 
   describe("caching", () => {
-    it("caches artifacts when download button clicked", async () => {
+    it("fetches proxy URLs and caches artifacts when download button clicked", async () => {
       const { toast } = await import("sonner");
+      const { cacheArtifacts } = await import("@/lib/offline/artifact-cache");
 
       render(<OfflineStatus {...mockProps} />);
 
@@ -104,9 +104,19 @@ describe("OfflineStatus", () => {
       fireEvent.click(downloadButton);
 
       await waitFor(() => {
-        expect(global.fetch).toHaveBeenCalledWith(mockProps.mp3R2Key);
-        expect(global.fetch).toHaveBeenCalledWith(mockProps.mp4R2Key);
-        expect(global.fetch).toHaveBeenCalledWith(mockProps.chaptersR2Key);
+        expect(global.fetch).toHaveBeenCalledWith("/api/offline/cache?renderJobId=test-job");
+      });
+
+      await waitFor(() => {
+        expect(cacheArtifacts).toHaveBeenCalledWith(
+          "test-job",
+          {
+            mp3Url: "/api/r2/artifact/test-job/output.mp3",
+            mp4Url: "/api/r2/artifact/test-job/output.mp4",
+            chaptersUrl: "/api/r2/artifact/test-job/chapters.json",
+          },
+          expect.any(Function)
+        );
       });
 
       await waitFor(() => {
@@ -116,8 +126,8 @@ describe("OfflineStatus", () => {
 
     it("shows error when caching fails", async () => {
       const { toast } = await import("sonner");
-
-      global.fetch = vi.fn().mockRejectedValue(new Error("Network error"));
+      const { cacheArtifacts } = await import("@/lib/offline/artifact-cache");
+      vi.mocked(cacheArtifacts).mockRejectedValueOnce(new Error("Network error"));
 
       render(<OfflineStatus {...mockProps} />);
 
@@ -132,6 +142,9 @@ describe("OfflineStatus", () => {
 
   describe("iOS version check", () => {
     it("shows iOS warning for iOS < 17.4", async () => {
+      const { isOfflineSupportedOnCurrentDevice } = await import("@/lib/offline/artifact-cache");
+      vi.mocked(isOfflineSupportedOnCurrentDevice).mockReturnValueOnce(false);
+
       Object.defineProperty(navigator, "userAgent", {
         value: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_3_1 like Mac OS X)",
         writable: true,
@@ -163,14 +176,7 @@ describe("OfflineStatus", () => {
 
   describe("storage persistence", () => {
     it("requests persistent storage on first cache", async () => {
-      const mockPersist = vi.fn().mockResolvedValue(true);
-      Object.defineProperty(navigator, "storage", {
-        value: {
-          persist: mockPersist,
-        },
-        writable: true,
-        configurable: true,
-      });
+      const { requestPersistentStorage } = await import("@/lib/offline/artifact-cache");
 
       render(<OfflineStatus {...mockProps} />);
 
@@ -178,7 +184,7 @@ describe("OfflineStatus", () => {
       fireEvent.click(downloadButton);
 
       await waitFor(() => {
-        expect(mockPersist).toHaveBeenCalled();
+        expect(requestPersistentStorage).toHaveBeenCalled();
       });
     });
   });

--- a/webapp/src/test/lib/render/chapters.test.ts
+++ b/webapp/src/test/lib/render/chapters.test.ts
@@ -8,6 +8,7 @@ import {
   parseChaptersManifest,
   getChapterDurations,
   getChapterProgress,
+  normalizeChaptersManifest,
 } from "@/lib/render/chapters";
 import { AudioSegmentInfo } from "@/lib/render/chapters";
 import { AssetFetcher } from "@/lib/render/asset-fetcher";
@@ -469,6 +470,106 @@ describe("chapters", () => {
     it("returns null for time outside chapters", () => {
       expect(getChapterProgress(manifest, -1)).toBeNull();
       expect(getChapterProgress(manifest, 101)).toBeNull();
+    });
+  });
+
+  describe("normalizeChaptersManifest", () => {
+    it("normalizes snake_case keys to camelCase", () => {
+      const snakeCaseData = {
+        chapters: [
+          {
+            position: 1,
+            song_title: "Song A",
+            start_seconds: 0,
+            end_seconds: 30,
+            lines: [
+              { text: "Line 1", start_seconds: 5 },
+            ],
+          },
+        ],
+        total_duration_seconds: 30,
+        generated_at: "2024-01-01T00:00:00Z",
+      };
+
+      const manifest = normalizeChaptersManifest(snakeCaseData);
+
+      expect(manifest.chapters).toHaveLength(1);
+      expect(manifest.chapters[0].songTitle).toBe("Song A");
+      expect(manifest.chapters[0].startSeconds).toBe(0);
+      expect(manifest.chapters[0].endSeconds).toBe(30);
+      expect(manifest.chapters[0].lines[0].startSeconds).toBe(5);
+      expect(manifest.totalDurationSeconds).toBe(30);
+      expect(manifest.generatedAt).toBe("2024-01-01T00:00:00Z");
+    });
+
+    it("passes through already-camelCase data unchanged", () => {
+      const camelCaseData = {
+        chapters: [
+          {
+            position: 1,
+            songTitle: "Song A",
+            startSeconds: 0,
+            endSeconds: 30,
+            lines: [
+              { text: "Line 1", startSeconds: 5 },
+            ],
+          },
+        ],
+        totalDurationSeconds: 30,
+        generatedAt: "2024-01-01T00:00:00Z",
+      };
+
+      const manifest = normalizeChaptersManifest(camelCaseData);
+
+      expect(manifest.chapters).toHaveLength(1);
+      expect(manifest.chapters[0].songTitle).toBe("Song A");
+      expect(manifest.chapters[0].startSeconds).toBe(0);
+    });
+
+    it("handles mixed snake_case and camelCase keys", () => {
+      const mixedData = {
+        chapters: [
+          {
+            position: 1,
+            songTitle: "Song A",
+            start_seconds: 0,
+            endSeconds: 30,
+            lines: [
+              { text: "Line 1", start_seconds: 5 },
+            ],
+          },
+        ],
+        total_duration_seconds: 30,
+        generatedAt: "2024-01-01",
+      };
+
+      const manifest = normalizeChaptersManifest(mixedData);
+
+      expect(manifest.chapters[0].songTitle).toBe("Song A");
+      expect(manifest.chapters[0].startSeconds).toBe(0);
+      expect(manifest.chapters[0].lines[0].startSeconds).toBe(5);
+      expect(manifest.totalDurationSeconds).toBe(30);
+    });
+
+    it("throws on invalid chapters structure", () => {
+      expect(() => normalizeChaptersManifest({ chapters: "not an array" }))
+        .toThrow("chapters must be an array");
+    });
+
+    it("throws on missing startSeconds in chapter", () => {
+      expect(() => normalizeChaptersManifest({
+        chapters: [{ position: 1, songTitle: "Test" }],
+      })).toThrow("missing or invalid startSeconds/endSeconds");
+    });
+
+    it("handles empty chapters array", () => {
+      const manifest = normalizeChaptersManifest({
+        chapters: [],
+        totalDurationSeconds: 0,
+        generatedAt: "2024-01-01",
+      });
+
+      expect(manifest.chapters).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes multiple issues with the Worship screen playback experience, including offline caching, chapter navigation, and UX bugs affecting both desktop and mobile.

## Changes

### 1. Offline Caching with Signed URLs
- Use signed URLs from `/api/offline/cache` endpoint for fetching R2 artifacts
- Map R2 keys to signed URLs for proper cache storage and retrieval
- Add error handling with user-friendly messages

### 2. R2 Download Proxy for CORS
- Add `/api/r2/artifact/[...path]` proxy route to stream R2 content through same origin
- Update offline caching to use proxy URLs instead of direct R2 signed URLs
- Add `NetworkOnly` rule in service worker for `/api/r2/` routes
- Fixes CORS errors when fetching artifacts for offline caching

### 3. Chapter Skip Buttons Fix
- Backend: Replace `dataclasses.asdict()` with `to_camel_case_dict()` for proper camelCase serialization
- Frontend: Add `normalizeChaptersManifest()` to handle existing R2 data with snake_case keys
- Consolidate Chapter type to single source in `chapters.ts`
- Fixes `chapter.startSeconds` being undefined when loaded from R2

### 4. Worship Screen UX Fixes (v3)

| Bug | Platform | Fix |
|-----|----------|-----|
| Lyrics panel not opening on desktop click | Desktop | `handleTouchEnd` with 3-branch logic + 100ms debounce |
| Timestamps shown as "NaN:NaN" | Mobile | `isFinite` guard in `formatTime` + `Number.isFinite` checks in chapters.ts |
| Controls only visible on click (pauses playback) | Desktop | `onMouseMove` to reveal, hover to keep visible, `pointer-events-none` when hidden |
| Fullscreen flickers on play/pause | Desktop | Ref for `showControls` in effect, `onDoubleClick` preventDefault, re-enter button |
| Playback controls too wide, Play button cut off | Mobile | Responsive `sm:` variants, mute button hidden on mobile |

## Files Changed

- `webapp/src/components/play/ControllerPlayer.tsx` - Fullscreen, controls visibility
- `webapp/src/components/play/LyricJumpList.tsx` - Lyrics panel toggle, timestamp formatting
- `webapp/src/components/play/PlaybackControls.tsx` - Responsive button sizes
- `webapp/src/lib/render/chapters.ts` - NaN validation, normalize function
- `webapp/src/app/api/r2/artifact/[...path]/route.ts` - R2 proxy endpoint
- `webapp/src/app/api/offline/cache/route.ts` - Proxy URL support
- `services/render-worker/src/sow_render_worker/chapters.py` - CamelCase serialization

## Testing

- All 80 test files pass (1344 tests)
- ESLint passes with no errors
- Production build succeeds