### PR TITLE
fix: embedding job DB persist error + admin embed command config

### DIFF
--- a/services/analysis/src/sow_analysis/models.py
+++ b/services/analysis/src/sow_analysis/models.py
@@ -130,7 +130,7 @@ class JobResponse(BaseModel):
     stage: str = ""
     error_message: Optional[str] = None
     warning: Optional[str] = None
-    result: Optional[JobResult] = None
+    result: Optional[Union[JobResult, "EmbeddingJobResult"]] = None
 
 
 class EmbeddingJobRequest(BaseModel):
@@ -141,6 +141,7 @@ class EmbeddingJobRequest(BaseModel):
     composer: str = ""
     lyrics_raw: str = ""
     lyrics_lines: List[str] = []
+    content_hash: str
 
 
 class LineEmbedding(BaseModel):

--- a/services/analysis/src/sow_analysis/storage/db.py
+++ b/services/analysis/src/sow_analysis/storage/db.py
@@ -50,6 +50,9 @@ class JobStore:
         # Check if we need to migrate from old schema (without 'cancelled')
         await self._migrate_cancelled_status()
 
+        # Check if we need to migrate from old schema (without 'embedding' job type)
+        await self._migrate_embedding_type()
+
         await self._db.executescript(
             """
             CREATE TABLE IF NOT EXISTS jobs (
@@ -69,7 +72,7 @@ class JobStore:
                 content_hash    TEXT NOT NULL,
 
                 CHECK (status IN ('queued', 'processing', 'completed', 'failed', 'cancelled')),
-                CHECK (type IN ('analyze', 'lrc', 'stem_separation'))
+                CHECK (type IN ('analyze', 'lrc', 'stem_separation', 'embedding'))
             );
 
             CREATE INDEX IF NOT EXISTS idx_jobs_status ON jobs(status);
@@ -138,7 +141,7 @@ class JobStore:
                         content_hash    TEXT NOT NULL,
 
                         CHECK (status IN ('queued', 'processing', 'completed', 'failed', 'cancelled')),
-                        CHECK (type IN ('analyze', 'lrc', 'stem_separation'))
+                        CHECK (type IN ('analyze', 'lrc', 'stem_separation', 'embedding'))
                     );
 
                     -- Copy data from old table
@@ -158,6 +161,78 @@ class JobStore:
 
         except Exception as e:
             logger.error(f"Database migration failed: {e}")
+            raise
+
+    async def _migrate_embedding_type(self) -> None:
+        """Migrate old schema to support 'embedding' job type.
+
+        SQLite doesn't support ALTER TABLE for CHECK constraints,
+        so we need to recreate the table if it has the old schema.
+        """
+        if not self._db:
+            return
+
+        try:
+            async with self._db.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='jobs'"
+            ) as cursor:
+                row = await cursor.fetchone()
+                if not row:
+                    return
+
+                async with self._db.execute(
+                    "SELECT sql FROM sqlite_master WHERE type='table' AND name='jobs'"
+                ) as cursor:
+                    row = await cursor.fetchone()
+                    if not row:
+                        return
+
+                    schema = row[0]
+                    if "'embedding'" in schema:
+                        return
+
+                    logger.warning(
+                        "Migrating database schema to support EMBEDDING job type"
+                    )
+
+                    await self._db.executescript(
+                        """
+                        ALTER TABLE jobs RENAME TO jobs_old;
+
+                        CREATE TABLE jobs (
+                            id              TEXT PRIMARY KEY,
+                            type            TEXT NOT NULL,
+                            status          TEXT NOT NULL DEFAULT 'queued',
+                            progress        REAL NOT NULL DEFAULT 0.0,
+                            stage           TEXT NOT NULL DEFAULT '',
+                            error_message   TEXT,
+
+                            request_json    TEXT NOT NULL,
+                            result_json     TEXT,
+
+                            created_at      TEXT NOT NULL,
+                            updated_at      TEXT NOT NULL,
+
+                            content_hash    TEXT NOT NULL,
+
+                            CHECK (status IN ('queued', 'processing', 'completed', 'failed', 'cancelled')),
+                            CHECK (type IN ('analyze', 'lrc', 'stem_separation', 'embedding'))
+                        );
+
+                        INSERT INTO jobs SELECT * FROM jobs_old;
+
+                        CREATE INDEX idx_jobs_status ON jobs(status);
+                        CREATE INDEX idx_jobs_content_hash ON jobs(content_hash);
+                        CREATE INDEX idx_jobs_created_at ON jobs(created_at);
+
+                        DROP TABLE jobs_old;
+                        """
+                    )
+                    await self._db.commit()
+                    logger.info("Database migration for embedding type complete")
+
+        except Exception as e:
+            logger.error(f"Database migration for embedding type failed: {e}")
             raise
 
     async def insert_job(self, job: Job) -> None:
@@ -264,15 +339,24 @@ class JobStore:
             request = LrcJobRequest.model_validate_json(request_json)
         elif job_type == JobType.STEM_SEPARATION:
             request = StemSeparationJobRequest.model_validate_json(request_json)
+        elif job_type == JobType.EMBEDDING:
+            from ..models import EmbeddingJobRequest
+
+            request = EmbeddingJobRequest.model_validate_json(request_json)
         else:
             raise ValueError(f"Unknown job type: {job_type}")
 
         # Deserialize result if present
         result = None
         if result_json:
-            from ..models import JobResult
+            if job_type == JobType.EMBEDDING:
+                from ..models import EmbeddingJobResult
 
-            result = JobResult.model_validate_json(result_json)
+                result = EmbeddingJobResult.model_validate_json(result_json)
+            else:
+                from ..models import JobResult
+
+                result = JobResult.model_validate_json(result_json)
 
         # Parse timestamps
         created_at = datetime.fromisoformat(created_at_str)

--- a/services/analysis/src/sow_analysis/workers/embedder.py
+++ b/services/analysis/src/sow_analysis/workers/embedder.py
@@ -1,7 +1,6 @@
 """Embedding worker for generating text embeddings via OpenAI-compatible API."""
 
 import asyncio
-import hashlib
 import logging
 from typing import List
 
@@ -20,13 +19,6 @@ _MAX_INPUT_CHARS_HEURISTIC = 6000
 
 def _count_cjk_chars(text: str) -> int:
     return sum(1 for ch in text if _CJK_RANGE_START <= ord(ch) <= _CJK_RANGE_END)
-
-
-def _compute_content_hash(
-    title: str, composer: str, lyrics_raw: str, lyrics_lines: List[str]
-) -> str:
-    content = f"{title}\0{composer}\0{lyrics_raw}\0{'|'.join(lyrics_lines)}"
-    return hashlib.sha256(content.encode("utf-8")).hexdigest()[:16]
 
 
 class EmbeddingWorker:
@@ -83,16 +75,12 @@ class EmbeddingWorker:
             for (idx, line), emb in zip(eligible_lines, line_embeddings_raw)
         ]
 
-        content_hash = _compute_content_hash(
-            request.title, request.composer, request.lyrics_raw, request.lyrics_lines
-        )
-
         return EmbeddingJobResult(
             song_id=request.song_id,
             embedding=song_embedding[0],
             line_embeddings=line_embeddings,
             model_version="text-embedding-3-small",
-            content_hash=content_hash,
+            content_hash=request.content_hash,
         )
 
     async def _embed_texts(self, texts: List[str]) -> List[List[float]]:

--- a/services/analysis/tests/test_job_store.py
+++ b/services/analysis/tests/test_job_store.py
@@ -10,9 +10,12 @@ from pytest_mock import MockerFixture
 from sow_analysis.models import (
     AnalyzeJobRequest,
     AnalyzeOptions,
+    EmbeddingJobRequest,
+    EmbeddingJobResult,
     Job,
     JobStatus,
     JobType,
+    LineEmbedding,
     LrcJobRequest,
     LrcOptions,
     Section,
@@ -423,3 +426,76 @@ async def test_purge_includes_cancelled_jobs(job_store: JobStore) -> None:
 
     # Verify recent cancelled job remains
     assert await job_store.get_job("job_recent_cancelled") is not None
+
+
+@pytest.mark.asyncio
+async def test_insert_and_get_embedding_job(job_store: JobStore) -> None:
+    """Test round-trip for embedding job."""
+    request = EmbeddingJobRequest(
+        song_id="song_001",
+        title="Test Song",
+        composer="Test Composer",
+        lyrics_raw="Verse 1\nChorus",
+        lyrics_lines=["Verse 1", "Chorus"],
+        content_hash="emb_hash_001",
+    )
+
+    job = Job(
+        id="job_emb001",
+        type=JobType.EMBEDDING,
+        status=JobStatus.QUEUED,
+        request=request,
+    )
+
+    await job_store.insert_job(job)
+
+    retrieved = await job_store.get_job("job_emb001")
+    assert retrieved is not None
+    assert retrieved.id == "job_emb001"
+    assert retrieved.type == JobType.EMBEDDING
+    assert retrieved.status == JobStatus.QUEUED
+    assert isinstance(retrieved.request, EmbeddingJobRequest)
+    assert retrieved.request.song_id == "song_001"
+    assert retrieved.request.title == "Test Song"
+    assert retrieved.request.content_hash == "emb_hash_001"
+
+
+@pytest.mark.asyncio
+async def test_embedding_job_with_result(job_store: JobStore) -> None:
+    """Test embedding job round-trip including result."""
+    request = EmbeddingJobRequest(
+        song_id="song_002",
+        title="Another Song",
+        composer="Composer",
+        lyrics_raw="Lyrics here",
+        lyrics_lines=["Lyrics here"],
+        content_hash="emb_hash_002",
+    )
+
+    job = Job(
+        id="job_emb002",
+        type=JobType.EMBEDDING,
+        status=JobStatus.COMPLETED,
+        request=request,
+        result=EmbeddingJobResult(
+            song_id="song_002",
+            embedding=[0.1, 0.2, 0.3],
+            line_embeddings=[
+                LineEmbedding(line_index=0, line_text="Lyrics here", embedding=[0.4, 0.5])
+            ],
+            model_version="text-embedding-3-small",
+            content_hash="emb_hash_002",
+        ),
+    )
+
+    await job_store.insert_job(job)
+
+    retrieved = await job_store.get_job("job_emb002")
+    assert retrieved is not None
+    assert retrieved.status == JobStatus.COMPLETED
+    assert isinstance(retrieved.result, EmbeddingJobResult)
+    assert retrieved.result.song_id == "song_002"
+    assert retrieved.result.embedding == [0.1, 0.2, 0.3]
+    assert len(retrieved.result.line_embeddings) == 1
+    assert retrieved.result.line_embeddings[0].line_text == "Lyrics here"
+    assert retrieved.result.content_hash == "emb_hash_002"

--- a/src/stream_of_worship/admin/commands/audio.py
+++ b/src/stream_of_worship/admin/commands/audio.py
@@ -768,8 +768,12 @@ def download_audio(
     video_title = video_info.get("title") if video_info else None
     chinese_title = _extract_chinese_title_from_youtube(video_title)
     if chinese_title and chinese_title != song.title:
-        console.print(f"[yellow]⚠ Title mismatch: expected '{song.title}', got '{chinese_title}' from video '{video_title}'[/yellow]")
-        console.print(f"[yellow]  This may be the wrong video. Consider using --url to specify the correct video.[/yellow]")
+        console.print(
+            f"[yellow]⚠ Title mismatch: expected '{song.title}', got '{chinese_title}' from video '{video_title}'[/yellow]"
+        )
+        console.print(
+            f"[yellow]  This may be the wrong video. Consider using --url to specify the correct video.[/yellow]"
+        )
 
     # Step 4: Confirmation prompt
     download_confirmed = skip_confirm
@@ -803,7 +807,9 @@ def download_audio(
         video_title = video_info.get("title") if video_info else None
         chinese_title = _extract_chinese_title_from_youtube(video_title)
         if chinese_title and chinese_title != song.title:
-            console.print(f"[yellow]⚠ Title mismatch: expected '{song.title}', got '{chinese_title}' from video '{video_title}'[/yellow]")
+            console.print(
+                f"[yellow]⚠ Title mismatch: expected '{song.title}', got '{chinese_title}' from video '{video_title}'[/yellow]"
+            )
             console.print(f"[yellow]  This may be the wrong video.[/yellow]")
 
         # Confirm the manual URL
@@ -1041,7 +1047,9 @@ def _delete_recordings_batch(
             not_found.append(sid)
 
     if not_found:
-        console.print(f"[yellow]No recording found for {len(not_found)} song(s): {', '.join(not_found[:5])}{'...' if len(not_found) > 5 else ''}[/yellow]")
+        console.print(
+            f"[yellow]No recording found for {len(not_found)} song(s): {', '.join(not_found[:5])}{'...' if len(not_found) > 5 else ''}[/yellow]"
+        )
 
     if not recordings_to_delete:
         console.print("[yellow]No valid recordings to delete.[/yellow]")
@@ -1069,7 +1077,9 @@ def _delete_recordings_batch(
 
     if not yes:
         console.print("[red bold]Warning: This action cannot be undone![/red bold]")
-        confirmed = _prompt_confirmation(f"Delete {len(recordings_to_delete)} recording(s) and all associated files?")
+        confirmed = _prompt_confirmation(
+            f"Delete {len(recordings_to_delete)} recording(s) and all associated files?"
+        )
         if not confirmed:
             console.print("[yellow]Deletion cancelled.[/yellow]")
             raise typer.Exit(0)
@@ -1305,9 +1315,7 @@ def show_recording(
     if recording.r2_lrc_url:
         info_lines.append(f"[cyan]LRC URL:[/cyan] {recording.r2_lrc_url}")
 
-    info_lines.append(
-        f"[cyan]YouTube URL:[/cyan] {recording.youtube_url or '- none -'}"
-    )
+    info_lines.append(f"[cyan]YouTube URL:[/cyan] {recording.youtube_url or '- none -'}")
 
     # Status
     info_lines.append("")
@@ -1806,10 +1814,14 @@ def embed_songs(
     elif all_songs:
         if force:
             songs_to_embed = db_client.get_all_songs_with_lyrics()
-            console.print(f"Found {len(songs_to_embed)} songs with lyrics (force mode)")
+            console.print(
+                f"Found {len(songs_to_embed)} songs with published recordings (force mode)"
+            )
         else:
             songs_to_embed = db_client.get_songs_without_embeddings()
-            console.print(f"Found {len(songs_to_embed)} songs without embeddings")
+            console.print(
+                f"Found {len(songs_to_embed)} songs without embeddings (with published recordings)"
+            )
     else:
         songs_to_embed = []
 
@@ -1819,9 +1831,7 @@ def embed_songs(
 
     job_ids: list[str] = []
     for song in songs_to_embed:
-        jid = _submit_embedding_single(
-            song, analysis_client, db_client, console, force=force
-        )
+        jid = _submit_embedding_single(song, analysis_client, db_client, console, force=force)
         if jid:
             job_ids.append(jid)
 
@@ -2172,7 +2182,9 @@ def check_status(
                 reconcile_queue.append(rec)
 
         if not reconcile_queue:
-            console.print("[green]No recordings with incomplete LRC, analysis, or download status.[/green]")
+            console.print(
+                "[green]No recordings with incomplete LRC, analysis, or download status.[/green]"
+            )
         else:
             console.print(f"[cyan]Scanning R2 across {len(reconcile_queue)} recording(s)...[/cyan]")
             reconciled_lrc = 0
@@ -2538,7 +2550,9 @@ def check_status(
 def cancel_jobs(
     job_id: Optional[str] = typer.Argument(None, help="Job ID to cancel"),
     all: bool = typer.Option(False, "--all", "-a", help="Cancel all queued and processing jobs"),
-    dry_run: bool = typer.Option(False, "--dry-run", "-n", help="Show what would be cancelled without cancelling"),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", "-n", help="Show what would be cancelled without cancelling"
+    ),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
     config_path: Optional[Path] = typer.Option(None, "--config", "-c", help="Path to config file"),
 ) -> None:
@@ -2555,7 +2569,9 @@ def cancel_jobs(
     Requires SOW_ADMIN_API_KEY environment variable to be set.
     """
     if not job_id and not all:
-        console.print("[red]Error: Provide a JOB_ID argument or use --all to cancel all jobs.[/red]")
+        console.print(
+            "[red]Error: Provide a JOB_ID argument or use --all to cancel all jobs.[/red]"
+        )
         raise typer.Exit(1)
 
     if job_id and all:
@@ -2599,18 +2615,22 @@ def _cancel_single_job(
             raise typer.Exit(1)
 
         if job.status in ("completed", "failed", "cancelled"):
-            console.print(f"[yellow]Job {job_id} is already {job.status} (nothing to cancel)[/yellow]")
+            console.print(
+                f"[yellow]Job {job_id} is already {job.status} (nothing to cancel)[/yellow]"
+            )
             return
 
-        console.print(Panel.fit(
-            f"[cyan]Job ID:[/cyan] {job_id}\n"
-            f"[cyan]Type:[/cyan] {job.job_type}\n"
-            f"[cyan]Status:[/cyan] {_colorize_status(job.status)}\n"
-            f"[cyan]Progress:[/cyan] {int(job.progress * 100)}%\n"
-            f"[cyan]Stage:[/cyan] {job.stage or '-'}",
-            title="Dry Run - Would Cancel Job",
-            border_style="yellow",
-        ))
+        console.print(
+            Panel.fit(
+                f"[cyan]Job ID:[/cyan] {job_id}\n"
+                f"[cyan]Type:[/cyan] {job.job_type}\n"
+                f"[cyan]Status:[/cyan] {_colorize_status(job.status)}\n"
+                f"[cyan]Progress:[/cyan] {int(job.progress * 100)}%\n"
+                f"[cyan]Stage:[/cyan] {job.stage or '-'}",
+                title="Dry Run - Would Cancel Job",
+                border_style="yellow",
+            )
+        )
         return
 
     try:
@@ -2629,14 +2649,16 @@ def _cancel_single_job(
         console.print(f"[red]{e}[/red]")
         raise typer.Exit(1)
 
-    console.print(Panel.fit(
-        f"[green]Job cancelled successfully![/green]\n\n"
-        f"[cyan]Job ID:[/cyan] {job.job_id}\n"
-        f"[cyan]Type:[/cyan] {job.job_type}\n"
-        f"[cyan]Status:[/cyan] {_colorize_status(job.status)}",
-        title="Job Cancelled",
-        border_style="green",
-    ))
+    console.print(
+        Panel.fit(
+            f"[green]Job cancelled successfully![/green]\n\n"
+            f"[cyan]Job ID:[/cyan] {job.job_id}\n"
+            f"[cyan]Type:[/cyan] {job.job_type}\n"
+            f"[cyan]Status:[/cyan] {_colorize_status(job.status)}",
+            title="Job Cancelled",
+            border_style="green",
+        )
+    )
 
 
 def _cancel_all_jobs(
@@ -2706,14 +2728,16 @@ def _cancel_all_jobs(
     cancelled_count = result.get("cancelled_count", 0)
     cancelled_ids = result.get("cancelled_job_ids", [])
 
-    console.print(Panel.fit(
-        f"[green]Successfully cancelled {cancelled_count} job(s)![/green]\n\n"
-        f"[dim]Cancelled job IDs:[/dim]\n"
-        + "\n".join(f"  • {jid}" for jid in cancelled_ids[:20])
-        + (f"\n  ... and {len(cancelled_ids) - 20} more" if len(cancelled_ids) > 20 else ""),
-        title="Jobs Cancelled",
-        border_style="green",
-    ))
+    console.print(
+        Panel.fit(
+            f"[green]Successfully cancelled {cancelled_count} job(s)![/green]\n\n"
+            f"[dim]Cancelled job IDs:[/dim]\n"
+            + "\n".join(f"  • {jid}" for jid in cancelled_ids[:20])
+            + (f"\n  ... and {len(cancelled_ids) - 20} more" if len(cancelled_ids) > 20 else ""),
+            title="Jobs Cancelled",
+            border_style="green",
+        )
+    )
 
 
 def _update_recording_status_force(
@@ -3535,7 +3559,9 @@ def batch(
         False, "--dry-run", help="Show what would be processed without executing"
     ),
     force_lrc: bool = typer.Option(
-        False, "--force-lrc", help="Force re-generate LRC from scratch (skip R2 check and existing job reuse)"
+        False,
+        "--force-lrc",
+        help="Force re-generate LRC from scratch (skip R2 check and existing job reuse)",
     ),
     format: str = typer.Option("rich", "--format", help="Output format (rich, json)"),
     config_path: Optional[Path] = typer.Option(None, "--config", "-c", help="Path to config file"),
@@ -3797,10 +3823,17 @@ def _download_and_create_recording(
 
         chinese_title = _extract_chinese_title_from_youtube(video_title)
         if chinese_title and chinese_title != song.title:
-            console.print(f"  [yellow]⚠ Title mismatch: expected '{song.title}', got '{chinese_title}' from video '{video_title}'[/yellow]")
-            console.print(f"  [yellow]  Use 'sow_admin audio download {song_id} --youtube-url <url>' to manually specify the correct video.[/yellow]")
+            console.print(
+                f"  [yellow]⚠ Title mismatch: expected '{song.title}', got '{chinese_title}' from video '{video_title}'[/yellow]"
+            )
+            console.print(
+                f"  [yellow]  Use 'sow_admin audio download {song_id} --youtube-url <url>' to manually specify the correct video.[/yellow]"
+            )
             audio_path.unlink(missing_ok=True)
-            return None, f"title mismatch: expected '{song.title}', got '{chinese_title}' from video '{video_title}'"
+            return (
+                None,
+                f"title mismatch: expected '{song.title}', got '{chinese_title}' from video '{video_title}'",
+            )
 
         file_size = audio_path.stat().st_size
         console.print(f"  [dim]Downloaded: {audio_path.name} ({_format_size_mb(file_size)})[/dim]")
@@ -3814,10 +3847,20 @@ def _download_and_create_recording(
 
         existing_recording = db_client.get_recording_by_hash(prefix)
         if existing_recording:
-            existing_song = db_client.get_song(existing_recording.song_id) if existing_recording.song_id else None
-            existing_song_title = existing_song.title if existing_song else existing_recording.song_id
-            console.print(f"  [yellow]⚠ Duplicate hash: audio matches existing recording for song '{existing_song_title}'[/yellow]")
-            console.print(f"  [yellow]  This song likely downloaded the wrong video. Use 'sow_admin audio download {song_id} --youtube-url <url>' to manually specify the correct video.[/yellow]")
+            existing_song = (
+                db_client.get_song(existing_recording.song_id)
+                if existing_recording.song_id
+                else None
+            )
+            existing_song_title = (
+                existing_song.title if existing_song else existing_recording.song_id
+            )
+            console.print(
+                f"  [yellow]⚠ Duplicate hash: audio matches existing recording for song '{existing_song_title}'[/yellow]"
+            )
+            console.print(
+                f"  [yellow]  This song likely downloaded the wrong video. Use 'sow_admin audio download {song_id} --youtube-url <url>' to manually specify the correct video.[/yellow]"
+            )
             audio_path.unlink(missing_ok=True)
             return None, f"duplicate hash: shares audio with song '{existing_song_title}'"
 
@@ -3902,11 +3945,18 @@ def _download_if_needed(
 
         chinese_title = _extract_chinese_title_from_youtube(video_title)
         if chinese_title and chinese_title != song.title:
-            console.print(f"[{song_id}] [yellow]⚠ Title mismatch: expected '{song.title}', got '{chinese_title}' from video '{video_title}'[/yellow]")
-            console.print(f"[{song_id}] [yellow]  Use 'sow_admin audio download {song_id} --youtube-url <url>' to manually specify the correct video.[/yellow]")
+            console.print(
+                f"[{song_id}] [yellow]⚠ Title mismatch: expected '{song.title}', got '{chinese_title}' from video '{video_title}'[/yellow]"
+            )
+            console.print(
+                f"[{song_id}] [yellow]  Use 'sow_admin audio download {song_id} --youtube-url <url>' to manually specify the correct video.[/yellow]"
+            )
             audio_path.unlink(missing_ok=True)
             db_client.update_recording_download(hash_prefix, "failed")
-            return {"download": "failed", "error": f"title mismatch: expected '{song.title}', got '{chinese_title}' from video '{video_title}'"}
+            return {
+                "download": "failed",
+                "error": f"title mismatch: expected '{song.title}', got '{chinese_title}' from video '{video_title}'",
+            }
 
         content_hash = compute_file_hash(audio_path)
         prefix = get_hash_prefix(content_hash)
@@ -4134,11 +4184,11 @@ def _process_batch(
                 songs_needing_embedding.append(song)
 
     if songs_needing_embedding:
-        console.print(f"[cyan]Phase 3.5: Submitting {len(songs_needing_embedding)} embedding jobs[/cyan]")
+        console.print(
+            f"[cyan]Phase 3.5: Submitting {len(songs_needing_embedding)} embedding jobs[/cyan]"
+        )
         for song in songs_needing_embedding:
-            jid = _submit_embedding_single(
-                song, analysis_client, db_client, console, force=False
-            )
+            jid = _submit_embedding_single(song, analysis_client, db_client, console, force=False)
             if jid:
                 embedding_job_ids.append(jid)
 
@@ -4278,9 +4328,9 @@ def _poll_all_jobs(
                                     f"{max_resubmits} resubmits, marking as failed[/red]"
                                 )
                                 results[song_id]["lrc"] = "failed"
-                                results[song_id][
-                                    "lrc_error"
-                                ] = f"Job lost (404) and not found on R2 after {max_resubmits} resubmits"
+                                results[song_id]["lrc_error"] = (
+                                    f"Job lost (404) and not found on R2 after {max_resubmits} resubmits"
+                                )
                                 db_client.update_recording_status(
                                     hash_prefix=recording.hash_prefix,
                                     lrc_status="failed",
@@ -4296,9 +4346,9 @@ def _poll_all_jobs(
                                     song = db_client.get_song(song_id)
                                     if not song or not song.lyrics_raw:
                                         results[song_id]["lrc"] = "failed"
-                                        results[song_id][
-                                            "lrc_error"
-                                        ] = "Job lost and no lyrics available for resubmit"
+                                        results[song_id]["lrc_error"] = (
+                                            "Job lost and no lyrics available for resubmit"
+                                        )
                                         db_client.update_recording_status(
                                             hash_prefix=recording.hash_prefix,
                                             lrc_status="failed",
@@ -4523,12 +4573,8 @@ def _print_stats(
     lrc_skipped_download = sum(1 for r in results.values() if r.get("download") == "failed")
 
     # LRC source breakdown (YouTube vs ASR)
-    lrc_youtube = sum(
-        1 for r in results.values() if r.get("lrc_source") == "youtube_transcript"
-    )
-    lrc_asr = sum(
-        1 for r in results.values() if r.get("lrc_source") == "whisper_asr"
-    )
+    lrc_youtube = sum(1 for r in results.values() if r.get("lrc_source") == "youtube_transcript")
+    lrc_asr = sum(1 for r in results.values() if r.get("lrc_source") == "whisper_asr")
     lrc_unknown = lrc_completed - lrc_skipped_existing - lrc_youtube - lrc_asr
 
     # LRC timing stats (only for ASR/Whisper jobs, not YouTube or R2 pre-existing)
@@ -4617,7 +4663,9 @@ def _print_stats(
 @app.command("probe")
 def probe(
     song_id: str = typer.Argument(..., help="Song ID to probe"),
-    force: bool = typer.Option(False, "--force", "-f", help="Re-probe even if duration_seconds is already set"),
+    force: bool = typer.Option(
+        False, "--force", "-f", help="Re-probe even if duration_seconds is already set"
+    ),
     config_path: Optional[Path] = typer.Option(None, "--config", "-c", help="Path to config file"),
 ) -> None:
     """Probe audio duration via ffprobe and update the recording in the database.
@@ -4691,9 +4739,15 @@ def probe(
 def probe_batch(
     album: Optional[str] = typer.Option(None, "--album", help="Filter by album name"),
     song: Optional[str] = typer.Option(None, "--song", help="Filter by song name (partial match)"),
-    analysis_status: Optional[str] = typer.Option(None, "--analysis-status", help="Filter by analysis status"),
-    force: bool = typer.Option(False, "--force", "-f", help="Re-probe even if duration_seconds is already set"),
-    dry_run: bool = typer.Option(False, "--dry-run", help="Show what would be probed without executing"),
+    analysis_status: Optional[str] = typer.Option(
+        None, "--analysis-status", help="Filter by analysis status"
+    ),
+    force: bool = typer.Option(
+        False, "--force", "-f", help="Re-probe even if duration_seconds is already set"
+    ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Show what would be probed without executing"
+    ),
     limit: Optional[int] = typer.Option(None, "--limit", help="Maximum number of songs to process"),
     config_path: Optional[Path] = typer.Option(None, "--config", "-c", help="Path to config file"),
 ) -> None:
@@ -4726,15 +4780,19 @@ def probe_batch(
 
     if album:
         recordings = [
-            r for r in recordings
-            if r.song_id and db_client.get_song(r.song_id)
+            r
+            for r in recordings
+            if r.song_id
+            and db_client.get_song(r.song_id)
             and album.lower() in (db_client.get_song(r.song_id).album_name or "").lower()
         ]
 
     if song:
         recordings = [
-            r for r in recordings
-            if r.song_id and db_client.get_song(r.song_id)
+            r
+            for r in recordings
+            if r.song_id
+            and db_client.get_song(r.song_id)
             and song.lower() in (db_client.get_song(r.song_id).title or "").lower()
         ]
 

--- a/src/stream_of_worship/admin/commands/audio.py
+++ b/src/stream_of_worship/admin/commands/audio.py
@@ -676,7 +676,7 @@ def download_audio(
         lrc = True
 
     try:
-        config = AdminConfig.load(config_path) if config_path else AdminConfig.load()
+        config = AdminConfig.load(config_path)
     except FileNotFoundError:
         console.print("[red]Config file not found. Run 'sow-admin db init' first.[/red]")
         raise typer.Exit(1)
@@ -929,7 +929,7 @@ def delete_recording(
         raise typer.Exit(1)
 
     try:
-        config = AdminConfig.load(config_path) if config_path else AdminConfig.load()
+        config = AdminConfig.load(config_path)
     except FileNotFoundError:
         console.print("[red]Config file not found. Run 'sow-admin db init' first.[/red]")
         raise typer.Exit(1)
@@ -1142,7 +1142,7 @@ def list_recordings(
     filter by album name. Use ``--format ids`` for one song ID per line (pipeable).
     """
     try:
-        config = AdminConfig.load(config_path) if config_path else AdminConfig.load()
+        config = AdminConfig.load(config_path)
     except FileNotFoundError:
         console.print("[red]Config file not found. Run 'sow-admin db init' first.[/red]")
         raise typer.Exit(1)
@@ -1267,7 +1267,7 @@ def show_recording(
     when available.
     """
     try:
-        config = AdminConfig.load(config_path) if config_path else AdminConfig.load()
+        config = AdminConfig.load(config_path)
     except FileNotFoundError:
         console.print("[red]Config file not found. Run 'sow-admin db init' first.[/red]")
         raise typer.Exit(1)
@@ -1379,7 +1379,7 @@ def set_visibility(
     """
     # Standard config/db boilerplate
     try:
-        config = AdminConfig.load(config_path) if config_path else AdminConfig.load()
+        config = AdminConfig.load(config_path)
     except FileNotFoundError:
         console.print("[red]Config file not found. Run 'sow-admin db init' first.[/red]")
         raise typer.Exit(1)
@@ -1429,7 +1429,7 @@ def analyze_recording(
     """
     # Standard config/db boilerplate
     try:
-        config = AdminConfig.load(config_path) if config_path else AdminConfig.load()
+        config = AdminConfig.load(config_path)
     except FileNotFoundError:
         console.print("[red]Config file not found. Run 'sow-admin db init' first.[/red]")
         raise typer.Exit(1)
@@ -1621,7 +1621,7 @@ def lrc_recording(
 
     # Standard config/db boilerplate
     try:
-        config = AdminConfig.load(config_path) if config_path else AdminConfig.load()
+        config = AdminConfig.load(config_path)
     except FileNotFoundError:
         console.print("[red]Config file not found. Run 'sow-admin db init' first.[/red]")
         raise typer.Exit(1)
@@ -1782,7 +1782,6 @@ def embed_songs(
     """
     from rich.console import Console
 
-    from stream_of_worship.admin.db.client import DatabaseClient
     from stream_of_worship.admin.db.models import Song
     from stream_of_worship.admin.services.analysis import AnalysisClient, AnalysisServiceError
 
@@ -1793,7 +1792,7 @@ def embed_songs(
         raise typer.Exit(1)
 
     try:
-        config = AdminConfig.load(config_path) if config_path else AdminConfig.load()
+        config = AdminConfig.load(config_path)
     except FileNotFoundError:
         console.print("[red]Config file not found. Run 'sow-admin db init' first.[/red]")
         raise typer.Exit(1)
@@ -1894,7 +1893,7 @@ def vocal_clean(
     from stream_of_worship.app.services.asset_cache import AssetCache
 
     try:
-        config = AdminConfig.load(config_path) if config_path else AdminConfig.load()
+        config = AdminConfig.load(config_path)
     except FileNotFoundError:
         console.print("[red]Config file not found. Run 'sow-admin db init' first.[/red]")
         raise typer.Exit(1)
@@ -2119,7 +2118,7 @@ def check_status(
     """
     # Standard config/db boilerplate
     try:
-        config = AdminConfig.load(config_path) if config_path else AdminConfig.load()
+        config = AdminConfig.load(config_path)
     except FileNotFoundError:
         console.print("[red]Config file not found. Run 'sow-admin db init' first.[/red]")
         raise typer.Exit(1)
@@ -2579,7 +2578,7 @@ def cancel_jobs(
         raise typer.Exit(1)
 
     try:
-        config = AdminConfig.load(config_path) if config_path else AdminConfig.load()
+        config = AdminConfig.load(config_path)
     except FileNotFoundError:
         console.print("[red]Config file not found. Run 'sow-admin db init' first.[/red]")
         raise typer.Exit(1)
@@ -3012,7 +3011,7 @@ def view_lrc(
 
     # Load config
     try:
-        config = AdminConfig.load(config_path) if config_path else AdminConfig.load()
+        config = AdminConfig.load(config_path)
     except FileNotFoundError:
         console.print(
             "[red]Config file not found. Please create it using 'sow-admin config init'[/red]"
@@ -3099,7 +3098,7 @@ def cache_assets(
     that need local access to audio files.
     """
     try:
-        config = AdminConfig.load(config_path) if config_path else AdminConfig.load()
+        config = AdminConfig.load(config_path)
     except FileNotFoundError:
         console.print("[red]Config file not found. Run 'sow-admin db init' first.[/red]")
         raise typer.Exit(1)
@@ -3230,7 +3229,7 @@ def upload_lrc(
     The LRC file format will be validated before upload.
     """
     try:
-        config = AdminConfig.load(config_path) if config_path else AdminConfig.load()
+        config = AdminConfig.load(config_path)
     except FileNotFoundError:
         console.print("[red]Config file not found. Run 'sow-admin db init' first.[/red]")
         raise typer.Exit(1)
@@ -3387,7 +3386,7 @@ def playback_audio(
     Controls: Left/Right arrows to skip -/+5s, Ctrl+C to stop.
     """
     try:
-        config = AdminConfig.load(config_path) if config_path else AdminConfig.load()
+        config = AdminConfig.load(config_path)
     except FileNotFoundError:
         console.print("[red]Config file not found. Run 'sow-admin db init' first.[/red]")
         raise typer.Exit(1)
@@ -3605,7 +3604,7 @@ def batch(
 
     # Load config
     try:
-        config = AdminConfig.load(config_path) if config_path else AdminConfig.load()
+        config = AdminConfig.load(config_path)
     except FileNotFoundError:
         console.print("[red]Config file not found. Run 'sow-admin db init' first.[/red]")
         raise typer.Exit(1)
@@ -4683,7 +4682,7 @@ def probe(
         raise typer.Exit(1)
 
     try:
-        config = AdminConfig.load(config_path) if config_path else AdminConfig.load()
+        config = AdminConfig.load(config_path)
     except FileNotFoundError:
         console.print("[red]Config file not found. Run 'sow-admin db init' first.[/red]")
         raise typer.Exit(1)
@@ -4764,7 +4763,7 @@ def probe_batch(
         raise typer.Exit(1)
 
     try:
-        config = AdminConfig.load(config_path) if config_path else AdminConfig.load()
+        config = AdminConfig.load(config_path)
     except FileNotFoundError:
         console.print("[red]Config file not found. Run 'sow-admin db init' first.[/red]")
         raise typer.Exit(1)

--- a/src/stream_of_worship/admin/commands/audio.py
+++ b/src/stream_of_worship/admin/commands/audio.py
@@ -1759,6 +1759,7 @@ def embed_songs(
     all_songs: bool = typer.Option(False, "--all", help="Embed all songs without embeddings"),
     force: bool = typer.Option(False, "--force", help="Re-embed even if content hash matches"),
     wait: bool = typer.Option(False, "--wait", help="Wait for all jobs to complete"),
+    config_path: Optional[Path] = typer.Option(None, "--config", "-c", help="Path to config file"),
 ) -> None:
     """Generate text embeddings for songs using OpenAI text-embedding-3-small.
 
@@ -1776,7 +1777,6 @@ def embed_songs(
     from stream_of_worship.admin.db.client import DatabaseClient
     from stream_of_worship.admin.db.models import Song
     from stream_of_worship.admin.services.analysis import AnalysisClient, AnalysisServiceError
-    from stream_of_worship.db.connection import ConnectionProvider
 
     console = Console()
 
@@ -1784,13 +1784,17 @@ def embed_songs(
         console.print("[red]Error:[/red] Provide a song_id or use --all")
         raise typer.Exit(1)
 
-    db_client = DatabaseClient(ConnectionProvider.from_env())
     try:
-        analysis_client = AnalysisClient(
-            os.environ.get("SOW_ANALYSIS_SERVICE_URL", "http://localhost:8000")
-        )
+        config = AdminConfig.load(config_path) if config_path else AdminConfig.load()
+    except FileNotFoundError:
+        console.print("[red]Config file not found. Run 'sow-admin db init' first.[/red]")
+        raise typer.Exit(1)
+
+    db_client = get_db_client(config)
+    try:
+        analysis_client = AnalysisClient(config.analysis_url)
     except ValueError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[red]Analysis service not configured: {e}[/red]")
         raise typer.Exit(1)
 
     if song_id:

--- a/src/stream_of_worship/admin/commands/catalog.py
+++ b/src/stream_of_worship/admin/commands/catalog.py
@@ -91,7 +91,7 @@ def scrape_catalog(
     Use --dry-run to preview without saving. Use --force to re-scrape existing songs.
     """
     try:
-        config = AdminConfig.load(config_path) if config_path else AdminConfig.load()
+        config = AdminConfig.load(config_path)
     except FileNotFoundError:
         console.print("[red]Config file not found. Run 'sow-admin db init' first.[/red]")
         raise typer.Exit(1)
@@ -227,7 +227,7 @@ def list_songs(
         raise typer.Exit(1)
 
     try:
-        config = AdminConfig.load(config_path) if config_path else AdminConfig.load()
+        config = AdminConfig.load(config_path)
     except FileNotFoundError:
         console.print("[red]Config file not found. Run 'sow-admin db init' first.[/red]")
         raise typer.Exit(1)
@@ -342,7 +342,7 @@ def search_songs(
     Results are ordered by song ID.
     """
     try:
-        config = AdminConfig.load(config_path) if config_path else AdminConfig.load()
+        config = AdminConfig.load(config_path)
     except FileNotFoundError:
         console.print("[red]Config file not found. Run 'sow-admin db init' first.[/red]")
         raise typer.Exit(1)
@@ -397,7 +397,7 @@ def show_song(
     Display all fields for a specific song including full lyrics.
     """
     try:
-        config = AdminConfig.load(config_path) if config_path else AdminConfig.load()
+        config = AdminConfig.load(config_path)
     except FileNotFoundError:
         console.print("[red]Config file not found. Run 'sow-admin db init' first.[/red]")
         raise typer.Exit(1)

--- a/src/stream_of_worship/admin/commands/db.py
+++ b/src/stream_of_worship/admin/commands/db.py
@@ -87,7 +87,7 @@ def init_db(
     NOT NULL column on the songsets table).
     """
     try:
-        config = AdminConfig.load(config_path) if config_path else AdminConfig.load()
+        config = AdminConfig.load(config_path)
     except FileNotFoundError:
         # Create default config if it doesn't exist
         config = AdminConfig()
@@ -174,7 +174,7 @@ def show_status(
     - Table row counts
     """
     try:
-        config = AdminConfig.load(config_path) if config_path else AdminConfig.load()
+        config = AdminConfig.load(config_path)
     except FileNotFoundError:
         console.print("[red]Config file not found. Run 'sow-admin db init' first.[/red]")
         raise typer.Exit(1)
@@ -211,7 +211,7 @@ def show_url(
     for security. Also indicates whether SOW_DATABASE_PASSWORD is set.
     """
     try:
-        config = AdminConfig.load(config_path) if config_path else AdminConfig.load()
+        config = AdminConfig.load(config_path)
     except FileNotFoundError:
         # Use default config
         config = AdminConfig()

--- a/src/stream_of_worship/admin/commands/users.py
+++ b/src/stream_of_worship/admin/commands/users.py
@@ -26,7 +26,7 @@ def _get_user_client(config: AdminConfig) -> UserClient:
 
 def _load_config(config_path: Optional[Path]) -> AdminConfig:
     try:
-        return AdminConfig.load(config_path) if config_path else AdminConfig.load()
+        return AdminConfig.load(config_path)
     except FileNotFoundError:
         console.print("[red]Config file not found. Run 'sow-admin db init' first.[/red]")
         raise typer.Exit(1)

--- a/src/stream_of_worship/admin/db/client.py
+++ b/src/stream_of_worship/admin/db/client.py
@@ -93,9 +93,7 @@ class DatabaseClient:
             cursor = conn.cursor()
 
             if wipe_songsets:
-                cursor.execute(
-                    "DROP TABLE IF EXISTS songset_items, songsets CASCADE;"
-                )
+                cursor.execute("DROP TABLE IF EXISTS songset_items, songsets CASCADE;")
 
             for statement in ALL_SCHEMA_STATEMENTS:
                 cursor.execute(statement)
@@ -259,7 +257,9 @@ class DatabaseClient:
             cursor = conn.cursor()
             cursor.executemany(sql, params_list)
             elapsed = time.time() - start_time
-            logger.info(f"Bulk insert completed: {len(songs)} songs in {elapsed:.2f}s ({len(songs)/elapsed:.1f} songs/sec)")
+            logger.info(
+                f"Bulk insert completed: {len(songs)} songs in {elapsed:.2f}s ({len(songs) / elapsed:.1f} songs/sec)"
+            )
             return len(songs)
 
     def get_song(self, song_id: str, include_deleted: bool = False) -> Optional[Song]:
@@ -388,13 +388,17 @@ class DatabaseClient:
         deleted_clause = "" if include_deleted else "deleted_at IS NULL AND "
 
         if field == "title":
-            sql = f"SELECT * FROM songs WHERE {deleted_clause}(title LIKE %s OR title_pinyin LIKE %s)"
+            sql = (
+                f"SELECT * FROM songs WHERE {deleted_clause}(title LIKE %s OR title_pinyin LIKE %s)"
+            )
             params = [search_pattern, search_pattern]
         elif field == "lyrics":
             sql = f"SELECT * FROM songs WHERE {deleted_clause}lyrics_raw LIKE %s"
             params = [search_pattern]
         elif field == "composer":
-            sql = f"SELECT * FROM songs WHERE {deleted_clause}(composer LIKE %s OR lyricist LIKE %s)"
+            sql = (
+                f"SELECT * FROM songs WHERE {deleted_clause}(composer LIKE %s OR lyricist LIKE %s)"
+            )
             params = [search_pattern, search_pattern]
         elif field == "album":
             sql = f"SELECT * FROM songs WHERE {deleted_clause}(album_name LIKE %s OR album_series LIKE %s)"
@@ -759,7 +763,7 @@ class DatabaseClient:
 
             sql = f"""
                 UPDATE recordings
-                SET {', '.join(updates)}, updated_at = NOW()
+                SET {", ".join(updates)}, updated_at = NOW()
                 WHERE hash_prefix = %s
             """
             cursor.execute(sql, params)
@@ -1156,17 +1160,13 @@ class DatabaseClient:
 
         with self.transaction() as conn:
             cursor = conn.cursor()
-            cursor.execute(
-                "DELETE FROM song_line_embedding WHERE song_id = %s", (song_id,)
-            )
+            cursor.execute("DELETE FROM song_line_embedding WHERE song_id = %s", (song_id,))
             if not line_embeddings:
                 return
             values = []
             for le in line_embeddings:
                 emb_str = json.dumps(le["embedding"])
-                values.append(
-                    (song_id, le["line_index"], le["line_text"], emb_str, model_version)
-                )
+                values.append((song_id, le["line_index"], le["line_text"], emb_str, model_version))
             cursor.executemany(
                 """
                 INSERT INTO song_line_embedding (song_id, line_index, line_text, embedding, model_version)
@@ -1176,7 +1176,8 @@ class DatabaseClient:
             )
 
     def get_songs_without_embeddings(self) -> list[Song]:
-        """Get songs that have no embedding and have non-empty lyrics.
+        """Get songs that have no embedding, have non-empty lyrics, and have
+        at least one published recording (i.e. visible in webapp Browse Song).
 
         Returns:
             List of Song objects without embeddings.
@@ -1195,15 +1196,22 @@ class DatabaseClient:
               AND s.deleted_at IS NULL
               AND s.lyrics_raw IS NOT NULL
               AND s.lyrics_raw != ''
+              AND EXISTS (
+                  SELECT 1 FROM recordings r
+                  WHERE r.song_id = s.id
+                    AND r.visibility_status = 'published'
+                    AND r.deleted_at IS NULL
+              )
             """
         )
         return [Song.from_row(tuple(row)) for row in cursor.fetchall()]
 
     def get_all_songs_with_lyrics(self) -> list[Song]:
-        """Get all non-deleted songs that have non-empty lyrics.
+        """Get all non-deleted songs that have non-empty lyrics and at least
+        one published recording (i.e. visible in webapp Browse Song).
 
         Returns:
-            List of Song objects with lyrics.
+            List of Song objects with lyrics and published recordings.
         """
         cursor = self.connection.cursor()
         cursor.execute(
@@ -1217,6 +1225,12 @@ class DatabaseClient:
             WHERE s.deleted_at IS NULL
               AND s.lyrics_raw IS NOT NULL
               AND s.lyrics_raw != ''
+              AND EXISTS (
+                  SELECT 1 FROM recordings r
+                  WHERE r.song_id = s.id
+                    AND r.visibility_status = 'published'
+                    AND r.deleted_at IS NULL
+              )
             """
         )
         return [Song.from_row(tuple(row)) for row in cursor.fetchall()]

--- a/src/stream_of_worship/admin/services/analysis.py
+++ b/src/stream_of_worship/admin/services/analysis.py
@@ -358,12 +358,18 @@ class AnalysisClient:
         Raises:
             AnalysisServiceError: If submission fails
         """
+        import hashlib
+
+        content = f"{title}\0{composer}\0{lyrics_raw}\0{'|'.join(lyrics_lines or [])}"
+        content_hash = hashlib.sha256(content.encode("utf-8")).hexdigest()[:16]
+
         payload = {
             "song_id": song_id,
             "title": title,
             "composer": composer,
             "lyrics_raw": lyrics_raw,
             "lyrics_lines": lyrics_lines or [],
+            "content_hash": content_hash,
         }
 
         try:

--- a/webapp/src/lib/db/songs.ts
+++ b/webapp/src/lib/db/songs.ts
@@ -313,13 +313,9 @@ export interface SemanticSearchResult extends SongWithRecordings {
   whyThisMatch: string[];
 }
 
-export async function semanticSearchSongs(
-  embedding: number[],
-  expectedModelVersion: string,
-  limit: number = 20,
-): Promise<SemanticSearchResult[]> {
-  if (embedding.length !== 1536) {
-    throw new Error(`Invalid embedding: expected 1536 dimensions, got ${embedding.length}`);
+function validateEmbedding(embedding: number[], expectedDims: number = 1536): string {
+  if (embedding.length !== expectedDims) {
+    throw new Error(`Invalid embedding: expected ${expectedDims} dimensions, got ${embedding.length}`);
   }
   for (const v of embedding) {
     if (typeof v !== "number" || !isFinite(v)) {
@@ -329,11 +325,19 @@ export async function semanticSearchSongs(
       throw new Error("Invalid embedding value: values must be in range [-100, 100]");
     }
   }
-
   const vectorStr = `[${embedding.join(",")}]`;
   if (!/^\[-?\d+(\.\d+)?(,-?\d+(\.\d+)?)*\]$/.test(vectorStr)) {
     throw new Error("Invalid embedding: vector string contains unexpected characters");
   }
+  return vectorStr;
+}
+
+export async function semanticSearchSongs(
+  embedding: number[],
+  expectedModelVersion: string,
+  limit: number = 20,
+): Promise<SemanticSearchResult[]> {
+  const vectorStr = validateEmbedding(embedding);
 
   const rows = await db.execute(sql`
     SELECT * FROM (
@@ -417,7 +421,7 @@ export async function findTopMatchingLines(
 ): Promise<Map<string, { lineText: string; lineSimilarity: number }[]>> {
   if (songIds.length === 0) return new Map();
 
-  const vectorStr = `[${queryEmbedding.join(",")}]`;
+  const vectorStr = validateEmbedding(queryEmbedding);
 
   const rows = await db.execute(sql`
     SELECT song_id, line_text, line_similarity
@@ -431,7 +435,7 @@ export async function findTopMatchingLines(
           ORDER BY sle.embedding <=> ${vectorStr}::vector ASC
         ) AS rn
       FROM song_line_embedding sle
-      WHERE sle.song_id = ANY(${songIds}::text[])
+      WHERE sle.song_id = ANY(ARRAY[${sql.join(songIds.map(id => sql`${id}`), sql`, `)}]::text[])
         AND length(regexp_replace(sle.line_text, '[^\u4e00-\u9fff]', '', 'g')) >= 4
     ) ranked
     WHERE rn <= 2

--- a/webapp/src/test/lib/db/songs.test.ts
+++ b/webapp/src/test/lib/db/songs.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { findTopMatchingLines } from "@/lib/db/songs";
+import { db } from "@/db";
+import { PgDialect } from "drizzle-orm/pg-core";
+
+vi.mock("@/db", () => ({
+  db: {
+    execute: vi.fn(),
+  },
+}));
+
+const dialect = new PgDialect();
+
+const NON_ZERO_EMBEDDING = Array.from({ length: 1536 }, () => 0.01);
+
+describe("findTopMatchingLines", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns empty Map for empty songIds without calling DB", async () => {
+    const result = await findTopMatchingLines(NON_ZERO_EMBEDDING, []);
+    expect(result.size).toBe(0);
+    expect(db.execute).not.toHaveBeenCalled();
+  });
+
+  it("builds ARRAY[] syntax for ANY() clause", async () => {
+    vi.mocked(db.execute).mockResolvedValue({ rows: [] } as unknown as Awaited<ReturnType<typeof db.execute>>);
+    await findTopMatchingLines(NON_ZERO_EMBEDDING, ["song-1", "song-2"]);
+    const callArgs = vi.mocked(db.execute).mock.calls[0][0];
+    const query = dialect.sqlToQuery(callArgs);
+    expect(query.sql).toContain("ARRAY[");
+    expect(query.sql).toContain("::text[]");
+  });
+
+  it("throws on invalid embedding (wrong dimensions)", async () => {
+    const badEmbedding = [1, 2, 3];
+    await expect(
+      findTopMatchingLines(badEmbedding, ["song-1"])
+    ).rejects.toThrow("Invalid embedding");
+  });
+
+  it("throws on embedding with NaN", async () => {
+    const nanEmbedding = Array.from({ length: 1536 }, (_, i) =>
+      i === 0 ? NaN : 0.01
+    );
+    await expect(
+      findTopMatchingLines(nanEmbedding, ["song-1"])
+    ).rejects.toThrow("Invalid embedding");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes multiple issues in the admin embedding pipeline and webapp semantic search:

1. **Embedding job DB persist error** — `EmbeddingJobRequest` was missing `content_hash`, causing DB insert failures. The `content_hash` is now a required field on the request model, computed in `AnalysisClient.submit_embedding_job()` and passed through to the worker, eliminating the duplicate hash computation in the embedder.

2. **Admin embed command config** — `embed_songs` command was using raw `ConnectionProvider.from_env()` and hardcoded env vars instead of the project's `AdminConfig` / `get_db_client()` pattern. Now uses `--config` flag and `AdminConfig.load()` consistently with other admin commands.

3. **Restrict `--all` to songs with published recordings** — `get_songs_without_embeddings()` and `get_all_songs_with_lyrics()` now filter to songs that have at least one published recording, so `--all` and default embed only target songs visible in the webapp Browse Song view.

4. **Semantic search `ANY()` array parameter error** — `findTopMatchingLines` in `webapp/src/lib/db/songs.ts` failed at runtime because Drizzle's `sql` template expanded a JS array into individual positional parameters, producing `ANY(($3, $4, $5)::text[])` — a PostgreSQL row constructor, not an array. Fixed by using `sql.join()` to build `ARRAY[$3, $4, $5]::text[]`.

5. **Embedding validation hardening** — Extracted `validateEmbedding()` helper from `semanticSearchSongs` and added it to `findTopMatchingLines` for defense-in-depth against invalid vector input.

## Changes by Area

### Analysis Service (`services/analysis/`)
- `models.py`: Added `content_hash` field to `EmbeddingJobRequest`; widened `JobResponse.result` type union
- `storage/db.py`: Added `_migrate_embedding_type()` for SQLite schema migration; added `embedding` to CHECK constraint; added embedding-specific deserialization in `get_job()`
- `workers/embedder.py`: Removed `_compute_content_hash()` — now uses `request.content_hash`
- `tests/test_job_store.py`: Added tests for embedding job insert/get round-trip and result deserialization

### Admin CLI (`src/stream_of_worship/admin/`)
- `commands/audio.py`: `embed_songs` now uses `AdminConfig` + `get_db_client()` with `--config` flag; lint formatting fixes
- `db/client.py`: `get_songs_without_embeddings()` and `get_all_songs_with_lyrics()` now require `EXISTS (published recording)`; lint formatting fixes
- `services/analysis.py`: `submit_embedding_job()` now computes and sends `content_hash`

### Webapp (`webapp/`)
- `src/lib/db/songs.ts`: Extracted `validateEmbedding()` helper; added validation to `findTopMatchingLines`; fixed `ANY()` array parameter using `sql.join()`
- `src/test/lib/db/songs.test.ts`: **New** — unit tests for `findTopMatchingLines` (empty input, ARRAY[] SQL syntax, invalid embedding rejection)

## Migration Notes

- Analysis Service SQLite DB will auto-migrate on startup to add `embedding` to the job type CHECK constraint
- `EmbeddingJobRequest` now requires `content_hash` — any callers must be updated

## Testing

- All existing tests pass (`semantic.test.ts`, `search.test.ts`)
- New `songs.test.ts` tests pass (4 tests)
- `pnpm lint` passes
- Build failure is pre-existing (missing `openai` package, unrelated to this PR)