### PR TITLE
fix: reduce render worker peak memory by ~1.1-1.4 GB to avoid Lambda OOM

### DIFF
--- a/services/render-worker/src/sow_render_worker/asset_fetcher.py
+++ b/services/render-worker/src/sow_render_worker/asset_fetcher.py
@@ -58,28 +58,29 @@ class AssetFetcher:
             )
 
             response = self._http.request("GET", signed_url, preload_content=False)
-            if response.status != 200:
-                response.release_conn()
-                raise RuntimeError(
-                    f"Failed to download audio: HTTP {response.status}"
-                )
-
-            self._cache_dir.mkdir(parents=True, exist_ok=True)
-            tmp_path = cache_path.with_suffix(".tmp")
             try:
-                total_bytes = 0
-                with open(tmp_path, "wb") as f:
-                    for chunk in response.stream(8192):
-                        f.write(chunk)
-                        total_bytes += len(chunk)
-                response.release_conn()
-                os.replace(tmp_path, cache_path)
-            except BaseException:
+                if response.status != 200:
+                    raise RuntimeError(
+                        f"Failed to download audio: HTTP {response.status}"
+                    )
+
+                self._cache_dir.mkdir(parents=True, exist_ok=True)
+                tmp_path = cache_path.with_suffix(".tmp")
                 try:
-                    tmp_path.unlink()
-                except OSError:
-                    pass
-                raise
+                    total_bytes = 0
+                    with open(tmp_path, "wb") as f:
+                        for chunk in response.stream(8192):
+                            f.write(chunk)
+                            total_bytes += len(chunk)
+                    os.replace(tmp_path, cache_path)
+                except BaseException:
+                    try:
+                        tmp_path.unlink()
+                    except OSError:
+                        pass
+                    raise
+            finally:
+                response.release_conn()
 
             logger.info(
                 "Audio downloaded: %s (%d bytes, cached at %s)",
@@ -103,23 +104,23 @@ class AssetFetcher:
             )
 
             response = self._http.request("GET", signed_url, preload_content=False)
-            if response.status != 200:
-                response.release_conn()
-                raise RuntimeError(
-                    f"Failed to download LRC: HTTP {response.status}"
-                )
-
             chunks: list[bytes] = []
             total_size = 0
-            for chunk in response.stream(8192):
-                total_size += len(chunk)
-                if total_size > MAX_LRC_SIZE_BYTES:
-                    response.release_conn()
+            try:
+                if response.status != 200:
                     raise RuntimeError(
-                        f"LRC response too large: exceeds {MAX_LRC_SIZE_BYTES} limit"
+                        f"Failed to download LRC: HTTP {response.status}"
                     )
-                chunks.append(chunk)
-            response.release_conn()
+
+                for chunk in response.stream(8192):
+                    total_size += len(chunk)
+                    if total_size > MAX_LRC_SIZE_BYTES:
+                        raise RuntimeError(
+                            f"LRC response too large: exceeds {MAX_LRC_SIZE_BYTES} limit"
+                        )
+                    chunks.append(chunk)
+            finally:
+                response.release_conn()
 
             content = b"".join(chunks).decode("utf-8")
             self._lrc_cache[hash_prefix] = content

--- a/services/render-worker/src/sow_render_worker/asset_fetcher.py
+++ b/services/render-worker/src/sow_render_worker/asset_fetcher.py
@@ -57,8 +57,9 @@ class AssetFetcher:
                 hash_prefix, expires_in_seconds=3600
             )
 
-            response = self._http.request("GET", signed_url)
+            response = self._http.request("GET", signed_url, preload_content=False)
             if response.status != 200:
+                response.release_conn()
                 raise RuntimeError(
                     f"Failed to download audio: HTTP {response.status}"
                 )
@@ -66,7 +67,12 @@ class AssetFetcher:
             self._cache_dir.mkdir(parents=True, exist_ok=True)
             tmp_path = cache_path.with_suffix(".tmp")
             try:
-                tmp_path.write_bytes(response.data)
+                total_bytes = 0
+                with open(tmp_path, "wb") as f:
+                    for chunk in response.stream(8192):
+                        f.write(chunk)
+                        total_bytes += len(chunk)
+                response.release_conn()
                 os.replace(tmp_path, cache_path)
             except BaseException:
                 try:
@@ -77,7 +83,7 @@ class AssetFetcher:
 
             logger.info(
                 "Audio downloaded: %s (%d bytes, cached at %s)",
-                hash_prefix, len(response.data), cache_path,
+                hash_prefix, total_bytes, cache_path,
             )
             return str(cache_path)
         except Exception as exc:
@@ -96,20 +102,28 @@ class AssetFetcher:
                 hash_prefix, expires_in_seconds=3600
             )
 
-            response = self._http.request("GET", signed_url)
+            response = self._http.request("GET", signed_url, preload_content=False)
             if response.status != 200:
+                response.release_conn()
                 raise RuntimeError(
                     f"Failed to download LRC: HTTP {response.status}"
                 )
 
-            if len(response.data) > MAX_LRC_SIZE_BYTES:
-                raise RuntimeError(
-                    f"LRC response too large: {len(response.data)} bytes exceeds {MAX_LRC_SIZE_BYTES} limit"
-                )
+            chunks: list[bytes] = []
+            total_size = 0
+            for chunk in response.stream(8192):
+                total_size += len(chunk)
+                if total_size > MAX_LRC_SIZE_BYTES:
+                    response.release_conn()
+                    raise RuntimeError(
+                        f"LRC response too large: exceeds {MAX_LRC_SIZE_BYTES} limit"
+                    )
+                chunks.append(chunk)
+            response.release_conn()
 
-            content = response.data.decode("utf-8")
+            content = b"".join(chunks).decode("utf-8")
             self._lrc_cache[hash_prefix] = content
-            logger.info("LRC downloaded: %s (%d bytes)", hash_prefix, len(response.data))
+            logger.info("LRC downloaded: %s (%d bytes)", hash_prefix, total_size)
             return content
         except Exception as exc:
             logger.exception("Failed to download LRC for %s", hash_prefix)

--- a/services/render-worker/src/sow_render_worker/pipeline.py
+++ b/services/render-worker/src/sow_render_worker/pipeline.py
@@ -460,6 +460,8 @@ def execute_render_pipeline(
                 job_id=job_id,
             )
 
+            video_engine.frame_renderer.clear_cache()
+
             chapters_for_video = [
                 _segment_to_chapter_info(seg, i)
                 for i, seg in enumerate(audio_result.segments)

--- a/services/render-worker/src/sow_render_worker/uploader.py
+++ b/services/render-worker/src/sow_render_worker/uploader.py
@@ -5,6 +5,7 @@ import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
 from sow_render_worker.chapters import ChaptersManifest
 from sow_render_worker.r2_client import R2Client, create_r2_client_from_env
@@ -63,11 +64,23 @@ class R2Uploader:
         metadata: dict[str, str] | None = None,
     ) -> str:
         file_path_obj = Path(file_path)
-        body = file_path_obj.read_bytes()
+        file_size = file_path_obj.stat().st_size
+        ct = content_type or infer_content_type(key)
         logger.info(
-            "Uploading %s (%s, %d bytes)", key, content_type or infer_content_type(key), len(body)
+            "Uploading %s (%s, %d bytes)", key, ct, file_size
         )
-        self._put_object(key, body, content_type, cache_control, metadata)
+        extra_args: dict[str, Any] = {
+            "ContentType": ct,
+            "CacheControl": cache_control or DEFAULT_CACHE_CONTROL,
+        }
+        if metadata:
+            extra_args["Metadata"] = metadata
+        self._client.upload_file(
+            str(file_path_obj),
+            self._bucket_name,
+            key,
+            ExtraArgs=extra_args,
+        )
         logger.info("Upload complete: %s", key)
         return key
 

--- a/services/render-worker/tests/test_asset_fetcher.py
+++ b/services/render-worker/tests/test_asset_fetcher.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -120,17 +120,15 @@ class TestDownloadAudio:
         mock_r2 = _make_mock_r2_client()
         fetcher = _make_fetcher(cache_dir=cache_dir, r2_client=mock_r2)
 
-        with patch("sow_render_worker.asset_fetcher.urllib3") as mock_urllib3:
-            mock_response = MagicMock()
-            mock_response.status = 200
-            mock_response.data = b"downloaded audio data"
-            mock_http = MagicMock()
-            mock_http.request.return_value = mock_response
-            mock_urllib3.PoolManager.return_value = mock_http
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.stream.return_value = [b"downloaded audio data"]
+        mock_http = MagicMock()
+        mock_http.request.return_value = mock_response
 
-            fetcher._http = mock_http
+        fetcher._http = mock_http
 
-            result = fetcher.download_audio("abc123")
+        result = fetcher.download_audio("abc123")
 
         assert result is not None
         assert Path(result).exists()
@@ -139,6 +137,7 @@ class TestDownloadAudio:
         mock_r2.get_audio_signed_url.assert_called_once_with(
             "abc123", expires_in_seconds=3600
         )
+        mock_response.release_conn.assert_called()
 
     def test_raises_on_download_failure(self, tmp_path):
         cache_dir = str(tmp_path / "cache")
@@ -147,17 +146,16 @@ class TestDownloadAudio:
         mock_r2 = _make_mock_r2_client()
         fetcher = _make_fetcher(cache_dir=cache_dir, r2_client=mock_r2)
 
-        with patch("sow_render_worker.asset_fetcher.urllib3") as mock_urllib3:
-            mock_response = MagicMock()
-            mock_response.status = 403
-            mock_http = MagicMock()
-            mock_http.request.return_value = mock_response
-            mock_urllib3.PoolManager.return_value = mock_http
+        mock_response = MagicMock()
+        mock_response.status = 403
+        mock_http = MagicMock()
+        mock_http.request.return_value = mock_response
 
-            fetcher._http = mock_http
+        fetcher._http = mock_http
 
-            with pytest.raises(RuntimeError, match="Failed to download audio"):
-                fetcher.download_audio("abc123")
+        with pytest.raises(RuntimeError, match="Failed to download audio"):
+            fetcher.download_audio("abc123")
+        mock_response.release_conn.assert_called()
 
     def test_raises_on_exception(self, tmp_path):
         cache_dir = str(tmp_path / "cache")
@@ -166,15 +164,13 @@ class TestDownloadAudio:
         mock_r2 = _make_mock_r2_client()
         fetcher = _make_fetcher(cache_dir=cache_dir, r2_client=mock_r2)
 
-        with patch("sow_render_worker.asset_fetcher.urllib3") as mock_urllib3:
-            mock_http = MagicMock()
-            mock_http.request.side_effect = Exception("network error")
-            mock_urllib3.PoolManager.return_value = mock_http
+        mock_http = MagicMock()
+        mock_http.request.side_effect = Exception("network error")
 
-            fetcher._http = mock_http
+        fetcher._http = mock_http
 
-            with pytest.raises(RuntimeError, match="Failed to download audio"):
-                fetcher.download_audio("abc123")
+        with pytest.raises(RuntimeError, match="Failed to download audio"):
+            fetcher.download_audio("abc123")
 
     def test_creates_cache_dir_if_missing(self, tmp_path):
         cache_dir = str(tmp_path / "new_cache")
@@ -182,17 +178,15 @@ class TestDownloadAudio:
         mock_r2 = _make_mock_r2_client()
         fetcher = _make_fetcher(cache_dir=cache_dir, r2_client=mock_r2)
 
-        with patch("sow_render_worker.asset_fetcher.urllib3") as mock_urllib3:
-            mock_response = MagicMock()
-            mock_response.status = 200
-            mock_response.data = b"audio data"
-            mock_http = MagicMock()
-            mock_http.request.return_value = mock_response
-            mock_urllib3.PoolManager.return_value = mock_http
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.stream.return_value = [b"audio data"]
+        mock_http = MagicMock()
+        mock_http.request.return_value = mock_response
 
-            fetcher._http = mock_http
+        fetcher._http = mock_http
 
-            result = fetcher.download_audio("abc123")
+        result = fetcher.download_audio("abc123")
 
         assert result is not None
         assert Path(cache_dir).exists()
@@ -203,69 +197,63 @@ class TestDownloadLrc:
         mock_r2 = _make_mock_r2_client()
         fetcher = _make_fetcher(r2_client=mock_r2)
 
-        with patch("sow_render_worker.asset_fetcher.urllib3") as mock_urllib3:
-            mock_response = MagicMock()
-            mock_response.status = 200
-            mock_response.data = "[00:01.00]第一行\n[00:05.00]第二行".encode("utf-8")
-            mock_http = MagicMock()
-            mock_http.request.return_value = mock_response
-            mock_urllib3.PoolManager.return_value = mock_http
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.stream.return_value = ["[00:01.00]第一行\n[00:05.00]第二行".encode("utf-8")]
+        mock_http = MagicMock()
+        mock_http.request.return_value = mock_response
 
-            fetcher._http = mock_http
+        fetcher._http = mock_http
 
-            result = fetcher.download_lrc("abc123")
+        result = fetcher.download_lrc("abc123")
 
         assert result == "[00:01.00]第一行\n[00:05.00]第二行"
         mock_r2.get_lrc_signed_url.assert_called_once_with(
             "abc123", expires_in_seconds=3600
         )
+        mock_response.release_conn.assert_called()
 
     def test_raises_on_download_failure(self, tmp_path):
         mock_r2 = _make_mock_r2_client()
         fetcher = _make_fetcher(r2_client=mock_r2)
 
-        with patch("sow_render_worker.asset_fetcher.urllib3") as mock_urllib3:
-            mock_response = MagicMock()
-            mock_response.status = 404
-            mock_http = MagicMock()
-            mock_http.request.return_value = mock_response
-            mock_urllib3.PoolManager.return_value = mock_http
+        mock_response = MagicMock()
+        mock_response.status = 404
+        mock_http = MagicMock()
+        mock_http.request.return_value = mock_response
 
-            fetcher._http = mock_http
+        fetcher._http = mock_http
 
-            with pytest.raises(RuntimeError, match="Failed to download LRC"):
-                fetcher.download_lrc("abc123")
+        with pytest.raises(RuntimeError, match="Failed to download LRC"):
+            fetcher.download_lrc("abc123")
+        mock_response.release_conn.assert_called()
 
     def test_raises_on_exception(self, tmp_path):
         mock_r2 = _make_mock_r2_client()
         fetcher = _make_fetcher(r2_client=mock_r2)
 
-        with patch("sow_render_worker.asset_fetcher.urllib3") as mock_urllib3:
-            mock_http = MagicMock()
-            mock_http.request.side_effect = Exception("network error")
-            mock_urllib3.PoolManager.return_value = mock_http
+        mock_http = MagicMock()
+        mock_http.request.side_effect = Exception("network error")
 
-            fetcher._http = mock_http
+        fetcher._http = mock_http
 
-            with pytest.raises(RuntimeError, match="Failed to download LRC"):
-                fetcher.download_lrc("abc123")
+        with pytest.raises(RuntimeError, match="Failed to download LRC"):
+            fetcher.download_lrc("abc123")
 
     def test_caches_lrc_content(self, tmp_path):
         mock_r2 = _make_mock_r2_client()
         fetcher = _make_fetcher(r2_client=mock_r2)
 
-        with patch("sow_render_worker.asset_fetcher.urllib3") as mock_urllib3:
-            mock_response = MagicMock()
-            mock_response.status = 200
-            mock_response.data = b"cached lrc"
-            mock_http = MagicMock()
-            mock_http.request.return_value = mock_response
-            mock_urllib3.PoolManager.return_value = mock_http
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.stream.return_value = [b"cached lrc"]
+        mock_http = MagicMock()
+        mock_http.request.return_value = mock_response
 
-            fetcher._http = mock_http
+        fetcher._http = mock_http
 
-            result1 = fetcher.download_lrc("abc123")
-            result2 = fetcher.download_lrc("abc123")
+        result1 = fetcher.download_lrc("abc123")
+        result2 = fetcher.download_lrc("abc123")
 
         assert result1 == "cached lrc"
         assert result2 == "cached lrc"
@@ -313,17 +301,15 @@ class TestCachingWorkflow:
         mock_r2 = _make_mock_r2_client()
         fetcher = _make_fetcher(cache_dir=cache_dir, r2_client=mock_r2)
 
-        with patch("sow_render_worker.asset_fetcher.urllib3") as mock_urllib3:
-            mock_response = MagicMock()
-            mock_response.status = 200
-            mock_response.data = b"audio data"
-            mock_http = MagicMock()
-            mock_http.request.return_value = mock_response
-            mock_urllib3.PoolManager.return_value = mock_http
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.stream.return_value = [b"audio data"]
+        mock_http = MagicMock()
+        mock_http.request.return_value = mock_response
 
-            fetcher._http = mock_http
+        fetcher._http = mock_http
 
-            result1 = fetcher.download_audio("abc123")
+        result1 = fetcher.download_audio("abc123")
 
         assert result1 is not None
         assert mock_r2.get_audio_signed_url.call_count == 1
@@ -340,24 +326,21 @@ class TestCachingWorkflow:
         mock_r2 = _make_mock_r2_client()
         fetcher = _make_fetcher(cache_dir=cache_dir, r2_client=mock_r2)
 
-        with patch("sow_render_worker.asset_fetcher.urllib3") as mock_urllib3:
-            mock_http = MagicMock()
-            mock_urllib3.PoolManager.return_value = mock_http
+        mock_response1 = MagicMock()
+        mock_response1.status = 200
+        mock_response1.stream.return_value = [b"audio1"]
 
-            fetcher._http = mock_http
+        mock_response2 = MagicMock()
+        mock_response2.status = 200
+        mock_response2.stream.return_value = [b"audio2"]
 
-            mock_response1 = MagicMock()
-            mock_response1.status = 200
-            mock_response1.data = b"audio1"
+        mock_http = MagicMock()
+        mock_http.request.side_effect = [mock_response1, mock_response2]
 
-            mock_response2 = MagicMock()
-            mock_response2.status = 200
-            mock_response2.data = b"audio2"
+        fetcher._http = mock_http
 
-            mock_http.request.side_effect = [mock_response1, mock_response2]
-
-            result1 = fetcher.download_audio("song1")
-            result2 = fetcher.download_audio("song2")
+        result1 = fetcher.download_audio("song1")
+        result2 = fetcher.download_audio("song2")
 
         assert result1 is not None
         assert result2 is not None

--- a/services/render-worker/tests/test_uploader.py
+++ b/services/render-worker/tests/test_uploader.py
@@ -73,7 +73,6 @@ class TestContentTypeMap:
 class TestUploadFile:
     def test_uploads_file_with_default_options(self, tmp_path):
         uploader = _make_uploader()
-        uploader._client.put_object.return_value = {"ETag": '"abc123"'}
 
         file_path = tmp_path / "output.mp3"
         file_path.write_bytes(b"fake audio data")
@@ -82,16 +81,16 @@ class TestUploadFile:
 
         assert result == "renders/job1/output.mp3"
 
-        call_kwargs = uploader._client.put_object.call_args[1]
-        assert call_kwargs["Bucket"] == "test-bucket"
-        assert call_kwargs["Key"] == "renders/job1/output.mp3"
-        assert call_kwargs["Body"] == b"fake audio data"
-        assert call_kwargs["ContentType"] == "audio/mpeg"
-        assert call_kwargs["CacheControl"] == "public, max-age=3600"
+        call_args = uploader._client.upload_file.call_args
+        assert call_args[0][0] == str(file_path)
+        assert call_args[0][1] == "test-bucket"
+        assert call_args[0][2] == "renders/job1/output.mp3"
+        extra_args = call_args[1]["ExtraArgs"]
+        assert extra_args["ContentType"] == "audio/mpeg"
+        assert extra_args["CacheControl"] == "public, max-age=3600"
 
     def test_uploads_file_with_custom_options(self, tmp_path):
         uploader = _make_uploader()
-        uploader._client.put_object.return_value = {"ETag": '"def456"'}
 
         file_path = tmp_path / "output.mp4"
         file_path.write_bytes(b"fake video data")
@@ -104,34 +103,32 @@ class TestUploadFile:
             metadata={"render-job-id": "job1"},
         )
 
-        call_kwargs = uploader._client.put_object.call_args[1]
-        assert call_kwargs["ContentType"] == "video/mp4"
-        assert call_kwargs["CacheControl"] == "no-cache"
-        assert call_kwargs["Metadata"] == {"render-job-id": "job1"}
+        extra_args = uploader._client.upload_file.call_args[1]["ExtraArgs"]
+        assert extra_args["ContentType"] == "video/mp4"
+        assert extra_args["CacheControl"] == "no-cache"
+        assert extra_args["Metadata"] == {"render-job-id": "job1"}
 
     def test_uses_inferred_content_type_when_not_specified(self, tmp_path):
         uploader = _make_uploader()
-        uploader._client.put_object.return_value = {"ETag": '"ghi789"'}
 
         file_path = tmp_path / "data.json"
         file_path.write_bytes(b'{"key": "value"}')
 
         uploader.upload_file("data.json", str(file_path))
 
-        call_kwargs = uploader._client.put_object.call_args[1]
-        assert call_kwargs["ContentType"] == "application/json"
+        extra_args = uploader._client.upload_file.call_args[1]["ExtraArgs"]
+        assert extra_args["ContentType"] == "application/json"
 
     def test_no_metadata_key_when_metadata_is_none(self, tmp_path):
         uploader = _make_uploader()
-        uploader._client.put_object.return_value = {"ETag": '"abc"'}
 
         file_path = tmp_path / "output.mp3"
         file_path.write_bytes(b"data")
 
         uploader.upload_file("output.mp3", str(file_path))
 
-        call_kwargs = uploader._client.put_object.call_args[1]
-        assert "Metadata" not in call_kwargs
+        extra_args = uploader._client.upload_file.call_args[1]["ExtraArgs"]
+        assert "Metadata" not in extra_args
 
 
 class TestUploadBuffer:
@@ -177,7 +174,6 @@ class TestUploadBuffer:
 class TestUploadRenderArtifacts:
     def test_uploads_all_artifacts(self, tmp_path):
         uploader = _make_uploader()
-        uploader._client.put_object.return_value = {"ETag": '"etag"'}
 
         mp3_path = tmp_path / "output.mp3"
         mp3_path.write_bytes(b"fake mp3 audio data here")
@@ -197,30 +193,29 @@ class TestUploadRenderArtifacts:
         assert result.chapters_r2_key == "renders/job-123/chapters.json"
         assert isinstance(result.uploaded_at, datetime)
 
-        calls = uploader._client.put_object.call_args_list
-        assert len(calls) == 3
+        upload_file_calls = uploader._client.upload_file.call_args_list
+        assert len(upload_file_calls) == 2
 
-        mp3_call = calls[0]
-        assert mp3_call[1]["Key"] == "renders/job-123/output.mp3"
-        assert mp3_call[1]["ContentType"] == "audio/mpeg"
-        assert mp3_call[1]["Metadata"]["render-job-id"] == "job-123"
-        assert mp3_call[1]["Metadata"]["content-type"] == "audio"
+        mp3_extra = upload_file_calls[0][1]["ExtraArgs"]
+        assert upload_file_calls[0][0][2] == "renders/job-123/output.mp3"
+        assert mp3_extra["ContentType"] == "audio/mpeg"
+        assert mp3_extra["Metadata"]["render-job-id"] == "job-123"
+        assert mp3_extra["Metadata"]["content-type"] == "audio"
 
-        mp4_call = calls[1]
-        assert mp4_call[1]["Key"] == "renders/job-123/output.mp4"
-        assert mp4_call[1]["ContentType"] == "video/mp4"
-        assert mp4_call[1]["Metadata"]["render-job-id"] == "job-123"
-        assert mp4_call[1]["Metadata"]["content-type"] == "video"
+        mp4_extra = upload_file_calls[1][1]["ExtraArgs"]
+        assert upload_file_calls[1][0][2] == "renders/job-123/output.mp4"
+        assert mp4_extra["ContentType"] == "video/mp4"
+        assert mp4_extra["Metadata"]["render-job-id"] == "job-123"
+        assert mp4_extra["Metadata"]["content-type"] == "video"
 
-        chapters_call = calls[2]
-        assert chapters_call[1]["Key"] == "renders/job-123/chapters.json"
-        assert chapters_call[1]["ContentType"] == "application/json"
-        assert chapters_call[1]["Metadata"]["render-job-id"] == "job-123"
-        assert chapters_call[1]["Metadata"]["content-type"] == "chapters"
+        chapters_call_kwargs = uploader._client.put_object.call_args[1]
+        assert chapters_call_kwargs["Key"] == "renders/job-123/chapters.json"
+        assert chapters_call_kwargs["ContentType"] == "application/json"
+        assert chapters_call_kwargs["Metadata"]["render-job-id"] == "job-123"
+        assert chapters_call_kwargs["Metadata"]["content-type"] == "chapters"
 
     def test_uploads_only_mp3(self, tmp_path):
         uploader = _make_uploader()
-        uploader._client.put_object.return_value = {"ETag": '"etag"'}
 
         mp3_path = tmp_path / "output.mp3"
         mp3_path.write_bytes(b"mp3 data")
@@ -232,11 +227,10 @@ class TestUploadRenderArtifacts:
         assert result.mp3_r2_key == "renders/job-456/output.mp3"
         assert result.mp4_r2_key is None
         assert result.chapters_r2_key is None
-        assert uploader._client.put_object.call_count == 1
+        assert uploader._client.upload_file.call_count == 1
 
     def test_uploads_only_mp4(self, tmp_path):
         uploader = _make_uploader()
-        uploader._client.put_object.return_value = {"ETag": '"etag"'}
 
         mp4_path = tmp_path / "output.mp4"
         mp4_path.write_bytes(b"mp4 data")
@@ -276,6 +270,7 @@ class TestUploadRenderArtifacts:
         assert result.mp3_r2_key is None
         assert result.mp4_r2_key is None
         assert result.chapters_r2_key is None
+        uploader._client.upload_file.assert_not_called()
         uploader._client.put_object.assert_not_called()
 
     def test_chapters_json_is_utf8_encoded(self):
@@ -398,7 +393,6 @@ class TestR2UploaderInit:
 class TestKeyConstruction:
     def test_mp3_key_format(self, tmp_path):
         uploader = _make_uploader()
-        uploader._client.put_object.return_value = {"ETag": '"e"'}
 
         mp3_path = tmp_path / "output.mp3"
         mp3_path.write_bytes(b"data")
@@ -410,7 +404,6 @@ class TestKeyConstruction:
 
     def test_mp4_key_format(self, tmp_path):
         uploader = _make_uploader()
-        uploader._client.put_object.return_value = {"ETag": '"e"'}
 
         mp4_path = tmp_path / "output.mp4"
         mp4_path.write_bytes(b"data")


### PR DESCRIPTION
## Summary

The Render Worker was hitting OOM on AWS Lambda (3008 MB limit) during video rendering and upload. The root cause was two-fold:

1. **Frame cache persisted through upload phase** — the `OrderedDict`-based LRU frame cache (~933 MB at 150 entries / 1080p) was never cleared after video encoding completed, so it consumed memory uselessly during the subsequent upload phase
2. **Upload read entire files into memory** — `upload_file()` used `Path.read_bytes()` + `put_object()`, loading the entire output MP4 (~200-500 MB) into Python memory before uploading
3. **HTTP responses buffered entirely** — `urllib3.PoolManager.request()` defaults to `preload_content=True`, buffering the entire audio/LRC response body in memory before writing to disk

These three issues combined meant peak memory during upload could reach ~1.6-2.0 GB just for cache + MP4 + MP3, on top of Python runtime (~150 MB) and FFmpeg subprocess (~300-500 MB), easily exceeding the 3008 MB Lambda limit.

## Changes

### 1. Clear frame cache after video encoding (`pipeline.py`)
- Added `video_engine.frame_renderer.clear_cache()` immediately after `generate_video()` returns
- The cache is only useful during encoding; keeping it through upload wastes ~933 MB
- **Memory saved: ~933 MB**

### 2. Streaming upload via `boto3.upload_file()` (`uploader.py`)
- Replaced `Path.read_bytes()` + `client.put_object()` with `client.upload_file()`
- boto3's `upload_file()` streams from disk using automatic multipart upload for large files
- The entire output MP4/MP3 is never loaded into Python memory
- `_put_object()` is retained for `upload_buffer()` (chapters.json, which is small)
- **Memory saved: ~200-500 MB** (depending on video duration/resolution)

### 3. Streaming HTTP downloads (`asset_fetcher.py`)
- Changed `urllib3.request()` to use `preload_content=False`
- `download_audio()`: streams response chunks (8192 bytes) directly to disk via `open().write()`, never buffering the entire MP3 in memory
- `download_lrc()`: streams response chunks into a list, with size limit enforcement during streaming (not after full download)
- Added `response.release_conn()` calls on all code paths (success, error, size limit exceeded)
- **Memory saved: ~10-15 MB per song** (minor but consistent with streaming approach)

### 4. Test updates (`test_asset_fetcher.py`, `test_uploader.py`)
- Updated uploader tests to assert on `client.upload_file()` calls instead of `client.put_object()`
- Updated asset fetcher tests to mock streaming responses (`response.stream.return_value` instead of `response.data`)
- Added `response.release_conn` assertions for proper connection cleanup
- Simplified test setup by removing unnecessary `patch("urllib3")` context managers
- All 584 tests pass

## Memory Budget (After Fix)

| Consumer | Before | After |
|----------|--------|-------|
| Python runtime + libs | ~150 MB | ~150 MB |
| FFmpeg subprocess | ~300-500 MB | ~300-500 MB |
| Frame cache (150 entries @ 1080p) | ~933 MB (persists through upload) | ~933 MB (cleared before upload) |
| MP4 upload buffer | ~200-500 MB | ~0 MB (streamed from disk) |
| MP3 upload buffer | ~10-50 MB | ~0 MB (streamed from disk) |
| Audio download buffer | ~10-15 MB/song | ~8 KB (chunked) |
| **Peak during upload** | **~1.6-2.0 GB** | **~450-650 MB** |

## Testing

- All 584 existing tests pass
- No functional behavior changes — same output, same upload semantics
- `upload_file()` handles multipart automatically for files >8 MB (boto3 default)

## Future Considerations

If OOM still occurs (e.g., with very long songsets at 1080p), additional options include:
- Reducing `SOW_MAX_CACHE_ENTRIES` below 150 (e.g., 50-75 entries saves ~310-620 MB)
- Using 720p resolution (frame size drops from 6.2 MB to 2.76 MB)
- Disabling frame cache entirely (`SOW_FRAME_CACHE_ENABLED=false`)
- Moving to ECS/Fargate for higher memory ceiling