### PR TITLE
feat: Render worker performance improvement, documentation update, and spec documents for upcoming title card audio mode feature.

### DIFF
--- a/services/render-worker/README.md
+++ b/services/render-worker/README.md
@@ -296,7 +296,7 @@ Pushes to `main` that modify `services/render-worker/` trigger the deploy workfl
 3. Builds, tags, and pushes the Docker image
 4. Updates the Lambda function code with the new image URI
 
-Required GitHub secrets: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`
+Required GitHub secrets: `SOW_AWS_ACCESS_KEY_ID`, `SOW_AWS_SECRET_ACCESS_KEY`
 
 ### SQS Queue Setup
 

--- a/services/render-worker/src/sow_render_worker/audio_engine.py
+++ b/services/render-worker/src/sow_render_worker/audio_engine.py
@@ -222,10 +222,21 @@ def generate_songset_audio(
         if not audio_path:
             raise ValueError(f"Could not get audio for recording {item.recording_hash_prefix}")
 
-        info = get_audio_info(audio_path)
-        if not info:
-            raise ValueError(f"Could not probe audio file: {audio_path}")
-        duration_ms = info["duration_ms"]
+        if item.duration_seconds is not None:
+            duration_ms = round(item.duration_seconds * 1000)
+            logger.info(
+                "[%s] Audio: song %d duration from DB - duration=%.1fs",
+                job_id or "unknown", i + 1, item.duration_seconds,
+            )
+        else:
+            info = get_audio_info(audio_path)
+            if not info:
+                raise ValueError(f"Could not probe audio file: {audio_path}")
+            duration_ms = info["duration_ms"]
+            logger.info(
+                "[%s] Audio: song %d probed (no DB duration) - duration=%.1fs",
+                job_id or "unknown", i + 1, duration_ms / 1000.0,
+            )
 
         gap_ms = 0
         crossfade_ms = 0
@@ -234,7 +245,7 @@ def generate_songset_audio(
             crossfade_ms = min(get_crossfade_ms(item), duration_ms)
 
         logger.info(
-            "[%s] Audio: song %d probed - duration=%.1fs, gap_ms=%d, crossfade_ms=%d",
+            "[%s] Audio: song %d - duration=%.1fs, gap_ms=%d, crossfade_ms=%d",
             job_id or "unknown", i + 1, duration_ms / 1000.0, gap_ms, crossfade_ms,
         )
 

--- a/specs/fix-title-card-lyrics-timeline-desync-v2.md
+++ b/specs/fix-title-card-lyrics-timeline-desync-v2.md
@@ -1,0 +1,342 @@
+# Fix: Title Card Audio Mode — Configurable Overlay vs Delay
+
+## Problem
+
+When `include_title_card=True`, the title card **replaces** the first N seconds of video frames while audio continues playing from time 0. This has two observable effects:
+
+1. **Audio plays during the title card** — The prelude/intro music is audible while the title card is displayed. Any lyrics that fall within the title card window (0–N seconds of the audio timeline) are never rendered on screen.
+
+2. **`TitleCardConfig.duration_seconds` is semantically wrong** — Set to `total_duration_seconds` (the full audio duration) instead of the title card's own display duration. This doesn't affect rendering today (`render_title_card` uses `config.total_duration_seconds`), but it's a misleading data model.
+
+### Is This Actually a Bug?
+
+**No — it's a design choice with tradeoffs.** After the title card ends, `current_time = frame_count / fps` maps directly to the audio timeline, so lyrics ARE in sync with what the viewer hears. The only "loss" is lyrics in the first N seconds of audio that fall under the title card window. For worship sets with long intros (15s+), this is typically unnoticeable.
+
+The current "overlay" behavior (prelude plays under title card) is often desirable — it provides a musical intro before lyrics begin. The alternative "delay" behavior (silence during title card, audio shifted) is also valid for cases where you want a clean separation.
+
+**The fix should make this configurable rather than replacing one behavior with another.**
+
+### What the Previous Spec Got Wrong
+
+The v1 spec (`fix-title-card-lyrics-timeline-desync.md`) presented three "cascading desynchronization issues," but:
+
+- **Problem #1 (audio plays during title card)** — This IS the current behavior, not a bug. It's often desirable.
+- **Problem #2 (lyrics appear at wrong video times)** — Misleading. After the title card, `current_time` maps to the audio timeline, so lyrics are in sync with the audio the viewer hears. The only issue is lyrics in the title card window are lost.
+- **Problem #3 (chapter timestamps not offset)** — NOT a current bug. In the current behavior, audio and video timelines are identical — a chapter at audio time 180s IS at video time 180s, so seeking works correctly. This issue only arises AFTER implementing the audio delay fix. It's a necessary accompaniment to the delay mode, not a pre-existing bug.
+
+---
+
+## Proposed Solution: Configurable `title_card_audio_mode`
+
+Add a `title_card_audio_mode` option to `VideoEngine` with two modes:
+
+| Mode | Behavior | Video Length | Chapter Offset | Audio During Title Card |
+|---|---|---|---|---|
+| `overlay` (default) | Prelude plays under title card | `audio_duration` | No offset needed | Audible (current behavior) |
+| `delay` | Silence during title card, audio shifted | `audio_duration + title_card_duration` | Offset by `title_card_duration` | Silent, then audio starts |
+
+### Why `overlay` as Default
+
+- Preserves current behavior (no breaking change)
+- Prelude under title card is often musically desirable
+- No video length increase, no silence period
+- Existing videos render identically
+
+---
+
+## File Changes
+
+### 1. `src/sow_render_worker/video_engine.py`
+
+#### 1a. Add `title_card_audio_mode` parameter to `VideoEngine.__init__()` (line 64)
+
+```python
+class TitleCardAudioMode(str, Enum):
+    OVERLAY = "overlay"
+    DELAY = "delay"
+
+class VideoEngine:
+    def __init__(
+        self,
+        asset_fetcher: AssetFetcherProtocol,
+        template: VideoTemplateName = "dark",
+        font_size_preset: FontSizePreset = "M",
+        resolution: str = "1080p",
+        fps: int = 24,
+        include_title_card: bool = True,
+        title_card_duration_seconds: float = 5.0,
+        title_card_audio_mode: TitleCardAudioMode = TitleCardAudioMode.OVERLAY,
+        ffmpeg_path: str | None = None,
+        ffprobe_path: str | None = None,
+    ):
+        ...
+        self.title_card_audio_mode = title_card_audio_mode
+```
+
+#### 1b. Compute `title_card_offset` in `generate_video()` (after line 125)
+
+```python
+title_card_offset = (
+    self.title_card_duration_seconds
+    if (self.include_title_card and self.title_card_audio_mode == TitleCardAudioMode.DELAY)
+    else 0.0
+)
+video_duration_seconds = total_duration_seconds + title_card_offset
+total_frames = math.ceil(video_duration_seconds * self.fps)
+```
+
+Pass `title_card_offset` to `encode_video_with_ffmpeg()` and use `video_duration_seconds` for `VideoExportResult.duration_seconds`.
+
+#### 1c. Add `title_card_offset` parameter to `encode_video_with_ffmpeg()` (line 241)
+
+Add parameter `title_card_offset: float = 0.0`.
+
+#### 1d. Delay audio in FFmpeg command when `title_card_offset > 0` (lines 262-286)
+
+When `title_card_offset > 0`, add an `adelay` filter:
+
+```python
+if title_card_offset > 0:
+    delay_ms = round(title_card_offset * 1000)
+    args = [
+        self.ffmpeg_path, "-y",
+        "-f", "rawvideo", "-vcodec", "rawvideo",
+        "-s", f"{width}x{height}", "-pix_fmt", "rgba",
+        "-r", str(self.fps),
+        "-i", "-",
+        "-i", audio_path,
+        "-filter_complex", f"[1:a]adelay={delay_ms}|{delay_ms}[delayed]",
+        "-map", "0:v", "-map", "[delayed]",
+        *self.get_video_codec_args(),
+        "-c:a", "aac", "-b:a", "192k",
+        output_path,
+    ]
+else:
+    args = [
+        self.ffmpeg_path, "-y",
+        "-f", "rawvideo", "-vcodec", "rawvideo",
+        "-s", f"{width}x{height}", "-pix_fmt", "rgba",
+        "-r", str(self.fps),
+        "-i", "-",
+        "-i", audio_path,
+        *self.get_video_codec_args(),
+        "-c:a", "aac", "-b:a", "192k",
+        "-shortest",
+        output_path,
+    ]
+```
+
+**Note:** Remove `-shortest` when `adelay` is used. With `adelay`, the audio stream becomes `title_card_offset + audio_duration` long, matching the video stream length exactly.
+
+#### 1e. Fix `current_time` calculation in delay mode (line 332)
+
+```python
+if title_card_config and frame_count < title_card_frame_count:
+    frame_bytes = title_card_bytes
+else:
+    current_time = (frame_count - title_card_frame_count) / self.fps if title_card_offset > 0 else frame_count / self.fps
+    img = self.frame_renderer.render_frame(lyrics, segments, current_time)
+    frame_bytes = img.tobytes()
+```
+
+In `overlay` mode, `current_time = frame_count / self.fps` (unchanged — maps to audio timeline).
+In `delay` mode, `current_time = (frame_count - title_card_frame_count) / self.fps` (maps to audio timeline starting at 0.0 after title card).
+
+#### 1f. Fix `TitleCardConfig.duration_seconds` (line 206) — applies to BOTH modes
+
+```python
+title_card_config = TitleCardConfig(
+    enabled=True,
+    duration_seconds=self.title_card_duration_seconds,
+    ...
+)
+```
+
+This is a semantic fix regardless of audio mode. `render_title_card()` uses `config.total_duration_seconds` (not `config.duration_seconds`) for the "X:XX" subtitle, so rendering is unaffected.
+
+#### 1g. Update `VideoExportResult` to return video duration
+
+```python
+return VideoExportResult(
+    output_path=output_path,
+    total_frames=total_frames,
+    duration_seconds=video_duration_seconds,
+    width=self.resolution[0],
+    height=self.resolution[1],
+    fps=self.fps,
+)
+```
+
+In `overlay` mode, `video_duration_seconds == total_duration_seconds` (no change).
+In `delay` mode, `video_duration_seconds == total_duration_seconds + title_card_offset`.
+
+### 2. `src/sow_render_worker/pipeline.py`
+
+#### 2a. Offset chapter timestamps in delay mode (lines 436-441)
+
+```python
+title_card_offset = (
+    job.title_card_duration_seconds
+    if (job.include_title_card and job.title_card_audio_mode == TitleCardAudioMode.DELAY)
+    else 0.0
+)
+
+chapters_for_video = [
+    ChapterInfo(
+        position=ch.position,
+        song_title=ch.song_title,
+        start_seconds=ch.start_seconds + title_card_offset,
+        end_seconds=ch.end_seconds + title_card_offset,
+        lines=tuple(
+            {
+                "text": line["text"],
+                "startSeconds": line["startSeconds"] + title_card_offset,
+            }
+            for line in ch.lines
+        ) if ch.lines else (),
+    )
+    for ch in (
+        _segment_to_chapter_info(seg, i)
+        for i, seg in enumerate(audio_result.segments)
+    )
+]
+```
+
+#### 2b. Offset chapters manifest timestamps (lines 445-449)
+
+Pass `title_card_offset` to `generate_chapters_manifest()`.
+
+### 3. `src/sow_render_worker/chapters.py`
+
+#### 3a. Add `title_card_offset` parameter to `generate_chapters_manifest()` (line 75)
+
+```python
+def generate_chapters_manifest(
+    segments: list[SegmentInfo],
+    download_lrc: Callable[[str], str | None | object],
+    total_duration_seconds: float,
+    title_card_offset: float = 0.0,
+) -> ChaptersManifest:
+```
+
+Offset all `ChapterLine.start_seconds` and `Chapter.start_seconds`/`Chapter.end_seconds` by `title_card_offset`. When `title_card_offset == 0.0`, behavior is identical to current code.
+
+### 4. `src/sow_render_worker/frame_renderer.py`
+
+No changes needed. `render_frame()` receives `current_time` on the audio timeline (regardless of mode), so segment and lyric lookups work correctly.
+
+---
+
+## Test Updates
+
+### `tests/test_video_engine.py`
+
+#### Test 1: `total_frames` includes title card duration in delay mode
+
+When `title_card_audio_mode=DELAY` with `title_card_duration_seconds=10.0` and audio duration 180s:
+- `total_frames = ceil((180 + 10) * 24) = 4560`
+
+When `title_card_audio_mode=OVERLAY`:
+- `total_frames = ceil(180 * 24) = 4320` (unchanged)
+
+#### Test 2: FFmpeg command includes `adelay` in delay mode
+
+Verify the FFmpeg args contain `-filter_complex` with `adelay={offset_ms}|{offset_ms}` and `-map 0:v -map [delayed]` when `title_card_audio_mode=DELAY`.
+
+#### Test 3: FFmpeg command has no `adelay` in overlay mode
+
+Verify the existing FFmpeg args (no `-filter_complex`, has `-shortest`) when `title_card_audio_mode=OVERLAY`.
+
+#### Test 4: `current_time` starts at 0.0 after title card in delay mode
+
+With `title_card_audio_mode=DELAY`, `title_card_duration_seconds=5.0`, `fps=24`:
+- Title card frames: 0–119
+- First lyrics frame (120): `current_time = (120 - 120) / 24 = 0.0`
+- Frame 240: `current_time = (240 - 120) / 24 = 5.0`
+
+With `title_card_audio_mode=OVERLAY`:
+- Title card frames: 0–119
+- First lyrics frame (120): `current_time = 120 / 24 = 5.0` (maps to audio timeline, unchanged)
+
+#### Test 5: `VideoExportResult.duration_seconds` includes title card in delay mode
+
+In delay mode: `result.duration_seconds == audio_duration + title_card_duration_seconds`
+In overlay mode: `result.duration_seconds == audio_duration`
+
+#### Test 6: `TitleCardConfig.duration_seconds` equals title card duration (both modes)
+
+Verify `title_card_config.duration_seconds == self.title_card_duration_seconds` (not `total_duration_seconds`).
+
+### `tests/test_chapters.py`
+
+#### Test 7: Chapter timestamps offset by `title_card_offset`
+
+Verify that `generate_chapters_manifest()` with `title_card_offset=10.0` shifts all `start_seconds`/`end_seconds` and `ChapterLine.start_seconds` by 10.0.
+Verify that `title_card_offset=0.0` produces identical output to current behavior.
+
+### `tests/test_pipeline.py`
+
+#### Test 8: Pipeline offsets chapter timestamps in delay mode only
+
+Verify that `chapters_for_video` and `chapters_manifest` have timestamps shifted by `title_card_duration_seconds` when `title_card_audio_mode=DELAY`.
+Verify no offset when `title_card_audio_mode=OVERLAY`.
+
+---
+
+## Implementation Order
+
+1. Add `TitleCardAudioMode` enum and `title_card_audio_mode` parameter to `VideoEngine.__init__()` (1a)
+2. Add `title_card_offset` computation in `generate_video()` (1b)
+3. Add `title_card_offset` parameter to `encode_video_with_ffmpeg()` (1c)
+4. Delay audio in FFmpeg command when `title_card_offset > 0` (1d)
+5. Fix `current_time` calculation for delay mode (1e)
+6. Fix `TitleCardConfig.duration_seconds` (1f) — applies to both modes
+7. Update `VideoExportResult` (1g)
+8. Offset chapter timestamps in `pipeline.py` (2a, 2b)
+9. Add `title_card_offset` to `generate_chapters_manifest()` (3a)
+10. Add/update tests
+11. Run `PYTHONPATH=src pytest tests/test_video_engine.py tests/test_chapters.py tests/test_pipeline.py -v`
+
+---
+
+## Edge Cases
+
+### Title card disabled (`include_title_card=False`)
+
+`title_card_offset = 0.0` regardless of mode. No changes to FFmpeg command, `current_time`, or chapter timestamps. Behavior identical to current code.
+
+### Overlay mode (default)
+
+`title_card_offset = 0.0`. All code paths fall through to existing behavior. The only change is `TitleCardConfig.duration_seconds` (semantic fix, no rendering impact).
+
+### Delay mode with title card duration > first song intro gap
+
+If the first song's intro gap is shorter than `title_card_duration_seconds`, the title card still shows for the full duration. After the title card, `current_time = 0.0` and the intro info display works correctly from the start of the audio timeline. No lyrics are lost.
+
+### Very short audio (< title card duration) in delay mode
+
+If audio is shorter than `title_card_duration_seconds`, the `adelay` filter would push audio beyond the video end. The video would show the title card then silence. This is unlikely in practice (worship sets are long) but should be documented.
+
+### `generate_blank_video()` with title card
+
+When no lyrics are found, `generate_blank_video()` is called. This method doesn't support title cards. No change needed — title cards are only meaningful when lyrics exist.
+
+---
+
+## Verification Checklist
+
+- [ ] `TitleCardAudioMode` enum added with `OVERLAY` and `DELAY` values
+- [ ] `VideoEngine.__init__()` accepts `title_card_audio_mode` parameter (default `OVERLAY`)
+- [ ] `title_card_offset` computed correctly based on mode
+- [ ] `total_frames = ceil((audio_duration + title_card_offset) * fps)` in delay mode
+- [ ] `total_frames = ceil(audio_duration * fps)` in overlay mode (unchanged)
+- [ ] FFmpeg command includes `adelay` filter when `title_card_offset > 0`
+- [ ] FFmpeg command omits `adelay` and uses `-shortest` when `title_card_offset == 0`
+- [ ] `current_time = (frame_count - title_card_frame_count) / fps` in delay mode
+- [ ] `current_time = frame_count / fps` in overlay mode (unchanged)
+- [ ] `TitleCardConfig.duration_seconds = self.title_card_duration_seconds` (both modes)
+- [ ] `VideoExportResult.duration_seconds` includes title card offset in delay mode
+- [ ] Chapter timestamps offset by `title_card_offset` in delay mode
+- [ ] Chapter timestamps unchanged in overlay mode
+- [ ] All existing tests pass
+- [ ] New tests pass

--- a/specs/fix-title-card-lyrics-timeline-desync-v3.md
+++ b/specs/fix-title-card-lyrics-timeline-desync-v3.md
@@ -1,0 +1,529 @@
+# Fix: Title Card Audio Mode — Configurable Overlay vs Delay (v3)
+
+## Problem
+
+When `include_title_card=True`, the title card **replaces** the first N seconds of video frames while audio continues playing from time 0. This has two observable effects:
+
+1. **Audio plays during the title card** — The prelude/intro music is audible while the title card is displayed. Any lyrics that fall within the title card window (0–N seconds of the audio timeline) are never rendered on screen.
+
+2. **`TitleCardConfig.duration_seconds` is semantically wrong** — Set to `total_duration_seconds` (the full audio duration) instead of the title card's own display duration. This doesn't affect rendering today (`render_title_card` uses `config.total_duration_seconds`), but it's a misleading data model.
+
+### Is This Actually a Bug?
+
+**No — it's a design choice with tradeoffs.** After the title card ends, `current_time = frame_count / fps` maps directly to the audio timeline, so lyrics ARE in sync with what the viewer hears. The only "loss" is lyrics in the first N seconds of audio that fall under the title card window. For worship sets with long intros (15s+), this is typically unnoticeable.
+
+The current "overlay" behavior (prelude plays under title card) is often desirable — it provides a musical intro before lyrics begin. The alternative "delay" behavior (silence during title card, audio shifted) is also valid for cases where you want a clean separation.
+
+**The fix should make this configurable rather than replacing one behavior with another.**
+
+### What the Previous Specs Got Wrong
+
+**v1** (`fix-title-card-lyrics-timeline-desync.md`) presented three "cascading desynchronization issues," but:
+
+- **Problem #1 (audio plays during title card)** — This IS the current behavior, not a bug. It's often desirable.
+- **Problem #2 (lyrics appear at wrong video times)** — Misleading. After the title card, `current_time` maps to the audio timeline, so lyrics are in sync with the audio the viewer hears. The only issue is lyrics in the title card window are lost.
+- **Problem #3 (chapter timestamps not offset)** — NOT a current bug. In the current behavior, audio and video timelines are identical — a chapter at audio time 180s IS at video time 180s, so seeking works correctly. This issue only arises AFTER implementing the audio delay fix. It's a necessary accompaniment to the delay mode, not a pre-existing bug.
+
+**v2** (`fix-title-card-lyrics-timeline-desync-v2.md`) corrected the above but introduced new issues:
+
+- **adelay timing mismatch** — `adelay` was computed from `title_card_duration_seconds` (a float), but the actual title card display duration is `ceil(title_card_duration_seconds * fps) / fps`, which can be up to ~42ms longer at 24fps. This causes audio to start slightly before lyrics frames begin at the title-card-to-lyrics transition.
+- **Missing full-stack schema changes** — No mention of adding `title_card_audio_mode` to `RenderJob`, DB schema, API validation, or pipeline wiring. The feature can't be used from the web app without these.
+- **Stale `ChaptersManifest.total_duration_seconds`** — Chapter/line timestamps were offset but the manifest's `total_duration_seconds` was not updated, misrepresenting the video length.
+- **Dead code in pipeline chapter offset** — The proposed code offset `ch.lines` but `_segment_to_chapter_info()` never populates `lines`, making the offset logic a no-op.
+
+---
+
+## Proposed Solution: Configurable `title_card_audio_mode`
+
+Add a `title_card_audio_mode` option to `VideoEngine` with two modes:
+
+| Mode | Behavior | Video Length | Chapter Offset | Audio During Title Card |
+|---|---|---|---|---|
+| `overlay` (default) | Prelude plays under title card | `audio_duration` | No offset needed | Audible (current behavior) |
+| `delay` | Silence during title card, audio shifted | `audio_duration + title_card_duration` | Offset by `title_card_duration` | Silent, then audio starts |
+
+### Why `overlay` as Default
+
+- Preserves current behavior (no breaking change)
+- Prelude under title card is often musically desirable
+- No video length increase, no silence period
+- Existing videos render identically
+
+---
+
+## File Changes
+
+### 1. `src/sow_render_worker/video_engine.py`
+
+#### 1a. Add `TitleCardAudioMode` enum and `title_card_audio_mode` parameter to `VideoEngine.__init__()` (line 64)
+
+```python
+class TitleCardAudioMode(str, Enum):
+    OVERLAY = "overlay"
+    DELAY = "delay"
+
+class VideoEngine:
+    def __init__(
+        self,
+        asset_fetcher: AssetFetcherProtocol,
+        template: VideoTemplateName = "dark",
+        font_size_preset: FontSizePreset = "M",
+        resolution: str = "1080p",
+        fps: int = 24,
+        include_title_card: bool = True,
+        title_card_duration_seconds: float = 5.0,
+        title_card_audio_mode: TitleCardAudioMode = TitleCardAudioMode.OVERLAY,
+        ffmpeg_path: str | None = None,
+        ffprobe_path: str | None = None,
+    ):
+        ...
+        self.title_card_audio_mode = title_card_audio_mode
+```
+
+#### 1b. Compute `title_card_offset` and `title_card_frame_count` in `generate_video()` (after line 125)
+
+**Key v3 fix:** Compute `title_card_frame_count` once in `generate_video()` (not separately in `encode_video_with_ffmpeg`) and derive `title_card_offset` from the frame-accurate duration, not the float `title_card_duration_seconds`. This eliminates the adelay timing mismatch.
+
+```python
+title_card_frame_count = (
+    math.ceil(self.title_card_duration_seconds * self.fps)
+    if self.include_title_card
+    else 0
+)
+title_card_offset = (
+    title_card_frame_count / self.fps
+    if (self.include_title_card and self.title_card_audio_mode == TitleCardAudioMode.DELAY)
+    else 0.0
+)
+video_duration_seconds = total_duration_seconds + title_card_offset
+total_frames = math.ceil(video_duration_seconds * self.fps)
+```
+
+Pass `title_card_offset` and `title_card_frame_count` to `encode_video_with_ffmpeg()`. Use `video_duration_seconds` for `VideoExportResult.duration_seconds`.
+
+**Why frame-accurate offset?** `ceil(title_card_duration_seconds * fps) / fps` can differ from `title_card_duration_seconds` by up to `(fps-1)/fps²` seconds (~41.7ms at 24fps). Using the frame-accurate value ensures the `adelay` filter delays audio by exactly the same duration the title card is displayed, preventing a subtle de-sync at the transition point.
+
+#### 1c. Add `title_card_offset` and `title_card_frame_count` parameters to `encode_video_with_ffmpeg()` (line 241)
+
+Add parameters `title_card_offset: float = 0.0` and `title_card_frame_count: int = 0`.
+
+Remove the local `title_card_frame_count` computation at lines 311-315 (now received from caller).
+
+#### 1d. Delay audio in FFmpeg command when `title_card_offset > 0` (lines 262-286)
+
+When `title_card_offset > 0`, add an `adelay` filter using the **frame-accurate** offset:
+
+```python
+if title_card_offset > 0:
+    delay_ms = round(title_card_offset * 1000)
+    args = [
+        self.ffmpeg_path, "-y",
+        "-f", "rawvideo", "-vcodec", "rawvideo",
+        "-s", f"{width}x{height}", "-pix_fmt", "rgba",
+        "-r", str(self.fps),
+        "-i", "-",
+        "-i", audio_path,
+        "-filter_complex", f"[1:a]adelay={delay_ms}|{delay_ms}[delayed]",
+        "-map", "0:v", "-map", "[delayed]",
+        *self.get_video_codec_args(),
+        "-c:a", "aac", "-b:a", "192k",
+        output_path,
+    ]
+else:
+    args = [
+        self.ffmpeg_path, "-y",
+        "-f", "rawvideo", "-vcodec", "rawvideo",
+        "-s", f"{width}x{height}", "-pix_fmt", "rgba",
+        "-r", str(self.fps),
+        "-i", "-",
+        "-i", audio_path,
+        *self.get_video_codec_args(),
+        "-c:a", "aac", "-b:a", "192k",
+        "-shortest",
+        output_path,
+    ]
+```
+
+**Note:** Remove `-shortest` when `adelay` is used. With `adelay`, the audio stream becomes `title_card_offset + audio_duration` long, matching the video stream length exactly.
+
+#### 1e. Fix `current_time` calculation in delay mode (line 332)
+
+```python
+if title_card_config and frame_count < title_card_frame_count:
+    frame_bytes = title_card_bytes
+else:
+    current_time = (
+        (frame_count - title_card_frame_count) / self.fps
+        if title_card_offset > 0
+        else frame_count / self.fps
+    )
+    img = self.frame_renderer.render_frame(lyrics, segments, current_time)
+    frame_bytes = img.tobytes()
+```
+
+In `overlay` mode, `current_time = frame_count / self.fps` (unchanged — maps to audio timeline).
+In `delay` mode, `current_time = (frame_count - title_card_frame_count) / self.fps` (maps to audio timeline starting at 0.0 after title card).
+
+#### 1f. Fix `TitleCardConfig.duration_seconds` (line 206) — applies to BOTH modes
+
+```python
+title_card_config = TitleCardConfig(
+    enabled=True,
+    duration_seconds=self.title_card_duration_seconds,
+    ...
+)
+```
+
+This is a semantic fix regardless of audio mode. `render_title_card()` uses `config.total_duration_seconds` (not `config.duration_seconds`) for the "X:XX" subtitle, so rendering is unaffected.
+
+#### 1g. Update `VideoExportResult` to return video duration
+
+```python
+return VideoExportResult(
+    output_path=output_path,
+    total_frames=total_frames,
+    duration_seconds=video_duration_seconds,
+    width=self.resolution[0],
+    height=self.resolution[1],
+    fps=self.fps,
+)
+```
+
+In `overlay` mode, `video_duration_seconds == total_duration_seconds` (no change).
+In `delay` mode, `video_duration_seconds == total_duration_seconds + title_card_offset`.
+
+### 2. `src/sow_render_worker/pipeline.py`
+
+#### 2a. Pass `title_card_audio_mode` to `VideoEngine` (line 347)
+
+```python
+video_engine = VideoEngine(
+    asset_fetcher,
+    template=job.template,
+    font_size_preset=job.font_size_preset,
+    resolution=job.resolution,
+    include_title_card=job.include_title_card,
+    title_card_duration_seconds=job.title_card_duration_seconds or 5.0,
+    title_card_audio_mode=TitleCardAudioMode(job.title_card_audio_mode)
+        if job.title_card_audio_mode
+        else TitleCardAudioMode.OVERLAY,
+)
+```
+
+#### 2b. Offset chapter timestamps in delay mode (lines 436-441)
+
+**v3 fix:** Remove the dead `ch.lines` offset from v2. `_segment_to_chapter_info()` does not populate `lines`, so offsetting them was a no-op. Only offset `start_seconds` and `end_seconds`.
+
+```python
+title_card_offset = (
+    job.title_card_duration_seconds or 5.0
+    if (job.include_title_card and job.title_card_audio_mode == TitleCardAudioMode.DELAY)
+    else 0.0
+)
+
+chapters_for_video = [
+    ChapterInfo(
+        position=ch.position,
+        song_title=ch.song_title,
+        start_seconds=ch.start_seconds + title_card_offset,
+        end_seconds=ch.end_seconds + title_card_offset,
+    )
+    for ch in (
+        _segment_to_chapter_info(seg, i)
+        for i, seg in enumerate(audio_result.segments)
+    )
+]
+```
+
+#### 2c. Pass `title_card_offset` to `generate_chapters_manifest()` (lines 445-449)
+
+```python
+chapters_manifest = generate_chapters_manifest(
+    list(audio_result.segments),
+    asset_fetcher.download_lrc,
+    audio_result.total_duration_seconds,
+    title_card_offset=title_card_offset,
+)
+```
+
+### 3. `src/sow_render_worker/chapters.py`
+
+#### 3a. Add `title_card_offset` parameter to `generate_chapters_manifest()` (line 75)
+
+```python
+def generate_chapters_manifest(
+    segments: list[SegmentInfo],
+    download_lrc: Callable[[str], str | None | object],
+    total_duration_seconds: float,
+    title_card_offset: float = 0.0,
+) -> ChaptersManifest:
+```
+
+Offset all `ChapterLine.start_seconds` and `Chapter.start_seconds`/`Chapter.end_seconds` by `title_card_offset`. When `title_card_offset == 0.0`, behavior is identical to current code.
+
+**v3 fix:** Also update `ChaptersManifest.total_duration_seconds` to `total_duration_seconds + title_card_offset` so the manifest accurately reflects the video duration.
+
+```python
+return ChaptersManifest(
+    chapters=tuple(offset_chapters),
+    total_duration_seconds=total_duration_seconds + title_card_offset,
+    generated_at=datetime.now(timezone.utc).isoformat(),
+)
+```
+
+### 4. `src/sow_render_worker/frame_renderer.py`
+
+No changes needed. `render_frame()` receives `current_time` on the audio timeline (regardless of mode), so segment and lyric lookups work correctly.
+
+### 5. `src/sow_render_worker/db.py`
+
+#### 5a. Add `title_card_audio_mode` field to `RenderJob` (line 28)
+
+```python
+@dataclass
+class RenderJob:
+    ...
+    include_title_card: bool = False
+    title_card_duration_seconds: Optional[float] = None
+    title_card_audio_mode: Optional[str] = None  # "overlay" or "delay"
+    ...
+```
+
+Update `_row_to_render_job()` to read the new column.
+
+### 6. Web App — DB Schema
+
+#### 6a. Add `titleCardAudioMode` column to `renderJobs` table (`webapp/src/db/schema.ts`, line 237)
+
+```typescript
+titleCardDurationSeconds: real("title_card_duration_seconds").default(10),
+titleCardAudioMode: text("title_card_audio_mode").default("overlay"),
+```
+
+Run `npx drizzle-kit push` to apply the schema change.
+
+### 7. Web App — API Validation
+
+#### 7a. Add `titleCardAudioMode` to Zod schema (`webapp/src/app/api/render-jobs/route.ts`, line 7)
+
+```typescript
+const createRenderJobSchema = z.object({
+  songsetId: z.string().min(1),
+  template: z.enum(["dark", "gradient_warm", "gradient_blue"]).optional(),
+  resolution: z.enum(["720p", "1080p"]).optional(),
+  audioEnabled: z.boolean().optional(),
+  videoEnabled: z.boolean().optional(),
+  fontSizePreset: z.enum(["S", "M", "L", "XL"]).optional(),
+  includeTitleCard: z.boolean().optional(),
+  titleCardDurationSeconds: z.number().min(5).max(30).optional(),
+  titleCardAudioMode: z.enum(["overlay", "delay"]).optional(),
+});
+```
+
+### 8. Web App — Job Manager
+
+#### 8a. Add `titleCardAudioMode` to `CreateRenderJobInput` (`webapp/src/lib/render/job-manager.ts`, line 24)
+
+```typescript
+export interface CreateRenderJobInput {
+  songsetId: string;
+  template?: string;
+  resolution?: string;
+  audioEnabled?: boolean;
+  videoEnabled?: boolean;
+  fontSizePreset?: string;
+  includeTitleCard?: boolean;
+  titleCardDurationSeconds?: number;
+  titleCardAudioMode?: "overlay" | "delay";
+}
+```
+
+#### 8b. Persist `titleCardAudioMode` in `createRenderJob()` (line 129)
+
+```typescript
+const [job] = await db
+    .insert(renderJobs)
+    .values({
+      ...
+      includeTitleCard: input.includeTitleCard ?? false,
+      titleCardDurationSeconds: input.titleCardDurationSeconds ?? null,
+      titleCardAudioMode: input.titleCardAudioMode ?? null,
+      ...
+    })
+    .returning();
+```
+
+### 9. Web App — Frontend Render Form
+
+Add a dropdown/select for `titleCardAudioMode` (only visible when `includeTitleCard` is true):
+
+- **"Overlay (prelude plays under title card)"** — default, selected
+- **"Delay (silence during title card)"**
+
+---
+
+## Test Updates
+
+### `tests/test_video_engine.py`
+
+#### Test 1: `total_frames` includes title card duration in delay mode
+
+When `title_card_audio_mode=DELAY` with `title_card_duration_seconds=10.0` and audio duration 180s:
+- `title_card_frame_count = ceil(10.0 * 24) = 240`
+- `title_card_offset = 240 / 24 = 10.0`
+- `total_frames = ceil((180 + 10.0) * 24) = 4560`
+
+When `title_card_audio_mode=OVERLAY`:
+- `title_card_offset = 0.0`
+- `total_frames = ceil(180 * 24) = 4320` (unchanged)
+
+#### Test 2: Frame-accurate `title_card_offset` when duration doesn't divide evenly by fps
+
+With `title_card_duration_seconds=5.5` and `fps=24`:
+- `title_card_frame_count = ceil(5.5 * 24) = 132`
+- `title_card_offset = 132 / 24 = 5.5` (exact in this case)
+
+With `title_card_duration_seconds=5.3` and `fps=24`:
+- `title_card_frame_count = ceil(5.3 * 24) = ceil(127.2) = 128`
+- `title_card_offset = 128 / 24 = 5.333...` (NOT 5.3 — this is the frame-accurate value)
+- `adelay_ms = round(5.333... * 1000) = 5333`
+
+This ensures audio delay matches the actual title card display duration.
+
+#### Test 3: FFmpeg command includes `adelay` in delay mode
+
+Verify the FFmpeg args contain `-filter_complex` with `adelay={offset_ms}|{offset_ms}` and `-map 0:v -map [delayed]` when `title_card_audio_mode=DELAY`.
+
+#### Test 4: FFmpeg command has no `adelay` in overlay mode
+
+Verify the existing FFmpeg args (no `-filter_complex`, has `-shortest`) when `title_card_audio_mode=OVERLAY`.
+
+#### Test 5: `current_time` starts at 0.0 after title card in delay mode
+
+With `title_card_audio_mode=DELAY`, `title_card_duration_seconds=5.0`, `fps=24`:
+- Title card frames: 0–119
+- First lyrics frame (120): `current_time = (120 - 120) / 24 = 0.0`
+- Frame 240: `current_time = (240 - 120) / 24 = 5.0`
+
+With `title_card_audio_mode=OVERLAY`:
+- Title card frames: 0–119
+- First lyrics frame (120): `current_time = 120 / 24 = 5.0` (maps to audio timeline, unchanged)
+
+#### Test 6: `VideoExportResult.duration_seconds` includes title card in delay mode
+
+In delay mode: `result.duration_seconds == audio_duration + title_card_offset`
+In overlay mode: `result.duration_seconds == audio_duration`
+
+#### Test 7: `TitleCardConfig.duration_seconds` equals title card duration (both modes)
+
+Verify `title_card_config.duration_seconds == self.title_card_duration_seconds` (not `total_duration_seconds`).
+
+### `tests/test_chapters.py`
+
+#### Test 8: Chapter timestamps offset by `title_card_offset`
+
+Verify that `generate_chapters_manifest()` with `title_card_offset=10.0` shifts all `start_seconds`/`end_seconds` and `ChapterLine.start_seconds` by 10.0.
+Verify that `title_card_offset=0.0` produces identical output to current behavior.
+
+#### Test 9: `ChaptersManifest.total_duration_seconds` includes offset
+
+Verify that `ChaptersManifest.total_duration_seconds == audio_duration + title_card_offset` when `title_card_offset > 0`.
+Verify that `ChaptersManifest.total_duration_seconds == audio_duration` when `title_card_offset == 0.0`.
+
+### `tests/test_pipeline.py`
+
+#### Test 10: Pipeline offsets chapter timestamps in delay mode only
+
+Verify that `chapters_for_video` and `chapters_manifest` have timestamps shifted by `title_card_offset` when `title_card_audio_mode=DELAY`.
+Verify no offset when `title_card_audio_mode=OVERLAY`.
+
+#### Test 11: Pipeline passes `title_card_audio_mode` to `VideoEngine`
+
+Verify that `VideoEngine` is constructed with the correct `title_card_audio_mode` from the job.
+
+---
+
+## Implementation Order
+
+1. Add `TitleCardAudioMode` enum and `title_card_audio_mode` parameter to `VideoEngine.__init__()` (1a)
+2. Compute `title_card_frame_count` and `title_card_offset` in `generate_video()` (1b)
+3. Add `title_card_offset` and `title_card_frame_count` parameters to `encode_video_with_ffmpeg()` (1c)
+4. Delay audio in FFmpeg command when `title_card_offset > 0` (1d)
+5. Fix `current_time` calculation for delay mode (1e)
+6. Fix `TitleCardConfig.duration_seconds` (1f) — applies to both modes
+7. Update `VideoExportResult` (1g)
+8. Add `title_card_audio_mode` to `RenderJob` dataclass (5a)
+9. Offset chapter timestamps in `pipeline.py` (2a, 2b, 2c)
+10. Add `title_card_offset` to `generate_chapters_manifest()` (3a)
+11. Add DB column, API validation, job manager, and frontend changes (6–9)
+12. Add/update tests
+13. Run `PYTHONPATH=src pytest tests/test_video_engine.py tests/test_chapters.py tests/test_pipeline.py -v`
+
+---
+
+## Edge Cases
+
+### Title card disabled (`include_title_card=False`)
+
+`title_card_offset = 0.0` regardless of mode. No changes to FFmpeg command, `current_time`, or chapter timestamps. Behavior identical to current code.
+
+### Overlay mode (default)
+
+`title_card_offset = 0.0`. All code paths fall through to existing behavior. The only change is `TitleCardConfig.duration_seconds` (semantic fix, no rendering impact).
+
+### Delay mode with title card duration > first song intro gap
+
+If the first song's intro gap is shorter than `title_card_duration_seconds`, the title card still shows for the full duration. After the title card, `current_time = 0.0` and the intro info display works correctly from the start of the audio timeline. No lyrics are lost.
+
+### Very short audio (< title card duration) in delay mode
+
+If audio is shorter than `title_card_duration_seconds`, the `adelay` filter would push audio beyond the video end. The video would show the title card then silence. This is unlikely in practice (worship sets are long) but should be documented.
+
+### `generate_blank_video()` with title card
+
+When no lyrics are found, `generate_blank_video()` is called. This method doesn't support title cards. No change needed — title cards are only meaningful when lyrics exist.
+
+### Frame-accurate offset rounding
+
+When `title_card_duration_seconds` doesn't divide evenly by `1/fps`, the frame-accurate offset (`title_card_frame_count / fps`) may differ from the float duration by up to `(fps-1)/fps²` seconds (~41.7ms at 24fps). This is intentional — the `adelay` filter must match the actual title card display duration to prevent de-sync. The title card is always displayed for an integer number of frames, so the audio delay must match that exact frame-accurate duration.
+
+### `title_card_duration_seconds` default inconsistency
+
+The current defaults are inconsistent across the stack:
+
+| Location | Default |
+|---|---|
+| DB column (`schema.ts:237`) | `10` |
+| `VideoEngine.__init__` (`video_engine.py:73`) | `5.0` |
+| Pipeline fallback (`pipeline.py:353`) | `5.0` |
+
+This is a pre-existing issue, not introduced by this spec. A separate cleanup should align these defaults (recommend `5.0` everywhere, since the DB column default of `10` is never actually used — the API schema defaults to `null` and the pipeline falls back to `5.0`).
+
+---
+
+## Verification Checklist
+
+- [ ] `TitleCardAudioMode` enum added with `OVERLAY` and `DELAY` values
+- [ ] `VideoEngine.__init__()` accepts `title_card_audio_mode` parameter (default `OVERLAY`)
+- [ ] `title_card_frame_count` computed in `generate_video()`, not `encode_video_with_ffmpeg()`
+- [ ] `title_card_offset` computed from **frame-accurate** duration (`title_card_frame_count / fps`), not float `title_card_duration_seconds`
+- [ ] `total_frames = ceil((audio_duration + title_card_offset) * fps)` in delay mode
+- [ ] `total_frames = ceil(audio_duration * fps)` in overlay mode (unchanged)
+- [ ] FFmpeg command includes `adelay` filter when `title_card_offset > 0`
+- [ ] FFmpeg command omits `adelay` and uses `-shortest` when `title_card_offset == 0`
+- [ ] `current_time = (frame_count - title_card_frame_count) / fps` in delay mode
+- [ ] `current_time = frame_count / fps` in overlay mode (unchanged)
+- [ ] `TitleCardConfig.duration_seconds = self.title_card_duration_seconds` (both modes)
+- [ ] `VideoExportResult.duration_seconds` includes title card offset in delay mode
+- [ ] `RenderJob` dataclass includes `title_card_audio_mode` field
+- [ ] DB schema includes `title_card_audio_mode` column
+- [ ] API Zod schema validates `titleCardAudioMode`
+- [ ] `CreateRenderJobInput` includes `titleCardAudioMode`
+- [ ] `createRenderJob()` persists `titleCardAudioMode`
+- [ ] Pipeline passes `title_card_audio_mode` to `VideoEngine`
+- [ ] Chapter timestamps offset by `title_card_offset` in delay mode
+- [ ] Chapter timestamps unchanged in overlay mode
+- [ ] `ChaptersManifest.total_duration_seconds` includes `title_card_offset` in delay mode
+- [ ] Pipeline chapter offset does NOT reference `ch.lines` (dead code removed)
+- [ ] All existing tests pass
+- [ ] New tests pass

--- a/specs/fix-title-card-lyrics-timeline-desync.md
+++ b/specs/fix-title-card-lyrics-timeline-desync.md
@@ -1,0 +1,337 @@
+# Fix: Title Card Desynchronizes Lyrics and Chapter Timelines
+
+## Problem
+
+When `include_title_card=True`, the title card **replaces** the first N seconds of video content instead of **inserting** time at the beginning. This causes three cascading desynchronization issues:
+
+1. **Audio plays during the title card** — FFmpeg receives both video frames and audio starting at time 0. During the title card period (e.g., 0–10s), the audio is already playing but no lyrics are rendered. Lyrics that fall within the title card window are silently swallowed.
+
+2. **Lyrics appear at wrong video times** — After the title card, `current_time = frame_count / fps` (line 332) maps directly to the audio timeline. A lyric at `global_time_seconds = 36` appears at video time 36s, but the audio has been playing for 36s while the video has been showing content for only 26s (36s − 10s title card). The lyric appears 10s early relative to when it should appear in the video timeline.
+
+3. **Chapter timestamps are not offset** — Both the FFmpeg chapter metadata and the chapters manifest JSON use `seg.start_time_seconds` from the audio engine without adding the title card duration. Chapter markers point to the wrong video positions.
+
+### Concrete Example
+
+With a 10-second title card and a 3-song worship set:
+
+| Event | Audio Timeline | Current Video Time | Expected Video Time |
+|---|---|---|---|
+| Title card | 0–10s (audio playing!) | 0–10s (title card shown) | 0–10s (silence, no audio) |
+| Song 1 starts | 0s | 10s | 10s |
+| 2nd lyric line | 36s | 36s | **46s** |
+| Song 2 starts | 180s | 180s | **190s** |
+| Song 3 starts | 360s | 360s | **370s** |
+
+The 2nd lyric line at audio time 36s appears at video time 36s, but the viewer has only seen 26s of content (36s − 10s title card). The lyric appears 10 seconds too early in the viewing experience.
+
+### Root Cause Analysis
+
+The previous spec (`fix-ffmpeg-epipe-title-card-frame-count.md`) fixed the EPIPE crash and corrected `current_time = frame_count / fps`, but that fix assumed the title card **overlays** the first N seconds of audio. The correct behavior is for the title card to **insert** time — the audio should be delayed, and all timestamps should be shifted.
+
+Three specific code locations cause the desync:
+
+#### 1. `video_engine.py:126` — `total_frames` doesn't include title card duration
+
+```python
+total_frames = math.ceil(total_duration_seconds * self.fps)
+```
+
+This uses only the audio duration. The title card adds extra video time that isn't accounted for. The video should be `audio_duration + title_card_duration` long.
+
+#### 2. `video_engine.py:262-286` — FFmpeg command doesn't delay audio
+
+```python
+args = [
+    self.ffmpeg_path, "-y",
+    "-f", "rawvideo", "-vcodec", "rawvideo",
+    "-s", f"{width}x{height}", "-pix_fmt", "rgba",
+    "-r", str(self.fps),
+    "-i", "-",           # video stdin (starts at frame 0)
+    "-i", audio_path,    # audio file (starts at time 0)
+    *self.get_video_codec_args(),
+    "-c:a", "aac", "-b:a", "192k",
+    "-shortest",
+    output_path,
+]
+```
+
+Both streams start at time 0. Audio plays immediately during the title card. The audio needs to be delayed by `title_card_duration_seconds` using FFmpeg's `adelay` filter.
+
+#### 3. `video_engine.py:332` — `current_time` doesn't subtract title card offset
+
+```python
+current_time = frame_count / self.fps
+```
+
+After the title card, `frame_count` includes the title card frames. At the first lyrics frame (frame 240 for 10s at 24fps), `current_time = 10.0`. But the audio is also at 10s — the lyric lookup uses the audio timeline, so a lyric at `global_time_seconds = 10` would be found. However, the lyric at `global_time_seconds = 5` was never shown because the title card was displayed during video time 0–10s while audio was at 0–10s.
+
+With the fix (audio delayed), after the title card, `current_time` should map to the **audio** timeline starting at 0.0: `current_time = (frame_count - title_card_frame_count) / self.fps`.
+
+#### 4. `pipeline.py:436-449` — Chapter timestamps not offset
+
+```python
+chapters_for_video = [
+    _segment_to_chapter_info(seg, i)
+    for i, seg in enumerate(audio_result.segments)
+]
+# ...
+chapters_manifest = generate_chapters_manifest(
+    list(audio_result.segments),
+    asset_fetcher.download_lrc,
+    audio_result.total_duration_seconds,
+)
+```
+
+Both use `seg.start_time_seconds` from the audio engine (starting at 0). With the title card insert, all chapter timestamps need `+ title_card_duration_seconds`.
+
+---
+
+## File Changes
+
+### 1. `src/sow_render_worker/video_engine.py`
+
+#### 1a. Add `title_card_offset` computation in `generate_video()` (after line 125)
+
+```python
+title_card_offset = self.title_card_duration_seconds if self.include_title_card else 0.0
+video_duration_seconds = total_duration_seconds + title_card_offset
+total_frames = math.ceil(video_duration_seconds * self.fps)
+```
+
+Pass `title_card_offset` to `encode_video_with_ffmpeg()` and use `video_duration_seconds` for `VideoExportResult.duration_seconds`.
+
+#### 1b. Add `title_card_offset` parameter to `encode_video_with_ffmpeg()` (line 241)
+
+Add parameter `title_card_offset: float = 0.0`.
+
+#### 1c. Delay audio in FFmpeg command when `title_card_offset > 0` (lines 262-286)
+
+When `title_card_offset > 0`, add an `adelay` filter to push audio start by `title_card_offset` milliseconds:
+
+```python
+if title_card_offset > 0:
+    delay_ms = round(title_card_offset * 1000)
+    args = [
+        self.ffmpeg_path, "-y",
+        "-f", "rawvideo", "-vcodec", "rawvideo",
+        "-s", f"{width}x{height}", "-pix_fmt", "rgba",
+        "-r", str(self.fps),
+        "-i", "-",
+        "-i", audio_path,
+        "-filter_complex", f"[1:a]adelay={delay_ms}|{delay_ms}[delayed]",
+        "-map", "0:v", "-map", "[delayed]",
+        *self.get_video_codec_args(),
+        "-c:a", "aac", "-b:a", "192k",
+        output_path,
+    ]
+else:
+    # existing command (no delay needed)
+    args = [
+        self.ffmpeg_path, "-y",
+        "-f", "rawvideo", "-vcodec", "rawvideo",
+        "-s", f"{width}x{height}", "-pix_fmt", "rgba",
+        "-r", str(self.fps),
+        "-i", "-",
+        "-i", audio_path,
+        *self.get_video_codec_args(),
+        "-c:a", "aac", "-b:a", "192k",
+        "-shortest",
+        output_path,
+    ]
+```
+
+**Note:** Remove `-shortest` when `adelay` is used. With `adelay`, the audio stream becomes `title_card_offset + audio_duration` long, matching the video stream length exactly. `-shortest` is unnecessary and could cause premature termination if there's any rounding difference.
+
+#### 1d. Fix `current_time` calculation after title card (line 332)
+
+```python
+# Before:
+current_time = frame_count / self.fps
+
+# After:
+current_time = (frame_count - title_card_frame_count) / self.fps
+```
+
+This maps `current_time` back to the audio timeline (starting at 0.0 after the title card), keeping it in sync with lyrics `global_time_seconds` and segment `start_time_seconds`.
+
+#### 1e. Fix `TitleCardConfig.duration_seconds` (line 206)
+
+```python
+# Before:
+title_card_config = TitleCardConfig(
+    enabled=True,
+    duration_seconds=total_duration_seconds,  # confusing: set to audio duration
+    ...
+)
+
+# After:
+title_card_config = TitleCardConfig(
+    enabled=True,
+    duration_seconds=self.title_card_duration_seconds,  # actual title card display duration
+    ...
+)
+```
+
+The `duration_seconds` field is currently set to the total audio duration, which is semantically wrong. It should represent the title card's own display duration. Note: `render_title_card()` uses `config.total_duration_seconds` (not `config.duration_seconds`) for the "X:XX" subtitle text, so this change doesn't affect rendering.
+
+#### 1f. Update `VideoExportResult` to return video duration (not audio duration)
+
+```python
+return VideoExportResult(
+    output_path=output_path,
+    total_frames=total_frames,
+    duration_seconds=video_duration_seconds,  # was total_duration_seconds
+    width=self.resolution[0],
+    height=self.resolution[1],
+    fps=self.fps,
+)
+```
+
+### 2. `src/sow_render_worker/pipeline.py`
+
+#### 2a. Offset chapter timestamps by `title_card_duration_seconds` (lines 436-441)
+
+```python
+title_card_offset = job.title_card_duration_seconds if job.include_title_card else 0.0
+
+chapters_for_video = [
+    ChapterInfo(
+        position=ch.position,
+        song_title=ch.song_title,
+        start_seconds=ch.start_seconds + title_card_offset,
+        end_seconds=ch.end_seconds + title_card_offset,
+        lines=tuple(
+            {
+                "text": line["text"],
+                "startSeconds": line["startSeconds"] + title_card_offset,
+            }
+            for line in ch.lines
+        ) if ch.lines else (),
+    )
+    for ch in (
+        _segment_to_chapter_info(seg, i)
+        for i, seg in enumerate(audio_result.segments)
+    )
+]
+```
+
+#### 2b. Offset chapters manifest timestamps (lines 445-449)
+
+Pass `title_card_offset` to `generate_chapters_manifest()` and offset all `start_seconds` values. This requires adding an optional `title_card_offset` parameter to `generate_chapters_manifest()` in `chapters.py`.
+
+### 3. `src/sow_render_worker/chapters.py`
+
+#### 3a. Add `title_card_offset` parameter to `generate_chapters_manifest()` (line 75)
+
+```python
+def generate_chapters_manifest(
+    segments: list[SegmentInfo],
+    download_lrc: Callable[[str], str | None | object],
+    total_duration_seconds: float,
+    title_card_offset: float = 0.0,  # NEW
+) -> ChaptersManifest:
+```
+
+Offset all `ChapterLine.start_seconds` and `Chapter.start_seconds`/`Chapter.end_seconds` by `title_card_offset`.
+
+### 4. `src/sow_render_worker/frame_renderer.py`
+
+No changes needed. The `render_frame()` method receives `current_time` on the audio timeline (after title card offset subtraction in video_engine), so segment and lyric lookups work correctly. The `render_intro_info()` method also works correctly since `current_time` maps to the audio timeline.
+
+---
+
+## Test Updates
+
+### `tests/test_video_engine.py`
+
+#### Test 1: `total_frames` includes title card duration
+
+When `include_title_card=True` with `title_card_duration_seconds=10.0` and audio duration 180s:
+- `total_frames = ceil((180 + 10) * 24) = 4560` (not `4320`)
+
+#### Test 2: FFmpeg command includes `adelay` when title card enabled
+
+Verify the FFmpeg args contain `-filter_complex` with `adelay={offset_ms}|{offset_ms}` and `-map 0:v -map [delayed]` when `title_card_offset > 0`.
+
+#### Test 3: FFmpeg command has no `adelay` when title card disabled
+
+Verify the existing FFmpeg args (no `-filter_complex`, has `-shortest`) when `title_card_offset == 0`.
+
+#### Test 4: `current_time` starts at 0.0 after title card
+
+With `title_card_duration_seconds=5.0` and `fps=24`:
+- Title card frames: 0–119 (`current_time` not computed)
+- First lyrics frame (120): `current_time = (120 - 120) / 24 = 0.0`
+- Frame 240: `current_time = (240 - 120) / 24 = 5.0`
+
+Capture `current_time` values passed to `render_frame()` and verify the first value is 0.0.
+
+#### Test 5: `VideoExportResult.duration_seconds` includes title card
+
+Verify `result.duration_seconds == audio_duration + title_card_duration_seconds`.
+
+#### Test 6: `TitleCardConfig.duration_seconds` equals title card duration
+
+Verify `title_card_config.duration_seconds == self.title_card_duration_seconds` (not `total_duration_seconds`).
+
+### `tests/test_chapters.py`
+
+#### Test 7: Chapter timestamps offset by `title_card_offset`
+
+Verify that `generate_chapters_manifest()` with `title_card_offset=10.0` shifts all `start_seconds`/`end_seconds` and `ChapterLine.start_seconds` by 10.0.
+
+### `tests/test_pipeline.py`
+
+#### Test 8: Pipeline offsets chapter timestamps when title card enabled
+
+Verify that `chapters_for_video` and `chapters_manifest` have timestamps shifted by `title_card_duration_seconds` when `job.include_title_card=True`.
+
+---
+
+## Implementation Order
+
+1. Add `title_card_offset` computation in `generate_video()` (1a)
+2. Add `title_card_offset` parameter to `encode_video_with_ffmpeg()` (1b)
+3. Delay audio in FFmpeg command (1c)
+4. Fix `current_time` calculation (1d)
+5. Fix `TitleCardConfig.duration_seconds` (1e)
+6. Update `VideoExportResult` (1f)
+7. Offset chapter timestamps in `pipeline.py` (2a, 2b)
+8. Add `title_card_offset` to `generate_chapters_manifest()` (3a)
+9. Add/update tests
+10. Run `PYTHONPATH=src pytest tests/test_video_engine.py tests/test_chapters.py tests/test_pipeline.py -v`
+
+---
+
+## Edge Cases
+
+### Title card disabled (`include_title_card=False`)
+
+`title_card_offset = 0.0`. No changes to FFmpeg command, `current_time`, or chapter timestamps. Behavior identical to current code.
+
+### Title card duration > first song intro gap
+
+If the first song's intro gap (time before first lyric) is shorter than `title_card_duration_seconds`, the title card still shows for the full duration. After the title card, `current_time = 0.0` and the intro info display in `render_intro_info()` will show correctly from the start of the audio timeline. No lyrics are lost.
+
+### Very short audio (< title card duration)
+
+If audio is shorter than `title_card_duration_seconds`, the `adelay` filter would push audio beyond the video end. The video would show the title card then silence. This is unlikely in practice (worship sets are long) but should be documented.
+
+### `generate_blank_video()` with title card
+
+When no lyrics are found, `generate_blank_video()` is called. This method doesn't support title cards — it generates a solid-color video with audio. This is acceptable since title cards are only meaningful when lyrics exist. No change needed.
+
+---
+
+## Verification Checklist
+
+- [ ] `total_frames = ceil((audio_duration + title_card_offset) * fps)` when title card enabled
+- [ ] FFmpeg command includes `adelay` filter when `title_card_offset > 0`
+- [ ] FFmpeg command omits `adelay` and uses `-shortest` when `title_card_offset == 0`
+- [ ] `current_time = (frame_count - title_card_frame_count) / fps` after title card
+- [ ] `TitleCardConfig.duration_seconds = self.title_card_duration_seconds`
+- [ ] `VideoExportResult.duration_seconds` includes title card offset
+- [ ] Chapter timestamps in FFmpeg metadata offset by `title_card_offset`
+- [ ] Chapter timestamps in manifest JSON offset by `title_card_offset`
+- [ ] All existing tests pass
+- [ ] New tests pass


### PR DESCRIPTION
## Summary

Render worker performance improvement, documentation update, and spec documents for upcoming title card audio mode feature.

## Changes

### Performance: Use DB duration instead of ffprobe

- **`services/render-worker/src/sow_render_worker/audio_engine.py`**: When `item.duration_seconds` is available from the database, use it directly instead of running ffprobe. Falls back to ffprobe when DB duration is `None`. Improved logging to indicate which source was used.

### Documentation

- **`services/render-worker/README.md`**: Updated required GitHub secrets from `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` to `SOW_AWS_ACCESS_KEY_ID`/`SOW_AWS_SECRET_ACCESS_KEY` to reflect the SOW_-prefixed env var alignment done in a previous PR.

### Specs: Title card audio mode (overlay vs delay)

Three spec documents for an upcoming feature to make title card audio behavior configurable:

- **`specs/fix-title-card-lyrics-timeline-desync.md`** (v1): Initial analysis identifying the desync issue and proposing audio delay as the fix.
- **`specs/fix-title-card-lyrics-timeline-desync-v2.md`** (v2): Refined spec with configurable `overlay`/`delay` modes, but had issues with adelay timing mismatch and missing full-stack schema changes.
- **`specs/fix-title-card-lyrics-timeline-desync-v3.md`** (v3): Final spec addressing v2 issues — frame-accurate offset computation, full-stack DB/API/frontend changes, `ChaptersManifest.total_duration_seconds` update, and removal of dead `ch.lines` offset code.
