### PR TITLE
Implement DashScope Qwen3 ASR LRC pipeline

### DIFF
--- a/reports/current_impl_status.md
+++ b/reports/current_impl_status.md
@@ -1,6 +1,6 @@
 # Stream of Worship - Current Implementation Status Report
 
-**Generated:** 2026-05-17 (updated 2026-06-08)
+**Generated:** 2026-05-17 (updated 2026-06-10)
 **Project:** Stream of Worship - Admin CLI, Analysis Service, Web App & Render Worker
 **Repository:** sow_deployment_preps
 
@@ -13,6 +13,8 @@ The Stream of Worship project consists of an Admin CLI for backend management, a
 **Overall Progress:** All phases complete (100%)
 
 **Latest Milestone:** Admin LRC editor preview transition display improved — preview now shows the previous lyric before transitioning to the current lyric, with a blank lead-in before line 1.
+
+**PR #101 Review Fixes (2026-06-10):** Tightened Qwen3 ASR Flash routing to the documented 10 MB / 5 minute limits with best-effort duration probing, fixed DashScope millisecond timestamp conversion, flattened FileTrans transcript sentences, removed canonical lyric final-line search bias, and made cancelled LRC parent jobs stop waiting on stem-child jobs before transcription.
 
 **Maintenance Update (2026-06-07):** Fixed stale row highlight events in the admin LRC editor by suppressing programmatic DataTable highlight messages during table rebuilds, syncing preview start from the active table cursor, and resetting resumed editor sessions to row 1 at launch.
 

--- a/services/analysis/pyproject.toml
+++ b/services/analysis/pyproject.toml
@@ -19,6 +19,9 @@ dependencies = [
     "openai>=1.10.0",
     "aiosqlite>=0.19.0",
     "youtube-transcript-api>=1.0.0",
+    "dashscope>=1.23.0",
+    "rapidfuzz>=3.9.0",
+    "zhconv>=1.4.3",
 ]
 
 [project.optional-dependencies]

--- a/services/analysis/src/sow_analysis/config.py
+++ b/services/analysis/src/sow_analysis/config.py
@@ -24,7 +24,9 @@ class Settings(BaseSettings):
 
     # Cache and Processing
     CACHE_DIR: Path = Path("/cache")
-    SOW_MAX_CONCURRENT_LOCAL_MODEL_JOBS: int = 1  # Global limit for local model execution (Whisper, Qwen3, audio-separator, allin1, demucs)
+    SOW_MAX_CONCURRENT_LOCAL_MODEL_JOBS: int = (
+        1  # Global limit for local model execution (Whisper, Qwen3, audio-separator, allin1, demucs)
+    )
 
     @field_validator("SOW_MAX_CONCURRENT_LOCAL_MODEL_JOBS")
     @classmethod
@@ -52,6 +54,18 @@ class Settings(BaseSettings):
     # Whisper Configuration
     SOW_WHISPER_DEVICE: str = "cpu"  # "cuda" or "cpu"
     SOW_WHISPER_CACHE_DIR: Path = Path("/cache/whisper")
+
+    # DashScope Qwen3 ASR Configuration
+    SOW_DASHSCOPE_API_KEY: str = ""
+    SOW_DASHSCOPE_ASR_REGION: str = "intl"  # intl, cn, us
+    SOW_DASHSCOPE_ASR_FLASH_MODEL: str = "qwen3-asr-flash"
+    SOW_DASHSCOPE_ASR_FILETRANS_MODEL: str = "qwen3-asr-flash-filetrans"
+    SOW_DASHSCOPE_ASR_CONTEXT_MAX_CHARS: int = 10000
+    SOW_DASHSCOPE_ASR_SNAP_THRESHOLD: float = 0.60
+    SOW_DASHSCOPE_ASR_TIMEOUT_SECONDS: int = 300
+    SOW_DASHSCOPE_ASR_FILETRANS_TIMEOUT_SECONDS: int = 1800
+    SOW_DASHSCOPE_ASR_MAX_CONCURRENT: int = 2
+    SOW_DASHSCOPE_ASR_CACHE_VERSION: int = 1
 
     # Stem Separation Configuration
     SOW_AUDIO_SEPARATOR_MODEL_DIR: Path = Path("/models/audio-separator")
@@ -107,7 +121,9 @@ class Settings(BaseSettings):
     SOW_QWEN3_API_KEY: str = ""  # Optional API key for Qwen3 service authentication
 
     # YouTube Proxy Configuration
-    SOW_YOUTUBE_PROXY: str = ""  # HTTP/HTTPS/SOCKS proxy URL for YouTube transcript requests (e.g., "http://proxy:8080", "socks5://proxy:1080")
+    SOW_YOUTUBE_PROXY: str = (
+        ""  # HTTP/HTTPS/SOCKS proxy URL for YouTube transcript requests (e.g., "http://proxy:8080", "socks5://proxy:1080")
+    )
     SOW_YOUTUBE_PROXY_RETRIES: int = 3  # Number of retries on HTTP 429 when using rotating proxies
 
 

--- a/services/analysis/src/sow_analysis/main.py
+++ b/services/analysis/src/sow_analysis/main.py
@@ -91,12 +91,21 @@ async def lifespan(app: FastAPI):
     # Log startup configuration (non-sensitive values only)
     headers = ("Category", "Setting", "Value")
     config_rows = [
-        ("Processing", "max_concurrent_local_model", str(settings.SOW_MAX_CONCURRENT_LOCAL_MODEL_JOBS)),
+        (
+            "Processing",
+            "max_concurrent_local_model",
+            str(settings.SOW_MAX_CONCURRENT_LOCAL_MODEL_JOBS),
+        ),
         ("Processing", "cache_dir", str(settings.CACHE_DIR)),
         ("Processing", "queue_start_delay", f"{settings.SOW_QUEUE_START_DELAY_SECONDS}s"),
         ("LLM", "model", settings.SOW_LLM_MODEL or "(not set)"),
         ("LLM", "provider", settings.SOW_LLM_BASE_URL or "(not set)"),
-        ("Qwen3", "base_url", settings.SOW_QWEN3_BASE_URL),
+        ("DashScope Qwen3 ASR", "configured", str(bool(settings.SOW_DASHSCOPE_API_KEY))),
+        ("DashScope Qwen3 ASR", "region", settings.SOW_DASHSCOPE_ASR_REGION),
+        ("DashScope Qwen3 ASR", "flash_model", settings.SOW_DASHSCOPE_ASR_FLASH_MODEL),
+        ("DashScope Qwen3 ASR", "filetrans_model", settings.SOW_DASHSCOPE_ASR_FILETRANS_MODEL),
+        ("DashScope Qwen3 ASR", "max_concurrent", str(settings.SOW_DASHSCOPE_ASR_MAX_CONCURRENT)),
+        ("Qwen3 ForcedAligner", "base_url", settings.SOW_QWEN3_BASE_URL),
         ("Whisper", "device", settings.SOW_WHISPER_DEVICE),
         ("Whisper", "cache_dir", str(settings.SOW_WHISPER_CACHE_DIR)),
         ("Demucs", "model", settings.SOW_DEMUCS_MODEL),
@@ -115,9 +124,15 @@ async def lifespan(app: FastAPI):
     ]
     col_widths = [max(len(r[i]) for r in config_rows + [headers]) for i in range(3)]
     separator = f"+-{'-' * col_widths[0]}-+-{'-' * col_widths[1]}-+-{'-' * col_widths[2]}-+"
-    table_lines = [separator, f"| {headers[0]:<{col_widths[0]}} | {headers[1]:<{col_widths[1]}} | {headers[2]:<{col_widths[2]}} |", separator]
+    table_lines = [
+        separator,
+        f"| {headers[0]:<{col_widths[0]}} | {headers[1]:<{col_widths[1]}} | {headers[2]:<{col_widths[2]}} |",
+        separator,
+    ]
     for row in config_rows:
-        table_lines.append(f"| {row[0]:<{col_widths[0]}} | {row[1]:<{col_widths[1]}} | {row[2]:<{col_widths[2]}} |")
+        table_lines.append(
+            f"| {row[0]:<{col_widths[0]}} | {row[1]:<{col_widths[1]}} | {row[2]:<{col_widths[2]}} |"
+        )
     table_lines.append(separator)
     logger.info("Startup configuration:\n%s", "\n".join(table_lines))
 

--- a/services/analysis/src/sow_analysis/models.py
+++ b/services/analysis/src/sow_analysis/models.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import List, Optional, Union
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class JobStatus(str, Enum):
@@ -46,6 +46,8 @@ class AnalyzeJobRequest(BaseModel):
 class LrcOptions(BaseModel):
     """Options for LRC generation jobs."""
 
+    model_config = ConfigDict(extra="allow")
+
     whisper_model: str = "large-v3"
     llm_model: str = (
         ""  # LLM model (e.g., "openai/gpt-4o-mini"), falls back to SOW_LLM_MODEL env var
@@ -54,8 +56,14 @@ class LrcOptions(BaseModel):
     language: str = "zh"  # Whisper language hint
     force: bool = False  # Re-generate even if cached
     force_whisper: bool = False  # Bypass Whisper transcription cache
-    use_qwen3: bool = True  # Use Qwen3 service for timestamp refinement
-    max_qwen3_duration: int = 300  # 5 minutes in seconds (Qwen3 service limit)
+    use_qwen3_asr: bool = True  # Use DashScope Qwen3 ASR before Whisper fallback
+    force_qwen3_asr: bool = False  # Bypass Qwen3 ASR cache only
+    qwen3_asr_context_max_chars: int = 10000
+    qwen3_asr_snap_threshold: float = 0.60
+    qwen3_asr_min_usable_segments: int = 3
+    # Deprecated: accepted only when reconstructing old persisted job JSON.
+    use_qwen3: Optional[bool] = None
+    max_qwen3_duration: Optional[int] = None
 
 
 class LrcJobRequest(BaseModel):
@@ -110,7 +118,7 @@ class JobResult(BaseModel):
     # LRC results
     lrc_url: Optional[str] = None
     line_count: Optional[int] = None
-    lrc_source: Optional[str] = None  # "youtube_transcript" or "whisper_asr"
+    lrc_source: Optional[str] = None  # youtube_transcript, qwen3_asr, or whisper_asr
 
     # Stem separation results
     vocals_dry_url: Optional[str] = None  # Stage 2 output (de-reverb/dry)

--- a/services/analysis/src/sow_analysis/routes/jobs.py
+++ b/services/analysis/src/sow_analysis/routes/jobs.py
@@ -124,6 +124,7 @@ def job_to_response(job, warning: Optional[str] = None) -> JobResponse:
                 stems_url=job.result.stems_url,
                 lrc_url=job.result.lrc_url,
                 line_count=job.result.line_count,
+                lrc_source=job.result.lrc_source,
                 vocals_dry_url=job.result.vocals_dry_url,
                 vocals_url=job.result.vocals_url,
                 instrumental_url=job.result.instrumental_url,
@@ -166,7 +167,7 @@ async def submit_analysis_job(
 
 @router.post("/jobs/lrc", response_model=JobResponse)
 async def submit_lrc_job(
-    request: LrcJobRequest,
+    request_payload: dict,
     api_key: str = Depends(verify_api_key),
 ) -> JobResponse:
     """Submit LRC generation job.
@@ -181,6 +182,16 @@ async def submit_lrc_job(
     if job_queue is None:
         raise HTTPException(500, "Job queue not initialized")
 
+    options = request_payload.get("options") or {}
+    legacy = {"use_qwen3", "max_qwen3_duration"} & set(options)
+    if legacy:
+        raise HTTPException(
+            422,
+            "Qwen3 ForcedAligner options are no longer part of automatic LRC generation. "
+            "Use use_qwen3_asr/force_qwen3_asr or --no-qwen3-asr instead.",
+        )
+
+    request = LrcJobRequest.model_validate(request_payload)
     job = await job_queue.submit(JobType.LRC, request)
     return job_to_response(job)
 

--- a/services/analysis/src/sow_analysis/services/canonical_snap.py
+++ b/services/analysis/src/sow_analysis/services/canonical_snap.py
@@ -1,0 +1,131 @@
+"""Snap ASR phrases to canonical lyric lines."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from difflib import SequenceMatcher
+
+try:
+    from rapidfuzz import fuzz
+except ImportError:  # pragma: no cover - dependency is declared for the service image
+
+    class _FallbackFuzz:
+        @staticmethod
+        def ratio(a: str, b: str) -> float:
+            return SequenceMatcher(None, a, b).ratio() * 100.0
+
+    fuzz = _FallbackFuzz()
+
+try:
+    from zhconv import convert
+except ImportError:  # pragma: no cover - dependency is declared for the service image
+
+    def convert(text: str, _target: str) -> str:
+        return text
+
+
+from .qwen3_asr_client import Qwen3AsrResult, Qwen3AsrSegment, Qwen3AsrWord
+
+
+@dataclass
+class SnappedPhrase:
+    text: str
+    start: float
+    end: float
+    confidence: float
+    snapped: bool
+    asr_text: str
+
+
+def _normalize(text: str) -> str:
+    text = convert(text, "zh-tw")
+    text = re.sub(r"[\s，。！？、,.!?;；:：'\"“”‘’（）()\[\]【】\-]", "", text)
+    return text.lower()
+
+
+def _canonical_lines(lyrics_text: str) -> list[str]:
+    return [line.strip() for line in lyrics_text.splitlines() if line.strip()]
+
+
+def snap_qwen3_asr_to_canonical(
+    result: Qwen3AsrResult,
+    lyrics_text: str,
+    threshold: float,
+) -> list[SnappedPhrase]:
+    """Snap Qwen ASR phrases to canonical lyrics without deduplicating repeats."""
+    canonical = _canonical_lines(lyrics_text)
+    phrases = _phrases_from_words(result.words, canonical) if result.words else []
+    if not phrases:
+        phrases = [
+            SnappedPhrase(s.text, s.start, s.end, 0.0, False, s.text)
+            for s in result.segments
+            if s.text.strip()
+        ]
+
+    snapped: list[SnappedPhrase] = []
+    search_start = 0
+    for phrase in phrases:
+        best_line = ""
+        best_score = 0.0
+        best_index = search_start
+        phrase_norm = _normalize(phrase.text)
+        if phrase_norm:
+            for index in range(search_start, len(canonical)):
+                score = fuzz.ratio(phrase_norm, _normalize(canonical[index])) / 100.0
+                if score > best_score:
+                    best_score = score
+                    best_line = canonical[index]
+                    best_index = index
+            if best_score < threshold:
+                for index, line in enumerate(canonical):
+                    score = fuzz.ratio(phrase_norm, _normalize(line)) / 100.0
+                    if score > best_score:
+                        best_score = score
+                        best_line = line
+                        best_index = index
+
+        if best_line and best_score >= threshold:
+            snapped.append(
+                SnappedPhrase(best_line, phrase.start, phrase.end, best_score, True, phrase.text)
+            )
+            search_start = min(best_index + 1, len(canonical) - 1)
+        else:
+            snapped.append(
+                SnappedPhrase(phrase.text, phrase.start, phrase.end, best_score, False, phrase.text)
+            )
+    return snapped
+
+
+def _phrases_from_words(words: list[Qwen3AsrWord], canonical: list[str]) -> list[SnappedPhrase]:
+    if not words:
+        return []
+    target_lengths = [max(2, len(_normalize(line))) for line in canonical] or [12]
+    phrases: list[SnappedPhrase] = []
+    cursor = 0
+    bucket: list[Qwen3AsrWord] = []
+    norm_len = 0
+    for word in words:
+        bucket.append(word)
+        norm_len += len(_normalize(word.text))
+        target = target_lengths[min(cursor, len(target_lengths) - 1)]
+        if norm_len >= target:
+            phrases.append(_bucket_to_phrase(bucket))
+            bucket = []
+            norm_len = 0
+            cursor += 1
+    if bucket:
+        phrases.append(_bucket_to_phrase(bucket))
+    return phrases
+
+
+def _bucket_to_phrase(bucket: list[Qwen3AsrWord]) -> SnappedPhrase:
+    return SnappedPhrase(
+        text="".join(w.text for w in bucket).strip(),
+        start=bucket[0].start,
+        end=bucket[-1].end,
+        confidence=0.0,
+        snapped=False,
+        asr_text="".join(w.text for w in bucket).strip(),
+    )

--- a/services/analysis/src/sow_analysis/services/canonical_snap.py
+++ b/services/analysis/src/sow_analysis/services/canonical_snap.py
@@ -90,7 +90,7 @@ def snap_qwen3_asr_to_canonical(
             snapped.append(
                 SnappedPhrase(best_line, phrase.start, phrase.end, best_score, True, phrase.text)
             )
-            search_start = min(best_index + 1, len(canonical) - 1)
+            search_start = best_index + 1
         else:
             snapped.append(
                 SnappedPhrase(phrase.text, phrase.start, phrase.end, best_score, False, phrase.text)

--- a/services/analysis/src/sow_analysis/services/qwen3_asr_client.py
+++ b/services/analysis/src/sow_analysis/services/qwen3_asr_client.py
@@ -20,6 +20,8 @@ REGION_URLS = {
     "cn": "https://dashscope.aliyuncs.com/api/v1",
     "us": "https://dashscope-us.aliyuncs.com/api/v1",
 }
+DIRECT_FLASH_MAX_SIZE_MB = 10.0
+DIRECT_FLASH_MAX_DURATION_SECONDS = 300.0
 
 
 class Qwen3AsrError(Exception):
@@ -123,11 +125,32 @@ class Qwen3AsrClient:
 
     def _choose_mode(self, audio_path: Path) -> str:
         size_mb = audio_path.stat().st_size / (1024 * 1024)
-        if size_mb > 95:
+        if size_mb > DIRECT_FLASH_MAX_SIZE_MB:
             logger.info("Routing Qwen3 ASR to filetrans: audio size %.1fMB", size_mb)
             return "filetrans"
-        logger.info("Routing Qwen3 ASR to direct flash: audio size %.1fMB", size_mb)
+
+        duration_seconds = self._probe_duration_seconds(audio_path)
+        if duration_seconds is not None and duration_seconds > DIRECT_FLASH_MAX_DURATION_SECONDS:
+            logger.info(
+                "Routing Qwen3 ASR to filetrans: audio duration %.1fs", duration_seconds
+            )
+            return "filetrans"
+
+        logger.info(
+            "Routing Qwen3 ASR to direct flash: audio size %.1fMB duration %s",
+            size_mb,
+            f"{duration_seconds:.1f}s" if duration_seconds is not None else "unknown",
+        )
         return "direct"
+
+    def _probe_duration_seconds(self, audio_path: Path) -> Optional[float]:
+        try:
+            import librosa
+
+            return float(librosa.get_duration(path=audio_path))
+        except Exception as exc:
+            logger.warning("Could not probe audio duration for Qwen3 ASR routing: %s", exc)
+            return None
 
     async def _with_retries(self, call):
         last_error: Optional[Exception] = None
@@ -265,7 +288,18 @@ class Qwen3AsrClient:
         for item in direct:
             if item.get("type") == "audio_transcription":
                 return item.get("audio_transcription_results", {}).get("sentences", [])
-        return raw.get("sentences") or raw.get("transcripts") or raw.get("results", [])
+        if raw.get("sentences"):
+            return raw["sentences"]
+        if raw.get("transcripts"):
+            sentences: list[dict[str, Any]] = []
+            for transcript in raw["transcripts"]:
+                transcript_sentences = (
+                    transcript.get("sentences") if isinstance(transcript, dict) else None
+                )
+                if transcript_sentences:
+                    sentences.extend(transcript_sentences)
+            return sentences
+        return raw.get("results", [])
 
     def _extract_words(self, raw: dict[str, Any]) -> list[Qwen3AsrWord]:
         candidates: list[dict[str, Any]] = []
@@ -286,5 +320,4 @@ class Qwen3AsrClient:
         return words
 
     def _ms_to_seconds(self, value: Any) -> float:
-        seconds = float(value or 0)
-        return seconds / 1000.0 if seconds >= 1000 else seconds
+        return float(value or 0) / 1000.0

--- a/services/analysis/src/sow_analysis/services/qwen3_asr_client.py
+++ b/services/analysis/src/sow_analysis/services/qwen3_asr_client.py
@@ -1,0 +1,290 @@
+"""DashScope Qwen3 ASR client for LRC transcription."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+import httpx
+
+from ..config import settings
+
+logger = logging.getLogger(__name__)
+
+REGION_URLS = {
+    "intl": "https://dashscope-intl.aliyuncs.com/api/v1",
+    "cn": "https://dashscope.aliyuncs.com/api/v1",
+    "us": "https://dashscope-us.aliyuncs.com/api/v1",
+}
+
+
+class Qwen3AsrError(Exception):
+    """Base error for Qwen3 ASR failures."""
+
+
+class Qwen3AsrNonRetriableError(Qwen3AsrError):
+    """Raised for auth/configuration errors that should not be retried."""
+
+
+class Qwen3AsrTimeoutError(Qwen3AsrError):
+    """Raised when DashScope does not complete before timeout."""
+
+
+@dataclass
+class Qwen3AsrSegment:
+    text: str
+    start: float
+    end: float
+
+
+@dataclass
+class Qwen3AsrWord:
+    text: str
+    start: float
+    end: float
+
+
+@dataclass
+class Qwen3AsrResult:
+    segments: list[Qwen3AsrSegment]
+    words: list[Qwen3AsrWord]
+    text: str
+    raw_response: dict[str, Any]
+    model: str
+    region: str
+    mode: str
+
+    def to_cache_payload(self) -> dict[str, Any]:
+        return {
+            "segments": [s.__dict__ for s in self.segments],
+            "words": [w.__dict__ for w in self.words],
+            "text": self.text,
+            "raw_response": self.raw_response,
+            "model": self.model,
+            "region": self.region,
+            "mode": self.mode,
+        }
+
+    @classmethod
+    def from_cache_payload(cls, payload: dict[str, Any]) -> "Qwen3AsrResult":
+        return cls(
+            segments=[Qwen3AsrSegment(**s) for s in payload.get("segments", [])],
+            words=[Qwen3AsrWord(**w) for w in payload.get("words", [])],
+            text=str(payload.get("text") or ""),
+            raw_response=dict(payload.get("raw_response") or {}),
+            model=str(payload.get("model") or settings.SOW_DASHSCOPE_ASR_FLASH_MODEL),
+            region=str(payload.get("region") or settings.SOW_DASHSCOPE_ASR_REGION),
+            mode=str(payload.get("mode") or "cache"),
+        )
+
+
+class Qwen3AsrClient:
+    """Async wrapper around the blocking DashScope SDK."""
+
+    _circuit_open = False
+
+    def __init__(
+        self,
+        api_key: str,
+        region: str = "intl",
+        flash_model: str = "qwen3-asr-flash",
+        filetrans_model: str = "qwen3-asr-flash-filetrans",
+    ):
+        self.api_key = api_key
+        self.region = region
+        self.flash_model = flash_model
+        self.filetrans_model = filetrans_model
+
+    async def transcribe(self, audio_path: Path, context: str = "") -> Qwen3AsrResult:
+        if not self.api_key:
+            raise Qwen3AsrNonRetriableError("SOW_DASHSCOPE_API_KEY is not configured")
+        if self._circuit_open:
+            raise Qwen3AsrNonRetriableError("DashScope Qwen3 ASR circuit breaker is open")
+
+        mode = self._choose_mode(audio_path)
+        try:
+            if mode == "direct":
+                return await self._with_retries(
+                    lambda: self._transcribe_direct(audio_path, context)
+                )
+            return await self._with_retries(lambda: self._transcribe_filetrans(audio_path))
+        except Qwen3AsrNonRetriableError:
+            self.__class__._circuit_open = True
+            raise
+        except Qwen3AsrError:
+            if mode == "direct":
+                logger.info("Qwen3 ASR direct call failed; trying filetrans fallback once")
+                return await self._with_retries(lambda: self._transcribe_filetrans(audio_path))
+            raise
+
+    def _choose_mode(self, audio_path: Path) -> str:
+        size_mb = audio_path.stat().st_size / (1024 * 1024)
+        if size_mb > 95:
+            logger.info("Routing Qwen3 ASR to filetrans: audio size %.1fMB", size_mb)
+            return "filetrans"
+        logger.info("Routing Qwen3 ASR to direct flash: audio size %.1fMB", size_mb)
+        return "direct"
+
+    async def _with_retries(self, call):
+        last_error: Optional[Exception] = None
+        for attempt in range(3):
+            try:
+                return await call()
+            except Qwen3AsrNonRetriableError:
+                raise
+            except Qwen3AsrTimeoutError:
+                raise
+            except Exception as exc:
+                last_error = exc
+                if attempt == 2:
+                    break
+                await asyncio.sleep(2**attempt)
+        raise Qwen3AsrError(f"Qwen3 ASR failed after retries: {last_error}") from last_error
+
+    async def _transcribe_direct(self, audio_path: Path, context: str) -> Qwen3AsrResult:
+        loop = asyncio.get_running_loop()
+
+        def _call() -> dict[str, Any]:
+            import dashscope
+
+            dashscope.base_http_api_url = REGION_URLS.get(self.region, REGION_URLS["intl"])
+            messages: list[dict[str, Any]] = [
+                {"role": "user", "content": [{"audio": f"file://{audio_path.resolve()}"}]},
+            ]
+            if context:
+                messages.insert(0, {"role": "system", "content": [{"text": context}]})
+            resp = dashscope.MultiModalConversation.call(
+                api_key=self.api_key,
+                model=self.flash_model,
+                messages=messages,
+                result_format="message",
+                asr_options={"enable_itn": False, "enable_words": True, "language": "zh"},
+            )
+            self._raise_for_response(resp)
+            return dict(resp.output or {})
+
+        raw = await asyncio.wait_for(
+            loop.run_in_executor(None, _call),
+            timeout=settings.SOW_DASHSCOPE_ASR_TIMEOUT_SECONDS,
+        )
+        return self._parse_result(raw, self.flash_model, "direct")
+
+    async def _transcribe_filetrans(self, audio_path: Path) -> Qwen3AsrResult:
+        loop = asyncio.get_running_loop()
+
+        def _call() -> dict[str, Any]:
+            import dashscope
+            from dashscope.audio.qwen_asr import QwenTranscription
+            from dashscope.utils.oss_utils import OssUtils
+
+            dashscope.base_http_api_url = REGION_URLS.get(self.region, REGION_URLS["intl"])
+            file_url, _ = OssUtils.upload(
+                model=self.filetrans_model,
+                file_path=str(audio_path.resolve()),
+                api_key=self.api_key,
+            )
+            if not file_url:
+                raise Qwen3AsrError("DashScope OSS upload returned no file URL")
+            task = QwenTranscription.async_call(
+                model=self.filetrans_model,
+                file_url=file_url,
+                api_key=self.api_key,
+                enable_words=True,
+                headers={"X-DashScope-OssResourceResolve": "enable"},
+            )
+            self._raise_for_response(task)
+            start = time.time()
+            while time.time() - start < settings.SOW_DASHSCOPE_ASR_FILETRANS_TIMEOUT_SECONDS:
+                resp = QwenTranscription.fetch(task=task, api_key=self.api_key)
+                self._raise_for_response(resp)
+                output = dict(resp.output or {})
+                status = output.get("task_status")
+                if status == "SUCCEEDED":
+                    return output
+                if status in {"FAILED", "CANCELED"}:
+                    raise Qwen3AsrError(f"DashScope filetrans task failed: {output}")
+                time.sleep(5)
+            raise Qwen3AsrTimeoutError("DashScope filetrans polling timed out")
+
+        raw = await loop.run_in_executor(None, _call)
+        fetched = await self._fetch_filetrans_json(raw)
+        return self._parse_result(fetched, self.filetrans_model, "filetrans")
+
+    async def _fetch_filetrans_json(self, raw: dict[str, Any]) -> dict[str, Any]:
+        url = raw.get("result", {}).get("transcription_url") or (raw.get("results") or [{}])[0].get(
+            "transcription_url"
+        )
+        if not url:
+            return raw
+        async with httpx.AsyncClient(timeout=60) as client:
+            response = await client.get(url)
+            response.raise_for_status()
+            data = response.json()
+        return {"filetrans_task": raw, **data}
+
+    def _raise_for_response(self, resp: Any) -> None:
+        status = int(getattr(resp, "status_code", 0) or 0)
+        if status == 200:
+            return
+        message = str(getattr(resp, "message", "") or getattr(resp, "output", ""))
+        if status in {401, 403}:
+            raise Qwen3AsrNonRetriableError(f"DashScope auth error {status}: {message}")
+        if status == 429 or status >= 500:
+            raise Qwen3AsrError(f"DashScope transient error {status}: {message}")
+        raise Qwen3AsrError(f"DashScope API error {status}: {message}")
+
+    def _parse_result(self, raw: dict[str, Any], model: str, mode: str) -> Qwen3AsrResult:
+        sentences = self._extract_sentences(raw)
+        words = self._extract_words(raw)
+        segments = [
+            Qwen3AsrSegment(
+                text=str(s.get("text", "")).strip(),
+                start=self._ms_to_seconds(
+                    s.get("begin_time", s.get("start_time", s.get("start", 0)))
+                ),
+                end=self._ms_to_seconds(s.get("end_time", s.get("end", 0))),
+            )
+            for s in sentences
+            if str(s.get("text", "")).strip()
+        ]
+        if not segments and words:
+            segments = [
+                Qwen3AsrSegment("".join(w.text for w in words), words[0].start, words[-1].end)
+            ]
+        text = "".join(s.text for s in segments).strip()
+        if not text or not segments:
+            raise Qwen3AsrError("Qwen3 ASR returned no usable transcription")
+        return Qwen3AsrResult(segments, words, text, raw, model, self.region, mode)
+
+    def _extract_sentences(self, raw: dict[str, Any]) -> list[dict[str, Any]]:
+        direct = raw.get("choices", [{}])[0].get("message", {}).get("content", [])
+        for item in direct:
+            if item.get("type") == "audio_transcription":
+                return item.get("audio_transcription_results", {}).get("sentences", [])
+        return raw.get("sentences") or raw.get("transcripts") or raw.get("results", [])
+
+    def _extract_words(self, raw: dict[str, Any]) -> list[Qwen3AsrWord]:
+        candidates: list[dict[str, Any]] = []
+        for sentence in self._extract_sentences(raw):
+            candidates.extend(sentence.get("words") or [])
+        candidates.extend(raw.get("words") or [])
+        words = []
+        for item in candidates:
+            text = str(item.get("text") or item.get("word") or "").strip()
+            if text:
+                words.append(
+                    Qwen3AsrWord(
+                        text=text,
+                        start=self._ms_to_seconds(item.get("begin_time", item.get("start", 0))),
+                        end=self._ms_to_seconds(item.get("end_time", item.get("end", 0))),
+                    )
+                )
+        return words
+
+    def _ms_to_seconds(self, value: Any) -> float:
+        seconds = float(value or 0)
+        return seconds / 1000.0 if seconds >= 1000 else seconds

--- a/services/analysis/src/sow_analysis/storage/cache.py
+++ b/services/analysis/src/sow_analysis/storage/cache.py
@@ -174,6 +174,32 @@ class CacheManager:
         cache_file.write_text(json.dumps(cache_data, indent=2))
         return cache_file
 
+    def get_qwen3_asr_transcription(self, cache_key: str) -> Optional[dict]:
+        """Check if Qwen3 ASR transcription exists in cache."""
+        hash_prefix = self._get_hash_prefix(cache_key)
+        cache_dir = self.cache_dir / "qwen3_asr"
+        cache_file = cache_dir / f"{hash_prefix}.json"
+
+        if cache_file.exists():
+            try:
+                return json.loads(cache_file.read_text())
+            except (json.JSONDecodeError, IOError):
+                return None
+        return None
+
+    def save_qwen3_asr_transcription(self, cache_key: str, payload: dict) -> Path:
+        """Save Qwen3 ASR transcription payload to cache."""
+        hash_prefix = self._get_hash_prefix(cache_key)
+        cache_dir = self.cache_dir / "qwen3_asr"
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        cache_file = cache_dir / f"{hash_prefix}.json"
+        cache_data = {
+            **payload,
+            "cached_at": datetime.now(timezone.utc).isoformat(),
+        }
+        cache_file.write_text(json.dumps(cache_data, indent=2, ensure_ascii=False))
+        return cache_file
+
     def clear(self) -> None:
         """Clear all cached data."""
         if self.cache_dir.exists():

--- a/services/analysis/src/sow_analysis/workers/lrc.py
+++ b/services/analysis/src/sow_analysis/workers/lrc.py
@@ -7,18 +7,20 @@ Generates timestamped LRC files by:
 """
 
 import asyncio
+import hashlib
 import json
 import logging
 import re
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional
+from typing import Callable, List, Optional
 
 from ..config import settings
 from ..models import LrcOptions
-from ..services import Qwen3Client
-from ..services.qwen3_client import OutputFormat
+from ..services.canonical_snap import snap_qwen3_asr_to_canonical
+from ..services.qwen3_asr_client import Qwen3AsrClient, Qwen3AsrError, Qwen3AsrResult
+from ..storage.cache import CacheManager
 from .exceptions import LLMConfigError, WorkerError
 
 logger = logging.getLogger(__name__)
@@ -270,6 +272,39 @@ Example showing repeated chorus:
 Return ONLY the JSON array, no explanation or markdown code blocks."""
 
 
+def _build_qwen3_asr_alignment_prompt(
+    lyrics_text: str, whisper_phrases: List[WhisperPhrase]
+) -> str:
+    phrases_json = json.dumps(
+        [
+            {"text": p.text, "start": round(p.start, 2), "end": round(p.end, 2)}
+            for p in whisper_phrases
+        ],
+        ensure_ascii=False,
+        indent=2,
+    )
+    return f"""You are a lyrics alignment assistant for Chinese worship songs.
+
+## Canonical Lyrics
+```
+{lyrics_text}
+```
+
+## Qwen3 ASR Phrases
+These phrases may already be snapped to canonical lyric lines. Preserve each timestamp. Only fix
+text, assign or reorder canonical lyric lines, and preserve repeated sung sections.
+```json
+{phrases_json}
+```
+
+Return the same JSON shape:
+[
+  {{"time_seconds": 12.34, "text": "canonical lyric line"}}
+]
+
+Return ONLY the JSON array, no explanation or markdown code blocks."""
+
+
 def _parse_llm_response(response_text: str) -> List[LRCLine]:
     """Parse LLM response into LRCLine objects.
 
@@ -369,6 +404,7 @@ async def _llm_align(
     whisper_phrases: List[WhisperPhrase],
     llm_model: str,
     max_retries: int = 3,
+    prompt_builder: Callable[[str, List[WhisperPhrase]], str] = _build_alignment_prompt,
 ) -> List[LRCLine]:
     """Use LLM to align lyrics with Whisper timestamps.
 
@@ -407,7 +443,7 @@ async def _llm_align(
         )
 
     loop = asyncio.get_event_loop()
-    prompt = _build_alignment_prompt(lyrics_text, whisper_phrases)
+    prompt = prompt_builder(lyrics_text, whisper_phrases)
 
     # Log the full LLM prompt
     logger.info("=" * 80)
@@ -501,104 +537,103 @@ def _write_lrc(lines: List[LRCLine], output_path: Path) -> int:
     return len(lines)
 
 
-def _parse_qwen3_lrc(lrc_content: str) -> List[LRCLine]:
-    """Parse Qwen3 LRC output into LRCLine objects.
-
-    Args:
-        lrc_content: Raw LRC format string from Qwen3 service
-
-    Returns:
-        List of LRCLine objects
-    """
-    lines = []
-    # Pattern: [mm:ss.xx] text
-    pattern = r"\[(\d{2}):(\d{2}\.\d{2})\](.*)"  # [MM:SS.ms] text
-
-    for line in lrc_content.strip().split("\n"):
-        match = re.match(pattern, line)
-        if match:
-            minutes = int(match.group(1))
-            seconds = float(match.group(2))
-            text = match.group(3).strip()
-            time_seconds = minutes * 60 + seconds
-            if text:  # Skip empty lines
-                lines.append(LRCLine(time_seconds=time_seconds, text=text))
-
-    if not lines:
-        logger.warning("No valid LRC lines parsed from Qwen3 output")
-        logger.debug(f"Qwen3 LRC content: {lrc_content}")
-
-    return lines
-
-
-async def _qwen3_refine(
-    content_hash: str, lyrics_text: str, vocals_stem_url: Optional[str] = None
+def build_qwen3_asr_cache_key(
+    content_hash: str,
+    lyrics_text: str,
+    stem_kind: str,
+    model: str,
+    region: str,
+    language: str,
+    context_max_chars: int,
+    context: str,
 ) -> str:
-    """Run Qwen3 forced alignment for timestamp refinement.
+    """Build rich Qwen3 ASR cache key."""
+    parts = {
+        "content_hash": content_hash,
+        "lyrics_hash": hashlib.sha256(lyrics_text.encode("utf-8")).hexdigest(),
+        "stem_kind": stem_kind,
+        "model": model,
+        "region": region,
+        "language": language,
+        "context_max_chars": context_max_chars,
+        "context_hash": hashlib.sha256(context.encode("utf-8")).hexdigest(),
+        "cache_version": settings.SOW_DASHSCOPE_ASR_CACHE_VERSION,
+    }
+    return hashlib.sha256(json.dumps(parts, sort_keys=True).encode("utf-8")).hexdigest()
 
-    Args:
-        content_hash: Full content hash (will be truncated to 12-char prefix)
-        lyrics_text: Lyrics text to align with audio
-        vocals_stem_url: Optional R2 URL for clean vocals stem. When provided,
-            Qwen3 aligns against the de-reverbed vocals instead of the full mix,
-            improving timestamp precision.
 
-    Returns:
-        Refined LRC content string
+def _build_qwen3_context(lyrics_text: str, max_chars: int) -> str:
+    header = "這是一首中文敬拜詩歌。請優先辨識下列正式歌詞中的詞句，保留演唱重複。"
+    lines = []
+    total = len(header) + 2
+    for line in lyrics_text.splitlines():
+        candidate = line.strip()
+        if not candidate:
+            continue
+        if total + len(candidate) + 1 > max_chars:
+            break
+        lines.append(candidate)
+        total += len(candidate) + 1
+    return header + "\n" + "\n".join(lines)
 
-    Raises:
-        Exception: If Qwen3 service call fails
-    """
-    if vocals_stem_url:
-        audio_url = vocals_stem_url
-        logger.info(f"Using clean vocals stem for Qwen3 alignment: {audio_url}")
+
+async def generate_lrc_from_qwen3_asr(
+    audio_path: Path,
+    lyrics_text: str,
+    options: LrcOptions,
+    output_path: Path,
+    cache_key: str,
+    cache_manager: CacheManager,
+    dashscope_semaphore: asyncio.Semaphore,
+) -> tuple[Path, int, list[WhisperPhrase]]:
+    """Generate LRC from DashScope Qwen3 ASR, snap, then LLM alignment."""
+    context_limit = min(
+        options.qwen3_asr_context_max_chars,
+        settings.SOW_DASHSCOPE_ASR_CONTEXT_MAX_CHARS,
+    )
+    context = _build_qwen3_context(lyrics_text, context_limit)
+
+    cached_payload = (
+        None if options.force_qwen3_asr else cache_manager.get_qwen3_asr_transcription(cache_key)
+    )
+    if cached_payload:
+        logger.info("Qwen3 ASR cache hit")
+        result = Qwen3AsrResult.from_cache_payload(cached_payload)
     else:
-        hash_prefix = content_hash[:12]
-        audio_url = f"s3://{settings.SOW_R2_BUCKET}/{hash_prefix}/audio.mp3"
-        logger.info(f"Constructing R2 audio URL from full mix: {audio_url}")
+        logger.info("Qwen3 ASR cache miss; calling DashScope")
+        client = Qwen3AsrClient(
+            api_key=settings.SOW_DASHSCOPE_API_KEY,
+            region=settings.SOW_DASHSCOPE_ASR_REGION,
+            flash_model=settings.SOW_DASHSCOPE_ASR_FLASH_MODEL,
+            filetrans_model=settings.SOW_DASHSCOPE_ASR_FILETRANS_MODEL,
+        )
+        async with dashscope_semaphore:
+            result = await client.transcribe(audio_path, context=context)
+        cache_manager.save_qwen3_asr_transcription(cache_key, result.to_cache_payload())
 
-    # Instantiate Qwen3 client
-    client = Qwen3Client(
-        base_url=settings.SOW_QWEN3_BASE_URL,
-        api_key=settings.SOW_QWEN3_API_KEY or None,
+    if len(result.segments) < options.qwen3_asr_min_usable_segments:
+        raise Qwen3AsrError(f"Qwen3 ASR returned too few usable segments: {len(result.segments)}")
+
+    snapped = snap_qwen3_asr_to_canonical(
+        result,
+        lyrics_text,
+        threshold=options.qwen3_asr_snap_threshold,
     )
+    qwen_phrases = [WhisperPhrase(p.text, p.start, p.end) for p in snapped if p.text.strip()]
+    if len(qwen_phrases) < options.qwen3_asr_min_usable_segments:
+        raise Qwen3AsrError(
+            f"Qwen3 ASR snapping returned too few usable phrases: {len(qwen_phrases)}"
+        )
 
-    # Request alignment from Qwen3 service
-    response = await client.align(
-        audio_url=audio_url,
-        lyrics_text=lyrics_text,
-        language="Chinese",
-        format=OutputFormat.LRC,
+    lrc_lines = await _llm_align(
+        lyrics_text,
+        qwen_phrases,
+        llm_model=options.llm_model,
+        prompt_builder=_build_qwen3_asr_alignment_prompt,
     )
-
-    logger.info(
-        f"Qwen3 alignment received: {response.line_count} lines, "
-        f"{response.duration_seconds:.2f}s duration"
-    )
-
-    if response.lrc_content is None:
-        raise ValueError("Qwen3 service returned empty LRC content")
-
-    return response.lrc_content
-
-
-def _get_audio_duration(whisper_phrases: List[WhisperPhrase]) -> float:
-    """Calculate audio duration from Whisper transcription phrases.
-
-    Args:
-        whisper_phrases: List of WhisperPhrase with timing information
-
-    Returns:
-        Maximum end time in seconds (audio duration)
-
-    Raises:
-        ValueError: If whisper_phrases is empty
-    """
-    if not whisper_phrases:
-        raise ValueError("Cannot calculate duration: no Whisper phrases available")
-
-    # Duration is the maximum end time of all phrases
-    return max(p.end for p in whisper_phrases)
+    line_count = _write_lrc(lrc_lines, output_path)
+    logger.info("Qwen3 ASR LRC generation wrote %s lines", line_count)
+    return output_path, line_count, qwen_phrases
 
 
 async def try_youtube_transcript_lrc(
@@ -679,12 +714,10 @@ async def generate_lrc(
         output_path: Where to write the LRC file (default: audio_path with .lrc extension)
         cached_phrases: Optional cached Whisper transcription phrases to skip transcription
         youtube_url: Optional YouTube URL for transcript-based LRC (primary path)
-        content_hash: Optional content hash for Qwen3 audio URL construction (s3://{bucket}/audio/{hash}.mp3)
-        vocals_stem_url: Optional R2 URL for clean vocals stem; passed to Qwen3 alignment so it
-            uses de-reverbed vocals instead of the full mix for better timestamp precision
+        content_hash: Deprecated, retained for caller compatibility.
+        vocals_stem_url: Deprecated, retained for caller compatibility.
         local_model_semaphore: Optional semaphore to limit concurrent local model execution.
-            Acquired around Whisper transcription and Qwen3 refinement (both use local models).
-            LLM alignment (cloud API) does not acquire this semaphore.
+            Acquired around Whisper transcription. LLM alignment does not acquire this semaphore.
 
     Returns:
         Tuple of (path to LRC file, number of lines, transcription phrases)
@@ -742,63 +775,6 @@ async def generate_lrc(
         whisper_phrases,
         llm_model=options.llm_model,
     )
-
-    # Step 2.5: Qwen3 refinement (improve timestamp precision)
-    if options.use_qwen3 and content_hash:
-        logger.info("=" * 80)
-        logger.info("LRC GENERATION: Running Qwen3 timestamp refinement")
-        logger.info("=" * 80)
-
-        # Calculate audio duration from Whisper phrases
-        try:
-            audio_duration = _get_audio_duration(whisper_phrases)
-            logger.info(f"Audio duration: {audio_duration:.2f} seconds")
-
-            # Skip Qwen3 if audio exceeds max duration
-            if audio_duration > options.max_qwen3_duration:
-                logger.warning(
-                    f"Audio duration ({audio_duration:.2f}s) exceeds Qwen3 limit "
-                    f"({options.max_qwen3_duration}s), skipping Qwen3 refinement. "
-                    f"Using LLM-aligned timestamps."
-                )
-            else:
-                try:
-                    async with optional_semaphore(local_model_semaphore):
-                        refined_lrc_text = await _qwen3_refine(
-                            content_hash=content_hash,
-                            lyrics_text=lyrics_text,
-                            vocals_stem_url=vocals_stem_url,
-                        )
-                    # Parse refined LRC to update lrc_lines
-                    refined_lines = _parse_qwen3_lrc(refined_lrc_text)
-                    if refined_lines:
-                        lrc_lines = refined_lines
-                        logger.info(
-                            f"Qwen3 refinement successful: {len(lrc_lines)} lines "
-                            f"replaced LLM-aligned timestamps"
-                        )
-                    else:
-                        logger.warning(
-                            "Qwen3 returned empty LRC content, using LLM-aligned timestamps"
-                        )
-                except ConnectionError as e:
-                    logger.warning(
-                        f"Qwen3 service unavailable (connection error): {e}, "
-                        f"using LLM-aligned timestamps"
-                    )
-                except asyncio.TimeoutError as e:
-                    logger.warning(
-                        f"Qwen3 service request timed out: {e}, using LLM-aligned timestamps"
-                    )
-                except Exception as e:
-                    # Catch Qwen3ClientError and any other exceptions
-                    logger.warning(f"Qwen3 refinement failed: {e}, using LLM-aligned timestamps")
-        except ValueError as e:
-            # Fallback if duration calculation fails
-            logger.warning(
-                f"Cannot calculate audio duration for Qwen3 validation: {e}, "
-                f"using LLM-aligned timestamps"
-            )
 
     # Step 3: Write LRC file
     line_count = _write_lrc(lrc_lines, output_path)

--- a/services/analysis/src/sow_analysis/workers/queue.py
+++ b/services/analysis/src/sow_analysis/workers/queue.py
@@ -6,6 +6,7 @@ import logging
 import time
 import uuid
 from contextlib import asynccontextmanager
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, AsyncIterator, Dict, Optional, Union
@@ -14,6 +15,14 @@ from ..config import settings
 from ..logging_config import set_job_id
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ResolvedTranscriptionAudio:
+    path: Path
+    r2_url: Optional[str]
+    stem_kind: str
+    is_dry_or_clean_vocals: bool
 
 
 @asynccontextmanager
@@ -75,10 +84,19 @@ except ImportError:
 
 # Optional LRC imports - require whisper and openai
 try:
-    from .lrc import LRCWorkerError, generate_lrc
+    from .lrc import (
+        LRCWorkerError,
+        build_qwen3_asr_cache_key,
+        generate_lrc,
+        generate_lrc_from_qwen3_asr,
+    )
+    from ..services.qwen3_asr_client import Qwen3AsrError
 except ImportError:
     LRCWorkerError = Exception
+    Qwen3AsrError = Exception
+    build_qwen3_asr_cache_key = None
     generate_lrc = None
+    generate_lrc_from_qwen3_asr = None
 
 # Optional embedding imports - require openai
 try:
@@ -122,6 +140,7 @@ class JobQueue:
         # Global semaphore for local model execution (Whisper, Qwen3, audio-separator, allin1, demucs)
         # Cloud operations (YouTube transcript, MVSEP, LLM alignment) don't acquire this.
         self._local_model_semaphore = asyncio.Semaphore(max_concurrent_local_model)
+        self._dashscope_asr_semaphore = asyncio.Semaphore(settings.SOW_DASHSCOPE_ASR_MAX_CONCURRENT)
         # Separate semaphore for embedding jobs (external API, no GPU needed)
         self._embedding_semaphore = asyncio.Semaphore(5)
         self._running = False
@@ -532,6 +551,87 @@ class JobQueue:
         finally:
             job.updated_at = datetime.now(timezone.utc)
 
+    async def _update_stage(
+        self,
+        job: Job,
+        stage: str,
+        progress: Optional[float] = None,
+    ) -> None:
+        job.stage = stage
+        if progress is not None:
+            job.progress = progress
+        job.updated_at = datetime.now(timezone.utc)
+        fields: dict[str, Any] = {"stage": stage}
+        if progress is not None:
+            fields["progress"] = progress
+        try:
+            await self.job_store.update_job(job.id, **fields)
+        except Exception as e:
+            logger.error(f"Failed to update job {job.id} in database: {e}")
+
+    async def _resolve_lrc_transcription_audio(
+        self,
+        job: Job,
+        request: LrcJobRequest,
+        temp_path: Path,
+        audio_path: Path,
+    ) -> ResolvedTranscriptionAudio:
+        """Resolve the best shared audio input for Qwen ASR and Whisper."""
+        await self._update_stage(job, "resolving_transcription_audio", 0.3)
+        if not request.options.use_vocals_stem or not self.r2_client:
+            return ResolvedTranscriptionAudio(audio_path, None, "full_mix", False)
+
+        from .stem_separation import get_vocals_dry_url
+
+        vocals_url = await get_vocals_dry_url(request.content_hash, self.r2_client)
+        if vocals_url:
+            ext = ".flac" if vocals_url.endswith(".flac") else ".wav"
+            stem_path = temp_path / f"vocals_stem{ext}"
+            await self.r2_client.download_audio(vocals_url, stem_path)
+            return ResolvedTranscriptionAudio(stem_path, vocals_url, "vocals_dry", True)
+
+        logger.info("No clean vocals found, auto-triggering stem separation")
+        await self._update_stage(job, "submitting_stem_separation_child")
+        child_request = StemSeparationJobRequest(
+            audio_url=request.audio_url,
+            content_hash=request.content_hash,
+            options={"force": False},
+        )
+        child_job = await self.submit(JobType.STEM_SEPARATION, child_request)
+        child_id = child_job.id
+        await self._update_stage(job, f"awaiting_stem_separation:{child_id}")
+
+        wait_start = time.time()
+        while True:
+            await asyncio.sleep(3.0)
+            child_job = await self.get_job(child_id)
+            if not child_job:
+                logger.error("Child stem separation job %s not found", child_id)
+                break
+            if child_job.status in (JobStatus.COMPLETED, JobStatus.FAILED):
+                break
+            if time.time() - wait_start > 7200.0:
+                logger.warning("Timeout waiting for child stem separation job %s", child_id)
+                break
+
+        child_job = await self.get_job(child_id)
+        if child_job and child_job.status == JobStatus.COMPLETED and child_job.result:
+            candidates = [
+                (child_job.result.vocals_dry_url, "vocals_dry", True),
+                (child_job.result.vocals_url, "vocals", False),
+            ]
+            for url, stem_kind, is_clean in candidates:
+                if not url:
+                    continue
+                ext = ".flac" if url.endswith(".flac") else ".wav"
+                stem_path = temp_path / f"{stem_kind}{ext}"
+                await self.r2_client.download_audio(url, stem_path)
+                logger.info("Using %s for transcription: %s", stem_kind, url)
+                return ResolvedTranscriptionAudio(stem_path, url, stem_kind, is_clean)
+
+        logger.warning("Stem resolution failed or incomplete; using full mix")
+        return ResolvedTranscriptionAudio(audio_path, None, "full_mix", False)
+
     async def _process_lrc_job(self, job: Job) -> None:
         """Process an LRC generation job.
 
@@ -599,9 +699,7 @@ class JobQueue:
 
         # Compute composite cache key based on audio hash + lyrics hash
         lrc_cache_key = _compute_lrc_cache_key(request.content_hash, request.lyrics_text)
-        logger.info(
-            f"LRC cache key: {lrc_cache_key} (audio_hash={request.content_hash[:12]}...)"
-        )
+        logger.info(f"LRC cache key: {lrc_cache_key} (audio_hash={request.content_hash[:12]}...)")
 
         try:
             # Check LRC result cache first (unless force=True - allows prompt improvements)
@@ -612,6 +710,7 @@ class JobQueue:
                     job.result = JobResult(
                         lrc_url=cached.get("lrc_url"),
                         line_count=cached.get("line_count"),
+                        lrc_source=cached.get("lrc_source"),
                     )
                     job.status = JobStatus.COMPLETED
                     job.progress = 1.0
@@ -668,187 +767,118 @@ class JobQueue:
                             "YouTube transcript succeeded — skipping audio download and stem separation"
                         )
 
-                # Stage 2: Whisper path — only when YouTube is unavailable or failed
+                # Stage 2: Qwen ASR then Whisper fallback — only when YouTube failed
                 if youtube_lrc_result is None:
-                    # Download audio from R2
-                    job.stage = "downloading"
-                    job.progress = 0.2
-                    job.updated_at = datetime.now(timezone.utc)
-
+                    await self._update_stage(job, "downloading", 0.2)
                     audio_path = temp_path / "audio.mp3"
                     if self.r2_client:
                         logger.info("Downloading audio from R2...")
                         download_start = time.time()
                         await self.r2_client.download_audio(request.audio_url, audio_path)
                         download_elapsed = time.time() - download_start
-                        logger.info(
-                            f"Audio download completed in {download_elapsed:.2f}s"
-                        )
+                        logger.info(f"Audio download completed in {download_elapsed:.2f}s")
 
-                    # Check if dry vocals stem exists and should be used for Whisper
-                    # Only vocals_dry.flac is preferred; if missing, trigger stem separation
-                    transcription_path = audio_path
-                    vocals_stem_url: Optional[str] = None
+                    resolved_audio = await self._resolve_lrc_transcription_audio(
+                        job, request, temp_path, audio_path
+                    )
 
-                    if request.options.use_vocals_stem and self.r2_client:
-                        # Check for dry vocals in priority order (with fallback to legacy)
-                        from .stem_separation import get_vocals_dry_url
+                    if (
+                        request.options.use_qwen3_asr
+                        and settings.SOW_DASHSCOPE_API_KEY
+                        and generate_lrc_from_qwen3_asr is not None
+                        and build_qwen3_asr_cache_key is not None
+                    ):
+                        try:
+                            from .lrc import _build_qwen3_context
 
-                        vocals_stem_url = await get_vocals_dry_url(
-                            request.content_hash, self.r2_client
-                        )
-
-                        if vocals_stem_url:
-                            ext = ".flac" if vocals_stem_url.endswith(".flac") else ".wav"
-                            stem_path = temp_path / f"vocals_stem{ext}"
-                            await self.r2_client.download_audio(vocals_stem_url, stem_path)
-                            transcription_path = stem_path
-                            logger.info(
-                                f"Using vocals stem for transcription: {vocals_stem_url}"
+                            context_limit = min(
+                                request.options.qwen3_asr_context_max_chars,
+                                settings.SOW_DASHSCOPE_ASR_CONTEXT_MAX_CHARS,
                             )
-                            job.stage = "using_vocals_stem"
-                        else:
-                            # No clean vocals cached — auto-trigger stem separation
-                            logger.info(
-                                "No clean vocals found, auto-triggering stem separation"
+                            context = _build_qwen3_context(request.lyrics_text, context_limit)
+                            qwen_cache_key = build_qwen3_asr_cache_key(
+                                request.content_hash,
+                                request.lyrics_text,
+                                resolved_audio.stem_kind,
+                                settings.SOW_DASHSCOPE_ASR_FLASH_MODEL,
+                                settings.SOW_DASHSCOPE_ASR_REGION,
+                                request.options.language,
+                                context_limit,
+                                context,
                             )
-                            job.stage = "submitting_stem_separation_child"
-                            job.updated_at = datetime.now(timezone.utc)
-
-                            try:
-                                await self.job_store.update_job(
-                                    job.id, stage="submitting_stem_separation_child"
-                                )
-                            except Exception as e:
-                                logger.error(f"Failed to update job {job.id} in database: {e}")
-
-                            child_request = StemSeparationJobRequest(
-                                audio_url=request.audio_url,
-                                content_hash=request.content_hash,
-                                options={"force": False},
-                            )
-                            child_job = await self.submit(JobType.STEM_SEPARATION, child_request)
-                            child_id = child_job.id
-                            logger.info(
-                                f"Submitted child stem separation job: {child_id}"
-                            )
-
-                            job.stage = f"awaiting_stem_separation:{child_id}"
-                            try:
-                                await self.job_store.update_job(
-                                    job.id, stage=f"awaiting_stem_separation:{child_id}"
-                                )
-                            except Exception as e:
-                                logger.error(f"Failed to update job {job.id} in database: {e}")
-
-                            logger.info(f"Waiting for child stem separation job {child_id}")
-
-                            poll_interval = 3.0
-                            max_wait = 7200.0  # 2 hour timeout
-                            wait_start = time.time()
-
-                            while True:
-                                await asyncio.sleep(poll_interval)
-
-                                child_job = await self.get_job(child_id)
-                                if not child_job:
-                                    logger.error(f"Child job {child_id} not found")
-                                    raise LRCWorkerError(
-                                        f"Child stem separation job {child_id} not found"
-                                    )
-
-                                if child_job.status == JobStatus.COMPLETED:
-                                    logger.info(
-                                        f"Child stem separation job {child_id} completed"
-                                    )
-                                    break
-                                elif child_job.status == JobStatus.FAILED:
-                                    logger.error(
-                                        f"Child stem separation job {child_id} failed: {child_job.error_message}"
-                                    )
-                                    break
-
-                                # Timeout — fall back to full audio rather than failing the LRC job
-                                if time.time() - wait_start > max_wait:
-                                    logger.warning(
-                                        f"Timeout waiting for child stem separation job {child_id} "
-                                        f"after {max_wait:.0f}s — falling back to full audio for transcription"
-                                    )
-                                    break
-
-                            child_job = await self.get_job(child_id)
                             if (
-                                child_job
-                                and child_job.status == JobStatus.COMPLETED
-                                and child_job.result
+                                not request.options.force_qwen3_asr
+                                and self.cache_manager.get_qwen3_asr_transcription(qwen_cache_key)
                             ):
-                                # Prefer dry vocals for transcription; fall back to raw vocals
-                                vocals_stem_url = child_job.result.vocals_dry_url or child_job.result.vocals_url
-                                if vocals_stem_url:
-                                    ext = ".flac" if vocals_stem_url.endswith(".flac") else ".wav"
-                                    stem_path = temp_path / f"vocals_dry{ext}"
-                                    await self.r2_client.download_audio(vocals_stem_url, stem_path)
-                                    transcription_path = stem_path
-                                    logger.info(
-                                        f"Downloaded vocals from child job: {vocals_stem_url}"
-                                    )
-                                    job.stage = "using_vocals_dry_stem"
-                                else:
-                                    logger.error(
-                                        f"Child job completed but no vocals URL in result"
-                                    )
+                                await self._update_stage(job, "qwen3_asr_cached", 0.4)
                             else:
-                                logger.warning(
-                                    f"Child stem separation failed or incomplete, using full audio"
-                                )
+                                await self._update_stage(job, "qwen3_asr_transcribing", 0.4)
+                            lrc_path, line_count, _qwen_phrases = await generate_lrc_from_qwen3_asr(
+                                resolved_audio.path,
+                                request.lyrics_text,
+                                request.options,
+                                output_path=lrc_path,
+                                cache_key=qwen_cache_key,
+                                cache_manager=self.cache_manager,
+                                dashscope_semaphore=self._dashscope_asr_semaphore,
+                            )
+                            lrc_source = "qwen3_asr"
+                            await self._update_stage(job, "qwen3_asr_done", 0.7)
+                        except Qwen3AsrError as e:
+                            logger.warning("Qwen3 ASR failed; falling back to Whisper: %s", e)
+                            await self._update_stage(job, "falling_back_to_whisper", 0.45)
+                        except Exception as e:
+                            logger.warning(
+                                "Qwen3 ASR unexpected failure; falling back to Whisper: %s", e
+                            )
+                            await self._update_stage(job, "falling_back_to_whisper", 0.45)
+                    else:
+                        logger.info("Qwen3 ASR disabled or DashScope not configured; using Whisper")
+                        await self._update_stage(job, "falling_back_to_whisper", 0.35)
 
                     # Check for cached Whisper transcription (audio hash only, not lyrics)
-                    cached_phrases = None
-                    if request.options.force_whisper:
-                        logger.info(f"Whisper cache bypassed (force_whisper=True)")
-                    else:
-                        cached_data = self.cache_manager.get_whisper_transcription(
-                            request.content_hash
-                        )
-                        if cached_data:
-                            from .lrc import WhisperPhrase
-
-                            cached_phrases = [WhisperPhrase(**p) for p in cached_data]
-                            logger.info(
-                                f"Whisper cache hit - using {len(cached_phrases)} cached phrases"
-                            )
-                            job.stage = "transcription_cached"
+                    if lrc_source != "qwen3_asr":
+                        cached_phrases = None
+                        if request.options.force_whisper:
+                            logger.info("Whisper cache bypassed (force_whisper=True)")
                         else:
-                            logger.info(f"Whisper cache miss - will run transcription")
+                            cached_data = self.cache_manager.get_whisper_transcription(
+                                request.content_hash
+                            )
+                            if cached_data:
+                                from .lrc import WhisperPhrase
 
-                    # Run Whisper transcription (or use cached); youtube_url=None since we already tried it
-                    job.stage = "transcribing"
-                    job.progress = 0.4
-                    job.updated_at = datetime.now(timezone.utc)
+                                cached_phrases = [WhisperPhrase(**p) for p in cached_data]
+                                logger.info(
+                                    f"Whisper cache hit - using {len(cached_phrases)} cached phrases"
+                                )
+                                await self._update_stage(job, "transcription_cached")
+                            else:
+                                logger.info("Whisper cache miss - will run transcription")
 
-                    lrc_path, line_count, whisper_phrases = await generate_lrc(
-                        transcription_path,
-                        request.lyrics_text,
-                        request.options,
-                        output_path=lrc_path,
-                        cached_phrases=cached_phrases,
-                        youtube_url=None,
-                        content_hash=request.content_hash,
-                        vocals_stem_url=vocals_stem_url,
-                        local_model_semaphore=self._local_model_semaphore,
-                    )
-                    lrc_source = "whisper_asr"
-
-                    # Cache the Whisper transcription for future use (if not using cache)
-                    if cached_phrases is None and whisper_phrases:
-                        phrases_data = [
-                            {"text": p.text, "start": p.start, "end": p.end}
-                            for p in whisper_phrases
-                        ]
-                        self.cache_manager.save_whisper_transcription(
-                            request.content_hash, phrases_data
+                        await self._update_stage(job, "transcribing", 0.5)
+                        lrc_path, line_count, whisper_phrases = await generate_lrc(
+                            resolved_audio.path,
+                            request.lyrics_text,
+                            request.options,
+                            output_path=lrc_path,
+                            cached_phrases=cached_phrases,
+                            youtube_url=None,
+                            content_hash=request.content_hash,
+                            vocals_stem_url=resolved_audio.r2_url,
+                            local_model_semaphore=self._local_model_semaphore,
                         )
-                        logger.info(f"Whisper transcription cached for future use")
+                        lrc_source = "whisper_asr"
+
+                        if cached_phrases is None and whisper_phrases:
+                            phrases_data = [
+                                {"text": p.text, "start": p.start, "end": p.end}
+                                for p in whisper_phrases
+                            ]
+                            self.cache_manager.save_whisper_transcription(
+                                request.content_hash, phrases_data
+                            )
+                            logger.info("Whisper transcription cached for future use")
 
                 job.stage = "uploading"
                 job.progress = 0.8
@@ -860,12 +890,18 @@ class JobQueue:
                     lrc_url = await self.r2_client.upload_lrc(hash_prefix, lrc_path)
 
                 # Save to cache using composite key (audio hash + lyrics hash)
-                cache_result = {"lrc_url": lrc_url, "line_count": line_count}
+                cache_result = {
+                    "lrc_url": lrc_url,
+                    "line_count": line_count,
+                    "lrc_source": lrc_source,
+                }
                 self.cache_manager.save_lrc_result(lrc_cache_key, cache_result)
                 logger.info(f"LRC result cached with key: {lrc_cache_key}")
 
                 # Set job result
-                job.result = JobResult(lrc_url=lrc_url, line_count=line_count, lrc_source=lrc_source)
+                job.result = JobResult(
+                    lrc_url=lrc_url, line_count=line_count, lrc_source=lrc_source
+                )
                 job.status = JobStatus.COMPLETED
                 job.progress = 1.0
                 job.stage = "complete"

--- a/services/analysis/src/sow_analysis/workers/queue.py
+++ b/services/analysis/src/sow_analysis/workers/queue.py
@@ -604,6 +604,9 @@ class JobQueue:
         wait_start = time.time()
         while True:
             await asyncio.sleep(3.0)
+            if job.status == JobStatus.CANCELLED:
+                logger.info("Parent job %s cancelled; aborting wait for child job", job.id)
+                break
             child_job = await self.get_job(child_id)
             if not child_job:
                 logger.error("Child stem separation job %s not found", child_id)
@@ -781,6 +784,9 @@ class JobQueue:
                     resolved_audio = await self._resolve_lrc_transcription_audio(
                         job, request, temp_path, audio_path
                     )
+                    if job.status == JobStatus.CANCELLED:
+                        logger.info("LRC job %s cancelled; skipping transcription", job.id)
+                        return
 
                     if (
                         request.options.use_qwen3_asr

--- a/src/stream_of_worship/admin/commands/audio.py
+++ b/src/stream_of_worship/admin/commands/audio.py
@@ -301,7 +301,8 @@ def _submit_lrc_single(
     no_vocals: bool,
     no_youtube: bool,
     no_whisper_cache: bool,
-    no_qwen3: bool,
+    no_qwen3_asr: bool,
+    force_qwen3_asr: bool,
     wait: bool,
     console: Console,
 ) -> None:
@@ -358,7 +359,8 @@ def _submit_lrc_single(
                 force=force,
                 force_whisper=no_whisper_cache,
                 youtube_url=youtube_url,
-                use_qwen3=not no_qwen3,
+                use_qwen3_asr=not no_qwen3_asr,
+                force_qwen3_asr=force_qwen3_asr,
             )
         except AnalysisServiceError as e:
             console.print(f"[red]Failed to submit LRC job: {e}[/red]")
@@ -440,7 +442,8 @@ def _submit_lrc_batch(
     no_vocals: bool,
     no_youtube: bool,
     no_whisper_cache: bool,
-    no_qwen3: bool,
+    no_qwen3_asr: bool,
+    force_qwen3_asr: bool,
     console: Console,
 ) -> None:
     """Submit LRC for multiple recordings (batch mode, no wait)."""
@@ -496,7 +499,8 @@ def _submit_lrc_batch(
                 force=force,
                 force_whisper=no_whisper_cache,
                 youtube_url=youtube_url,
-                use_qwen3=not no_qwen3,
+                use_qwen3_asr=not no_qwen3_asr,
+                force_qwen3_asr=force_qwen3_asr,
             )
 
             # Update DB
@@ -587,7 +591,8 @@ def _submit_lrc_job(
     no_vocals: bool = False,
     no_youtube: bool = False,
     no_whisper_cache: bool = False,
-    use_qwen3: bool = True,
+    use_qwen3_asr: bool = True,
+    force_qwen3_asr: bool = False,
 ) -> Optional[str]:
     """Submit LRC generation job for a recording.
 
@@ -603,7 +608,8 @@ def _submit_lrc_job(
         no_vocals: Don't use vocals stem
         no_youtube: Skip YouTube transcript, use Whisper directly
         no_whisper_cache: Bypass Whisper transcription cache
-        use_qwen3: Use Qwen3 for timestamp refinement (Whisper path only)
+        use_qwen3_asr: Use DashScope Qwen3 ASR before Whisper fallback
+        force_qwen3_asr: Bypass only the Qwen3 ASR cache
 
     Returns:
         Job ID if submission succeeded, None otherwise
@@ -630,7 +636,8 @@ def _submit_lrc_job(
             force=force,
             force_whisper=no_whisper_cache,
             youtube_url=youtube_url,
-            use_qwen3=use_qwen3,
+            use_qwen3_asr=use_qwen3_asr,
+            force_qwen3_asr=force_qwen3_asr,
         )
 
         # Update DB
@@ -906,7 +913,8 @@ def download_audio(
             whisper_model="large-v3",
             language="zh",
             no_vocals=False,
-            use_qwen3=True,
+            use_qwen3_asr=True,
+            force_qwen3_asr=False,
         )
 
 
@@ -1599,8 +1607,17 @@ def lrc_recording(
     no_whisper_cache: bool = typer.Option(
         False, "--no-whisper-cache", help="Bypass cached Whisper transcription, re-run Whisper"
     ),
-    no_qwen3: bool = typer.Option(
-        False, "--no-qwen3", help="Skip Qwen3 timestamp refinement (use LLM alignment only)"
+    no_qwen3_asr: bool = typer.Option(
+        False, "--no-qwen3-asr", help="Skip DashScope Qwen3 ASR and use Whisper fallback"
+    ),
+    force_qwen3_asr: bool = typer.Option(
+        False, "--force-qwen3-asr", help="Bypass cached Qwen3 ASR transcription only"
+    ),
+    no_qwen3_legacy: bool = typer.Option(
+        False,
+        "--no-qwen3",
+        help="Deprecated; Qwen3 ForcedAligner is no longer part of automatic LRC generation",
+        hidden=True,
     ),
     wait: bool = typer.Option(False, "--wait", "-w", help="Wait for LRC generation to complete"),
     config_path: Optional[Path] = typer.Option(None, "--config", "-c", help="Path to config file"),
@@ -1608,9 +1625,9 @@ def lrc_recording(
     """Submit a recording for lyrics alignment (LRC generation).
 
     By default, tries YouTube transcript first (if a YouTube URL is stored),
-    then falls back to Whisper transcription with Qwen3 timestamp refinement.
+    then falls back to DashScope Qwen3 ASR and finally Whisper transcription.
     Use --no-youtube to skip the YouTube path and use Whisper directly.
-    Use --no-qwen3 to skip Qwen3 refinement and use LLM alignment only.
+    Use --no-qwen3-asr to skip Qwen3 ASR and use Whisper.
 
     For batch processing, pipe song IDs via stdin:
         sow-admin audio list --lrc incomplete --format ids | sow-admin audio lrc --stdin
@@ -1624,6 +1641,12 @@ def lrc_recording(
         raise typer.Exit(1)
     if stdin and wait:
         console.print("[red]Error: --wait is not supported with --stdin (too many jobs)[/red]")
+        raise typer.Exit(1)
+    if no_qwen3_legacy:
+        console.print(
+            "[red]Error: --no-qwen3 is deprecated. Qwen3 ForcedAligner is no longer "
+            "part of automatic LRC generation; use --no-qwen3-asr instead.[/red]"
+        )
         raise typer.Exit(1)
 
     # Standard config/db boilerplate
@@ -1664,7 +1687,8 @@ def lrc_recording(
             no_vocals=no_vocals,
             no_youtube=no_youtube,
             no_whisper_cache=no_whisper_cache,
-            no_qwen3=no_qwen3,
+            no_qwen3_asr=no_qwen3_asr,
+            force_qwen3_asr=force_qwen3_asr,
             wait=wait,
             console=console,
         )
@@ -1680,7 +1704,8 @@ def lrc_recording(
             no_vocals=no_vocals,
             no_youtube=no_youtube,
             no_whisper_cache=no_whisper_cache,
-            no_qwen3=no_qwen3,
+            no_qwen3_asr=no_qwen3_asr,
+            force_qwen3_asr=force_qwen3_asr,
             console=console,
         )
 
@@ -3390,13 +3415,17 @@ def edit_lrc(
             r2_client.download_audio(recording.hash_prefix, audio_path)
         except Exception as e:
             console.print(f"[red]Failed to download audio: {e}[/red]")
-            console.print("[red]Audio is required for timestamp alignment. Cannot open editor.[/red]")
+            console.print(
+                "[red]Audio is required for timestamp alignment. Cannot open editor.[/red]"
+            )
             raise typer.Exit(1)
     else:
         try:
             r2_client.audio_exists(recording.hash_prefix)
         except ClientError:
-            console.print(f"[yellow]Warning: Could not verify audio in R2. Using cached file.[/yellow]")
+            console.print(
+                f"[yellow]Warning: Could not verify audio in R2. Using cached file.[/yellow]"
+            )
 
     transcribed_content: Optional[str] = None
     transcribed_identity = r2_client.get_lrc_identity(recording.hash_prefix)
@@ -3416,7 +3445,11 @@ def edit_lrc(
             console.print(f"[red]Failed to download transcribed LRC: {e}[/red]")
             raise typer.Exit(1)
 
-    from stream_of_worship.admin.editor.autosave import autosave_exists, load_autosave, AutosaveState
+    from stream_of_worship.admin.editor.autosave import (
+        autosave_exists,
+        load_autosave,
+        AutosaveState,
+    )
     from stream_of_worship.admin.editor.state import EditorState
     from stream_of_worship.admin.services.lrc_parser import LRCPreservedLine
 
@@ -3448,37 +3481,64 @@ def edit_lrc(
                     offset = editor_state.padding_offset_seconds
                     for i, line in enumerate(editor_state.timed_lines):
                         if i < len(editor_state.original_timestamps):
-                            line.time_seconds = max(0.0, editor_state.original_timestamps[i] + offset)
+                            line.time_seconds = max(
+                                0.0, editor_state.original_timestamps[i] + offset
+                            )
             else:
                 console.print("[red]Failed to load autosave. Starting fresh.[/red]")
                 editor_state = _build_fresh_editor_state(
-                    transcribed_content, song, recording, song_title, audio_path,
-                    transcribed_identity, source_mode,
+                    transcribed_content,
+                    song,
+                    recording,
+                    song_title,
+                    audio_path,
+                    transcribed_identity,
+                    source_mode,
                 )
         elif choice == 1:
             from stream_of_worship.admin.editor.autosave import clear_autosave
+
             clear_autosave(cache_dir, recording.hash_prefix)
             editor_state = _build_fresh_editor_state(
-                transcribed_content, song, recording, song_title, audio_path,
-                transcribed_identity, source_mode,
+                transcribed_content,
+                song,
+                recording,
+                song_title,
+                audio_path,
+                transcribed_identity,
+                source_mode,
             )
         else:
             from stream_of_worship.admin.editor.upload import save_local_draft
+
             autosave_state = load_autosave(cache_dir, recording.hash_prefix)
             if autosave_state:
-                draft_content = serialize_lrc(autosave_state.timed_lines, autosave_state.preserved_lines)
+                draft_content = serialize_lrc(
+                    autosave_state.timed_lines, autosave_state.preserved_lines
+                )
                 save_local_draft(cache_dir, recording.hash_prefix, draft_content)
                 console.print("[green]Autosave saved as local draft.[/green]")
             from stream_of_worship.admin.editor.autosave import clear_autosave
+
             clear_autosave(cache_dir, recording.hash_prefix)
             editor_state = _build_fresh_editor_state(
-                transcribed_content, song, recording, song_title, audio_path,
-                transcribed_identity, source_mode,
+                transcribed_content,
+                song,
+                recording,
+                song_title,
+                audio_path,
+                transcribed_identity,
+                source_mode,
             )
     else:
         editor_state = _build_fresh_editor_state(
-            transcribed_content, song, recording, song_title, audio_path,
-            transcribed_identity, source_mode,
+            transcribed_content,
+            song,
+            recording,
+            song_title,
+            audio_path,
+            transcribed_identity,
+            source_mode,
         )
 
     console.print(f"[cyan]Launching LRC editor for: {song_title}[/cyan]")
@@ -4378,7 +4438,8 @@ def _process_batch(
                     force=force_lrc,
                     force_whisper=False,
                     youtube_url=youtube_url,
-                    use_qwen3=True,
+                    use_qwen3_asr=True,
+                    force_qwen3_asr=False,
                 )
 
                 db_client.update_recording_status(
@@ -4572,9 +4633,9 @@ def _poll_all_jobs(
                                     f"{max_resubmits} resubmits, marking as failed[/red]"
                                 )
                                 results[song_id]["lrc"] = "failed"
-                                results[song_id]["lrc_error"] = (
-                                    f"Job lost (404) and not found on R2 after {max_resubmits} resubmits"
-                                )
+                                results[song_id][
+                                    "lrc_error"
+                                ] = f"Job lost (404) and not found on R2 after {max_resubmits} resubmits"
                                 db_client.update_recording_status(
                                     hash_prefix=recording.hash_prefix,
                                     lrc_status="failed",
@@ -4590,9 +4651,9 @@ def _poll_all_jobs(
                                     song = db_client.get_song(song_id)
                                     if not song or not song.lyrics_raw:
                                         results[song_id]["lrc"] = "failed"
-                                        results[song_id]["lrc_error"] = (
-                                            "Job lost and no lyrics available for resubmit"
-                                        )
+                                        results[song_id][
+                                            "lrc_error"
+                                        ] = "Job lost and no lyrics available for resubmit"
                                         db_client.update_recording_status(
                                             hash_prefix=recording.hash_prefix,
                                             lrc_status="failed",
@@ -4611,7 +4672,8 @@ def _poll_all_jobs(
                                         force=force_lrc,
                                         force_whisper=False,
                                         youtube_url=recording.youtube_url or "",
-                                        use_qwen3=True,
+                                        use_qwen3_asr=True,
+                                        force_qwen3_asr=False,
                                     )
                                     db_client.update_recording_status(
                                         hash_prefix=recording.hash_prefix,
@@ -4820,16 +4882,19 @@ def _print_stats(
     )
     lrc_skipped_download = sum(1 for r in results.values() if r.get("download") == "failed")
 
-    # LRC source breakdown (YouTube vs ASR)
+    # LRC source breakdown
     lrc_youtube = sum(1 for r in results.values() if r.get("lrc_source") == "youtube_transcript")
-    lrc_asr = sum(1 for r in results.values() if r.get("lrc_source") == "whisper_asr")
-    lrc_unknown = lrc_completed - lrc_skipped_existing - lrc_youtube - lrc_asr
+    lrc_qwen_asr = sum(1 for r in results.values() if r.get("lrc_source") == "qwen3_asr")
+    lrc_whisper_asr = sum(1 for r in results.values() if r.get("lrc_source") == "whisper_asr")
+    lrc_unknown = (
+        lrc_completed - lrc_skipped_existing - lrc_youtube - lrc_qwen_asr - lrc_whisper_asr
+    )
 
     # LRC timing stats (only for ASR/Whisper jobs, not YouTube or R2 pre-existing)
     lrc_timings = []
     for song_id, t in results.items():
-        # Only track timings for jobs that were generated by ASR/Whisper
-        if "elapsed" in t and t.get("lrc_source") == "whisper_asr":
+        # Only track timings for jobs that were generated by ASR, not YouTube or R2 pre-existing
+        if "elapsed" in t and t.get("lrc_source") in {"qwen3_asr", "whisper_asr"}:
             lrc_timings.append(t["elapsed"])
 
     if lrc_timings:
@@ -4864,7 +4929,8 @@ def _print_stats(
                 f"│ {'LRC source:':<30} {'':>18} │",
                 f"│ {'  R2 pre-existing:':<30} {lrc_skipped_existing:>18} │",
                 f"│ {'  YouTube Transcription:':<30} {lrc_youtube:>18} │",
-                f"│ {'  ASR (Whisper):':<30} {lrc_asr:>18} │",
+                f"│ {'  ASR (Qwen3):':<30} {lrc_qwen_asr:>18} │",
+                f"│ {'  ASR (Whisper):':<30} {lrc_whisper_asr:>18} │",
             ]
         )
         if lrc_unknown > 0:

--- a/src/stream_of_worship/admin/services/analysis.py
+++ b/src/stream_of_worship/admin/services/analysis.py
@@ -37,7 +37,7 @@ class AnalysisResult:
         embeddings_shape: Embedding dimensions
         stems_url: R2 URL for stems directory
         lrc_url: R2 URL for LRC file
-        lrc_source: Source of LRC generation ("youtube_transcript" or "whisper_asr")
+        lrc_source: Source of LRC generation ("youtube_transcript", "qwen3_asr", or "whisper_asr")
     """
 
     duration_seconds: Optional[float] = None
@@ -268,7 +268,8 @@ class AnalysisClient:
         force: bool = False,
         force_whisper: bool = False,
         youtube_url: str = "",
-        use_qwen3: bool = True,
+        use_qwen3_asr: bool = True,
+        force_qwen3_asr: bool = False,
     ) -> JobInfo:
         """Submit an audio file for LRC generation.
 
@@ -282,7 +283,8 @@ class AnalysisClient:
             force: Whether to force re-generation
             force_whisper: Bypass Whisper transcription cache
             youtube_url: YouTube URL for transcript-based LRC (primary path)
-            use_qwen3: Whether to use Qwen3 for timestamp refinement (Whisper path only)
+            use_qwen3_asr: Whether to use DashScope Qwen3 ASR before Whisper fallback
+            force_qwen3_asr: Bypass only the Qwen3 ASR cache
 
         Returns:
             JobInfo for the submitted job
@@ -301,7 +303,8 @@ class AnalysisClient:
                 "use_vocals_stem": use_vocals_stem,
                 "force": force,
                 "force_whisper": force_whisper,
-                "use_qwen3": use_qwen3,
+                "use_qwen3_asr": use_qwen3_asr,
+                "force_qwen3_asr": force_qwen3_asr,
             },
         }
 
@@ -422,9 +425,7 @@ class AnalysisClient:
             )
 
             if response.status_code == 404:
-                raise AnalysisServiceError(
-                    f"Job not found: {job_id}", status_code=404
-                )
+                raise AnalysisServiceError(f"Job not found: {job_id}", status_code=404)
 
             if response.status_code == 401:
                 raise AnalysisServiceError(
@@ -482,9 +483,7 @@ class AnalysisClient:
 
             elapsed = time.time() - start_time
             if elapsed >= timeout:
-                raise AnalysisServiceError(
-                    f"Timed out waiting for job {job_id} after {timeout}s"
-                )
+                raise AnalysisServiceError(f"Timed out waiting for job {job_id} after {timeout}s")
 
             time.sleep(poll_interval)
 
@@ -562,9 +561,7 @@ class AnalysisClient:
             )
 
             if response.status_code == 404:
-                raise AnalysisServiceError(
-                    f"Job not found: {job_id}", status_code=404
-                )
+                raise AnalysisServiceError(f"Job not found: {job_id}", status_code=404)
 
             if response.status_code == 401:
                 raise AnalysisServiceError(
@@ -664,9 +661,7 @@ class AnalysisClient:
                     song_id=result_data.get("song_id", ""),
                     embedding=result_data.get("embedding", []),
                     line_embeddings=line_embeddings,
-                    model_version=result_data.get(
-                        "model_version", "text-embedding-3-small"
-                    ),
+                    model_version=result_data.get("model_version", "text-embedding-3-small"),
                     content_hash=result_data.get("content_hash", ""),
                 )
             else:

--- a/tests/admin/test_audio_lrc_visibility.py
+++ b/tests/admin/test_audio_lrc_visibility.py
@@ -80,7 +80,8 @@ def test_submit_lrc_wait_completion_forces_review_visibility():
         no_vocals=False,
         no_youtube=False,
         no_whisper_cache=False,
-        no_qwen3=False,
+        no_qwen3_asr=False,
+        force_qwen3_asr=False,
         wait=True,
         console=_console(),
     )

--- a/tests/services/analysis/test_api.py
+++ b/tests/services/analysis/test_api.py
@@ -175,6 +175,22 @@ class TestJobsEndpoints:
         assert data["job_id"] == "job_def456"
         assert data["job_type"] == "lrc"
 
+    def test_submit_lrc_rejects_legacy_qwen3_options(self, client, mock_job_queue):
+        """Legacy ForcedAligner options are rejected for new submissions."""
+        response = client.post(
+            "/api/v1/jobs/lrc",
+            json={
+                "audio_url": "s3://bucket/hash/audio.mp3",
+                "content_hash": "abc123",
+                "lyrics_text": "Line 1\nLine 2",
+                "options": {"use_qwen3": False},
+            },
+            headers={"Authorization": "Bearer test-api-key"},
+        )
+
+        assert response.status_code == 422
+        assert "ForcedAligner" in response.json()["detail"]
+
     def test_get_job_status(self, client, mock_job_queue):
         """Test getting job status."""
 
@@ -255,18 +271,22 @@ class TestAdminEndpoints:
 
     def test_cancel_job_queued(self, client, mock_job_queue):
         """Test cancelling a queued job."""
+
         async def mock_cancel_job(job_id):
             now = datetime.now(timezone.utc)
-            return Job(
-                id=job_id,
-                type=JobType.ANALYZE,
-                status=JobStatus.CANCELLED,
-                request=MagicMock(),
-                created_at=now,
-                updated_at=now,
-                progress=0.0,
-                stage="cancelled",
-            ), None
+            return (
+                Job(
+                    id=job_id,
+                    type=JobType.ANALYZE,
+                    status=JobStatus.CANCELLED,
+                    request=MagicMock(),
+                    created_at=now,
+                    updated_at=now,
+                    progress=0.0,
+                    stage="cancelled",
+                ),
+                None,
+            )
 
         mock_job_queue.cancel_job = mock_cancel_job
 
@@ -282,18 +302,22 @@ class TestAdminEndpoints:
 
     def test_cancel_job_processing(self, client, mock_job_queue):
         """Test cancelling a processing job returns warning."""
+
         async def mock_cancel_job_processing(job_id):
             now = datetime.now(timezone.utc)
-            return Job(
-                id=job_id,
-                type=JobType.ANALYZE,
-                status=JobStatus.CANCELLED,
-                request=MagicMock(),
-                created_at=now,
-                updated_at=now,
-                progress=0.5,
-                stage="cancelled",
-            ), "Job was PROCESSING. The running task continues until service restart."
+            return (
+                Job(
+                    id=job_id,
+                    type=JobType.ANALYZE,
+                    status=JobStatus.CANCELLED,
+                    request=MagicMock(),
+                    created_at=now,
+                    updated_at=now,
+                    progress=0.5,
+                    stage="cancelled",
+                ),
+                "Job was PROCESSING. The running task continues until service restart.",
+            )
 
         mock_job_queue.cancel_job = mock_cancel_job_processing
 
@@ -306,10 +330,14 @@ class TestAdminEndpoints:
         data = response.json()
         assert data["job_id"] == "job_processing"
         assert data["status"] == "cancelled"
-        assert data["warning"] == "Job was PROCESSING. The running task continues until service restart."
+        assert (
+            data["warning"]
+            == "Job was PROCESSING. The running task continues until service restart."
+        )
 
     def test_cancel_job_not_found(self, client, mock_job_queue):
         """Test cancelling non-existent job returns 404."""
+
         async def mock_cancel_job_not_found(job_id):
             return None, None
 
@@ -341,6 +369,7 @@ class TestAdminEndpoints:
 
     def test_clear_queue(self, client, mock_job_queue):
         """Test clearing the queue."""
+
         async def mock_clear_queue():
             now = datetime.now(timezone.utc)
             return [

--- a/tests/services/analysis/test_models.py
+++ b/tests/services/analysis/test_models.py
@@ -37,9 +37,7 @@ class TestAnalyzeJobRequest:
 
     def test_required_fields(self):
         """Test required fields."""
-        req = AnalyzeJobRequest(
-            audio_url="s3://bucket/hash/audio.mp3", content_hash="abc123"
-        )
+        req = AnalyzeJobRequest(audio_url="s3://bucket/hash/audio.mp3", content_hash="abc123")
         assert req.audio_url == "s3://bucket/hash/audio.mp3"
         assert req.content_hash == "abc123"
         assert req.options.generate_stems is True
@@ -61,6 +59,9 @@ class TestLrcOptions:
         """Test default option values."""
         opts = LrcOptions()
         assert opts.whisper_model == "large-v3"
+        assert opts.use_qwen3_asr is True
+        assert opts.force_qwen3_asr is False
+        assert opts.qwen3_asr_context_max_chars == 10000
 
 
 class TestLrcJobRequest:
@@ -153,7 +154,10 @@ class TestJobResponse:
         )
         assert response.job_id == "job_abc123"
         assert response.status == JobStatus.CANCELLED
-        assert response.warning == "Job was PROCESSING. The running task continues until service restart."
+        assert (
+            response.warning
+            == "Job was PROCESSING. The running task continues until service restart."
+        )
 
 
 class TestJobStatus:

--- a/tests/services/analysis/test_queue.py
+++ b/tests/services/analysis/test_queue.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from sow_analysis.models import AnalyzeJobRequest, JobStatus, JobType, LrcJobRequest
+from sow_analysis.models import AnalyzeJobRequest, JobStatus, JobType, LrcJobRequest, LrcOptions
 from sow_analysis.workers.queue import Job, JobQueue, _compute_lrc_cache_key
 
 
@@ -117,6 +117,50 @@ class TestLRCJobProcessing:
         # LRC job should fail with invalid request type error
         assert job.status == JobStatus.FAILED
         assert "Invalid request type" in job.error_message
+
+    @pytest.mark.asyncio
+    async def test_lrc_child_stem_wait_stops_when_parent_cancelled(self, queue):
+        """LRC cancellation during child stem wait does not continue into transcription."""
+        request = LrcJobRequest(
+            audio_url="s3://bucket/hash/audio.mp3",
+            content_hash="abc123def456",
+            lyrics_text="Line 1\nLine 2",
+            options=LrcOptions(force=True, use_qwen3_asr=False),
+        )
+        job = Job(
+            id="job_cancel_parent",
+            type=JobType.LRC,
+            status=JobStatus.PROCESSING,
+            request=request,
+        )
+        queue._jobs[job.id] = job
+
+        async def download_audio(_url, path):
+            path.write_bytes(b"audio")
+
+        queue.r2_client = MagicMock()
+        queue.r2_client.download_audio = AsyncMock(side_effect=download_audio)
+        generate_lrc = AsyncMock()
+
+        async def cancel_parent(_delay):
+            job.status = JobStatus.CANCELLED
+            job.stage = "cancelled"
+
+        with (
+            patch(
+                "sow_analysis.workers.stem_separation.get_vocals_dry_url",
+                new=AsyncMock(return_value=None),
+            ),
+            patch("sow_analysis.workers.queue.generate_lrc", new=generate_lrc),
+            patch(
+                "sow_analysis.workers.queue.asyncio.sleep",
+                new=AsyncMock(side_effect=cancel_parent),
+            ),
+        ):
+            await queue._process_lrc_job(job)
+
+        assert job.status == JobStatus.CANCELLED
+        generate_lrc.assert_not_awaited()
 
 
 class TestJobQueueConcurrency:

--- a/tests/services/analysis/test_qwen3_asr_pipeline.py
+++ b/tests/services/analysis/test_qwen3_asr_pipeline.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -90,6 +91,89 @@ def test_qwen_client_parses_direct_segments_and_words():
     assert result.segments[0].text == "我要看見"
     assert result.segments[0].start == 1.0
     assert [w.text for w in result.words] == ["我要", "看見"]
+
+
+def test_qwen_client_always_converts_dashscope_milliseconds_to_seconds():
+    client = Qwen3AsrClient(api_key="test")
+
+    assert client._ms_to_seconds(500) == 0.5
+    assert client._ms_to_seconds(1000) == 1.0
+    assert client._ms_to_seconds(1050000) == 1050.0
+
+
+def test_qwen_client_flattens_filetrans_transcript_sentences():
+    client = Qwen3AsrClient(api_key="test")
+    result = client._parse_result(
+        {
+            "transcripts": [
+                {
+                    "channel_id": 0,
+                    "sentences": [
+                        {
+                            "text": "我要看見",
+                            "begin_time": 500,
+                            "end_time": 1500,
+                            "words": [
+                                {"text": "我要", "begin_time": 500, "end_time": 900},
+                                {"text": "看見", "begin_time": 900, "end_time": 1500},
+                            ],
+                        }
+                    ],
+                }
+            ]
+        },
+        model="qwen3-asr-flash-filetrans",
+        mode="filetrans",
+    )
+
+    assert result.segments[0].text == "我要看見"
+    assert result.segments[0].start == 0.5
+    assert [word.text for word in result.words] == ["我要", "看見"]
+
+
+def test_qwen_client_routes_to_filetrans_over_direct_size_limit(tmp_path: Path):
+    audio_path = tmp_path / "large.mp3"
+    with audio_path.open("wb") as file:
+        file.truncate((10 * 1024 * 1024) + 1)
+
+    assert Qwen3AsrClient(api_key="test")._choose_mode(audio_path) == "filetrans"
+
+
+def test_qwen_client_routes_to_filetrans_over_direct_duration_limit(tmp_path: Path):
+    audio_path = tmp_path / "long.mp3"
+    audio_path.write_bytes(b"small")
+    fake_librosa = SimpleNamespace(get_duration=lambda path: 301.0)
+
+    with patch.dict("sys.modules", {"librosa": fake_librosa}):
+        assert Qwen3AsrClient(api_key="test")._choose_mode(audio_path) == "filetrans"
+
+
+def test_qwen_client_routes_to_direct_for_small_short_audio(tmp_path: Path):
+    audio_path = tmp_path / "short.mp3"
+    audio_path.write_bytes(b"small")
+    fake_librosa = SimpleNamespace(get_duration=lambda path: 300.0)
+
+    with patch.dict("sys.modules", {"librosa": fake_librosa}):
+        assert Qwen3AsrClient(api_key="test")._choose_mode(audio_path) == "direct"
+
+
+def test_canonical_snap_does_not_bias_ordered_search_to_final_line():
+    result = Qwen3AsrResult(
+        segments=[
+            Qwen3AsrSegment("final", 0.0, 1.0),
+            Qwen3AsrSegment("fina", 1.0, 2.0),
+        ],
+        words=[],
+        text="finalfina",
+        raw_response={"ok": True},
+        model="qwen3-asr-flash",
+        region="intl",
+        mode="direct",
+    )
+
+    snapped = snap_qwen3_asr_to_canonical(result, "fina\nfinal", threshold=0.8)
+
+    assert [phrase.text for phrase in snapped] == ["final", "fina"]
 
 
 @pytest.mark.asyncio

--- a/tests/services/analysis/test_qwen3_asr_pipeline.py
+++ b/tests/services/analysis/test_qwen3_asr_pipeline.py
@@ -1,0 +1,134 @@
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from sow_analysis.models import LrcOptions
+from sow_analysis.services.canonical_snap import snap_qwen3_asr_to_canonical
+from sow_analysis.services.qwen3_asr_client import (
+    Qwen3AsrClient,
+    Qwen3AsrResult,
+    Qwen3AsrSegment,
+    Qwen3AsrWord,
+)
+from sow_analysis.storage.cache import CacheManager
+from sow_analysis.workers.lrc import generate_lrc_from_qwen3_asr
+
+
+def _qwen_result() -> Qwen3AsrResult:
+    return Qwen3AsrResult(
+        segments=[
+            Qwen3AsrSegment("我要看见", 0.0, 2.0),
+            Qwen3AsrSegment("如同摩西看见你的荣耀", 2.0, 5.0),
+            Qwen3AsrSegment("我要看见", 5.0, 7.0),
+        ],
+        words=[],
+        text="我要看见如同摩西看见你的荣耀我要看见",
+        raw_response={"ok": True},
+        model="qwen3-asr-flash",
+        region="intl",
+        mode="direct",
+    )
+
+
+def test_canonical_snap_preserves_repeated_lines():
+    result = _qwen_result()
+    snapped = snap_qwen3_asr_to_canonical(
+        result,
+        "我要看見\n如同摩西看見祢的榮耀\n我要看見",
+        threshold=0.5,
+    )
+
+    assert [p.text for p in snapped] == [
+        "我要看見",
+        "如同摩西看見祢的榮耀",
+        "我要看見",
+    ]
+
+
+def test_qwen_client_parses_direct_segments_and_words():
+    client = Qwen3AsrClient(api_key="test")
+    result = client._parse_result(
+        {
+            "choices": [
+                {
+                    "message": {
+                        "content": [
+                            {
+                                "type": "audio_transcription",
+                                "audio_transcription_results": {
+                                    "sentences": [
+                                        {
+                                            "text": "我要看見",
+                                            "begin_time": 1000,
+                                            "end_time": 3000,
+                                            "words": [
+                                                {
+                                                    "text": "我要",
+                                                    "begin_time": 1000,
+                                                    "end_time": 1800,
+                                                },
+                                                {
+                                                    "text": "看見",
+                                                    "begin_time": 1800,
+                                                    "end_time": 3000,
+                                                },
+                                            ],
+                                        }
+                                    ]
+                                },
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        model="qwen3-asr-flash",
+        mode="direct",
+    )
+
+    assert result.segments[0].text == "我要看見"
+    assert result.segments[0].start == 1.0
+    assert [w.text for w in result.words] == ["我要", "看見"]
+
+
+@pytest.mark.asyncio
+async def test_qwen_lrc_alignment_uses_snapped_phrases(tmp_path: Path):
+    audio_path = tmp_path / "audio.mp3"
+    audio_path.write_bytes(b"fake")
+    cache = CacheManager(tmp_path / "cache")
+    cache_key = "qwen-cache-key"
+    cache.save_qwen3_asr_transcription(cache_key, _qwen_result().to_cache_payload())
+    output_path = tmp_path / "lyrics.lrc"
+
+    aligned = [
+        {"time_seconds": 0.0, "text": "我要看見"},
+        {"time_seconds": 2.0, "text": "如同摩西看見祢的榮耀"},
+        {"time_seconds": 5.0, "text": "我要看見"},
+    ]
+
+    async def fake_llm_align(lyrics_text, phrases, llm_model, max_retries=3, prompt_builder=None):
+        assert [p.text for p in phrases] == [
+            "我要看見",
+            "如同摩西看見祢的榮耀",
+            "我要看見",
+        ]
+        from sow_analysis.workers.lrc import LRCLine
+
+        return [LRCLine(**item) for item in aligned]
+
+    with patch("sow_analysis.workers.lrc._llm_align", new=AsyncMock(side_effect=fake_llm_align)):
+        path, line_count, phrases = await generate_lrc_from_qwen3_asr(
+            audio_path,
+            "我要看見\n如同摩西看見祢的榮耀\n我要看見",
+            LrcOptions(qwen3_asr_min_usable_segments=3, qwen3_asr_snap_threshold=0.5),
+            output_path,
+            cache_key,
+            cache,
+            dashscope_semaphore=__import__("asyncio").Semaphore(1),
+        )
+
+    assert path == output_path
+    assert line_count == 3
+    assert [p.text for p in phrases] == [item["text"] for item in aligned]
+    assert "[00:02.00] 如同摩西看見祢的榮耀" in output_path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Implements the production LRC priority order from `specs/lrc-qwen3-asr-combined-implementation-plan.md`:

1. Final generated-LRC cache, unless `force=True`
2. YouTube transcript + existing LLM correction
3. DashScope Qwen3 ASR, canonical-line snap, then Qwen-specific LLM alignment
4. Local Whisper transcription + existing LLM alignment

## What changed

- Added DashScope Qwen3 ASR configuration, startup logging, and analysis-service dependencies (`dashscope`, `rapidfuzz`, `zhconv`).
- Added `Qwen3AsrClient` with typed result objects, direct/filetrans routing, SDK executor wrapping, retries, filetrans result fetching, typed errors, and an auth circuit breaker.
- Added canonical snap support that normalizes Chinese text, preserves repeated lyric sections, uses word timestamps when available, and falls back to segment timestamps.
- Added Qwen ASR cache storage separate from Whisper transcription cache, using a rich cache key that includes audio hash, lyrics hash, stem kind, model, region, language, context limit/hash, and cache version.
- Reworked LRC worker generation so Qwen ASR output is snapped and then passed to a dedicated Qwen LLM alignment prompt; removed the old automatic Qwen ForcedAligner refinement from `generate_lrc()`.
- Reworked LRC queue orchestration to keep YouTube/audio download/stem resolution/Qwen fallback/Whisper fallback/source propagation in `JobQueue._process_lrc_job()`.
- Added a separate DashScope ASR semaphore so cloud ASR does not acquire the local model semaphore.
- Preserved final LRC cache behavior and now saves/restores `lrc_source`.
- Added API rejection for new submissions using legacy `use_qwen3` / `max_qwen3_duration` options while keeping old persisted job JSON loadable.
- Updated admin client and CLI to use `use_qwen3_asr`, `force_qwen3_asr`, `--no-qwen3-asr`, and `--force-qwen3-asr`; deprecated `--no-qwen3` now errors clearly.
- Updated admin batch summaries to report YouTube, Qwen3 ASR, and Whisper ASR separately.

## Tests run

- `PYTHONPATH=services/analysis/src:src .venv/bin/python -m pytest tests/services/analysis/test_qwen3_asr_pipeline.py tests/services/analysis/test_models.py -q`
- `PYTHONPATH=src .venv/bin/python -m pytest tests/admin/test_audio_lrc_visibility.py -q`
- `PYTHONPATH=services/analysis/src:src .venv/bin/python -m py_compile services/analysis/src/sow_analysis/models.py services/analysis/src/sow_analysis/config.py services/analysis/src/sow_analysis/storage/cache.py services/analysis/src/sow_analysis/services/qwen3_asr_client.py services/analysis/src/sow_analysis/services/canonical_snap.py services/analysis/src/sow_analysis/workers/lrc.py services/analysis/src/sow_analysis/workers/queue.py services/analysis/src/sow_analysis/routes/jobs.py src/stream_of_worship/admin/services/analysis.py src/stream_of_worship/admin/commands/audio.py tests/services/analysis/test_qwen3_asr_pipeline.py`

## Notes

- `tests/services/analysis/test_api.py` and its targeted LRC API tests hung in this environment before producing output; the new API rejection test is committed but not fully verified here.
- `graphify update .` ran AST extraction but refused to overwrite `graphify-out/graph.json` because the regenerated graph had fewer nodes than the existing graph; graphify files were left unchanged.
- Black was not installed in the populated local venv, so formatting was not run; `git diff --check` passed.
