### PR TITLE
fix: render button double-submit prevention, toast notifications, and stale render screen

### DIFF
--- a/webapp/drizzle/0009_add_active_render_job_unique_index.sql
+++ b/webapp/drizzle/0009_add_active_render_job_unique_index.sql
@@ -1,0 +1,3 @@
+CREATE UNIQUE INDEX CONCURRENTLY uq_render_jobs_active_per_songset_user
+  ON render_jobs (songset_id, user_id)
+  WHERE status IN ('queued', 'running');--> statement-breakpoint

--- a/webapp/drizzle/meta/_journal.json
+++ b/webapp/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1779750000000,
       "tag": "0008_rebuild_song_embedding_add_song_line_embedding",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1779836400000,
+      "tag": "0009_add_active_render_job_unique_index",
+      "breakpoints": true
     }
   ]
 }

--- a/webapp/src/app/api/render-jobs/route.ts
+++ b/webapp/src/app/api/render-jobs/route.ts
@@ -4,8 +4,8 @@ import { createRenderJob, failRenderJob } from "@/lib/render/job-manager";
 import { dispatchToRenderWorker } from "@/lib/render/dispatcher";
 import { SONGSET_MAX_SONGS, SONGSET_MAX_DURATION_SECONDS } from "@/lib/constants";
 import { db } from "@/db";
-import { songsetItems } from "@/db/schema";
-import { eq } from "drizzle-orm";
+import { songsetItems, renderJobs } from "@/db/schema";
+import { eq, and, or, gte } from "drizzle-orm";
 import { z } from "zod";
 
 const createRenderJobSchema = z.object({
@@ -63,7 +63,43 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const job = await createRenderJob(Number(session.user.id), parsed.data);
+    const twentyMinutesAgo = new Date(Date.now() - 20 * 60 * 1000);
+    const activeJob = await db.query.renderJobs.findFirst({
+      where: and(
+        eq(renderJobs.songsetId, parsed.data.songsetId),
+        eq(renderJobs.userId, Number(session.user.id)),
+        or(eq(renderJobs.status, "queued"), eq(renderJobs.status, "running")),
+        gte(renderJobs.createdAt, twentyMinutesAgo)
+      ),
+    });
+
+    if (activeJob) {
+      return NextResponse.json(
+        {
+          error: "A render job is already in progress for this songset",
+          jobId: activeJob.id,
+          estimatedTotalSeconds: activeJob.estimatedTotalSeconds,
+          config: {
+            audioEnabled: activeJob.audioEnabled,
+            videoEnabled: activeJob.videoEnabled,
+          },
+        },
+        { status: 409 }
+      );
+    }
+
+    let job;
+    try {
+      job = await createRenderJob(Number(session.user.id), parsed.data);
+    } catch (err) {
+      if (err instanceof Error && err.message.includes("uq_render_jobs_active_per_songset_user")) {
+        return NextResponse.json(
+          { error: "A render job is already in progress for this songset" },
+          { status: 409 }
+        );
+      }
+      throw err;
+    }
 
     try {
       await dispatchToRenderWorker({

--- a/webapp/src/app/layout.tsx
+++ b/webapp/src/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import { Header } from "@/components/layout/Header";
 import { BottomNav } from "@/components/layout/BottomNav";
 import { GlobalAudioPlayer } from "@/components/audio/GlobalAudioPlayer";
+import { Toaster } from "@/components/ui/sonner";
 
 const geistSans = Geist({
   variable: "--font-sans",
@@ -40,6 +41,7 @@ export default function RootLayout({
           <main className="flex-1 pb-16 lg:pb-0">{children}</main>
           <BottomNav />
         </GlobalAudioPlayer>
+        <Toaster />
       </body>
     </html>
   );

--- a/webapp/src/app/songsets/[id]/render/page.tsx
+++ b/webapp/src/app/songsets/[id]/render/page.tsx
@@ -111,6 +111,7 @@ export default function RenderPage() {
               }
               setScreenState("submitted")
             } else if (job.status === "completed") {
+              setJobId(job.id)
               setJobData(job)
               setInitialData({
                 template: job.template as RenderFormData["template"],

--- a/webapp/src/app/songsets/[id]/render/page.tsx
+++ b/webapp/src/app/songsets/[id]/render/page.tsx
@@ -55,6 +55,7 @@ export default function RenderPage() {
   const [error, setError] = useState<string | null>(null)
   const [estimatedMinutes, setEstimatedMinutes] = useState(5)
   const [isCancelling, setIsCancelling] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
 
   // Load songset data
   useEffect(() => {
@@ -151,6 +152,7 @@ export default function RenderPage() {
 
   const handleSubmit = useCallback(
     async (formData: RenderFormData) => {
+      setIsSubmitting(true)
       try {
         const response = await fetch("/api/render-jobs", {
           method: "POST",
@@ -173,6 +175,23 @@ export default function RenderPage() {
             router.push("/login")
             return
           }
+          if (response.status === 409) {
+            const data = await response.json()
+            if (data.jobId) {
+              setJobId(data.jobId)
+              if (data.estimatedTotalSeconds) {
+                setEstimatedMinutes(Math.ceil(data.estimatedTotalSeconds / 60))
+              }
+              setScreenState("submitted")
+              const configSummary = []
+              if (data.config?.audioEnabled) configSummary.push("audio")
+              if (data.config?.videoEnabled) configSummary.push("video")
+              toast.info(`A render job is already in progress (${configSummary.join(" + ")})`)
+            } else {
+              toast.error(data.error || "A render job is already in progress")
+            }
+            return
+          }
           const errorData = await response.json()
           throw new Error(errorData.error || "Failed to create render job")
         }
@@ -186,6 +205,8 @@ export default function RenderPage() {
         toast.success("Render started")
       } catch (err) {
         toast.error(err instanceof Error ? err.message : "Failed to start render")
+      } finally {
+        setIsSubmitting(false)
       }
     },
     [songsetId, router]
@@ -275,6 +296,7 @@ export default function RenderPage() {
             initialData={initialData}
             onSubmit={handleSubmit}
             onCancel={() => router.push(`/songsets/${songsetId}`)}
+            isSubmitting={isSubmitting}
           />
         )}
 

--- a/webapp/src/app/songsets/[id]/render/page.tsx
+++ b/webapp/src/app/songsets/[id]/render/page.tsx
@@ -112,7 +112,6 @@ export default function RenderPage() {
               setScreenState("submitted")
             } else if (job.status === "completed") {
               setJobData(job)
-              setScreenState("complete")
               setInitialData({
                 template: job.template as RenderFormData["template"],
                 resolution: job.resolution as RenderFormData["resolution"],
@@ -123,6 +122,9 @@ export default function RenderPage() {
                 titleCardDurationSeconds: job.titleCardDurationSeconds,
                 titleCardLines: job.titleCardLines ?? [],
               })
+              if (renderState === "fresh") {
+                setScreenState("complete")
+              }
             }
           }
         }

--- a/webapp/src/components/render/RenderSubmitted.tsx
+++ b/webapp/src/components/render/RenderSubmitted.tsx
@@ -2,7 +2,7 @@
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
-import { Clock, X } from "lucide-react"
+import { Clock } from "lucide-react"
 
 interface RenderSubmittedProps {
   estimatedMinutes: number
@@ -18,18 +18,7 @@ export function RenderSubmitted({
   return (
     <Card className="w-full">
       <CardHeader>
-        <div className="flex items-center justify-between">
-          <CardTitle>Render Started</CardTitle>
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={onCancel}
-            disabled={isCancelling}
-            aria-label="Cancel render"
-          >
-            <X className="size-4" />
-          </Button>
-        </div>
+        <CardTitle>Render Started</CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
         <div className="flex items-center gap-2 text-muted-foreground">

--- a/webapp/src/test/api/render-jobs/route.test.ts
+++ b/webapp/src/test/api/render-jobs/route.test.ts
@@ -33,6 +33,9 @@ vi.mock("@/db", () => ({
           { recording: { durationSeconds: 200 } },
         ]),
       },
+      renderJobs: {
+        findFirst: vi.fn().mockResolvedValue(null),
+      },
     },
   },
 }));
@@ -42,6 +45,7 @@ import { db } from "@/db";
 
 const mockDispatchToRenderWorker = vi.mocked(dispatchToRenderWorker);
 const mockFindMany = vi.mocked(db.query.songsetItems.findMany);
+const mockFindFirst = vi.mocked(db.query.renderJobs.findFirst);
 
 function createMockRequest(url: string, options?: RequestInit): NextRequest {
   const request = new Request(url, options) as unknown as NextRequest;
@@ -408,6 +412,58 @@ describe("POST /api/render-jobs", () => {
     expect(response.status).toBe(400);
     const data = await response.json();
     expect(data.error).toContain("maximum of 5 songs");
+  });
+
+  it("returns 409 when active job already exists", async () => {
+    vi.mocked(auth.api.getSession).mockResolvedValue({
+      user: { id: 1 },
+    } as any);
+
+    mockFindFirst.mockResolvedValueOnce({
+      id: "existing-job-1",
+      songsetId: "songset-1",
+      userId: 1,
+      status: "queued",
+      estimatedTotalSeconds: 300,
+      audioEnabled: true,
+      videoEnabled: true,
+    } as any);
+
+    const request = createMockRequest("http://localhost:3000/api/render-jobs", {
+      method: "POST",
+      body: JSON.stringify({ songsetId: "songset-1" }),
+    });
+    const response = await POST(request);
+
+    expect(response.status).toBe(409);
+    const data = await response.json();
+    expect(data.error).toBe("A render job is already in progress for this songset");
+    expect(data.jobId).toBe("existing-job-1");
+    expect(data.estimatedTotalSeconds).toBe(300);
+    expect(data.config).toEqual({ audioEnabled: true, videoEnabled: true });
+    expect(createRenderJob).not.toHaveBeenCalled();
+    expect(mockDispatchToRenderWorker).not.toHaveBeenCalled();
+  });
+
+  it("returns 409 on unique constraint violation (TOCTOU race)", async () => {
+    vi.mocked(auth.api.getSession).mockResolvedValue({
+      user: { id: 1 },
+    } as any);
+
+    vi.mocked(createRenderJob).mockRejectedValueOnce(
+      new Error("uq_render_jobs_active_per_songset_user constraint violated")
+    );
+
+    const request = createMockRequest("http://localhost:3000/api/render-jobs", {
+      method: "POST",
+      body: JSON.stringify({ songsetId: "songset-1" }),
+    });
+    const response = await POST(request);
+
+    expect(response.status).toBe(409);
+    const data = await response.json();
+    expect(data.error).toBe("A render job is already in progress for this songset");
+    expect(mockDispatchToRenderWorker).not.toHaveBeenCalled();
   });
 
   it("returns 400 when songset exceeds maximum duration", async () => {

--- a/webapp/src/test/components/render/RenderSubmitted.test.tsx
+++ b/webapp/src/test/components/render/RenderSubmitted.test.tsx
@@ -32,23 +32,20 @@ describe("RenderSubmitted", () => {
 
     it("renders cancel button", () => {
       render(<RenderSubmitted {...defaultProps} />)
-      const cancelButtons = screen.getAllByRole("button", { name: /cancel render/i })
-      expect(cancelButtons.length).toBeGreaterThan(0)
+      expect(screen.getByRole("button", { name: /cancel render/i })).toBeInTheDocument()
     })
   })
 
   describe("cancel functionality", () => {
     it("calls onCancel when cancel button clicked", () => {
       render(<RenderSubmitted {...defaultProps} />)
-      const cancelButtons = screen.getAllByRole("button", { name: /cancel render/i })
-      fireEvent.click(cancelButtons[cancelButtons.length - 1])
+      fireEvent.click(screen.getByRole("button", { name: /cancel render/i }))
       expect(mockCancel).toHaveBeenCalled()
     })
 
-    it("disables cancel buttons when isCancelling is true", () => {
+    it("disables cancel button when isCancelling is true", () => {
       render(<RenderSubmitted {...defaultProps} isCancelling={true} />)
-      const cancelButtons = screen.getAllByRole("button", { name: /cancel render/i })
-      cancelButtons.forEach((btn) => expect(btn).toBeDisabled())
+      expect(screen.getByRole("button", { name: /cancel render/i })).toBeDisabled()
     })
   })
 


### PR DESCRIPTION
## Problem
When clicking "Start Render" on the Render screen, three issues combine to create a dangerous UX:
1. **No toast visible** — `<Toaster />` from sonner is never rendered in root layout, so `toast.error()` calls execute silently
2. **No submit guard** — `RenderForm` supports `isSubmitting` but `RenderPage` never tracks/passes this state, allowing rapid re-clicks
3. **No server-side idempotency** — API creates a new `render_jobs` row on every POST with no check for existing active jobs

## Changes
- **`webapp/src/app/layout.tsx`**: Add `<Toaster />` outside `<GlobalAudioPlayer>` so toasts render visibly
- **`webapp/src/app/songsets/[id]/render/page.tsx`**: Add `isSubmitting` state, wrap fetch with guard, pass prop to `RenderForm`, handle 409 with job recovery + config toast
- **`webapp/src/app/api/render-jobs/route.ts`**: Add 20-min staleness-filtered active-job check (returns 409 with job details), catch unique constraint violation for TOCTOU race
- **`webapp/drizzle/0009_add_active_render_job_unique_index.sql`**: Partial unique index on `(songset_id, user_id) WHERE status IN ('queued','running')`

## Previous fixes in this PR
- Show render form instead of complete screen when songset is stale
- Set jobId when completed job is loaded so RenderComplete downloads work
- Remove redundant X cancel button from RenderSubmitted card header