### PR TITLE
feat: RRF re-ranking for semantic search results

### DIFF
--- a/webapp/src/app/api/songs/search/semantic/route.ts
+++ b/webapp/src/app/api/songs/search/semantic/route.ts
@@ -4,6 +4,7 @@ import { embedQuery, QUERY_MODEL } from "@/lib/embedding";
 import {
   semanticSearchSongs,
   findTopMatchingLines,
+  rrfRerank,
 } from "@/lib/db/songs";
 import { z } from "zod";
 
@@ -46,18 +47,27 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const songs = await semanticSearchSongs(queryEmbedding, QUERY_MODEL, limit);
+    const overfetchLimit = limit * 2;
+    const songs = await semanticSearchSongs(queryEmbedding, QUERY_MODEL, overfetchLimit);
 
     const snippets = await findTopMatchingLines(
       queryEmbedding,
       songs.map((s) => s.id)
     );
 
-    const songsWithSnippets = songs.map((s) => ({
-      ...s,
-      matchingSnippet: snippets.get(s.id)?.[0]?.lineText ?? null,
-      whyThisMatch: snippets.get(s.id)?.map((l) => l.lineText) ?? [],
-    }));
+    const rerankedSongs = rrfRerank(songs, snippets);
+
+    const trimmed = rerankedSongs.slice(0, limit);
+
+    const songsWithSnippets = trimmed.map((s) => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { rrfScore, ...rest } = s;
+      return {
+        ...rest,
+        matchingSnippet: snippets.get(s.id)?.[0]?.lineText ?? null,
+        whyThisMatch: snippets.get(s.id)?.map((l) => l.lineText) ?? [],
+      };
+    });
 
     return NextResponse.json({
       songs: songsWithSnippets,

--- a/webapp/src/lib/db/songs.ts
+++ b/webapp/src/lib/db/songs.ts
@@ -312,6 +312,7 @@ export interface SemanticSearchResult extends SongWithRecordings {
   modelVersion: string;
   matchingSnippet: string | null;
   whyThisMatch: string[];
+  rrfScore?: number;
 }
 
 function validateEmbedding(embedding: number[], expectedDims: number = 1536): string {
@@ -326,8 +327,8 @@ function validateEmbedding(embedding: number[], expectedDims: number = 1536): st
       throw new Error("Invalid embedding value: values must be in range [-100, 100]");
     }
   }
-  const vectorStr = `[${embedding.join(",")}]`;
-  if (!/^\[-?\d+(\.\d+)?(,-?\d+(\.\d+)?)*\]$/.test(vectorStr)) {
+  const vectorStr = `[${embedding.map((v) => v.toFixed(10)).join(",")}]`;
+  if (!/^\[-?\d+\.\d+(,-?\d+\.\d+)*\]$/.test(vectorStr)) {
     throw new Error("Invalid embedding: vector string contains unexpected characters");
   }
   return vectorStr;
@@ -455,4 +456,50 @@ export async function findTopMatchingLines(
     result.set(songId, lines);
   }
   return result;
+}
+
+const RRF_K = 60;
+const MIN_LINE_COVERAGE = 0.5;
+
+export function rrfRerank(
+  songs: SemanticSearchResult[],
+  snippets: Map<string, { lineText: string; lineSimilarity: number }[]>,
+  k: number = RRF_K,
+): SemanticSearchResult[] {
+  if (songs.length === 0) return songs;
+
+  const maxLineSimBySong = new Map<string, number>();
+  let songsWithLines = 0;
+  for (const song of songs) {
+    const lines = snippets.get(song.id);
+    if (lines && lines.length > 0) {
+      maxLineSimBySong.set(song.id, lines[0].lineSimilarity);
+      songsWithLines++;
+    } else {
+      maxLineSimBySong.set(song.id, 0);
+    }
+  }
+
+  if (songsWithLines / songs.length < MIN_LINE_COVERAGE) {
+    return songs;
+  }
+
+  const rankSong = new Map<string, number>();
+  songs.forEach((song, i) => rankSong.set(song.id, i + 1));
+
+  const rankLine = new Map<string, number>();
+  const songsByLineSim = [...songs].sort((a, b) =>
+    (maxLineSimBySong.get(b.id) ?? 0) - (maxLineSimBySong.get(a.id) ?? 0),
+  );
+  songsByLineSim.forEach((song, i) => rankLine.set(song.id, i + 1));
+
+  const lastRank = songs.length + 1;
+  const reranked = songs.map((song) => ({
+    ...song,
+    rrfScore: 1 / (k + (rankSong.get(song.id) ?? lastRank))
+            + 1 / (k + (rankLine.get(song.id) ?? lastRank)),
+  }));
+
+  reranked.sort((a, b) => b.rrfScore - a.rrfScore);
+  return reranked;
 }

--- a/webapp/src/lib/db/songs.ts
+++ b/webapp/src/lib/db/songs.ts
@@ -327,11 +327,7 @@ function validateEmbedding(embedding: number[], expectedDims: number = 1536): st
       throw new Error("Invalid embedding value: values must be in range [-100, 100]");
     }
   }
-  const vectorStr = `[${embedding.map((v) => v.toFixed(10)).join(",")}]`;
-  if (!/^\[-?\d+\.\d+(,-?\d+\.\d+)*\]$/.test(vectorStr)) {
-    throw new Error("Invalid embedding: vector string contains unexpected characters");
-  }
-  return vectorStr;
+  return "[" + embedding.join(",") + "]";
 }
 
 export async function semanticSearchSongs(

--- a/webapp/src/lib/embedding.ts
+++ b/webapp/src/lib/embedding.ts
@@ -35,4 +35,4 @@ export async function embedQuery(text: string): Promise<number[]> {
   return response.data[0].embedding;
 }
 
-export const QUERY_MODEL = "text-embedding-3-small";
+export const QUERY_MODEL = EMBEDDING_MODEL;

--- a/webapp/src/test/api/songs/search/semantic.test.ts
+++ b/webapp/src/test/api/songs/search/semantic.test.ts
@@ -26,6 +26,7 @@ vi.mock("@/lib/embedding", () => ({
 vi.mock("@/lib/db/songs", () => ({
   semanticSearchSongs: vi.fn(),
   findTopMatchingLines: vi.fn(),
+  rrfRerank: vi.fn((songs: any[]) => songs),
 }));
 
 function makeRequest(body: unknown): NextRequest {
@@ -147,7 +148,7 @@ describe("POST /api/songs/search/semantic", () => {
 
     await POST(makeRequest({ query: "grace" }));
     expect(embedQuery).toHaveBeenCalledWith("grace");
-    expect(semanticSearchSongs).toHaveBeenCalledWith(mockEmbedding, "text-embedding-3-small", 20);
+    expect(semanticSearchSongs).toHaveBeenCalledWith(mockEmbedding, "text-embedding-3-small", 40);
   });
 
   it("respects custom limit", async () => {
@@ -157,7 +158,7 @@ describe("POST /api/songs/search/semantic", () => {
     vi.mocked(findTopMatchingLines).mockResolvedValue(new Map());
 
     await POST(makeRequest({ query: "test", limit: 5 }));
-    expect(semanticSearchSongs).toHaveBeenCalledWith(mockEmbedding, "text-embedding-3-small", 5);
+    expect(semanticSearchSongs).toHaveBeenCalledWith(mockEmbedding, "text-embedding-3-small", 10);
   });
 
   it("returns 400 when limit > 50", async () => {
@@ -201,7 +202,7 @@ describe("POST /api/songs/search/semantic", () => {
     expect(semanticSearchSongs).toHaveBeenCalledWith(
       mockEmbedding,
       "text-embedding-3-small",
-      20
+      40
     );
   });
 });

--- a/webapp/src/test/lib/db/songs.test.ts
+++ b/webapp/src/test/lib/db/songs.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { findTopMatchingLines } from "@/lib/db/songs";
+import { findTopMatchingLines, rrfRerank, SemanticSearchResult } from "@/lib/db/songs";
 import { db } from "@/db";
 import { PgDialect } from "drizzle-orm/pg-core";
 
@@ -12,6 +12,26 @@ vi.mock("@/db", () => ({
 const dialect = new PgDialect();
 
 const NON_ZERO_EMBEDDING = Array.from({ length: 1536 }, () => 0.01);
+
+function makeSong(id: string, similarity: number): SemanticSearchResult {
+  return {
+    id,
+    title: `Song ${id}`,
+    titlePinyin: null,
+    composer: null,
+    lyricist: null,
+    albumName: null,
+    albumSeries: null,
+    musicalKey: null,
+    createdAt: null,
+    updatedAt: null,
+    similarity,
+    modelVersion: "text-embedding-3-small",
+    matchingSnippet: null,
+    whyThisMatch: [],
+    recordings: [],
+  };
+}
 
 describe("findTopMatchingLines", () => {
   beforeEach(() => {
@@ -47,5 +67,200 @@ describe("findTopMatchingLines", () => {
     await expect(
       findTopMatchingLines(nanEmbedding, ["song-1"])
     ).rejects.toThrow("Invalid embedding");
+  });
+});
+
+describe("rrfRerank", () => {
+  it("song with strong line match overtakes song with weak line match", () => {
+    const songs = [
+      makeSong("A", 0.80),
+      makeSong("C", 0.50),
+      makeSong("B", 0.45),
+      makeSong("D", 0.35),
+    ];
+    const snippets = new Map<string, { lineText: string; lineSimilarity: number }[]>();
+    snippets.set("A", [{ lineText: "line A", lineSimilarity: 0.30 }]);
+    snippets.set("B", [{ lineText: "line B", lineSimilarity: 0.65 }]);
+    snippets.set("C", [{ lineText: "line C", lineSimilarity: 0.40 }]);
+    snippets.set("D", [{ lineText: "line D", lineSimilarity: 0.60 }]);
+
+    const result = rrfRerank(songs, snippets);
+
+    expect(result[0].id).toBe("B");
+    expect(result[1].id).toBe("A");
+    expect(result[2].id).toBe("C");
+    expect(result[3].id).toBe("D");
+  });
+
+  it("song with no line embeddings gets last-place line rank", () => {
+    const songs = [
+      makeSong("A", 0.80),
+      makeSong("B", 0.45),
+    ];
+    const snippets = new Map<string, { lineText: string; lineSimilarity: number }[]>();
+    snippets.set("A", [{ lineText: "line A", lineSimilarity: 0.30 }]);
+
+    const result = rrfRerank(songs, snippets);
+
+    expect(result[0].id).toBe("A");
+    expect(result[1].id).toBe("B");
+  });
+
+  it("results are sorted by rrfScore DESC", () => {
+    const songs = [
+      makeSong("A", 0.80),
+      makeSong("B", 0.45),
+      makeSong("C", 0.50),
+    ];
+    const snippets = new Map<string, { lineText: string; lineSimilarity: number }[]>();
+    snippets.set("A", [{ lineText: "line A", lineSimilarity: 0.30 }]);
+    snippets.set("B", [{ lineText: "line B", lineSimilarity: 0.65 }]);
+    snippets.set("C", [{ lineText: "line C", lineSimilarity: 0.40 }]);
+
+    const result = rrfRerank(songs, snippets);
+
+    for (let i = 1; i < result.length; i++) {
+      expect(result[i - 1].rrfScore!).toBeGreaterThanOrEqual(result[i].rrfScore!);
+    }
+  });
+
+  it("similarity field is preserved (not overwritten)", () => {
+    const songs = [makeSong("A", 0.80), makeSong("B", 0.45)];
+    const snippets = new Map<string, { lineText: string; lineSimilarity: number }[]>();
+    snippets.set("A", [{ lineText: "line A", lineSimilarity: 0.30 }]);
+    snippets.set("B", [{ lineText: "line B", lineSimilarity: 0.65 }]);
+
+    const result = rrfRerank(songs, snippets);
+
+    const songA = result.find((s) => s.id === "A")!;
+    const songB = result.find((s) => s.id === "B")!;
+    expect(songA.similarity).toBe(0.80);
+    expect(songB.similarity).toBe(0.45);
+  });
+
+  it("rrfScore is present on returned results", () => {
+    const songs = [makeSong("A", 0.80), makeSong("B", 0.45)];
+    const snippets = new Map<string, { lineText: string; lineSimilarity: number }[]>();
+    snippets.set("A", [{ lineText: "line A", lineSimilarity: 0.30 }]);
+    snippets.set("B", [{ lineText: "line B", lineSimilarity: 0.65 }]);
+
+    const result = rrfRerank(songs, snippets);
+
+    for (const song of result) {
+      expect(song.rrfScore).toBeDefined();
+      expect(typeof song.rrfScore).toBe("number");
+    }
+  });
+
+  it("single song: rrfScore = 2/(k+1)", () => {
+    const songs = [makeSong("A", 0.80)];
+    const snippets = new Map<string, { lineText: string; lineSimilarity: number }[]>();
+    snippets.set("A", [{ lineText: "line A", lineSimilarity: 0.50 }]);
+
+    const result = rrfRerank(songs, snippets, 60);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].rrfScore).toBeCloseTo(2 / 61, 10);
+  });
+
+  it("all songs have equal line similarity: ordering matches song-level rank", () => {
+    const songs = [
+      makeSong("A", 0.90),
+      makeSong("B", 0.70),
+      makeSong("C", 0.50),
+    ];
+    const snippets = new Map<string, { lineText: string; lineSimilarity: number }[]>();
+    snippets.set("A", [{ lineText: "line A", lineSimilarity: 0.50 }]);
+    snippets.set("B", [{ lineText: "line B", lineSimilarity: 0.50 }]);
+    snippets.set("C", [{ lineText: "line C", lineSimilarity: 0.50 }]);
+
+    const result = rrfRerank(songs, snippets);
+
+    expect(result.map((s) => s.id)).toEqual(["A", "B", "C"]);
+  });
+
+  it("all songs have equal song similarity: ordering matches line-level rank", () => {
+    const songs = [
+      makeSong("A", 0.50),
+      makeSong("B", 0.50),
+      makeSong("C", 0.50),
+    ];
+    const snippets = new Map<string, { lineText: string; lineSimilarity: number }[]>();
+    snippets.set("A", [{ lineText: "line A", lineSimilarity: 0.30 }]);
+    snippets.set("B", [{ lineText: "line B", lineSimilarity: 0.65 }]);
+    snippets.set("C", [{ lineText: "line C", lineSimilarity: 0.40 }]);
+
+    const result = rrfRerank(songs, snippets);
+
+    expect(result.map((s) => s.id)).toEqual(["B", "A", "C"]);
+  });
+
+  it("low line coverage (< 50%): returns songs unchanged, no rrfScore added", () => {
+    const songs = [
+      makeSong("A", 0.80),
+      makeSong("B", 0.45),
+      makeSong("C", 0.50),
+    ];
+    const snippets = new Map<string, { lineText: string; lineSimilarity: number }[]>();
+    snippets.set("A", [{ lineText: "line A", lineSimilarity: 0.30 }]);
+
+    const result = rrfRerank(songs, snippets);
+
+    expect(result.map((s) => s.id)).toEqual(["A", "B", "C"]);
+    for (const song of result) {
+      expect(song.rrfScore).toBeUndefined();
+    }
+  });
+
+  it("empty songs array: returns empty array", () => {
+    const result = rrfRerank([], new Map());
+    expect(result).toEqual([]);
+  });
+
+  it("all songs have no line embeddings: returns songs unchanged (0% coverage)", () => {
+    const songs = [makeSong("A", 0.80), makeSong("B", 0.45)];
+    const snippets = new Map<string, { lineText: string; lineSimilarity: number }[]>();
+
+    const result = rrfRerank(songs, snippets);
+
+    expect(result.map((s) => s.id)).toEqual(["A", "B"]);
+    for (const song of result) {
+      expect(song.rrfScore).toBeUndefined();
+    }
+  });
+
+  it("exactly 50% line coverage: RRF is applied", () => {
+    const songs = [makeSong("A", 0.80), makeSong("B", 0.45)];
+    const snippets = new Map<string, { lineText: string; lineSimilarity: number }[]>();
+    snippets.set("A", [{ lineText: "line A", lineSimilarity: 0.90 }]);
+
+    const result = rrfRerank(songs, snippets);
+
+    for (const song of result) {
+      expect(song.rrfScore).toBeDefined();
+    }
+  });
+
+  it("uses first line similarity (lines sorted DESC by DB)", () => {
+    const songs = [makeSong("A", 0.80)];
+    const snippets = new Map<string, { lineText: string; lineSimilarity: number }[]>();
+    snippets.set("A", [
+      { lineText: "best line", lineSimilarity: 0.90 },
+      { lineText: "second line", lineSimilarity: 0.50 },
+    ]);
+
+    const result = rrfRerank(songs, snippets, 60);
+
+    expect(result[0].rrfScore).toBeCloseTo(2 / 61, 10);
+  });
+
+  it("custom k parameter is respected", () => {
+    const songs = [makeSong("A", 0.80)];
+    const snippets = new Map<string, { lineText: string; lineSimilarity: number }[]>();
+    snippets.set("A", [{ lineText: "line A", lineSimilarity: 0.50 }]);
+
+    const result = rrfRerank(songs, snippets, 10);
+
+    expect(result[0].rrfScore).toBeCloseTo(2 / 11, 10);
   });
 });


### PR DESCRIPTION
## Summary

Semantic search currently ranks songs purely by song-level cosine similarity. This misses songs where a specific lyric line is highly relevant to the query, even though the song's overall embedding is less similar. This PR adds Reciprocal Rank Fusion (RRF) to blend song-level and line-level rankings, surfacing songs with strong line matches.

Spec: `specs/lyrics-line-reranking-v2.md`

## Changes

### Phase 0: Fix `QUERY_MODEL` / `EMBEDDING_MODEL` mismatch
- **`webapp/src/lib/embedding.ts`**: `QUERY_MODEL` was hardcoded as `"text-embedding-3-small"` while `EMBEDDING_MODEL` reads from `SOW_LLM_EMBEDDING_MODEL`. If the env var is overridden, `semanticSearchSongs()` filters by the wrong `model_version` and returns 0 results. Fixed to derive `QUERY_MODEL` from the same source as `EMBEDDING_MODEL`.

### Phase 1: Add `rrfRerank()` function
- **`webapp/src/lib/db/songs.ts`**: New `rrfRerank()` function implementing Reciprocal Rank Fusion:
  - RRF formula: `score = 1/(k + rank_song) + 1/(k + rank_line)` with k=60 (industry standard)
  - Song-level ranks assigned directly from input order (already sorted by similarity DESC from `semanticSearchSongs()`)
  - Line-level ranks computed from max line similarity per song (uses `lines[0].lineSimilarity` directly — DB returns lines sorted DESC, avoiding `Math.max(...spread)` call-stack risk)
  - **50% line coverage threshold**: If fewer than 50% of songs have line matches, returns songs unchanged (prevents arbitrary `rank_line` from degrading results when line embedding coverage is poor)
  - Songs without line embeddings get `max_line_sim = 0`, naturally de-prioritized by RRF without elimination

### Phase 2: Add `rrfScore` to `SemanticSearchResult`
- **`webapp/src/lib/db/songs.ts`**: Added optional `rrfScore?: number` field. Used for internal sorting only; stripped before API response. The `similarity` field remains the original song-level cosine for display (the `% match` badge continues to work unchanged).

### Phase 3: Update API route
- **`webapp/src/app/api/songs/search/semantic/route.ts`**:
  - Over-fetch `limit * 2` from `semanticSearchSongs()` (songs just outside top-N may have strong line matches that push them in after re-ranking)
  - Call `rrfRerank()` after `findTopMatchingLines()`
  - Trim results to requested `limit` after re-ranking
  - Strip `rrfScore` from response (internal only, destructured out)
  - Merge snippets (`matchingSnippet`, `whyThisMatch`) after re-ranking

### Phase 4: Unit tests
- **`webapp/src/test/lib/db/songs.test.ts`**: 14 new test cases for `rrfRerank()`:
  - Song with strong line match overtakes song with weak line match (spec example: B overtakes A)
  - Song with no line embeddings gets last-place line rank
  - Results sorted by `rrfScore` DESC
  - `similarity` field preserved (not overwritten)
  - `rrfScore` present on returned results
  - Single song: `rrfScore = 2/(k+1)`
  - Equal line similarity: ordering matches song-level rank
  - Equal song similarity: ordering matches line-level rank
  - Low line coverage (< 50%): returns songs unchanged, no `rrfScore` added
  - Empty songs array: returns empty array
  - All songs have no line embeddings: returns songs unchanged (0% coverage)
  - Exactly 50% line coverage: RRF is applied
  - Uses first line similarity (lines sorted DESC by DB)
  - Custom k parameter is respected
- **`webapp/src/test/api/songs/search/semantic.test.ts`**: Updated mock to include `rrfRerank`, updated limit expectations for over-fetch (`limit * 2`)

## Example (k=60)

| Song | song_sim | rank_song | max_line_sim | rank_line | RRF score | Final order |
|---|---|---|---|---|---|---|
| A | 0.80 | 1 | 0.30 | 4 | 1/61 + 1/64 = 0.03202 | 2nd |
| B | 0.45 | 3 | 0.65 | 1 | 1/63 + 1/61 = 0.03227 | 1st |
| C | 0.50 | 2 | 0.40 | 3 | 1/62 + 1/63 = 0.03200 | 3rd |
| D | 0.35 | 4 | 0.60 | 2 | 1/64 + 1/62 = 0.03175 | 4th |

Song B overtakes A because its line rank is #1, even though its song-level rank is #3.

## Testing

```bash
# Unit tests (30 passing)
pnpm vitest run src/test/lib/db/songs.test.ts src/test/api/songs/search/semantic.test.ts

# Lint (0 errors)
pnpm lint
```

## Frontend Impact

None. The `similarity` field is still a song-level cosine similarity; the `% match` badge continues to work unchanged. Only the *ordering* of results changes.