### PR TITLE
feat: two-step inline confirmation for song delete

### DIFF
--- a/webapp/src/app/songsets/[id]/page.tsx
+++ b/webapp/src/app/songsets/[id]/page.tsx
@@ -77,6 +77,7 @@ export default function SongsetEditorPage() {
   const [isBrowseSheetOpen, setIsBrowseSheetOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [isRemoving, setIsRemoving] = useState(false);
 
   // Load songset data
   useEffect(() => {
@@ -198,18 +199,12 @@ export default function SongsetEditorPage() {
   // Handle item removal
   const handleRemoveItem = useCallback(
     async (itemId: string) => {
-      const response = await fetch(
-        `/api/songsets/${songsetId}/items?itemId=${itemId}`,
-        {
-          method: "DELETE",
-        }
-      );
+      if (isRemoving) return;
+      setIsRemoving(true);
 
-      if (!response.ok) {
-        throw new Error("Failed to remove item");
-      }
+      const removedItem = items.find((item) => item.id === itemId);
+      const removedIndex = items.findIndex((item) => item.id === itemId);
 
-      // Update local state
       setItems((prev) => prev.filter((item) => item.id !== itemId));
       setSongset((prev) =>
         prev
@@ -221,8 +216,40 @@ export default function SongsetEditorPage() {
             }
           : prev
       );
+
+      try {
+        const response = await fetch(
+          `/api/songsets/${songsetId}/items?itemId=${itemId}`,
+          {
+            method: "DELETE",
+          }
+        );
+
+        if (!response.ok) {
+          throw new Error("Failed to remove item");
+        }
+      } catch {
+        if (removedItem && removedIndex >= 0) {
+          setItems((prev) => {
+            const next = [...prev];
+            next.splice(removedIndex, 0, removedItem);
+            return next;
+          });
+          setSongset((prev) =>
+            prev
+              ? {
+                  ...prev,
+                  itemCount: prev.itemCount + 1,
+                }
+              : prev
+          );
+        }
+        throw new Error("Failed to remove item");
+      } finally {
+        setIsRemoving(false);
+      }
     },
-    [songsetId]
+    [songsetId, items, isRemoving]
   );
 
   // Handle transition update
@@ -475,6 +502,7 @@ export default function SongsetEditorPage() {
         onDownloadAudio={handleDownloadAudio}
         onDownloadVideo={handleDownloadVideo}
         onAddSongs={handleAddSongs}
+        isRemoving={isRemoving}
       />
       <BrowseSheet
         isOpen={isBrowseSheetOpen}

--- a/webapp/src/app/songsets/[id]/page.tsx
+++ b/webapp/src/app/songsets/[id]/page.tsx
@@ -204,6 +204,8 @@ export default function SongsetEditorPage() {
 
       const removedItem = items.find((item) => item.id === itemId);
       const removedIndex = items.findIndex((item) => item.id === itemId);
+      const prevRenderState = songset?.renderState;
+      const prevIsArtifactsStale = songset?.isArtifactsStale;
 
       setItems((prev) => prev.filter((item) => item.id !== itemId));
       setSongset((prev) =>
@@ -240,6 +242,8 @@ export default function SongsetEditorPage() {
               ? {
                   ...prev,
                   itemCount: prev.itemCount + 1,
+                  renderState: prevRenderState ?? prev.renderState,
+                  isArtifactsStale: prevIsArtifactsStale ?? prev.isArtifactsStale,
                 }
               : prev
           );

--- a/webapp/src/components/songset/SongList.tsx
+++ b/webapp/src/components/songset/SongList.tsx
@@ -61,6 +61,7 @@ interface SongListProps {
   onSelectSong?: (itemId: string) => void;
   readOnly?: boolean;
   className?: string;
+  isRemoving?: boolean;
 }
 
 interface SortableSongItemProps {
@@ -73,6 +74,10 @@ interface SortableSongItemProps {
   isPlaying?: boolean;
   isPreviewLoading?: boolean;
   onPlaySong?: (songId: string) => void;
+  isConfirming: boolean;
+  onRequestConfirm: () => void;
+  onCancelConfirm: () => void;
+  isRemoving?: boolean;
 }
 
 function SortableSongItem({
@@ -85,6 +90,10 @@ function SortableSongItem({
   isPlaying = false,
   isPreviewLoading = false,
   onPlaySong,
+  isConfirming,
+  onRequestConfirm,
+  onCancelConfirm,
+  isRemoving = false,
 }: SortableSongItemProps) {
   const {
     attributes,
@@ -94,6 +103,12 @@ function SortableSongItem({
     transition,
     isDragging,
   } = useSortable({ id: item.id, disabled: readOnly });
+
+  const confirmRemove = isConfirming;
+
+  useEffect(() => {
+    if (isDragging) onCancelConfirm();
+  }, [isDragging, onCancelConfirm]);
 
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -121,7 +136,8 @@ function SortableSongItem({
     >
       <Card className={cn(
         "border-border/50 hover:border-border transition-colors",
-        isPlaying && "border-primary/30 bg-primary/5"
+        isPlaying && "border-primary/30 bg-primary/5",
+        confirmRemove && "border-destructive/40 bg-destructive/5"
       )}>
         <CardContent className="p-3">
           <div className="flex items-center gap-3">
@@ -217,15 +233,30 @@ function SortableSongItem({
 
             {/* Remove button */}
             {!readOnly && (
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                className="shrink-0 opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity"
-                onClick={() => onRemove(item.id)}
-                aria-label={`Remove ${item.song?.title || "song"}`}
-              >
-                <Trash2 className="size-4 text-destructive" />
-              </Button>
+              <div className="shrink-0 min-w-[32px] flex justify-end">
+                {!confirmRemove ? (
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    className="opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity"
+                    onClick={onRequestConfirm}
+                    aria-label={`Remove ${item.song?.title || "song"}`}
+                  >
+                    <Trash2 className="size-4 text-destructive" />
+                  </Button>
+                ) : (
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    className="h-7 px-2 text-xs"
+                    onClick={() => onRemove(item.id)}
+                    disabled={isRemoving}
+                    aria-label={`Confirm delete ${item.song?.title || "song"}`}
+                  >
+                    Delete
+                  </Button>
+                )}
+              </div>
             )}
           </div>
         </CardContent>
@@ -242,9 +273,17 @@ export function SongList({
   onSelectSong,
   readOnly = false,
   className,
+  isRemoving = false,
 }: SongListProps) {
   const [localItems, setLocalItems] = useState(items);
   const prevItemIdsRef = useRef<string | null>(null);
+  const [confirmingItemId, setConfirmingItemId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!confirmingItemId) return;
+    const timer = setTimeout(() => setConfirmingItemId(null), 5000);
+    return () => clearTimeout(timer);
+  }, [confirmingItemId]);
 
   const { currentTrack, state: playerState, play, pause } = useAudioPlayerContext();
   const [playingSongId, setPlayingSongId] = useState<string | null>(null);
@@ -402,6 +441,10 @@ export function SongList({
               isPlaying={playingSongId === item.songId}
               isPreviewLoading={previewLoadingSongId === item.songId}
               onPlaySong={handlePlaySong}
+              isConfirming={confirmingItemId === item.id}
+              onRequestConfirm={() => setConfirmingItemId(item.id)}
+              onCancelConfirm={() => setConfirmingItemId(null)}
+              isRemoving={isRemoving}
             />
           ))}
         </div>

--- a/webapp/src/components/songset/SongList.tsx
+++ b/webapp/src/components/songset/SongList.tsx
@@ -240,6 +240,7 @@ function SortableSongItem({
                     size="icon-sm"
                     className="opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity"
                     onClick={onRequestConfirm}
+                    disabled={isRemoving}
                     aria-label={`Remove ${item.song?.title || "song"}`}
                   >
                     <Trash2 className="size-4 text-destructive" />
@@ -280,10 +281,10 @@ export function SongList({
   const [confirmingItemId, setConfirmingItemId] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!confirmingItemId) return;
+    if (!confirmingItemId || isRemoving) return;
     const timer = setTimeout(() => setConfirmingItemId(null), 5000);
     return () => clearTimeout(timer);
-  }, [confirmingItemId]);
+  }, [confirmingItemId, isRemoving]);
 
   const { currentTrack, state: playerState, play, pause } = useAudioPlayerContext();
   const [playingSongId, setPlayingSongId] = useState<string | null>(null);

--- a/webapp/src/components/songset/SongsetEditor.tsx
+++ b/webapp/src/components/songset/SongsetEditor.tsx
@@ -72,6 +72,7 @@ export interface SongsetEditorProps {
   onDownloadAudio?: () => void;
   onDownloadVideo?: () => void;
   onAddSongs: () => void;
+  isRemoving?: boolean;
   className?: string;
 }
 
@@ -90,6 +91,7 @@ export function SongsetEditor({
   onDownloadAudio,
   onDownloadVideo,
   onAddSongs,
+  isRemoving = false,
   className,
 }: SongsetEditorProps) {
   const router = useRouter();
@@ -376,6 +378,7 @@ export function SongsetEditor({
           onRemove={handleRemove}
           onEditTransition={handleEditTransition}
           onSelectSong={() => {}}
+          isRemoving={isRemoving}
         />
       </main>
 


### PR DESCRIPTION
## Summary

Replaces the single-click per-song delete button in the Songset Editor with a two-step inline confirmation to prevent accidental deletions.

## Changes

### `webapp/src/components/songset/SongList.tsx`
- Added shared `confirmingItemId` state with 5-second auto-reset timer (only one song can be in confirm state at a time)
- `SortableSongItem` now receives `isConfirming`, `onRequestConfirm`, `onCancelConfirm`, `isRemoving` props
- First click on trash icon replaces it with a red "Delete" text button; second click confirms removal
- Row gets subtle red highlight (`border-destructive/40 bg-destructive/5`) during confirm state
- Dragging a song resets the confirm state
- Delete button is disabled while API call is in-flight (`isRemoving`)

### `webapp/src/components/songset/SongsetEditor.tsx`
- Added `isRemoving` prop, passed through to `SongList`

### `webapp/src/app/songsets/[id]/page.tsx`
- Added `isRemoving` state for in-flight deduplication (prevents concurrent delete requests)
- `handleRemoveItem` now does optimistic update (removes from UI immediately)
- On API failure, item is reinserted at its original position (rollback)
- `isRemoving` passed to `SongsetEditor`

## Design Decisions

| Decision | Rationale |
|----------|-----------|
| Single shared confirm state | Prevents UI clutter and accidental clicks on wrong row |
| `variant="destructive"` on confirm button | Red background makes confirm action visually distinct |
| 5-second auto-reset | Forgiving for accessibility/mobile; short enough to not linger |
| Inline confirmation (not dialog) | Lightweight, keeps context |
| Optimistic update + rollback | Faster perceived response; item reappears on failure |

## Verification

- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] ESLint passes (no new warnings)
- [ ] Manual testing: click trash → red "Delete" button + row highlight
- [ ] Manual testing: click "Delete" → song removed, success toast
- [ ] Manual testing: 5s auto-reset, drag reset, single confirm state
- [ ] Manual testing: API failure rollback