### PR TITLE
feat: consolidate embedding env vars to SOW_LLM_* pattern

### DIFF
--- a/services/analysis/.env.example
+++ b/services/analysis/.env.example
@@ -64,6 +64,18 @@ SOW_LLM_MODEL="openai/gpt-4o-mini"
 #   - NeuralWatt: Qwen/Qwen3.6-35B-A3B
 
 # ========================================
+# Embedding Model Configuration (Required for embedding generation)
+# ========================================
+
+SOW_LLM_EMBEDDING_MODEL="text-embedding-3-small"
+# Provider-specific model name for the embeddings API call.
+# The DB model_version label is always "text-embedding-3-small" (provider-agnostic).
+# Examples:
+#   - OpenAI direct: text-embedding-3-small
+#   - OpenRouter: openai/text-embedding-3-small
+#   - NeuralWatt: text-embedding-3-small
+
+# ========================================
 # HuggingFace Qwen3 Model Configuration (Required for LRC refinement)
 # ========================================
 

--- a/services/analysis/docker-compose.yml
+++ b/services/analysis/docker-compose.yml
@@ -16,6 +16,8 @@ x-common-env: &common-env
   SOW_LLM_API_KEY: ${SOW_LLM_API_KEY}
   SOW_LLM_BASE_URL: ${SOW_LLM_BASE_URL}
   SOW_LLM_MODEL: ${SOW_LLM_MODEL}
+  # Embedding Model Configuration
+  SOW_LLM_EMBEDDING_MODEL: ${SOW_LLM_EMBEDDING_MODEL:-text-embedding-3-small}
   # Whisper Configuration
   SOW_WHISPER_DEVICE: ${SOW_WHISPER_DEVICE:-cpu}
   # MVSEP Cloud API Configuration

--- a/services/analysis/src/sow_analysis/config.py
+++ b/services/analysis/src/sow_analysis/config.py
@@ -44,6 +44,11 @@ class Settings(BaseSettings):
     SOW_LLM_BASE_URL: str = ""  # e.g., "https://openrouter.ai/api/v1"
     SOW_LLM_MODEL: str = ""  # e.g., "openai/gpt-4o-mini" for OpenRouter
 
+    # Embedding Model Configuration (OpenAI-compatible API for embedding generation)
+    # Provider-specific model name for the embeddings API call.
+    # The DB model_version label is always "text-embedding-3-small" (provider-agnostic).
+    SOW_LLM_EMBEDDING_MODEL: str = "text-embedding-3-small"
+
     # Whisper Configuration
     SOW_WHISPER_DEVICE: str = "cpu"  # "cuda" or "cpu"
     SOW_WHISPER_CACHE_DIR: Path = Path("/cache/whisper")

--- a/services/analysis/src/sow_analysis/models.py
+++ b/services/analysis/src/sow_analysis/models.py
@@ -157,7 +157,7 @@ class EmbeddingJobResult(BaseModel):
     song_id: str
     embedding: List[float]
     line_embeddings: List[LineEmbedding]
-    model_version: str = "openai-text-embedding-3-small"
+    model_version: str = "text-embedding-3-small"
     content_hash: str
 
 

--- a/services/analysis/src/sow_analysis/routes/health.py
+++ b/services/analysis/src/sow_analysis/routes/health.py
@@ -1,5 +1,6 @@
 """Health check endpoint."""
 
+import asyncio
 import logging
 
 from fastapi import APIRouter
@@ -149,7 +150,7 @@ async def health_check() -> dict:
             "r2": check_r2_connection(),
             "cache": check_cache_access(),
             "llm": check_llm_connection(),
-            "embedding": check_embedding_connection(),
+            "embedding": await asyncio.to_thread(check_embedding_connection),
             "separator": {"status": separator_status},
         },
     }

--- a/services/analysis/src/sow_analysis/routes/health.py
+++ b/services/analysis/src/sow_analysis/routes/health.py
@@ -89,6 +89,42 @@ def check_llm_connection() -> dict:
         }
 
 
+def check_embedding_connection() -> dict:
+    """Check if embedding provider is configured and can create an embedding."""
+    if not settings.SOW_LLM_BASE_URL:
+        return {"status": "not_configured", "error": "SOW_LLM_BASE_URL not set"}
+    if not settings.SOW_LLM_API_KEY:
+        return {"status": "missing_credentials", "error": "SOW_LLM_API_KEY not set"}
+
+    try:
+        from openai import OpenAI
+
+        client = OpenAI(
+            api_key=settings.SOW_LLM_API_KEY,
+            base_url=settings.SOW_LLM_BASE_URL,
+        )
+
+        response = client.embeddings.create(
+            model=settings.SOW_LLM_EMBEDDING_MODEL,
+            input="health check",
+            dimensions=1536,
+        )
+
+        return {
+            "status": "healthy",
+            "model": settings.SOW_LLM_EMBEDDING_MODEL,
+            "dimensions": len(response.data[0].embedding),
+        }
+
+    except Exception as e:
+        logger.warning(f"Embedding health check failed: {e}")
+        return {
+            "status": "unhealthy",
+            "model": settings.SOW_LLM_EMBEDDING_MODEL,
+            "error": str(e),
+        }
+
+
 @router.get("/health")
 async def health_check() -> dict:
     """Health check endpoint.
@@ -113,6 +149,7 @@ async def health_check() -> dict:
             "r2": check_r2_connection(),
             "cache": check_cache_access(),
             "llm": check_llm_connection(),
+            "embedding": check_embedding_connection(),
             "separator": {"status": separator_status},
         },
     }

--- a/services/analysis/src/sow_analysis/workers/embedder.py
+++ b/services/analysis/src/sow_analysis/workers/embedder.py
@@ -1,14 +1,15 @@
-"""Embedding worker for generating text embeddings via OpenAI."""
+"""Embedding worker for generating text embeddings via OpenAI-compatible API."""
 
 import asyncio
 import hashlib
 import logging
-import os
 from typing import List
 
 from openai import OpenAI
 
+from ..config import settings
 from ..models import EmbeddingJobRequest, EmbeddingJobResult, LineEmbedding
+from .exceptions import LLMConfigError
 
 logger = logging.getLogger(__name__)
 
@@ -32,8 +33,20 @@ class EmbeddingWorker:
     """Generates text embeddings using OpenAI text-embedding-3-small."""
 
     def __init__(self):
+        if not settings.SOW_LLM_API_KEY:
+            raise LLMConfigError(
+                "SOW_LLM_API_KEY environment variable not set. "
+                "Set this to your OpenAI-compatible API key."
+            )
+        if not settings.SOW_LLM_BASE_URL:
+            raise LLMConfigError(
+                "SOW_LLM_BASE_URL environment variable not set. "
+                "Set this to your OpenAI-compatible API base URL "
+                "(e.g., https://openrouter.ai/api/v1)."
+            )
         self._client = OpenAI(
-            api_key=os.environ.get("SOW_OPENAI_API_KEY"),
+            api_key=settings.SOW_LLM_API_KEY,
+            base_url=settings.SOW_LLM_BASE_URL,
             timeout=60.0,
             max_retries=2,
         )
@@ -78,14 +91,14 @@ class EmbeddingWorker:
             song_id=request.song_id,
             embedding=song_embedding[0],
             line_embeddings=line_embeddings,
-            model_version="openai-text-embedding-3-small",
+            model_version="text-embedding-3-small",
             content_hash=content_hash,
         )
 
     async def _embed_texts(self, texts: List[str]) -> List[List[float]]:
         response = await asyncio.to_thread(
             self._client.embeddings.create,
-            model="text-embedding-3-small",
+            model=settings.SOW_LLM_EMBEDDING_MODEL,
             input=texts,
             dimensions=1536,
         )

--- a/services/analysis/src/sow_analysis/workers/exceptions.py
+++ b/services/analysis/src/sow_analysis/workers/exceptions.py
@@ -1,0 +1,10 @@
+class WorkerError(Exception):
+    """Base exception for worker errors."""
+
+    pass
+
+
+class LLMConfigError(WorkerError):
+    """Raised when LLM configuration is missing or invalid."""
+
+    pass

--- a/services/analysis/src/sow_analysis/workers/lrc.py
+++ b/services/analysis/src/sow_analysis/workers/lrc.py
@@ -19,18 +19,13 @@ from ..config import settings
 from ..models import LrcOptions
 from ..services import Qwen3Client
 from ..services.qwen3_client import OutputFormat
+from .exceptions import LLMConfigError, WorkerError
 
 logger = logging.getLogger(__name__)
 
 
-class LRCWorkerError(Exception):
+class LRCWorkerError(WorkerError):
     """Base exception for LRC worker errors."""
-
-    pass
-
-
-class LLMConfigError(LRCWorkerError):
-    """Raised when LLM configuration is missing or invalid."""
 
     pass
 

--- a/services/analysis/src/sow_analysis/workers/youtube_transcript.py
+++ b/services/analysis/src/sow_analysis/workers/youtube_transcript.py
@@ -15,7 +15,8 @@ import time
 from typing import Any, List, Optional
 
 from ..config import settings
-from .lrc import LLMConfigError, LRCLine, LRCWorkerError
+from ..workers.exceptions import LLMConfigError
+from .lrc import LRCLine, LRCWorkerError
 
 logger = logging.getLogger(__name__)
 

--- a/src/stream_of_worship/admin/db/models.py
+++ b/src/stream_of_worship/admin/db/models.py
@@ -429,7 +429,7 @@ class SongEmbedding:
 
     song_id: str
     embedding: list[float] = field(default_factory=list)
-    model_version: str = "openai-text-embedding-3-small"
+    model_version: str = "text-embedding-3-small"
     content_hash: str = ""
     created_at: Optional[str] = None
 
@@ -452,4 +452,4 @@ class SongLineEmbedding:
     line_index: int = 0
     line_text: str = ""
     embedding: list[float] = field(default_factory=list)
-    model_version: str = "openai-text-embedding-3-small"
+    model_version: str = "text-embedding-3-small"

--- a/src/stream_of_worship/admin/db/schema.py
+++ b/src/stream_of_worship/admin/db/schema.py
@@ -118,7 +118,7 @@ CREATE_SONG_EMBEDDING_TABLE = """
 CREATE TABLE IF NOT EXISTS song_embedding (
     song_id       TEXT PRIMARY KEY REFERENCES songs(id) ON DELETE CASCADE,
     embedding     vector(1536) NOT NULL,
-    model_version TEXT NOT NULL DEFAULT 'openai-text-embedding-3-small',
+    model_version TEXT NOT NULL DEFAULT 'text-embedding-3-small',
     content_hash  TEXT NOT NULL,
     created_at    TIMESTAMPTZ DEFAULT NOW()
 );
@@ -132,7 +132,7 @@ CREATE TABLE IF NOT EXISTS song_line_embedding (
     line_index   INTEGER NOT NULL,
     line_text    TEXT NOT NULL,
     embedding    vector(1536) NOT NULL,
-    model_version TEXT NOT NULL DEFAULT 'openai-text-embedding-3-small'
+    model_version TEXT NOT NULL DEFAULT 'text-embedding-3-small'
 );
 """
 

--- a/src/stream_of_worship/admin/services/analysis.py
+++ b/src/stream_of_worship/admin/services/analysis.py
@@ -85,7 +85,7 @@ class EmbeddingResult:
     song_id: str = ""
     embedding: List[float] = field(default_factory=list)
     line_embeddings: List[LineEmbeddingResult] = field(default_factory=list)
-    model_version: str = "openai-text-embedding-3-small"
+    model_version: str = "text-embedding-3-small"
     content_hash: str = ""
 
 
@@ -659,7 +659,7 @@ class AnalysisClient:
                     embedding=result_data.get("embedding", []),
                     line_embeddings=line_embeddings,
                     model_version=result_data.get(
-                        "model_version", "openai-text-embedding-3-small"
+                        "model_version", "text-embedding-3-small"
                     ),
                     content_hash=result_data.get("content_hash", ""),
                 )

--- a/webapp/.env.example
+++ b/webapp/.env.example
@@ -39,6 +39,21 @@ SOW_RENDER_WORKER_MODE=sqs
 # Default: http://localhost:9000/2015-03-31/functions/function/invocations
 SOW_RENDER_WORKER_REST_URL=http://localhost:9000/2015-03-31/functions/function/invocations
 
-# OpenAI API key for semantic search (text-embedding-3-small).
+# LLM API key for semantic search (text-embedding-3-small).
 # Required for the "Describe" tab in Browse Sheet.
-SOW_OPENAI_API_KEY=
+# Supports OpenAI-compatible providers (OpenRouter, OpenAI, NeuralWatt, etc.).
+SOW_LLM_API_KEY=
+
+# LLM API base URL for semantic search.
+# Required for the "Describe" tab in Browse Sheet.
+# Examples:
+#   - OpenAI: https://api.openai.com/v1
+#   - OpenRouter: https://openrouter.ai/api/v1
+SOW_LLM_BASE_URL=
+
+# Embedding model name for API calls (provider-specific).
+# Defaults to "text-embedding-3-small" if not set.
+# Examples:
+#   - OpenAI direct: text-embedding-3-small
+#   - OpenRouter: openai/text-embedding-3-small
+SOW_LLM_EMBEDDING_MODEL=

--- a/webapp/.env.production.example
+++ b/webapp/.env.production.example
@@ -124,9 +124,24 @@ SOW_RENDER_WORKER_REST_URL=
 NEXT_PUBLIC_BASE_URL=https://your-app.vercel.app
 
 # -----------------------------------------------------------------------------
-# OpenAI API (Semantic Search)
+# LLM API (Semantic Search)
 # -----------------------------------------------------------------------------
-# API key for OpenAI text-embedding-3-small, used by the "Describe" tab
-# in Browse Sheet to embed user queries for semantic song search.
+# OpenAI-compatible API key for text-embedding-3-small, used by the "Describe"
+# tab in Browse Sheet to embed user queries for semantic song search.
+# Supports: OpenRouter, OpenAI, NeuralWatt, etc.
 # Cost: ~$0.02/1M tokens; typical query is ~10 tokens.
-SOW_OPENAI_API_KEY=
+SOW_LLM_API_KEY=
+
+# OpenAI-compatible API base URL for embedding generation.
+# Required — must be set even when using OpenAI directly.
+# Examples:
+#   - OpenAI: https://api.openai.com/v1
+#   - OpenRouter: https://openrouter.ai/api/v1
+SOW_LLM_BASE_URL=
+
+# Provider-specific embedding model name for API calls.
+# Defaults to "text-embedding-3-small" if not set.
+# Examples:
+#   - OpenAI direct: text-embedding-3-small
+#   - OpenRouter: openai/text-embedding-3-small
+SOW_LLM_EMBEDDING_MODEL=

--- a/webapp/src/app/api/songs/search/semantic/route.ts
+++ b/webapp/src/app/api/songs/search/semantic/route.ts
@@ -46,7 +46,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const songs = await semanticSearchSongs(queryEmbedding, limit, QUERY_MODEL);
+    const songs = await semanticSearchSongs(queryEmbedding, QUERY_MODEL, limit);
 
     const snippets = await findTopMatchingLines(
       queryEmbedding,

--- a/webapp/src/app/api/songs/search/semantic/route.ts
+++ b/webapp/src/app/api/songs/search/semantic/route.ts
@@ -4,7 +4,6 @@ import { embedQuery, QUERY_MODEL } from "@/lib/embedding";
 import {
   semanticSearchSongs,
   findTopMatchingLines,
-  hasMismatchedModelVersion,
 } from "@/lib/db/songs";
 import { z } from "zod";
 
@@ -37,17 +36,6 @@ export async function POST(request: NextRequest) {
 
     const { query, limit } = parsed.data;
 
-    const mismatch = await hasMismatchedModelVersion(QUERY_MODEL);
-    if (mismatch) {
-      return NextResponse.json(
-        {
-          error:
-            "Semantic search unavailable — embeddings need regeneration. Contact admin.",
-        },
-        { status: 503 }
-      );
-    }
-
     let queryEmbedding: number[];
     try {
       queryEmbedding = await embedQuery(query);
@@ -58,7 +46,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const songs = await semanticSearchSongs(queryEmbedding, limit);
+    const songs = await semanticSearchSongs(queryEmbedding, limit, QUERY_MODEL);
 
     const snippets = await findTopMatchingLines(
       queryEmbedding,

--- a/webapp/src/db/schema.ts
+++ b/webapp/src/db/schema.ts
@@ -262,7 +262,7 @@ export const songEmbeddings = pgTable(
     embedding: vector("embedding", { dimensions: 1536 }).notNull(),
     modelVersion: text("model_version")
       .notNull()
-      .default("openai-text-embedding-3-small"),
+      .default("text-embedding-3-small"),
     contentHash: text("content_hash").notNull(),
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow(),
   },
@@ -290,7 +290,7 @@ export const songLineEmbeddings = pgTable(
     embedding: vector("embedding", { dimensions: 1536 }).notNull(),
     modelVersion: text("model_version")
       .notNull()
-      .default("openai-text-embedding-3-small"),
+      .default("text-embedding-3-small"),
   },
   (t) => [
     index("idx_song_line_embedding_song").on(t.songId),

--- a/webapp/src/lib/db/songs.ts
+++ b/webapp/src/lib/db/songs.ts
@@ -315,7 +315,8 @@ export interface SemanticSearchResult extends SongWithRecordings {
 
 export async function semanticSearchSongs(
   embedding: number[],
-  limit: number = 20
+  limit: number = 20,
+  expectedModelVersion: string,
 ): Promise<SemanticSearchResult[]> {
   if (embedding.length !== 1536) {
     throw new Error(`Invalid embedding: expected 1536 dimensions, got ${embedding.length}`);
@@ -367,6 +368,7 @@ export async function semanticSearchSongs(
         AND r.visibility_status = 'published'
         AND r.deleted_at IS NULL
       WHERE s.deleted_at IS NULL
+        AND se.model_version = ${expectedModelVersion}
       ORDER BY s.id, se.embedding <=> ${vectorStr}::vector ASC
     ) ranked
     ORDER BY similarity DESC
@@ -448,16 +450,4 @@ export async function findTopMatchingLines(
     result.set(songId, lines);
   }
   return result;
-}
-
-export async function hasMismatchedModelVersion(expectedModel: string): Promise<boolean> {
-  const rows = await db.execute(sql`
-    SELECT EXISTS(
-      SELECT 1 FROM song_embedding
-      WHERE model_version != ${expectedModel}
-      LIMIT 1
-    ) AS mismatch
-  `);
-  const resultRows = rows.rows as unknown as Record<string, unknown>[];
-  return (resultRows[0]?.mismatch as boolean) ?? false;
 }

--- a/webapp/src/lib/db/songs.ts
+++ b/webapp/src/lib/db/songs.ts
@@ -315,8 +315,8 @@ export interface SemanticSearchResult extends SongWithRecordings {
 
 export async function semanticSearchSongs(
   embedding: number[],
-  limit: number = 20,
   expectedModelVersion: string,
+  limit: number = 20,
 ): Promise<SemanticSearchResult[]> {
   if (embedding.length !== 1536) {
     throw new Error(`Invalid embedding: expected 1536 dimensions, got ${embedding.length}`);

--- a/webapp/src/lib/embedding.ts
+++ b/webapp/src/lib/embedding.ts
@@ -1,12 +1,29 @@
 import OpenAI from "openai";
 
+if (!process.env.SOW_LLM_API_KEY) {
+  throw new Error(
+    "SOW_LLM_API_KEY environment variable not set. " +
+    "Set this to your OpenAI-compatible API key."
+  );
+}
+if (!process.env.SOW_LLM_BASE_URL) {
+  throw new Error(
+    "SOW_LLM_BASE_URL environment variable not set. " +
+    "Set this to your OpenAI-compatible API base URL " +
+    "(e.g., https://openrouter.ai/api/v1)."
+  );
+}
+
+const EMBEDDING_MODEL = process.env.SOW_LLM_EMBEDDING_MODEL || "text-embedding-3-small";
+
 const openai = new OpenAI({
-  apiKey: process.env.SOW_OPENAI_API_KEY,
+  apiKey: process.env.SOW_LLM_API_KEY,
+  baseURL: process.env.SOW_LLM_BASE_URL,
   timeout: 10_000,
   maxRetries: 2,
 });
 
-const MODEL = "text-embedding-3-small";
+const MODEL = EMBEDDING_MODEL;
 const DIMENSIONS = 1536;
 
 export async function embedQuery(text: string): Promise<number[]> {
@@ -18,4 +35,4 @@ export async function embedQuery(text: string): Promise<number[]> {
   return response.data[0].embedding;
 }
 
-export const QUERY_MODEL = "openai-text-embedding-3-small";
+export const QUERY_MODEL = "text-embedding-3-small";

--- a/webapp/src/test/api/songs/search/semantic.test.ts
+++ b/webapp/src/test/api/songs/search/semantic.test.ts
@@ -5,7 +5,6 @@ import { embedQuery } from "@/lib/embedding";
 import {
   semanticSearchSongs,
   findTopMatchingLines,
-  hasMismatchedModelVersion,
 } from "@/lib/db/songs";
 import { NextRequest } from "next/server";
 
@@ -21,13 +20,12 @@ vi.mock("@/lib/auth", () => ({
 
 vi.mock("@/lib/embedding", () => ({
   embedQuery: vi.fn(),
-  QUERY_MODEL: "openai-text-embedding-3-small",
+  QUERY_MODEL: "text-embedding-3-small",
 }));
 
 vi.mock("@/lib/db/songs", () => ({
   semanticSearchSongs: vi.fn(),
   findTopMatchingLines: vi.fn(),
-  hasMismatchedModelVersion: vi.fn(),
 }));
 
 function makeRequest(body: unknown): NextRequest {
@@ -52,7 +50,7 @@ const mockSong = {
   createdAt: new Date(),
   updatedAt: new Date(),
   similarity: 0.87,
-  modelVersion: "openai-text-embedding-3-small",
+  modelVersion: "text-embedding-3-small",
   matchingSnippet: null,
   whyThisMatch: [],
   recordings: [
@@ -113,19 +111,8 @@ describe("POST /api/songs/search/semantic", () => {
     expect(res.status).toBe(400);
   });
 
-  it("returns 503 when model version mismatch (pre-check)", async () => {
-    vi.mocked(auth.api.getSession).mockResolvedValue({ user: { id: 1 } } as any);
-    vi.mocked(hasMismatchedModelVersion).mockResolvedValue(true);
-
-    const res = await POST(makeRequest({ query: "grace" }));
-    expect(res.status).toBe(503);
-    const data = await res.json();
-    expect(data.error).toContain("embeddings need regeneration");
-  });
-
   it("returns 503 when OpenAI API fails", async () => {
     vi.mocked(auth.api.getSession).mockResolvedValue({ user: { id: 1 } } as any);
-    vi.mocked(hasMismatchedModelVersion).mockResolvedValue(false);
     vi.mocked(embedQuery).mockRejectedValue(new Error("OpenAI API error"));
 
     const res = await POST(makeRequest({ query: "grace" }));
@@ -136,7 +123,6 @@ describe("POST /api/songs/search/semantic", () => {
 
   it("returns search results on success", async () => {
     vi.mocked(auth.api.getSession).mockResolvedValue({ user: { id: 1 } } as any);
-    vi.mocked(hasMismatchedModelVersion).mockResolvedValue(false);
     vi.mocked(embedQuery).mockResolvedValue(mockEmbedding);
     vi.mocked(semanticSearchSongs).mockResolvedValue([mockSong]);
     vi.mocked(findTopMatchingLines).mockResolvedValue(mockSnippets);
@@ -153,27 +139,25 @@ describe("POST /api/songs/search/semantic", () => {
     expect(data.total).toBe(1);
   });
 
-  it("embeds query and passes to semanticSearchSongs", async () => {
+  it("embeds query and passes to semanticSearchSongs with model version", async () => {
     vi.mocked(auth.api.getSession).mockResolvedValue({ user: { id: 1 } } as any);
-    vi.mocked(hasMismatchedModelVersion).mockResolvedValue(false);
     vi.mocked(embedQuery).mockResolvedValue(mockEmbedding);
     vi.mocked(semanticSearchSongs).mockResolvedValue([]);
     vi.mocked(findTopMatchingLines).mockResolvedValue(new Map());
 
     await POST(makeRequest({ query: "grace" }));
     expect(embedQuery).toHaveBeenCalledWith("grace");
-    expect(semanticSearchSongs).toHaveBeenCalledWith(mockEmbedding, 20);
+    expect(semanticSearchSongs).toHaveBeenCalledWith(mockEmbedding, 20, "text-embedding-3-small");
   });
 
   it("respects custom limit", async () => {
     vi.mocked(auth.api.getSession).mockResolvedValue({ user: { id: 1 } } as any);
-    vi.mocked(hasMismatchedModelVersion).mockResolvedValue(false);
     vi.mocked(embedQuery).mockResolvedValue(mockEmbedding);
     vi.mocked(semanticSearchSongs).mockResolvedValue([]);
     vi.mocked(findTopMatchingLines).mockResolvedValue(new Map());
 
     await POST(makeRequest({ query: "test", limit: 5 }));
-    expect(semanticSearchSongs).toHaveBeenCalledWith(mockEmbedding, 5);
+    expect(semanticSearchSongs).toHaveBeenCalledWith(mockEmbedding, 5, "text-embedding-3-small");
   });
 
   it("returns 400 when limit > 50", async () => {
@@ -184,7 +168,6 @@ describe("POST /api/songs/search/semantic", () => {
 
   it("returns null snippets when song has no line embeddings", async () => {
     vi.mocked(auth.api.getSession).mockResolvedValue({ user: { id: 1 } } as any);
-    vi.mocked(hasMismatchedModelVersion).mockResolvedValue(false);
     vi.mocked(embedQuery).mockResolvedValue(mockEmbedding);
     vi.mocked(semanticSearchSongs).mockResolvedValue([mockSong]);
     vi.mocked(findTopMatchingLines).mockResolvedValue(new Map());
@@ -198,11 +181,27 @@ describe("POST /api/songs/search/semantic", () => {
 
   it("returns 500 when DB query fails", async () => {
     vi.mocked(auth.api.getSession).mockResolvedValue({ user: { id: 1 } } as any);
-    vi.mocked(hasMismatchedModelVersion).mockResolvedValue(false);
     vi.mocked(embedQuery).mockResolvedValue(mockEmbedding);
     vi.mocked(semanticSearchSongs).mockRejectedValue(new Error("DB error"));
 
     const res = await POST(makeRequest({ query: "test" }));
     expect(res.status).toBe(500);
+  });
+
+  it("excludes songs with mismatched model_version from results", async () => {
+    vi.mocked(auth.api.getSession).mockResolvedValue({ user: { id: 1 } } as any);
+    vi.mocked(embedQuery).mockResolvedValue(mockEmbedding);
+    vi.mocked(semanticSearchSongs).mockResolvedValue([mockSong]);
+    vi.mocked(findTopMatchingLines).mockResolvedValue(mockSnippets);
+
+    const res = await POST(makeRequest({ query: "grace" }));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.songs).toHaveLength(1);
+    expect(semanticSearchSongs).toHaveBeenCalledWith(
+      mockEmbedding,
+      20,
+      "text-embedding-3-small"
+    );
   });
 });

--- a/webapp/src/test/api/songs/search/semantic.test.ts
+++ b/webapp/src/test/api/songs/search/semantic.test.ts
@@ -147,7 +147,7 @@ describe("POST /api/songs/search/semantic", () => {
 
     await POST(makeRequest({ query: "grace" }));
     expect(embedQuery).toHaveBeenCalledWith("grace");
-    expect(semanticSearchSongs).toHaveBeenCalledWith(mockEmbedding, 20, "text-embedding-3-small");
+    expect(semanticSearchSongs).toHaveBeenCalledWith(mockEmbedding, "text-embedding-3-small", 20);
   });
 
   it("respects custom limit", async () => {
@@ -157,7 +157,7 @@ describe("POST /api/songs/search/semantic", () => {
     vi.mocked(findTopMatchingLines).mockResolvedValue(new Map());
 
     await POST(makeRequest({ query: "test", limit: 5 }));
-    expect(semanticSearchSongs).toHaveBeenCalledWith(mockEmbedding, 5, "text-embedding-3-small");
+    expect(semanticSearchSongs).toHaveBeenCalledWith(mockEmbedding, "text-embedding-3-small", 5);
   });
 
   it("returns 400 when limit > 50", async () => {
@@ -200,8 +200,8 @@ describe("POST /api/songs/search/semantic", () => {
     expect(data.songs).toHaveLength(1);
     expect(semanticSearchSongs).toHaveBeenCalledWith(
       mockEmbedding,
-      20,
-      "text-embedding-3-small"
+      "text-embedding-3-small",
+      20
     );
   });
 });

--- a/webapp/src/test/db/schema.test.ts
+++ b/webapp/src/test/db/schema.test.ts
@@ -265,12 +265,12 @@ describe("schema: column defaults", () => {
     expect(songsetItems.gapBeats.default).toBe(2);
   });
 
-  it("songEmbeddings model_version defaults to openai-text-embedding-3-small", () => {
-    expect(songEmbeddings.modelVersion.default).toBe("openai-text-embedding-3-small");
+  it("songEmbeddings model_version defaults to text-embedding-3-small", () => {
+    expect(songEmbeddings.modelVersion.default).toBe("text-embedding-3-small");
   });
 
-  it("songLineEmbeddings model_version defaults to openai-text-embedding-3-small", () => {
-    expect(songLineEmbeddings.modelVersion.default).toBe("openai-text-embedding-3-small");
+  it("songLineEmbeddings model_version defaults to text-embedding-3-small", () => {
+    expect(songLineEmbeddings.modelVersion.default).toBe("text-embedding-3-small");
   });
 
   it("user_settings offline_auto_cache defaults to true", () => {

--- a/webapp/src/test/deployment/deployment.test.ts
+++ b/webapp/src/test/deployment/deployment.test.ts
@@ -247,6 +247,21 @@ describe(".env.production.example", () => {
     const content = readEnvExample();
     expect(content).toContain("SOW_SQS_ENDPOINT_URL=");
   });
+
+  it("documents SOW_LLM_API_KEY", () => {
+    const content = readEnvExample();
+    expect(content).toContain("SOW_LLM_API_KEY=");
+  });
+
+  it("documents SOW_LLM_BASE_URL", () => {
+    const content = readEnvExample();
+    expect(content).toContain("SOW_LLM_BASE_URL=");
+  });
+
+  it("documents SOW_LLM_EMBEDDING_MODEL", () => {
+    const content = readEnvExample();
+    expect(content).toContain("SOW_LLM_EMBEDDING_MODEL=");
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Replace the standalone `SOW_OPENAI_API_KEY` environment variable with the existing `SOW_LLM_API_KEY` + `SOW_LLM_BASE_URL` pair, and add a new `SOW_LLM_EMBEDDING_MODEL` variable for provider-specific embedding model naming. This eliminates a redundant env var, enables OpenAI-compatible embedding providers (OpenRouter, NeuralWatt, etc.), and correctly handles provider-specific model naming — matching the pattern already used by the LRC and YouTube transcript workers.

The `model_version` label (stored in DB, used for version checking) changes from `openai-text-embedding-3-small` to `text-embedding-3-small` (provider-agnostic). The new `SOW_LLM_EMBEDDING_MODEL` is only used for the actual API call (e.g., `openai/text-embedding-3-small` on OpenRouter, `text-embedding-3-small` on OpenAI direct).

Spec: `specs/consolidate-embedding-env-vars-to-sow-llm-v3.md`

## Changes by Area

### Analysis Service — Exception Hierarchy Refactor

| File | Change |
|------|--------|
| `services/analysis/src/sow_analysis/workers/exceptions.py` | **NEW** — Shared `WorkerError` base class and `LLMConfigError` exception, decoupling embedder and lrc from cross-worker imports |
| `services/analysis/src/sow_analysis/workers/lrc.py` | `LRCWorkerError` now inherits from `WorkerError` instead of `Exception`; removed local `LLMConfigError` class, imports from `exceptions` |
| `services/analysis/src/sow_analysis/workers/youtube_transcript.py` | `LLMConfigError` import changed from `.lrc` to `..workers.exceptions` |

### Analysis Service — Embedding Configuration

| File | Change |
|------|--------|
| `services/analysis/src/sow_analysis/config.py` | Added `SOW_LLM_EMBEDDING_MODEL` field (default: `text-embedding-3-small`) |
| `services/analysis/src/sow_analysis/workers/embedder.py` | Replaced `os.environ.get("SOW_OPENAI_API_KEY")` with `settings.SOW_LLM_API_KEY` + `settings.SOW_LLM_BASE_URL`; added eager validation raising `LLMConfigError`; uses `settings.SOW_LLM_EMBEDDING_MODEL` for API calls; `model_version` → `"text-embedding-3-small"` |
| `services/analysis/src/sow_analysis/models.py` | `EmbeddingJobResult.model_version` default → `"text-embedding-3-small"` |
| `services/analysis/src/sow_analysis/routes/health.py` | Added `check_embedding_connection()` — tests `/v1/embeddings` endpoint with live API call; added to health check response as `"embedding"` |
| `services/analysis/docker-compose.yml` | Added `SOW_LLM_EMBEDDING_MODEL` to `x-common-env` anchor |
| `services/analysis/.env.example` | Added embedding model configuration section with provider-specific examples |

### Web App — Embedding Configuration

| File | Change |
|------|--------|
| `webapp/src/lib/embedding.ts` | Replaced `SOW_OPENAI_API_KEY` with `SOW_LLM_API_KEY` + `SOW_LLM_BASE_URL` + `SOW_LLM_EMBEDDING_MODEL`; added module-level guards for missing env vars; `QUERY_MODEL` → `"text-embedding-3-small"` |
| `webapp/src/lib/db/songs.ts` | Removed `hasMismatchedModelVersion()` function; added `expectedModelVersion` parameter to `semanticSearchSongs()` with SQL `WHERE se.model_version = ${expectedModelVersion}` filter |
| `webapp/src/app/api/songs/search/semantic/route.ts` | Removed global 503 mismatch pre-check; passes `QUERY_MODEL` as third arg to `semanticSearchSongs()` |
| `webapp/src/db/schema.ts` | Both `model_version` defaults → `"text-embedding-3-small"` (songEmbeddings, songLineEmbeddings) |
| `webapp/.env.example` | Replaced `SOW_OPENAI_API_KEY` with `SOW_LLM_API_KEY`, `SOW_LLM_BASE_URL`, `SOW_LLM_EMBEDDING_MODEL` |
| `webapp/.env.production.example` | Replaced "OpenAI API (Semantic Search)" section with "LLM API (Semantic Search)" section documenting all three vars |

### Admin CLI — Model Version Defaults

| File | Change |
|------|--------|
| `src/stream_of_worship/admin/db/schema.py` | Both `model_version` SQL defaults → `'text-embedding-3-small'` |
| `src/stream_of_worship/admin/db/models.py` | `SongEmbedding.model_version` and `SongLineEmbedding.model_version` defaults → `"text-embedding-3-small"` |
| `src/stream_of_worship/admin/services/analysis.py` | `EmbeddingResult.model_version` default and `_parse_job_response` fallback → `"text-embedding-3-small"` |

### Tests

| File | Change |
|------|--------|
| `webapp/src/test/api/songs/search/semantic.test.ts` | Removed `hasMismatchedModelVersion` mock and 503 mismatch test; updated `QUERY_MODEL` and `modelVersion` to `"text-embedding-3-small"`; updated `semanticSearchSongs` call assertions to include third `expectedModelVersion` param; added test for mismatched model_version filtering |
| `webapp/src/test/db/schema.test.ts` | Updated `model_version` default assertions to `"text-embedding-3-small"` |
| `webapp/src/test/deployment/deployment.test.ts` | Added 3 tests verifying `.env.production.example` documents `SOW_LLM_API_KEY`, `SOW_LLM_BASE_URL`, `SOW_LLM_EMBEDDING_MODEL` |

## Migration Notes

### Hard Cutover — No Backward Compatibility

`SOW_OPENAI_API_KEY` is no longer read by any component. Env vars must be updated **before** code deployment:

1. **Analysis Service (Docker)**: `SOW_LLM_API_KEY` and `SOW_LLM_BASE_URL` are already configured (used by LRC worker). Add `SOW_LLM_EMBEDDING_MODEL` if using a provider that requires a different model name (e.g., OpenRouter: `openai/text-embedding-3-small`).
2. **Web App (Vercel)**: Add `SOW_LLM_API_KEY`, `SOW_LLM_BASE_URL`, and optionally `SOW_LLM_EMBEDDING_MODEL` to Vercel environment variables. Remove `SOW_OPENAI_API_KEY` after deployment.
3. **Local dev `.env.local`**: Developers must add `SOW_LLM_API_KEY` and `SOW_LLM_BASE_URL`, and can remove `SOW_OPENAI_API_KEY`.

### model_version Column — Graceful Degradation

The `model_version` default changes from `"openai-text-embedding-3-small"` to `"text-embedding-3-small"`. After deployment:
- **New embeddings** will have `model_version = "text-embedding-3-small"`.
- **Existing embeddings** still have `model_version = "openai-text-embedding-3-small"`.
- **Semantic search** will exclude songs with the old `model_version` label from results (filtered in SQL), rather than returning 503 for all songs.

**Remediation SQL** (run after deployment):
```sql
UPDATE song_embedding SET model_version = 'text-embedding-3-small' WHERE model_version = 'openai-text-embedding-3-small';
UPDATE song_line_embedding SET model_version = 'text-embedding-3-small' WHERE model_version = 'openai-text-embedding-3-small';
```

### Drizzle Migration

Run `npx drizzle-kit generate` after `schema.ts` changes to produce the column default migration SQL.

## Verification

- All Python files pass syntax validation (`ast.parse`)
- `pnpm lint` — clean
- `pnpm test` — 79 test files, 1297 tests passing