### PR TITLE
feat: navigate to songset editor with auto-open song picker after creation

### DIFF
--- a/webapp/src/app/songsets/[id]/layout.tsx
+++ b/webapp/src/app/songsets/[id]/layout.tsx
@@ -1,0 +1,9 @@
+import { Suspense } from "react";
+
+export default function SongsetEditorLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <Suspense>{children}</Suspense>;
+}

--- a/webapp/src/app/songsets/[id]/page.tsx
+++ b/webapp/src/app/songsets/[id]/page.tsx
@@ -163,11 +163,11 @@ export default function SongsetEditorPage() {
   }, [songsetId, router]);
 
   useEffect(() => {
-    if (!isLoading && isNew && items.length === 0) {
+    if (!isLoading && !error && songset && isNew && items.length === 0) {
       setIsBrowseSheetOpen(true);
       router.replace(`/songsets/${songsetId}`);
     }
-  }, [isLoading, isNew, items.length, songsetId, router]);
+  }, [isLoading, error, songset, isNew, items.length, songsetId, router]);
 
   const markStale = useCallback(() => {
     setSongset((prev) =>

--- a/webapp/src/app/songsets/[id]/page.tsx
+++ b/webapp/src/app/songsets/[id]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { useParams, useRouter } from "next/navigation";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { SongsetEditor } from "@/components/songset/SongsetEditor";
 import { BrowseSheet } from "@/components/songset/BrowseSheet";
 import { SongCardData } from "@/components/songset/SongCard";
@@ -70,7 +70,9 @@ interface ApiResponse {
 export default function SongsetEditorPage() {
   const params = useParams();
   const router = useRouter();
+  const searchParams = useSearchParams();
   const songsetId = params.id as string;
+  const isNew = searchParams.get("new") === "true";
 
   const [songset, setSongset] = useState<ApiSongset | null>(null);
   const [items, setItems] = useState<SongListItem[]>([]);
@@ -159,6 +161,13 @@ export default function SongsetEditorPage() {
       cancelled = true;
     };
   }, [songsetId, router]);
+
+  useEffect(() => {
+    if (!isLoading && isNew && items.length === 0) {
+      setIsBrowseSheetOpen(true);
+      router.replace(`/songsets/${songsetId}`);
+    }
+  }, [isLoading, isNew, items.length, songsetId, router]);
 
   const markStale = useCallback(() => {
     setSongset((prev) =>

--- a/webapp/src/app/songsets/page.tsx
+++ b/webapp/src/app/songsets/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { useRouter } from "next/navigation";
 import { SongsetList, Songset } from "@/components/songset/SongsetList";
 import { RenderState } from "@/components/songset/RenderStatusBadge";
 import { toast } from "sonner";
@@ -26,6 +27,7 @@ interface ApiResponse {
 }
 
 export default function SongsetsPage() {
+  const router = useRouter();
   const [songsets, setSongsets] = useState<Songset[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -103,10 +105,28 @@ export default function SongsetsPage() {
         throw new Error(data.error || "Failed to create songset");
       }
 
+      let songset: { id?: string };
+      try {
+        songset = await response.json();
+      } catch {
+        refreshSongsets();
+        toast.error("Songset created but could not open editor");
+        router.push("/songsets");
+        return;
+      }
+
+      if (!songset?.id) {
+        refreshSongsets();
+        toast.error("Songset created but could not open editor");
+        router.push("/songsets");
+        return;
+      }
+
       refreshSongsets();
       toast.success("Songset created successfully");
+      router.push(`/songsets/${songset.id}?new=true`);
     },
-    [refreshSongsets]
+    [refreshSongsets, router]
   );
 
   const handleRender = useCallback((id: string) => {


### PR DESCRIPTION
## Summary

After creating a new Songset, the user now navigates directly to the Songset Editor with the BrowseSheet (song picker) auto-opened, eliminating the extra step of clicking the new songset from the list page.

## Changes

- **`webapp/src/app/songsets/page.tsx`**: Modified `handleCreateSongset` to parse the 201 response body for the new songset `id`, navigate to `/songsets/${id}?new=true` via `router.push`, with fallback error handling for malformed/missing response body
- **`webapp/src/app/songsets/[id]/layout.tsx`**: New file — `<Suspense>` boundary required for `useSearchParams()` in production builds
- **`webapp/src/app/songsets/[id]/page.tsx`**: Added `useSearchParams` to detect `?new=true` query param, added `useEffect` that auto-opens BrowseSheet when data loads + songset is empty + `new=true`, then cleans the URL via `router.replace`

## Edge Cases Handled

- API error during creation: no navigation, error shown in dialog
- 201 with malformed/missing body: navigates to `/songsets` list with error toast
- Back button: returns to `/songsets` list with fresh data (fire-and-forget `refreshSongsets()`)
- Page refresh: `?new=true` is cleaned from URL, so BrowseSheet won't re-open
- Songset with existing items: `items.length === 0` check prevents auto-open

## Testing

1. Go to `/songsets`, click "+" FAB, enter a name, click "Create"
2. Verify: navigates to `/songsets/{id}` editor page
3. Verify: BrowseSheet auto-opens
4. Verify: URL no longer has `?new=true` after BrowseSheet opens
5. Verify: pressing Back returns to `/songsets` list with the new songset visible
6. Verify: refreshing the editor page does NOT auto-open BrowseSheet
7. Verify: TypeScript compilation passes (`tsc --noEmit` — no errors)