### PR TITLE
[codex] Add language-aware LRC pipeline

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -2,7 +2,7 @@
 
 ## 2026-06-15
 
-- Addressed PR #104 review feedback by hardening LRC language/script mismatch warnings against missing or non-string lyric payloads and adding regression coverage.
+- Addressed PR #104 review feedback by hardening LRC language/script mismatch warnings against missing or non-string lyric payloads, preserving the legacy `lyrics.lrc` R2 alias for renderers, and adding regression coverage.
 - Implemented `catalog-insert-youtube-v2` for the admin CLI.
 - Added curated `sow-admin catalog insert`, `catalog edit`, `catalog quarantine`, `catalog restore`, and `catalog list --deleted` flows.
 - Added reviewed YouTube metadata/transcript drafting plus shared song ID and lyrics normalization helpers.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -2,6 +2,7 @@
 
 ## 2026-06-15
 
+- Addressed PR #104 review feedback by hardening LRC language/script mismatch warnings against missing or non-string lyric payloads and adding regression coverage.
 - Implemented `catalog-insert-youtube-v2` for the admin CLI.
 - Added curated `sow-admin catalog insert`, `catalog edit`, `catalog quarantine`, `catalog restore`, and `catalog list --deleted` flows.
 - Added reviewed YouTube metadata/transcript drafting plus shared song ID and lyrics normalization helpers.

--- a/reports/current_impl_status.md
+++ b/reports/current_impl_status.md
@@ -14,6 +14,8 @@ The Stream of Worship project consists of an Admin CLI for backend management, a
 
 **Latest Milestone:** LRC generation now resolves `auto`/`zh`/`en` language per job from song title and lyrics, uses language-aware Whisper/Qwen3/YouTube prompts and transcript preferences, and versions LRC/ASR cache keys plus generated R2 LRC object names by resolved language.
 
+**PR #104 Review Fix (2026-06-15):** Hardened LRC language/script mismatch warnings so missing or non-string lyric payloads are treated as empty text instead of raising before warning checks, with regression coverage.
+
 **Maintenance Update (2026-06-15):** Added English/Chinese title-based LRC language detection, `song_title` request propagation from the admin CLI, language-specific YouTube transcript selection, prompt branching, and cache-key/R2 object isolation for language-aware reruns.
 
 **Maintenance Update (2026-06-15):** Added queue logging regression coverage for empty, completed-only, queued, processing, recent failed, and stale failed states. Also fixed async queue test cleanup calls that were leaving un-awaited coroutine warnings.

--- a/reports/current_impl_status.md
+++ b/reports/current_impl_status.md
@@ -1,6 +1,6 @@
 # Stream of Worship - Current Implementation Status Report
 
-**Generated:** 2026-05-17 (updated 2026-06-11)
+**Generated:** 2026-05-17 (updated 2026-06-15)
 **Project:** Stream of Worship - Admin CLI, Analysis Service, Web App & Render Worker
 **Repository:** sow_deployment_preps
 
@@ -12,7 +12,9 @@ The Stream of Worship project consists of an Admin CLI for backend management, a
 
 **Overall Progress:** All phases complete (100%)
 
-**Latest Milestone:** Qwen3 ASR Flash failure diagnostics added — direct Flash failures now log the safe failure reason and routing metadata before Filetrans fallback, Filetrans fallback failures log their own reason, and user-facing fallback log wording now says LLM-based ASR.
+**Latest Milestone:** Analysis queue state logging now suppresses empty periodic traces, still reports active queued/processing work, and reports failed jobs only while they remain within the existing 5-minute in-memory retention window.
+
+**Maintenance Update (2026-06-15):** Added queue logging regression coverage for empty, completed-only, queued, processing, recent failed, and stale failed states. Also fixed async queue test cleanup calls that were leaving un-awaited coroutine warnings.
 
 **Maintenance Update (2026-06-15):** Added the curated non-SOP catalog intake flow for `sow-admin catalog insert`, including reviewed YouTube metadata/caption drafts, duplicate-safe song insertion, nominal `catalog edit`, `catalog list --deleted`, and quarantine/restore recovery commands with shared YouTube audio import reuse.
 

--- a/reports/current_impl_status.md
+++ b/reports/current_impl_status.md
@@ -14,7 +14,7 @@ The Stream of Worship project consists of an Admin CLI for backend management, a
 
 **Latest Milestone:** LRC generation now resolves `auto`/`zh`/`en` language per job from song title and lyrics, uses language-aware Whisper/Qwen3/YouTube prompts and transcript preferences, and versions LRC/ASR cache keys plus generated R2 LRC object names by resolved language.
 
-**PR #104 Review Fix (2026-06-15):** Hardened LRC language/script mismatch warnings so missing or non-string lyric payloads are treated as empty text instead of raising before warning checks, with regression coverage.
+**PR #104 Review Fix (2026-06-15):** Hardened LRC language/script mismatch warnings so missing or non-string lyric payloads are treated as empty text instead of raising before warning checks, and kept publishing the legacy `{hash}/lyrics.lrc` alias alongside versioned language-specific LRC objects for renderer compatibility. Added regression coverage for both fixes.
 
 **Maintenance Update (2026-06-15):** Added English/Chinese title-based LRC language detection, `song_title` request propagation from the admin CLI, language-specific YouTube transcript selection, prompt branching, and cache-key/R2 object isolation for language-aware reruns.
 

--- a/reports/current_impl_status.md
+++ b/reports/current_impl_status.md
@@ -12,7 +12,9 @@ The Stream of Worship project consists of an Admin CLI for backend management, a
 
 **Overall Progress:** All phases complete (100%)
 
-**Latest Milestone:** Analysis queue state logging now suppresses empty periodic traces, still reports active queued/processing work, and reports failed jobs only while they remain within the existing 5-minute in-memory retention window.
+**Latest Milestone:** LRC generation now resolves `auto`/`zh`/`en` language per job from song title and lyrics, uses language-aware Whisper/Qwen3/YouTube prompts and transcript preferences, and versions LRC/ASR cache keys plus generated R2 LRC object names by resolved language.
+
+**Maintenance Update (2026-06-15):** Added English/Chinese title-based LRC language detection, `song_title` request propagation from the admin CLI, language-specific YouTube transcript selection, prompt branching, and cache-key/R2 object isolation for language-aware reruns.
 
 **Maintenance Update (2026-06-15):** Added queue logging regression coverage for empty, completed-only, queued, processing, recent failed, and stale failed states. Also fixed async queue test cleanup calls that were leaving un-awaited coroutine warnings.
 

--- a/services/analysis/src/sow_analysis/models.py
+++ b/services/analysis/src/sow_analysis/models.py
@@ -3,9 +3,9 @@
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
-from typing import List, Optional, Union
+from typing import List, Literal, Optional, Union
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class JobStatus(str, Enum):
@@ -53,7 +53,7 @@ class LrcOptions(BaseModel):
         ""  # LLM model (e.g., "openai/gpt-4o-mini"), falls back to SOW_LLM_MODEL env var
     )
     use_vocals_stem: bool = True  # Prefer vocals stem for cleaner transcription
-    language: str = "zh"  # Whisper language hint
+    language: Literal["auto", "zh", "en"] = "auto"  # LRC language mode
     force: bool = False  # Re-generate even if cached
     force_whisper: bool = False  # Bypass Whisper transcription cache
     use_qwen3_asr: bool = True  # Use DashScope Qwen3 ASR before Whisper fallback
@@ -65,6 +65,15 @@ class LrcOptions(BaseModel):
     use_qwen3: Optional[bool] = None
     max_qwen3_duration: Optional[int] = None
 
+    @field_validator("language", mode="before")
+    @classmethod
+    def validate_language(cls, value: str) -> str:
+        if value is None:
+            return "auto"
+        if value not in {"auto", "zh", "en"}:
+            raise ValueError("language must be one of: auto, zh, en")
+        return value
+
 
 class LrcJobRequest(BaseModel):
     """Request to submit an LRC generation job."""
@@ -72,6 +81,7 @@ class LrcJobRequest(BaseModel):
     audio_url: str
     content_hash: str
     lyrics_text: str
+    song_title: str = ""
     youtube_url: str = ""  # YouTube URL for transcript-based LRC (primary path)
     options: LrcOptions = Field(default_factory=LrcOptions)
 

--- a/services/analysis/src/sow_analysis/storage/r2.py
+++ b/services/analysis/src/sow_analysis/storage/r2.py
@@ -132,17 +132,23 @@ class R2Client:
 
         return f"s3://{self.bucket}/{key}"
 
-    async def upload_lrc(self, hash_prefix: str, lrc_path: Path) -> str:
+    async def upload_lrc(
+        self,
+        hash_prefix: str,
+        lrc_path: Path,
+        object_name: str = "lyrics.lrc",
+    ) -> str:
         """Upload lyrics.lrc to R2.
 
         Args:
             hash_prefix: Content hash prefix for the path
             lrc_path: Path to the LRC file
+            object_name: Filename to store under the hash prefix
 
         Returns:
-            s3://bucket/{hash}/lyrics.lrc URL
+            s3://bucket/{hash}/{object_name} URL
         """
-        key = f"{hash_prefix}/lyrics.lrc"
+        key = f"{hash_prefix}/{object_name}"
         loop = asyncio.get_event_loop()
 
         await loop.run_in_executor(None, self.s3.upload_file, str(lrc_path), self.bucket, key)

--- a/services/analysis/src/sow_analysis/workers/lrc.py
+++ b/services/analysis/src/sow_analysis/workers/lrc.py
@@ -14,7 +14,7 @@ import re
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, List, Optional
+from typing import Callable, List, Literal, Optional
 
 from ..config import settings
 from ..models import LrcOptions
@@ -24,6 +24,10 @@ from ..storage.cache import CacheManager
 from .exceptions import LLMConfigError, WorkerError
 
 logger = logging.getLogger(__name__)
+
+ResolvedLrcLanguage = Literal["zh", "en"]
+LRC_PROMPT_CACHE_VERSION = "lang-v2"
+WHISPER_INITIAL_PROMPT_VERSION = "lang-v2"
 
 
 class LRCWorkerError(WorkerError):
@@ -48,6 +52,80 @@ class Qwen3RefinementError(LRCWorkerError):
     """Raised when Qwen3 refinement fails (non-blocking, falls back to LLM)."""
 
     pass
+
+
+@dataclass(frozen=True)
+class LrcLanguageResolution:
+    requested: str
+    resolved: ResolvedLrcLanguage
+    reason: str
+
+
+_CJK_RE = re.compile(
+    "["
+    "\u3400-\u4dbf"
+    "\u4e00-\u9fff"
+    "\uf900-\ufaff"
+    "\U00020000-\U0002a6df"
+    "\U0002a700-\U0002b73f"
+    "\U0002b740-\U0002b81f"
+    "\U0002b820-\U0002ceaf"
+    "\U0002ceb0-\U0002ebef"
+    "]"
+)
+_LATIN_RE = re.compile(r"[A-Za-z]")
+
+
+def _contains_cjk(text: str) -> bool:
+    return bool(_CJK_RE.search(text or ""))
+
+
+def _contains_latin(text: str) -> bool:
+    return bool(_LATIN_RE.search(text or ""))
+
+
+def resolve_lrc_language(
+    language: str,
+    song_title: str,
+    lyrics_text: str,
+) -> LrcLanguageResolution:
+    """Resolve raw LRC language option to a concrete downstream language."""
+    if language in {"zh", "en"}:
+        return LrcLanguageResolution(language, language, "explicit")
+    if language != "auto":
+        raise ValueError("language must be one of: auto, zh, en")
+
+    if _contains_cjk(song_title):
+        return LrcLanguageResolution(language, "zh", "title_cjk")
+    if _contains_latin(song_title):
+        return LrcLanguageResolution(language, "en", "title_latin")
+    if _contains_cjk(lyrics_text):
+        return LrcLanguageResolution(language, "zh", "lyrics_cjk")
+    if _contains_latin(lyrics_text):
+        return LrcLanguageResolution(language, "en", "lyrics_latin")
+    return LrcLanguageResolution(language, "zh", "default_zh")
+
+
+def warn_if_lrc_language_script_mismatch(language: ResolvedLrcLanguage, lyrics_text: str) -> None:
+    stripped = lyrics_text.strip()
+    if not stripped:
+        return
+    cjk_count = len(_CJK_RE.findall(stripped))
+    latin_count = len(_LATIN_RE.findall(stripped))
+    if language == "en" and cjk_count > latin_count:
+        logger.warning(
+            "Resolved LRC language is en but lyrics contain more CJK than Latin characters "
+            "(cjk=%s latin=%s)",
+            cjk_count,
+            latin_count,
+        )
+    elif language == "zh" and latin_count > cjk_count:
+        logger.warning(
+            "Resolved LRC language is zh but lyrics contain more Latin than CJK characters "
+            "(latin=%s cjk=%s)",
+            latin_count,
+            cjk_count,
+        )
 
 
 @dataclass
@@ -83,7 +161,7 @@ def _format_timestamp(seconds: float) -> str:
 async def _run_whisper_transcription(
     audio_path: Path,
     model_name: str,
-    language: str,
+    language: ResolvedLrcLanguage,
     device: str,
     lyrics_text: Optional[str] = None,
 ) -> List[WhisperPhrase]:
@@ -126,7 +204,7 @@ async def _run_whisper_transcription(
         model_load_elapsed = time.time() - model_load_start
         logger.info(f"Whisper model loaded in {model_load_elapsed:.2f}s")
 
-        # Transcribe with Chinese worship song optimizations
+        # Transcribe with language-specific worship song context.
         logger.info(f"Running Whisper transcription: {audio_path}")
         transcribe_start = time.time()
 
@@ -136,10 +214,23 @@ async def _run_whisper_transcription(
             lyrics_truncated = "\n".join(lyrics_text.split("\n")[:50])
             if len(lyrics_truncated) > 2000:
                 lyrics_truncated = lyrics_truncated[:2000]
-            initial_prompt = f"这是一首中文敬拜诗歌。歌词如下：\n{lyrics_truncated}"
+            if language == "en":
+                initial_prompt = (
+                    "This is an English worship song. Preserve the English words, "
+                    "phrasing, contractions, casing, and punctuation from these official lyrics:\n"
+                    f"{lyrics_truncated}"
+                )
+            else:
+                initial_prompt = f"这是一首中文敬拜诗歌。歌词如下：\n{lyrics_truncated}"
             logger.info(f"Using lyrics-enhanced initial prompt ({len(lyrics_truncated)} chars)")
         else:
-            initial_prompt = "这是一首中文敬拜歌的歌詞"
+            if language == "en":
+                initial_prompt = (
+                    "This is an English worship song. Preserve English worship lyrics, "
+                    "phrasing, contractions, casing, and punctuation."
+                )
+            else:
+                initial_prompt = "这是一首中文敬拜歌的歌詞"
             logger.info("Using default initial prompt (no lyrics provided)")
 
         segments, info = model.transcribe(
@@ -195,7 +286,11 @@ async def _run_whisper_transcription(
     return phrases
 
 
-def _build_alignment_prompt(lyrics_text: str, whisper_phrases: List[WhisperPhrase]) -> str:
+def _build_alignment_prompt(
+    lyrics_text: str,
+    whisper_phrases: List[WhisperPhrase],
+    language: ResolvedLrcLanguage = "zh",
+) -> str:
     """Build the LLM prompt for lyrics alignment.
 
     Args:
@@ -217,6 +312,40 @@ def _build_alignment_prompt(lyrics_text: str, whisper_phrases: List[WhisperPhras
 
     # Calculate total duration from whisper phrases
     last_timestamp = max(p.end for p in whisper_phrases) if whisper_phrases else 0.0
+
+    if language == "en":
+        return f"""You are a lyrics alignment assistant for English worship songs. Your task is to assign accurate timestamps to every sung lyric line.
+
+## Official Lyrics (Gold Standard Text - Use exactly as written)
+```
+{lyrics_text}
+```
+
+## ASR Transcription (Phrases with Timestamps)
+```json
+{phrases_json}
+```
+
+## Song Structure Information
+- Total audio duration: {last_timestamp:.2f} seconds
+- The ASR transcription contains {len(whisper_phrases)} phrases
+
+## Critical Instructions
+
+1. Worship songs often repeat verses, choruses, bridges, and tags. Preserve repeated sung sections as separate output entries with their own timestamps.
+2. Process each ASR phrase in order. For each phrase, find the best matching line from the official lyrics.
+3. The same official lyric line can appear multiple times with different timestamps.
+4. Output approximately {len(whisper_phrases)} entries. Do not collapse repeated sections.
+5. Use the exact text from "Official Lyrics". Preserve English casing, punctuation, contractions, and line text exactly.
+6. Use the start time of each ASR phrase as the timestamp for the matched lyric line.
+7. Keep timestamps in ascending order.
+
+## Output Format
+Return a JSON array where each object has:
+- "time_seconds": float (start time from the corresponding ASR phrase)
+- "text": string (matched official lyric line, exactly as provided)
+
+Return ONLY the JSON array, no explanation or markdown code blocks."""
 
     return f"""You are a lyrics alignment assistant. Your task is to assign accurate timestamps to every line sung in the song.
 
@@ -273,7 +402,9 @@ Return ONLY the JSON array, no explanation or markdown code blocks."""
 
 
 def _build_qwen3_asr_alignment_prompt(
-    lyrics_text: str, whisper_phrases: List[WhisperPhrase]
+    lyrics_text: str,
+    whisper_phrases: List[WhisperPhrase],
+    language: ResolvedLrcLanguage = "zh",
 ) -> str:
     phrases_json = json.dumps(
         [
@@ -283,6 +414,29 @@ def _build_qwen3_asr_alignment_prompt(
         ensure_ascii=False,
         indent=2,
     )
+    if language == "en":
+        return f"""You are a lyrics alignment assistant for English worship songs.
+
+## Canonical English Lyrics
+```
+{lyrics_text}
+```
+
+## Qwen3 ASR Phrases
+These phrases may already be snapped to canonical lyric lines. Preserve each timestamp.
+Only fix text, assign or reorder canonical English lyric lines, preserve repeated sung
+sections, and preserve official casing, punctuation, and contractions.
+```json
+{phrases_json}
+```
+
+Return the same JSON shape:
+[
+  {{"time_seconds": 12.34, "text": "canonical lyric line"}}
+]
+
+Return ONLY the JSON array, no explanation or markdown code blocks."""
+
     return f"""You are a lyrics alignment assistant for Chinese worship songs.
 
 ## Canonical Lyrics
@@ -404,7 +558,10 @@ async def _llm_align(
     whisper_phrases: List[WhisperPhrase],
     llm_model: str,
     max_retries: int = 3,
-    prompt_builder: Callable[[str, List[WhisperPhrase]], str] = _build_alignment_prompt,
+    prompt_builder: Callable[
+        [str, List[WhisperPhrase], ResolvedLrcLanguage], str
+    ] = _build_alignment_prompt,
+    language: ResolvedLrcLanguage = "zh",
 ) -> List[LRCLine]:
     """Use LLM to align lyrics with Whisper timestamps.
 
@@ -443,7 +600,7 @@ async def _llm_align(
         )
 
     loop = asyncio.get_event_loop()
-    prompt = prompt_builder(lyrics_text, whisper_phrases)
+    prompt = prompt_builder(lyrics_text, whisper_phrases, language)
 
     # Log the full LLM prompt
     logger.info("=" * 80)
@@ -562,8 +719,35 @@ def build_qwen3_asr_cache_key(
     return hashlib.sha256(json.dumps(parts, sort_keys=True).encode("utf-8")).hexdigest()
 
 
-def _build_qwen3_context(lyrics_text: str, max_chars: int) -> str:
-    header = "這是一首中文敬拜詩歌。請優先辨識下列正式歌詞中的詞句，保留演唱重複。"
+def build_whisper_transcription_cache_key(
+    content_hash: str,
+    lyrics_text: str,
+    stem_kind: str,
+    model: str,
+    language: ResolvedLrcLanguage,
+) -> str:
+    """Build language-aware Whisper transcription cache key."""
+    parts = {
+        "content_hash": content_hash,
+        "lyrics_hash": hashlib.sha256(lyrics_text.encode("utf-8")).hexdigest(),
+        "stem_kind": stem_kind,
+        "model": model,
+        "language": language,
+        "prompt_version": WHISPER_INITIAL_PROMPT_VERSION,
+    }
+    return hashlib.sha256(json.dumps(parts, sort_keys=True).encode("utf-8")).hexdigest()
+
+
+def _build_qwen3_context(
+    lyrics_text: str, max_chars: int, language: ResolvedLrcLanguage = "zh"
+) -> str:
+    if language == "en":
+        header = (
+            "This is an English worship song. Prioritize these official lyric words and "
+            "phrases, preserve repeated sung sections, and preserve English casing and punctuation."
+        )
+    else:
+        header = "這是一首中文敬拜詩歌。請優先辨識下列正式歌詞中的詞句，保留演唱重複。"
     lines = []
     total = len(header) + 2
     for line in lyrics_text.splitlines():
@@ -585,13 +769,14 @@ async def generate_lrc_from_qwen3_asr(
     cache_key: str,
     cache_manager: CacheManager,
     dashscope_semaphore: asyncio.Semaphore,
+    resolved_language: ResolvedLrcLanguage = "zh",
 ) -> tuple[Path, int, list[WhisperPhrase]]:
     """Generate LRC from DashScope Qwen3 ASR, snap, then LLM alignment."""
     context_limit = min(
         options.qwen3_asr_context_max_chars,
         settings.SOW_DASHSCOPE_ASR_CONTEXT_MAX_CHARS,
     )
-    context = _build_qwen3_context(lyrics_text, context_limit)
+    context = _build_qwen3_context(lyrics_text, context_limit, resolved_language)
 
     cached_payload = (
         None if options.force_qwen3_asr else cache_manager.get_qwen3_asr_transcription(cache_key)
@@ -630,6 +815,7 @@ async def generate_lrc_from_qwen3_asr(
         qwen_phrases,
         llm_model=options.llm_model,
         prompt_builder=_build_qwen3_asr_alignment_prompt,
+        language=resolved_language,
     )
     line_count = _write_lrc(lrc_lines, output_path)
     logger.info("Qwen3 ASR LRC generation wrote %s lines", line_count)
@@ -641,6 +827,7 @@ async def try_youtube_transcript_lrc(
     lyrics_text: str,
     options: LrcOptions,
     output_path: Path,
+    resolved_language: ResolvedLrcLanguage = "zh",
 ) -> Optional[tuple[Path, int, List[WhisperPhrase]]]:
     """Attempt LRC generation via YouTube transcript (primary path).
 
@@ -667,6 +854,7 @@ async def try_youtube_transcript_lrc(
             youtube_url=youtube_url,
             lyrics_text=lyrics_text,
             llm_model=options.llm_model,
+            language=resolved_language,
         )
         line_count = _write_lrc(lrc_lines, output_path)
         total_elapsed = time.time() - lrc_start
@@ -701,6 +889,7 @@ async def generate_lrc(
     content_hash: Optional[str] = None,
     vocals_stem_url: Optional[str] = None,
     local_model_semaphore: Optional[asyncio.Semaphore] = None,
+    resolved_language: ResolvedLrcLanguage = "zh",
 ) -> tuple[Path, int, List[WhisperPhrase]]:
     """Generate timestamped LRC file from audio and lyrics.
 
@@ -736,7 +925,9 @@ async def generate_lrc(
 
     # Primary path: YouTube transcript + LLM correction
     if youtube_url:
-        result = await try_youtube_transcript_lrc(youtube_url, lyrics_text, options, output_path)
+        result = await try_youtube_transcript_lrc(
+            youtube_url, lyrics_text, options, output_path, resolved_language
+        )
         if result is not None:
             return result
 
@@ -764,7 +955,7 @@ async def generate_lrc(
             whisper_phrases = await _run_whisper_transcription(
                 audio_path,
                 model_name=options.whisper_model,
-                language=options.language,
+                language=resolved_language,
                 device=settings.SOW_WHISPER_DEVICE,
                 lyrics_text=lyrics_text,
             )
@@ -774,6 +965,7 @@ async def generate_lrc(
         lyrics_text,
         whisper_phrases,
         llm_model=options.llm_model,
+        language=resolved_language,
     )
 
     # Step 3: Write LRC file

--- a/services/analysis/src/sow_analysis/workers/lrc.py
+++ b/services/analysis/src/sow_analysis/workers/lrc.py
@@ -106,8 +106,8 @@ def resolve_lrc_language(
     return LrcLanguageResolution(language, "zh", "default_zh")
 
 
-def warn_if_lrc_language_script_mismatch(language: ResolvedLrcLanguage, lyrics_text: str) -> None:
-    stripped = lyrics_text.strip()
+def warn_if_lrc_language_script_mismatch(language: ResolvedLrcLanguage, lyrics_text: object) -> None:
+    stripped = lyrics_text.strip() if isinstance(lyrics_text, str) else ""
     if not stripped:
         return
     cjk_count = len(_CJK_RE.findall(stripped))

--- a/services/analysis/src/sow_analysis/workers/queue.py
+++ b/services/analysis/src/sow_analysis/workers/queue.py
@@ -960,6 +960,7 @@ class JobQueue:
                         lrc_path,
                         object_name=f"lyrics.{resolved_language}.v2.lrc",
                     )
+                    await self.r2_client.upload_lrc(hash_prefix, lrc_path)
 
                 # Save to cache using composite key (audio hash + lyrics hash)
                 cache_result = {

--- a/services/analysis/src/sow_analysis/workers/queue.py
+++ b/services/analysis/src/sow_analysis/workers/queue.py
@@ -40,7 +40,7 @@ async def optional_semaphore(sem: Optional[asyncio.Semaphore]) -> AsyncIterator[
         yield
 
 
-def _compute_lrc_cache_key(content_hash: str, lyrics_text: str) -> str:
+def _compute_lrc_cache_key(content_hash: str, lyrics_text: str, language: str = "zh") -> str:
     """Compute cache key for LRC generation based on audio hash and lyrics.
 
     The cache key is a hash of both the audio content hash and the lyrics text.
@@ -55,7 +55,7 @@ def _compute_lrc_cache_key(content_hash: str, lyrics_text: str) -> str:
     """
     # Create a composite string of both inputs
     lyrics_hash = hashlib.sha256(lyrics_text.encode("utf-8")).hexdigest()[:16]
-    composite = f"{content_hash}:{lyrics_hash}"
+    composite = f"{content_hash}:{lyrics_hash}:{language}:lrc-lang-v2"
     # Return a shorter hash of the composite
     return hashlib.sha256(composite.encode("utf-8")).hexdigest()[:32]
 
@@ -88,17 +88,23 @@ except ImportError:
 try:
     from .lrc import (
         LRCWorkerError,
+        build_whisper_transcription_cache_key,
         build_qwen3_asr_cache_key,
         generate_lrc,
         generate_lrc_from_qwen3_asr,
+        resolve_lrc_language,
+        warn_if_lrc_language_script_mismatch,
     )
     from ..services.qwen3_asr_client import Qwen3AsrError
 except ImportError:
     LRCWorkerError = Exception
     Qwen3AsrError = Exception
     build_qwen3_asr_cache_key = None
+    build_whisper_transcription_cache_key = None
     generate_lrc = None
     generate_lrc_from_qwen3_asr = None
+    resolve_lrc_language = None
+    warn_if_lrc_language_script_mismatch = None
 
 # Optional embedding imports - require openai
 try:
@@ -706,8 +712,41 @@ class JobQueue:
         else:
             logger.info("No YouTube URL — will use Whisper transcription directly")
 
+        if resolve_lrc_language is None or warn_if_lrc_language_script_mismatch is None:
+            job.status = JobStatus.FAILED
+            job.error_message = "LRC language resolver is not available"
+            job.stage = "missing_dependencies"
+            job.updated_at = datetime.now(timezone.utc)
+            try:
+                await self.job_store.update_job(
+                    job.id,
+                    status="failed",
+                    stage="missing_dependencies",
+                    error_message="LRC language resolver is not available",
+                )
+            except Exception as e:
+                logger.error(f"Failed to update job {job.id} in database: {e}")
+            return
+
+        language_resolution = resolve_lrc_language(
+            request.options.language,
+            request.song_title,
+            request.lyrics_text,
+        )
+        resolved_language = language_resolution.resolved
+        logger.info(
+            "Resolved LRC language: requested=%s resolved=%s reason=%s title=%r",
+            language_resolution.requested,
+            resolved_language,
+            language_resolution.reason,
+            request.song_title,
+        )
+        warn_if_lrc_language_script_mismatch(resolved_language, request.lyrics_text)
+
         # Compute composite cache key based on audio hash + lyrics hash
-        lrc_cache_key = _compute_lrc_cache_key(request.content_hash, request.lyrics_text)
+        lrc_cache_key = _compute_lrc_cache_key(
+            request.content_hash, request.lyrics_text, resolved_language
+        )
         logger.info(f"LRC cache key: {lrc_cache_key} (audio_hash={request.content_hash[:12]}...)")
 
         try:
@@ -767,6 +806,7 @@ class JobQueue:
                         request.lyrics_text,
                         request.options,
                         lrc_path,
+                        resolved_language,
                     )
                     if youtube_lrc_result:
                         lrc_path, line_count, whisper_phrases = youtube_lrc_result
@@ -807,14 +847,16 @@ class JobQueue:
                                 request.options.qwen3_asr_context_max_chars,
                                 settings.SOW_DASHSCOPE_ASR_CONTEXT_MAX_CHARS,
                             )
-                            context = _build_qwen3_context(request.lyrics_text, context_limit)
+                            context = _build_qwen3_context(
+                                request.lyrics_text, context_limit, resolved_language
+                            )
                             qwen_cache_key = build_qwen3_asr_cache_key(
                                 request.content_hash,
                                 request.lyrics_text,
                                 resolved_audio.stem_kind,
                                 settings.SOW_DASHSCOPE_ASR_FLASH_MODEL,
                                 settings.SOW_DASHSCOPE_ASR_REGION,
-                                request.options.language,
+                                resolved_language,
                                 context_limit,
                                 context,
                             )
@@ -833,6 +875,7 @@ class JobQueue:
                                 cache_key=qwen_cache_key,
                                 cache_manager=self.cache_manager,
                                 dashscope_semaphore=self._dashscope_asr_semaphore,
+                                resolved_language=resolved_language,
                             )
                             lrc_source = "qwen3_asr"
                             await self._update_stage(job, "qwen3_asr_done", 0.7)
@@ -851,14 +894,23 @@ class JobQueue:
                         logger.info("Qwen3 ASR disabled or DashScope not configured; using Whisper")
                         await self._update_stage(job, "falling_back_to_whisper", 0.35)
 
-                    # Check for cached Whisper transcription (audio hash only, not lyrics)
+                    # Check for cached Whisper transcription with language/prompt-aware key.
                     if lrc_source != "qwen3_asr":
                         cached_phrases = None
+                        if build_whisper_transcription_cache_key is None:
+                            raise LRCWorkerError("Whisper cache key builder is not available")
+                        whisper_cache_key = build_whisper_transcription_cache_key(
+                            request.content_hash,
+                            request.lyrics_text,
+                            resolved_audio.stem_kind,
+                            request.options.whisper_model,
+                            resolved_language,
+                        )
                         if request.options.force_whisper:
                             logger.info("Whisper cache bypassed (force_whisper=True)")
                         else:
                             cached_data = self.cache_manager.get_whisper_transcription(
-                                request.content_hash
+                                whisper_cache_key
                             )
                             if cached_data:
                                 from .lrc import WhisperPhrase
@@ -882,6 +934,7 @@ class JobQueue:
                             content_hash=request.content_hash,
                             vocals_stem_url=resolved_audio.r2_url,
                             local_model_semaphore=self._local_model_semaphore,
+                            resolved_language=resolved_language,
                         )
                         lrc_source = "whisper_asr"
 
@@ -891,7 +944,7 @@ class JobQueue:
                                 for p in whisper_phrases
                             ]
                             self.cache_manager.save_whisper_transcription(
-                                request.content_hash, phrases_data
+                                whisper_cache_key, phrases_data
                             )
                             logger.info("Whisper transcription cached for future use")
 
@@ -902,7 +955,11 @@ class JobQueue:
                 # Upload LRC to R2
                 lrc_url = None
                 if self.r2_client:
-                    lrc_url = await self.r2_client.upload_lrc(hash_prefix, lrc_path)
+                    lrc_url = await self.r2_client.upload_lrc(
+                        hash_prefix,
+                        lrc_path,
+                        object_name=f"lyrics.{resolved_language}.v2.lrc",
+                    )
 
                 # Save to cache using composite key (audio hash + lyrics hash)
                 cache_result = {

--- a/services/analysis/src/sow_analysis/workers/queue.py
+++ b/services/analysis/src/sow_analysis/workers/queue.py
@@ -16,6 +16,8 @@ from ..logging_config import set_job_id
 
 logger = logging.getLogger(__name__)
 
+FINISHED_JOB_MEMORY_RETENTION_SECONDS = 300.0
+
 
 @dataclass
 class ResolvedTranscriptionAudio:
@@ -369,7 +371,11 @@ class JobQueue:
         if job.status in (JobStatus.COMPLETED, JobStatus.FAILED, JobStatus.CANCELLED):
             asyncio.create_task(self._cleanup_finished_job(job.id))
 
-    async def _cleanup_finished_job(self, job_id: str, delay: float = 300.0):
+    async def _cleanup_finished_job(
+        self,
+        job_id: str,
+        delay: float = FINISHED_JOB_MEMORY_RETENTION_SECONDS,
+    ):
         """Remove finished job from in-memory cache after delay.
 
         Args:
@@ -1345,15 +1351,27 @@ class JobQueue:
             JobType.STEM_SEPARATION: [],
         }
 
+        has_reportable_jobs = False
         for job in self._jobs.values():
             stats[job.type][job.status] += 1
 
             if job.status == JobStatus.QUEUED:
                 wait_time = (now - job.created_at).total_seconds()
                 queued_wait_times[job.type].append(wait_time)
+                has_reportable_jobs = True
             elif job.status == JobStatus.PROCESSING:
                 duration = (now - job.updated_at).total_seconds()
                 processing_durations[job.type].append(duration)
+                has_reportable_jobs = True
+            elif (
+                job.status == JobStatus.FAILED
+                and (now - job.updated_at).total_seconds()
+                <= FINISHED_JOB_MEMORY_RETENTION_SECONDS
+            ):
+                has_reportable_jobs = True
+
+        if not has_reportable_jobs:
+            return
 
         # Build summary line
         analyze_stats = f"queued:{stats[JobType.ANALYZE][JobStatus.QUEUED]},processing:{stats[JobType.ANALYZE][JobStatus.PROCESSING]},completed:{stats[JobType.ANALYZE][JobStatus.COMPLETED]},failed:{stats[JobType.ANALYZE][JobStatus.FAILED]}"

--- a/services/analysis/src/sow_analysis/workers/youtube_transcript.py
+++ b/services/analysis/src/sow_analysis/workers/youtube_transcript.py
@@ -104,6 +104,7 @@ def _format_transcript_text(transcript: list) -> str:
 def build_correction_prompt(
     transcript_text: str,
     official_lyrics: list[str],
+    language: str = "zh",
 ) -> str:
     """Build LLM prompt for lyrics correction.
 
@@ -115,6 +116,35 @@ def build_correction_prompt(
         Correction prompt string
     """
     lyrics_str = "\n".join(official_lyrics)
+
+    if language == "en":
+        return f"""You are a lyrics correction assistant for English worship songs.
+
+## Task
+Compare the subtitle transcription against the official English lyrics. Correct each transcribed line to the matching official lyric while preserving the original timecodes.
+
+## Rules
+1. Each transcribed line corresponds to a sung phrase in the official lyrics. Replace the transcribed text with the matching official English lyric text.
+2. Songs often repeat sections (verse, chorus, bridge, tag). Keep all repeated phrases with their timecodes.
+3. Preserve the number of matching sung lyric lines and their timecodes. Only correct text content.
+4. Preserve casing, punctuation, contractions, and line text from the official lyrics.
+5. If a transcribed line clearly does not match sung lyrics (instrumental, audience noise, speech), remove that line entirely.
+
+## Transcribed Subtitle
+```
+{transcript_text}
+```
+
+## Official Lyrics
+```
+{lyrics_str}
+```
+
+## Output Format
+Output ONLY corrected lines in LRC format, one per line:
+[mm:ss.xx] English lyric
+
+No blank lines, no commentary, no markdown."""
 
     return f"""You are a lyrics correction assistant for Chinese worship songs.
 
@@ -183,6 +213,12 @@ EN_LANG_CODES = ["en-US", "en"]
 DEFAULT_LANGUAGES = ZH_LANG_CODES + EN_LANG_CODES
 
 
+def language_preference_codes(language: str) -> list[str]:
+    if language == "en":
+        return EN_LANG_CODES + ZH_LANG_CODES
+    return ZH_LANG_CODES + EN_LANG_CODES
+
+
 def _build_proxy_config() -> Optional[RotatingProxyConfig]:
     """Build proxy config from settings if proxy is configured.
 
@@ -198,14 +234,11 @@ def _build_proxy_config() -> Optional[RotatingProxyConfig]:
     )
 
 
-def _find_best_transcript(transcript_list: Any) -> Optional[Any]:
+def _find_best_transcript(transcript_list: Any, language: str = "zh") -> Optional[Any]:
     """Find the best available transcript from a TranscriptList.
 
-    Priority order:
-    1. Manually created Chinese transcript (most accurate for lyrics)
-    2. Generated Chinese transcript
-    3. Manually created English transcript
-    4. Generated English transcript
+    Priority order follows the resolved LRC language. Manual captions are preferred
+    within each language before generated captions.
 
     Args:
         transcript_list: Iterable of Transcript objects from YouTubeTranscriptApi.list()
@@ -233,12 +266,15 @@ def _find_best_transcript(transcript_list: Any) -> Optional[Any]:
             elif is_generated and best_en_generated is None:
                 best_en_generated = transcript
 
+    if language == "en":
+        return best_en_manual or best_en_generated or best_zh_manual or best_zh_generated
     return best_zh_manual or best_zh_generated or best_en_manual or best_en_generated
 
 
 async def fetch_youtube_transcript(
     video_id: str,
     languages: Optional[List[str]] = None,
+    language: str = "zh",
 ) -> list:
     """Download captions from YouTube via youtube-transcript-api.
 
@@ -260,7 +296,7 @@ async def fetch_youtube_transcript(
         YouTubeTranscriptError: If transcript cannot be fetched
     """
     if languages is None:
-        languages = DEFAULT_LANGUAGES
+        languages = language_preference_codes(language)
 
     proxy_config = _build_proxy_config()
     if proxy_config:
@@ -281,7 +317,7 @@ async def fetch_youtube_transcript(
 
         ytt_api = YouTubeTranscriptApi(proxy_config=proxy_config)
         transcript_list = ytt_api.list(video_id)
-        best = _find_best_transcript(transcript_list)
+        best = _find_best_transcript(transcript_list, language=language)
         if best is None:
             return None
         logger.info(
@@ -386,6 +422,7 @@ async def youtube_transcript_to_lrc(
     youtube_url: str,
     lyrics_text: str,
     llm_model: str,
+    language: str = "zh",
 ) -> List[LRCLine]:
     """End-to-end: YouTube transcript -> LLM correction -> LRC lines.
 
@@ -409,12 +446,12 @@ async def youtube_transcript_to_lrc(
     logger.info(f"Extracted video ID: {video_id}")
 
     # Step 2: Fetch transcript
-    transcript = await fetch_youtube_transcript(video_id)
+    transcript = await fetch_youtube_transcript(video_id, language=language)
 
     # Step 3: Format transcript and build prompt
     transcript_text = _format_transcript_text(transcript)
     lyrics_lines = [line for line in lyrics_text.split("\n") if line.strip()]
-    prompt = build_correction_prompt(transcript_text, lyrics_lines)
+    prompt = build_correction_prompt(transcript_text, lyrics_lines, language=language)
 
     # Log the prompt
     logger.info("=" * 80)

--- a/services/analysis/tests/test_youtube_transcript.py
+++ b/services/analysis/tests/test_youtube_transcript.py
@@ -4,12 +4,14 @@ import pytest
 
 from sow_analysis.workers.youtube_transcript import (
     DEFAULT_LANGUAGES,
+    EN_LANG_CODES,
     ZH_LANG_CODES,
     _build_proxy_config,
     _find_best_transcript,
     build_correction_prompt,
     extract_video_id,
     fetch_youtube_transcript,
+    language_preference_codes,
     parse_lrc_response,
     RotatingProxyConfig,
 )
@@ -68,6 +70,12 @@ class TestBuildCorrectionPrompt:
         prompt = build_correction_prompt("00:00.00\ntest\n", ["測試"])
         assert "Rules" in prompt
         assert "timecodes" in prompt
+
+    def test_english_prompt_preserves_official_casing(self):
+        prompt = build_correction_prompt("00:00.00\nill sing\n", ["I'll Sing"], language="en")
+        assert "English worship songs" in prompt
+        assert "Preserve casing" in prompt
+        assert "I'll Sing" in prompt
 
 
 class TestParseLrcResponse:
@@ -238,6 +246,16 @@ class TestDefaultLanguages:
         en_indices = [DEFAULT_LANGUAGES.index(c) for c in DEFAULT_LANGUAGES if c.startswith("en")]
         assert max(zh_indices) < min(en_indices)
 
+    def test_en_preference_codes_put_en_first(self):
+        languages = language_preference_codes("en")
+        assert languages[: len(EN_LANG_CODES)] == EN_LANG_CODES
+        assert languages[-len(ZH_LANG_CODES) :] == ZH_LANG_CODES
+
+    def test_zh_preference_codes_put_zh_first(self):
+        languages = language_preference_codes("zh")
+        assert languages[: len(ZH_LANG_CODES)] == ZH_LANG_CODES
+        assert languages[-len(EN_LANG_CODES) :] == EN_LANG_CODES
+
 
 class TestFindBestTranscript:
     """Tests for _find_best_transcript()."""
@@ -259,6 +277,17 @@ class TestFindBestTranscript:
         generated = self._make_transcript("zh-TW", "Chinese (Taiwan)", is_generated=True)
         result = _find_best_transcript([generated, manual])
         assert result is manual
+
+    def test_english_language_prefers_english_over_chinese(self):
+        zh_manual = self._make_transcript("zh-TW", "Chinese (Taiwan)", is_generated=False)
+        en_manual = self._make_transcript("en", "English", is_generated=False)
+        result = _find_best_transcript([zh_manual, en_manual], language="en")
+        assert result is en_manual
+
+    def test_english_language_falls_back_to_chinese(self):
+        zh_manual = self._make_transcript("zh-TW", "Chinese (Taiwan)", is_generated=False)
+        result = _find_best_transcript([zh_manual], language="en")
+        assert result is zh_manual
 
     def test_prefers_zh_over_en(self):
         zh_gen = self._make_transcript("zh-CN", "Chinese (China)", is_generated=True)

--- a/specs/lrc-pipeline-english-chinese-title-detection-v2.md
+++ b/specs/lrc-pipeline-english-chinese-title-detection-v2.md
@@ -1,0 +1,372 @@
+# LRC Pipeline English/Chinese Title-Based Language Detection v2
+
+## Summary
+
+Enhance LRC generation so English songs use English-aware transcription, transcript
+selection, prompts, and cache entries, while Chinese songs keep the current Chinese
+behavior. The analysis service resolves the effective language once per LRC job from
+`language` and `song_title`, then passes only resolved `zh` or `en` into downstream
+pipeline paths.
+
+This version incorporates review decisions:
+
+- `auto` is the default admin language option.
+- Any CJK character in the title resolves to `zh`, even when the title also contains
+  English.
+- Resolved language is logged only; it is not stored in job result or DB-visible
+  metadata.
+
+## Goals
+
+- Improve English LRC quality without regressing Chinese LRC generation.
+- Keep old persisted jobs and direct API clients compatible.
+- Prevent language-specific prompt/cache changes from reusing stale Chinese-only
+  outputs.
+- Avoid data loss or stale cache pointers when rerunning a recording under different
+  language modes.
+
+## Non-Goals
+
+- Do not add languages beyond `zh` and `en`.
+- Do not expose resolved language in `JobResult`, recording rows, or admin DB metadata.
+- Do not change canonical lyrics storage or scraping behavior.
+
+## Language Option Semantics
+
+`LrcOptions.language` should accept exactly:
+
+- `auto`: resolve from title/lyrics.
+- `zh`: force Chinese behavior.
+- `en`: force English behavior.
+
+Admin CLI commands should default to `language="auto"`. Explicit `--lang zh` and
+`--lang en` remain available for exceptions such as pinyin Chinese titles or imported
+metadata that does not reflect the actual sung language.
+
+The API should validate language values at submission time and reject anything other
+than `auto`, `zh`, or `en`. Internal transcription, prompt, transcript, and cache code
+must receive only resolved `zh` or `en`, never raw `auto`.
+
+## Request Model Changes
+
+Add `song_title: str = ""` to `LrcJobRequest`.
+
+Compatibility requirements:
+
+- Missing `song_title` remains valid for old persisted jobs and direct API clients.
+- Existing `language="zh"` payloads remain valid and force Chinese behavior.
+- Existing jobs with no language field continue to use the current Pydantic default.
+  If the model default changes to `auto`, confirm old persisted job JSON without an
+  options block still behaves acceptably. If not, preserve backward compatibility with
+  a migration shim or explicit legacy reconstruction behavior.
+
+## Language Resolver
+
+Create a shared resolver, for example:
+
+```python
+resolve_lrc_language(language: str, song_title: str, lyrics_text: str) -> Literal["zh", "en"]
+```
+
+Rules:
+
+1. Explicit `zh` or `en` wins.
+2. `auto` inspects `song_title`.
+3. If `song_title` contains any CJK character, resolve `zh`.
+4. Else if `song_title` contains Latin letters, resolve `en`.
+5. Else inspect `lyrics_text` with the same CJK-first rule.
+6. Empty, numeric-only, punctuation-only, or otherwise ambiguous title and lyrics
+   default to `zh` for backward compatibility.
+
+Recommended script detection:
+
+- CJK: Unicode ranges covering CJK Unified Ideographs and common CJK extensions used
+  by Chinese lyrics.
+- Latin: ASCII A-Z/a-z is sufficient for this feature unless current catalog data
+  shows accented English titles.
+
+Log the decision once near the start of `JobQueue._process_lrc_job`, including:
+
+- requested language
+- resolved language
+- title
+- reason, such as `explicit`, `title_cjk`, `title_latin`, `lyrics_cjk`,
+  `lyrics_latin`, or `default_zh`
+
+## Admin Submission Updates
+
+Update every admin LRC submission call site to pass `song.title` and default to
+`language="auto"` unless the user supplies a different `--lang` value.
+
+Known call sites to cover:
+
+- `sow-admin audio lrc` single submission.
+- `sow-admin audio lrc --stdin` batch submission.
+- helper `_submit_lrc_job`.
+- batch/download workflows that currently hard-code `language="zh"`.
+- lost-job resubmission paths that currently hard-code `language="zh"`.
+
+Update `AnalysisClient.submit_lrc()` to accept `song_title: str = ""` and include it
+in the payload.
+
+## Pipeline Updates
+
+In `JobQueue._process_lrc_job`:
+
+1. Validate/request-normalize language.
+2. Resolve language once after confirming the request is `LrcJobRequest`.
+3. Use the resolved language for:
+   - LRC result cache key.
+   - YouTube transcript language preference and correction prompt.
+   - Qwen3 ASR context.
+   - Qwen3 ASR cache key language field.
+   - Qwen3 ASR alignment prompt.
+   - Whisper transcription cache key.
+   - Whisper `language` parameter.
+   - Whisper initial prompt.
+   - Main LLM alignment prompt.
+
+Avoid mutating persisted request data unless there is a deliberate reason. Prefer
+passing `resolved_language` explicitly to functions that need it. If function
+signatures become noisy, create a small internal context object for LRC runtime state.
+
+## Prompt Updates
+
+All prompt builders should branch on resolved language.
+
+### Whisper Initial Prompt
+
+Chinese:
+
+- Preserve current Chinese worship wording and lyric-guided behavior.
+
+English:
+
+- Identify the audio as an English worship song.
+- Include truncated official lyrics when available.
+- Instruct Whisper via prompt context to preserve English words and phrasing.
+
+### Main LLM Alignment Prompt
+
+Chinese:
+
+- Preserve the current behavior and Chinese examples.
+
+English:
+
+- Refer to English worship songs and official lyrics.
+- Preserve English casing, punctuation, contractions, and line text exactly from
+  canonical lyrics.
+- Do not include Chinese-only example requirements in the English prompt.
+
+### Qwen3 ASR Context
+
+Chinese:
+
+- Preserve the current Chinese context header.
+
+English:
+
+- Use an English context header for English worship songs.
+- Include official English lyrics within the same character limit logic.
+
+### Qwen3 ASR Alignment Prompt
+
+Chinese:
+
+- Preserve Chinese worship wording.
+
+English:
+
+- Refer to English worship songs and canonical English lyric lines.
+- Preserve timestamps and repeated sung sections.
+- Preserve official casing/punctuation.
+
+### YouTube Transcript Correction Prompt
+
+Chinese:
+
+- Preserve current Chinese correction behavior.
+
+English:
+
+- Correct YouTube transcript lines against official English lyrics.
+- Preserve transcript timecodes.
+- Preserve repeated sung sections.
+- Preserve casing/punctuation from official lyrics.
+- Remove only lines that clearly do not correspond to sung lyrics.
+
+## YouTube Transcript Language Selection
+
+Make transcript fetching language-aware. The current Chinese-first preference is not
+safe for English songs because a video can have translated Chinese captions while the
+canonical lyrics are English.
+
+For resolved `zh`:
+
+- Prefer Chinese transcripts first, then English fallback if needed.
+
+For resolved `en`:
+
+- Prefer English transcripts first, then Chinese fallback only if no English transcript
+  is available.
+
+Apply the same preference order to both direct `fetch(video_id, languages=...)` and
+the list fallback transcript ranking. Tests should cover videos with both Chinese and
+English transcripts to ensure the resolved language controls the selected transcript.
+
+## Cache Behavior
+
+### LRC Result Cache
+
+Version the LRC result cache key so new language-aware prompts never reuse old
+Chinese-only LRC result cache entries.
+
+Include at least:
+
+- audio content hash
+- lyrics hash
+- resolved language
+- LRC prompt/cache version
+- source-relevant configuration if it can alter the final LRC
+
+### R2 Object Key Risk
+
+Do not let multiple language-specific cache entries point at a single mutable
+`{hash_prefix}/lyrics.lrc` object if the same recording can be rerun under different
+language modes. Otherwise, a later run can overwrite the object while older cache
+entries still return the same URL.
+
+Choose one of:
+
+- Keep only one canonical LRC per recording and invalidate or overwrite all prior
+  language-mode cache entries for that recording.
+- Store language/cache-version-specific LRC objects, such as
+  `{hash_prefix}/lyrics.{resolved_language}.vN.lrc`, and have the admin DB update point
+  to the chosen result.
+
+The second option is safer for debugging and reruns; the first option is simpler if
+the product guarantees one active LRC per recording.
+
+### Whisper Transcription Cache
+
+Replace the audio-hash-only Whisper cache with a derived key that includes:
+
+- audio content hash
+- resolved transcription audio or stem kind
+- resolved language
+- Whisper model
+- exact initial prompt version
+- lyrics hash or exact prompt-input hash when lyrics are included in the initial prompt
+
+Because Whisper currently uses lyrics in `initial_prompt`, do not use a cache entry
+generated with different lyrics or a different prompt version.
+
+### Qwen3 ASR Cache
+
+Continue using rich Qwen3 ASR cache keys, but ensure they use:
+
+- resolved language, not raw `auto`
+- language-specific context
+- context hash derived from the exact context sent to Qwen3
+
+Avoid building the Qwen context separately in queue and worker with different inputs.
+Either pass the computed context down or ensure both call the same deterministic helper
+with the same resolved language.
+
+## Runtime Safety Notes
+
+- If language validation rejects a payload, fail fast with a 422 API response.
+- If a direct API client sends `language="auto"` without `song_title`, fall back to
+  lyrics detection and then default `zh`.
+- If resolved language is `en` but lyrics contain mostly CJK, log a warning before
+  processing. Do not fail the job.
+- If resolved language is `zh` but lyrics contain mostly Latin, log a warning before
+  processing. Do not fail the job.
+- Keep force flags behavior unchanged:
+  - `force` bypasses LRC result cache.
+  - `force_whisper` bypasses Whisper transcription cache.
+  - `force_qwen3_asr` bypasses Qwen3 ASR cache only.
+
+## Test Plan
+
+### Resolver Tests
+
+- Explicit `zh` resolves `zh`.
+- Explicit `en` resolves `en`.
+- Chinese-only title resolves `zh`.
+- English-only title resolves `en`.
+- Mixed Chinese/English title resolves `zh`.
+- Empty title with Chinese lyrics resolves `zh`.
+- Empty title with English lyrics resolves `en`.
+- Numeric or punctuation-only title falls back to lyrics.
+- Empty or ambiguous title and lyrics defaults `zh`.
+- Invalid language values are rejected.
+
+### Admin Tests
+
+- `sow-admin audio lrc` default payload includes `language="auto"` and `song_title`.
+- Explicit `--lang zh` payload includes `language="zh"`.
+- Explicit `--lang en` payload includes `language="en"`.
+- Batch stdin submissions include `song_title`.
+- Helper and batch/download LRC submissions no longer hard-code `zh` unless explicitly
+  intended.
+- Lost-job resubmission preserves `auto` behavior and includes `song_title`.
+
+### Prompt Tests
+
+- English Whisper prompt uses English worship wording.
+- Chinese Whisper prompt preserves Chinese worship wording.
+- English main alignment prompt preserves English casing/punctuation and has no
+  Chinese-only example requirement.
+- Chinese main alignment prompt keeps current Chinese behavior.
+- Qwen3 context switches by resolved language.
+- Qwen3 ASR alignment prompt switches by resolved language.
+- YouTube correction prompt switches by resolved language.
+
+### Pipeline Tests
+
+- Queue resolves language once and logs requested/resolved/reason.
+- Queue passes resolved `en` to YouTube, Qwen3 ASR, and Whisper paths.
+- Queue passes resolved `zh` to YouTube, Qwen3 ASR, and Whisper paths.
+- No lower-level worker function receives raw `auto`.
+- Whisper transcription receives `language="en"` for English songs.
+- Qwen3 cache keys differ for the same audio/lyrics under `zh` vs `en`.
+- Whisper cache keys differ for the same audio/stem under `zh` vs `en`.
+- LRC result cache keys differ for the same audio/lyrics under `zh` vs `en`.
+- R2 object behavior is tested according to the chosen strategy:
+  - language/version-specific keys do not overwrite each other, or
+  - canonical overwrite invalidates stale language-specific cache entries.
+
+### YouTube Transcript Tests
+
+- Resolved `zh` prefers Chinese transcript over English when both exist.
+- Resolved `en` prefers English transcript over Chinese when both exist.
+- Resolved `en` falls back to Chinese transcript only when English is unavailable.
+- Direct fetch language order and list fallback ranking both honor resolved language.
+
+### Suggested Commands
+
+```bash
+PYTHONPATH=src uv run --python 3.11 --extra app --extra test pytest \
+  tests/services/analysis/test_lrc_worker.py \
+  tests/services/analysis/test_qwen3_asr_pipeline.py \
+  services/analysis/tests/test_youtube_transcript.py -v
+
+PYTHONPATH=src uv run --python 3.11 --extra app --extra test pytest \
+  tests/admin/test_audio_commands.py \
+  tests/admin/test_audio_lrc_visibility.py -v
+```
+
+## Rollout Checklist
+
+1. Add resolver and validation tests first.
+2. Add `song_title` to API/admin request flow.
+3. Resolve language once in queue and log the decision.
+4. Thread resolved language through YouTube, Qwen3 ASR, Whisper, prompt builders, and
+   cache key builders.
+5. Fix cache keys and chosen R2 object strategy together.
+6. Update admin hard-coded `zh` submission and resubmission paths.
+7. Run targeted tests.
+8. For the first production run, inspect logs for resolved-language decisions and any
+   script-mismatch warnings.

--- a/specs/lrc-pipeline-english-chinese-title-detection.md
+++ b/specs/lrc-pipeline-english-chinese-title-detection.md
@@ -1,0 +1,69 @@
+# LRC Pipeline English/Chinese Title-Based Language Detection
+
+## Summary
+
+Enhance LRC generation so English songs are transcribed and aligned with English-aware prompts, while Chinese songs keep the existing Chinese behavior. The analysis service will infer `zh` vs `en` from `song_title`, fall back to lyric script when the title is ambiguous, and allow explicit `--lang zh|en` overrides.
+
+## Key Changes
+
+- Add `song_title: str = ""` to `LrcJobRequest`.
+- Change LRC language option semantics to support `auto`, `zh`, and `en`; make `auto` the default for new admin submissions.
+- Add a shared resolver:
+  - Explicit `zh`/`en` wins.
+  - `auto` detects CJK vs Latin script from `song_title`.
+  - Mixed, empty, numeric, or punctuation-only titles fall back to `lyrics_text`.
+  - If still ambiguous, default to `zh` for backward compatibility.
+- Update admin LRC submission call sites to pass `song.title` and use `language="auto"` unless the user supplies `--lang`.
+- Preserve compatibility for old persisted jobs and direct API clients by allowing missing `song_title` and existing `language="zh"` payloads.
+
+## Pipeline Updates
+
+- Resolve language once in `JobQueue._process_lrc_job`, then pass the resolved `zh`/`en` value into all LRC paths.
+- Update all language-specific prompt builders:
+  - Whisper initial prompt in `_run_whisper_transcription`
+  - Main LLM alignment prompt in `_build_alignment_prompt`
+  - Qwen3 ASR context in `_build_qwen3_context`
+  - Qwen3 ASR alignment prompt in `_build_qwen3_asr_alignment_prompt`
+  - YouTube transcript correction prompt in `youtube_transcript.py`
+- For English prompts, refer to English worship songs, English official lyrics, and preserve English casing/punctuation from canonical lyrics.
+- For Chinese prompts, keep current Chinese-focused behavior and examples.
+- Use resolved language for Whisper's `language` parameter and Qwen3 ASR cache language field.
+
+## Cache Behavior
+
+- Version the LRC result cache key so language-aware prompt changes do not reuse old Chinese-only results.
+- Include `resolved_language` in the LRC cache key.
+- Replace Whisper transcription cache usage with a derived key including:
+  - audio content hash
+  - resolved transcription audio/stem kind
+  - resolved language
+  - lyrics hash or prompt version
+- Continue using Qwen3 ASR cache keys, but ensure they use the resolved language and language-specific context.
+
+## Test Plan
+
+- Add unit tests for language detection:
+  - Chinese title resolves `zh`
+  - English title resolves `en`
+  - mixed/ambiguous title falls back to lyrics
+  - empty title with English lyrics resolves `en`
+  - empty/ambiguous everything defaults `zh`
+  - explicit `zh` or `en` overrides detection
+- Add prompt tests:
+  - English alignment prompt contains English-specific wording and no Chinese-only example requirement.
+  - Chinese alignment prompt keeps Chinese behavior.
+  - Qwen3 context and YouTube correction prompts switch by language.
+- Add pipeline tests:
+  - Admin `submit_lrc` payload includes `song_title`.
+  - Queue passes resolved language to YouTube, Qwen3 ASR, and Whisper paths.
+  - Whisper transcription receives `language="en"` for English songs.
+  - Cache keys differ for the same audio/lyrics under `zh` vs `en`.
+- Run:
+  - `PYTHONPATH=src uv run --python 3.11 --extra app --extra test pytest tests/services/analysis/test_lrc_worker.py tests/services/analysis/test_qwen3_asr_pipeline.py tests/services/analysis/test_youtube_transcript.py -v`
+  - targeted admin tests covering LRC submission payloads.
+
+## Assumptions
+
+- Only Chinese and English are supported for this feature.
+- Title-based detection is the default product behavior; manual `--lang zh|en` remains available for exceptions such as pinyin Chinese titles.
+- Existing queued jobs without `song_title` remain valid and fall back to lyrics/default behavior.

--- a/src/stream_of_worship/admin/commands/audio.py
+++ b/src/stream_of_worship/admin/commands/audio.py
@@ -353,6 +353,7 @@ def _submit_lrc_single(
                 audio_url=recording.r2_audio_url,
                 content_hash=recording.content_hash,
                 lyrics_text=song.lyrics_raw,
+                song_title=song.title,
                 whisper_model=whisper_model,
                 language=language,
                 use_vocals_stem=not no_vocals,
@@ -493,6 +494,7 @@ def _submit_lrc_batch(
                 audio_url=recording.r2_audio_url,
                 content_hash=recording.content_hash,
                 lyrics_text=song.lyrics_raw,
+                song_title=song.title,
                 whisper_model=whisper_model,
                 language=language,
                 use_vocals_stem=not no_vocals,
@@ -587,7 +589,7 @@ def _submit_lrc_job(
     console: Console,
     force: bool = False,
     whisper_model: str = "large-v3",
-    language: str = "zh",
+    language: str = "auto",
     no_vocals: bool = False,
     no_youtube: bool = False,
     no_whisper_cache: bool = False,
@@ -630,6 +632,7 @@ def _submit_lrc_job(
             audio_url=recording.r2_audio_url,
             content_hash=recording.content_hash,
             lyrics_text=song.lyrics_raw,
+            song_title=song.title,
             whisper_model=whisper_model,
             language=language,
             use_vocals_stem=not no_vocals,
@@ -852,7 +855,7 @@ def import_youtube_audio_for_song(
             console=console,
             force=False,
             whisper_model="large-v3",
-            language="zh",
+            language="auto",
             no_vocals=False,
             use_qwen3_asr=True,
             force_qwen3_asr=False,
@@ -1608,7 +1611,7 @@ def lrc_recording(
     force: bool = typer.Option(False, "--force", "-f", help="Force re-generation"),
     stdin: bool = typer.Option(False, "--stdin", help="Read song IDs from stdin (one per line)"),
     whisper_model: str = typer.Option("large-v3", "--model", "-m", help="Whisper model to use"),
-    language: str = typer.Option("zh", "--lang", help="Language hint"),
+    language: str = typer.Option("auto", "--lang", help="Language mode: auto, zh, or en"),
     no_vocals: bool = typer.Option(False, "--no-vocals", help="Don't use vocals stem"),
     no_youtube: bool = typer.Option(
         False, "--no-youtube", help="Skip YouTube transcript, use Whisper directly"
@@ -1656,6 +1659,9 @@ def lrc_recording(
             "[red]Error: --no-qwen3 is deprecated. Qwen3 ForcedAligner is no longer "
             "part of automatic LRC generation; use --no-qwen3-asr instead.[/red]"
         )
+        raise typer.Exit(1)
+    if language not in {"auto", "zh", "en"}:
+        console.print("[red]Error: --lang must be one of: auto, zh, en[/red]")
         raise typer.Exit(1)
 
     # Standard config/db boilerplate
@@ -4441,8 +4447,9 @@ def _process_batch(
                     audio_url=recording.r2_audio_url,
                     content_hash=recording.content_hash,
                     lyrics_text=song.lyrics_raw,
+                    song_title=song.title,
                     whisper_model="large-v3",
-                    language="zh",
+                    language="auto",
                     use_vocals_stem=True,
                     force=force_lrc,
                     force_whisper=False,
@@ -4675,8 +4682,9 @@ def _poll_all_jobs(
                                         audio_url=recording.r2_audio_url,
                                         content_hash=recording.content_hash,
                                         lyrics_text=song.lyrics_raw,
+                                        song_title=song.title,
                                         whisper_model="large-v3",
-                                        language="zh",
+                                        language="auto",
                                         use_vocals_stem=True,
                                         force=force_lrc,
                                         force_whisper=False,

--- a/src/stream_of_worship/admin/services/analysis.py
+++ b/src/stream_of_worship/admin/services/analysis.py
@@ -262,8 +262,9 @@ class AnalysisClient:
         audio_url: str,
         content_hash: str,
         lyrics_text: str,
+        song_title: str = "",
         whisper_model: str = "large-v3",
-        language: str = "zh",
+        language: str = "auto",
         use_vocals_stem: bool = True,
         force: bool = False,
         force_whisper: bool = False,
@@ -277,8 +278,9 @@ class AnalysisClient:
             audio_url: R2 URL of the audio file
             content_hash: SHA-256 hash of the audio content
             lyrics_text: Raw lyrics text to align
+            song_title: Song title used for auto language detection
             whisper_model: Whisper model to use
-            language: Language hint for transcription
+            language: Language mode for transcription ("auto", "zh", or "en")
             use_vocals_stem: Whether to use vocals stem for better alignment
             force: Whether to force re-generation
             force_whisper: Bypass Whisper transcription cache
@@ -296,6 +298,7 @@ class AnalysisClient:
             "audio_url": audio_url,
             "content_hash": content_hash,
             "lyrics_text": lyrics_text,
+            "song_title": song_title,
             "youtube_url": youtube_url,
             "options": {
                 "whisper_model": whisper_model,

--- a/tests/admin/test_audio_lrc_visibility.py
+++ b/tests/admin/test_audio_lrc_visibility.py
@@ -91,6 +91,10 @@ def test_submit_lrc_wait_completion_forces_review_visibility():
         r2_lrc_url="s3://bucket/abc123def456/lyrics.lrc",
         visibility_status="review",
     )
+    analysis_client.submit_lrc.assert_called_once()
+    submit_kwargs = analysis_client.submit_lrc.call_args.kwargs
+    assert submit_kwargs["song_title"] == "Test Song"
+    assert submit_kwargs["language"] == "zh"
 
 
 def test_status_sync_lrc_completion_forces_review_visibility():

--- a/tests/services/analysis/test_lrc_worker.py
+++ b/tests/services/analysis/test_lrc_worker.py
@@ -470,7 +470,7 @@ class TestLRCJobQueueProcessing:
         with tempfile.TemporaryDirectory() as tmp:
             q = JobQueue(max_concurrent_local_model=1, cache_dir=Path(tmp))
             yield q
-            q.stop()
+            await q.stop()
 
     @pytest.mark.asyncio
     async def test_lrc_job_with_valid_request(self, queue):

--- a/tests/services/analysis/test_lrc_worker.py
+++ b/tests/services/analysis/test_lrc_worker.py
@@ -26,10 +26,14 @@ from sow_analysis.workers.lrc import (
     WhisperTranscriptionError,
     WhisperPhrase,
     _build_alignment_prompt,
+    _build_qwen3_asr_alignment_prompt,
     _parse_llm_response,
     _run_whisper_transcription,
     _write_lrc,
+    build_qwen3_asr_cache_key,
+    build_whisper_transcription_cache_key,
     generate_lrc,
+    resolve_lrc_language,
 )
 from sow_analysis.workers.queue import Job, JobQueue, _compute_lrc_cache_key
 
@@ -93,6 +97,73 @@ class TestBuildAlignmentPrompt:
         prompt = _build_alignment_prompt("Hello world", phrases)
         assert '"start": 0.0' in prompt
         assert '"end": 0.5' in prompt
+
+    def test_english_prompt_preserves_english_text_rules(self):
+        phrases = [WhisperPhrase("Amazing grace", 0.0, 1.0)]
+        prompt = _build_alignment_prompt("Amazing Grace\nI'll sing", phrases, language="en")
+        assert "English worship songs" in prompt
+        assert "Preserve English casing" in prompt
+        assert "我要看見" not in prompt
+
+    def test_qwen_english_alignment_prompt_preserves_casing(self):
+        phrases = [WhisperPhrase("I'll sing", 0.0, 1.0)]
+        prompt = _build_qwen3_asr_alignment_prompt("I'll sing", phrases, language="en")
+        assert "English worship songs" in prompt
+        assert "official casing" in prompt
+
+
+class TestResolveLrcLanguage:
+    """Test title/lyrics based LRC language resolution."""
+
+    @pytest.mark.parametrize(
+        ("language", "title", "lyrics", "expected", "reason"),
+        [
+            ("zh", "Amazing Grace", "Amazing grace", "zh", "explicit"),
+            ("en", "奇異恩典", "奇異恩典", "en", "explicit"),
+            ("auto", "奇異恩典", "", "zh", "title_cjk"),
+            ("auto", "Amazing Grace", "", "en", "title_latin"),
+            ("auto", "Amazing Grace 奇異恩典", "", "zh", "title_cjk"),
+            ("auto", "", "祢真偉大", "zh", "lyrics_cjk"),
+            ("auto", "", "Amazing grace", "en", "lyrics_latin"),
+            ("auto", "2026!!!", "Amazing grace", "en", "lyrics_latin"),
+            ("auto", "2026!!!", "", "zh", "default_zh"),
+        ],
+    )
+    def test_resolves_expected_language(self, language, title, lyrics, expected, reason):
+        result = resolve_lrc_language(language, title, lyrics)
+        assert result.resolved == expected
+        assert result.reason == reason
+
+    def test_invalid_language_raises(self):
+        with pytest.raises(ValueError):
+            resolve_lrc_language("ja", "Title", "Lyrics")
+
+
+class TestLanguageAwareCacheKeys:
+    """Test language-aware cache key builders."""
+
+    def test_lrc_cache_key_differs_by_language(self):
+        zh_key = _compute_lrc_cache_key("hash", "Amazing grace", "zh")
+        en_key = _compute_lrc_cache_key("hash", "Amazing grace", "en")
+        assert zh_key != en_key
+
+    def test_whisper_cache_key_differs_by_language(self):
+        zh_key = build_whisper_transcription_cache_key(
+            "hash", "Amazing grace", "full_mix", "large-v3", "zh"
+        )
+        en_key = build_whisper_transcription_cache_key(
+            "hash", "Amazing grace", "full_mix", "large-v3", "en"
+        )
+        assert zh_key != en_key
+
+    def test_qwen_cache_key_differs_by_language(self):
+        zh_key = build_qwen3_asr_cache_key(
+            "hash", "Amazing grace", "full_mix", "flash", "intl", "zh", 1000, "zh context"
+        )
+        en_key = build_qwen3_asr_cache_key(
+            "hash", "Amazing grace", "full_mix", "flash", "intl", "en", 1000, "en context"
+        )
+        assert zh_key != en_key
 
 
 class TestParseLLMResponse:
@@ -411,6 +482,7 @@ class TestLRCJobQueueProcessing:
             audio_url="s3://bucket/hash/audio.mp3",
             content_hash="abc123def456",
             lyrics_text="測試歌詞",
+            options=LrcOptions(use_vocals_stem=False),
         )
 
         # Pre-populate cache with correct composite key
@@ -491,6 +563,7 @@ class TestLRCJobQueueProcessing:
             audio_url="s3://bucket/hash/audio.mp3",
             content_hash="abc123def456",
             lyrics_text="測試歌詞",
+            options=LrcOptions(use_vocals_stem=False),
         )
 
         # Mock R2 download
@@ -544,7 +617,7 @@ class TestLRCOptions:
         assert options.whisper_model == "large-v3"
         assert options.llm_model == ""  # Empty by default, falls back to SOW_LLM_MODEL env var
         assert options.use_vocals_stem is True
-        assert options.language == "zh"
+        assert options.language == "auto"
         assert options.force is False
 
     def test_custom_values(self):

--- a/tests/services/analysis/test_lrc_worker.py
+++ b/tests/services/analysis/test_lrc_worker.py
@@ -34,6 +34,7 @@ from sow_analysis.workers.lrc import (
     build_whisper_transcription_cache_key,
     generate_lrc,
     resolve_lrc_language,
+    warn_if_lrc_language_script_mismatch,
 )
 from sow_analysis.workers.queue import Job, JobQueue, _compute_lrc_cache_key
 
@@ -137,6 +138,14 @@ class TestResolveLrcLanguage:
     def test_invalid_language_raises(self):
         with pytest.raises(ValueError):
             resolve_lrc_language("ja", "Title", "Lyrics")
+
+
+class TestWarnIfLrcLanguageScriptMismatch:
+    """Test warning guard for language/script mismatches."""
+
+    @pytest.mark.parametrize("lyrics_text", [None, 123])
+    def test_ignores_missing_or_non_string_lyrics(self, lyrics_text):
+        warn_if_lrc_language_script_mismatch("zh", lyrics_text)
 
 
 class TestLanguageAwareCacheKeys:

--- a/tests/services/analysis/test_models.py
+++ b/tests/services/analysis/test_models.py
@@ -62,6 +62,14 @@ class TestLrcOptions:
         assert opts.use_qwen3_asr is True
         assert opts.force_qwen3_asr is False
         assert opts.qwen3_asr_context_max_chars == 10000
+        assert opts.language == "auto"
+
+    def test_rejects_invalid_lrc_language(self):
+        """Test invalid LRC language values are rejected."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            LrcOptions(language="ja")
 
 
 class TestLrcJobRequest:
@@ -77,6 +85,7 @@ class TestLrcJobRequest:
         assert req.audio_url == "s3://bucket/hash/audio.mp3"
         assert req.content_hash == "abc123"
         assert req.lyrics_text == "Line 1\nLine 2"
+        assert req.song_title == ""
 
 
 class TestSection:

--- a/tests/services/analysis/test_queue.py
+++ b/tests/services/analysis/test_queue.py
@@ -5,7 +5,7 @@ import logging
 import tempfile
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 from sow_analysis.models import AnalyzeJobRequest, JobStatus, JobType, LrcJobRequest, LrcOptions
@@ -191,6 +191,43 @@ class TestLRCJobProcessing:
         assert job.status == JobStatus.COMPLETED
         assert job.stage == "cached"
         assert job.result.line_count == 2
+
+    @pytest.mark.asyncio
+    async def test_lrc_job_uploads_versioned_lrc_and_legacy_alias(self, queue):
+        """New LRC jobs preserve the legacy lyrics.lrc path consumed by renderers."""
+        request = LrcJobRequest(
+            audio_url="s3://bucket/hash/audio.mp3",
+            content_hash="abc123def456",
+            lyrics_text="Amazing grace",
+            options=LrcOptions(language="en", use_qwen3_asr=False, use_vocals_stem=False),
+        )
+        job = Job(
+            id="job_test_lrc_upload_alias",
+            type=JobType.LRC,
+            status=JobStatus.QUEUED,
+            request=request,
+        )
+        queue.r2_client = MagicMock()
+        queue.r2_client.download_audio = AsyncMock()
+
+        async def upload_lrc(hash_prefix, _lrc_path, object_name="lyrics.lrc"):
+            return f"s3://bucket/{hash_prefix}/{object_name}"
+
+        queue.r2_client.upload_lrc = AsyncMock(side_effect=upload_lrc)
+
+        async def generate_lrc(_audio_path, _lyrics_text, _options, output_path, **_kwargs):
+            output_path.write_text("[00:00.00] Amazing grace\n")
+            return output_path, 1, []
+
+        with patch("sow_analysis.workers.queue.generate_lrc", new=generate_lrc):
+            await queue._process_lrc_job(job)
+
+        assert job.status == JobStatus.COMPLETED
+        assert job.result.lrc_url == "s3://bucket/abc123def456/lyrics.en.v2.lrc"
+        queue.r2_client.upload_lrc.assert_any_await(
+            "abc123def456", ANY, object_name="lyrics.en.v2.lrc"
+        )
+        queue.r2_client.upload_lrc.assert_any_await("abc123def456", ANY)
 
     @pytest.mark.asyncio
     async def test_lrc_job_with_invalid_request(self, queue):

--- a/tests/services/analysis/test_queue.py
+++ b/tests/services/analysis/test_queue.py
@@ -1,13 +1,33 @@
 """Tests for job queue."""
 
 import asyncio
+import logging
 import tempfile
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from sow_analysis.models import AnalyzeJobRequest, JobStatus, JobType, LrcJobRequest, LrcOptions
-from sow_analysis.workers.queue import Job, JobQueue, _compute_lrc_cache_key
+from sow_analysis.workers.queue import (
+    FINISHED_JOB_MEMORY_RETENTION_SECONDS,
+    Job,
+    JobQueue,
+    _compute_lrc_cache_key,
+)
+
+
+def _queue_state_messages(caplog):
+    return [record.message for record in caplog.records if "Queue state:" in record.message]
+
+
+def _make_analysis_job(job_id: str, status: JobStatus) -> Job:
+    return Job(
+        id=job_id,
+        type=JobType.ANALYZE,
+        status=status,
+        request=AnalyzeJobRequest(audio_url=f"s3://bucket/{job_id}.mp3", content_hash=job_id),
+    )
 
 
 class TestJobQueue:
@@ -19,7 +39,7 @@ class TestJobQueue:
         with tempfile.TemporaryDirectory() as tmp:
             q = JobQueue(max_concurrent_local_model=1, cache_dir=Path(tmp))
             yield q
-            q.stop()
+            await q.stop()
 
     @pytest.mark.asyncio
     async def test_submit_job(self, queue):
@@ -65,6 +85,79 @@ class TestJobQueue:
         assert job.status == JobStatus.QUEUED
 
 
+class TestJobQueueStateLogging:
+    """Test queue state logging suppression and emission rules."""
+
+    def test_log_queue_state_skips_empty_queue(self, tmp_path, caplog):
+        queue = JobQueue(max_concurrent_local_model=1, cache_dir=tmp_path)
+
+        with caplog.at_level(logging.INFO, logger="sow_analysis.workers.queue"):
+            queue._log_queue_state()
+
+        assert _queue_state_messages(caplog) == []
+
+    def test_log_queue_state_skips_completed_only_queue(self, tmp_path, caplog):
+        queue = JobQueue(max_concurrent_local_model=1, cache_dir=tmp_path)
+        job = _make_analysis_job("job_completed", JobStatus.COMPLETED)
+        queue._jobs[job.id] = job
+
+        with caplog.at_level(logging.INFO, logger="sow_analysis.workers.queue"):
+            queue._log_queue_state()
+
+        assert _queue_state_messages(caplog) == []
+
+    def test_log_queue_state_emits_for_queued_job(self, tmp_path, caplog):
+        queue = JobQueue(max_concurrent_local_model=1, cache_dir=tmp_path)
+        job = _make_analysis_job("job_queued", JobStatus.QUEUED)
+        queue._jobs[job.id] = job
+
+        with caplog.at_level(logging.INFO, logger="sow_analysis.workers.queue"):
+            queue._log_queue_state()
+
+        messages = _queue_state_messages(caplog)
+        assert len(messages) == 1
+        assert "ANALYZE[queued:1,processing:0,completed:0,failed:0]" in messages[0]
+        assert "ANALYZE queued=[" in messages[0]
+
+    def test_log_queue_state_emits_for_processing_job(self, tmp_path, caplog):
+        queue = JobQueue(max_concurrent_local_model=1, cache_dir=tmp_path)
+        job = _make_analysis_job("job_processing", JobStatus.PROCESSING)
+        queue._jobs[job.id] = job
+
+        with caplog.at_level(logging.INFO, logger="sow_analysis.workers.queue"):
+            queue._log_queue_state()
+
+        messages = _queue_state_messages(caplog)
+        assert len(messages) == 1
+        assert "ANALYZE[queued:0,processing:1,completed:0,failed:0]" in messages[0]
+        assert "ANALYZE processing=" in messages[0]
+
+    def test_log_queue_state_emits_for_recent_failed_job(self, tmp_path, caplog):
+        queue = JobQueue(max_concurrent_local_model=1, cache_dir=tmp_path)
+        job = _make_analysis_job("job_failed", JobStatus.FAILED)
+        queue._jobs[job.id] = job
+
+        with caplog.at_level(logging.INFO, logger="sow_analysis.workers.queue"):
+            queue._log_queue_state()
+
+        messages = _queue_state_messages(caplog)
+        assert len(messages) == 1
+        assert "ANALYZE[queued:0,processing:0,completed:0,failed:1]" in messages[0]
+
+    def test_log_queue_state_skips_stale_failed_job(self, tmp_path, caplog):
+        queue = JobQueue(max_concurrent_local_model=1, cache_dir=tmp_path)
+        job = _make_analysis_job("job_stale_failed", JobStatus.FAILED)
+        job.updated_at = datetime.now(timezone.utc) - timedelta(
+            seconds=FINISHED_JOB_MEMORY_RETENTION_SECONDS + 1
+        )
+        queue._jobs[job.id] = job
+
+        with caplog.at_level(logging.INFO, logger="sow_analysis.workers.queue"):
+            queue._log_queue_state()
+
+        assert _queue_state_messages(caplog) == []
+
+
 class TestLRCJobProcessing:
     """Test LRC job processing."""
 
@@ -74,7 +167,7 @@ class TestLRCJobProcessing:
         with tempfile.TemporaryDirectory() as tmp:
             q = JobQueue(max_concurrent_local_model=1, cache_dir=Path(tmp))
             yield q
-            q.stop()
+            await q.stop()
 
     @pytest.mark.asyncio
     async def test_lrc_job_uses_cache(self, queue):
@@ -174,7 +267,7 @@ class TestJobQueueConcurrency:
 
             assert queue.max_concurrent_local_model == 2
 
-            queue.stop()
+            await queue.stop()
 
 
 class TestJobQueueR2:
@@ -195,4 +288,4 @@ class TestJobQueueR2:
                 assert queue.r2_client is not None
                 mock_r2.assert_called_once_with("my-bucket", "https://r2.example.com")
 
-            queue.stop()
+            await queue.stop()

--- a/tests/services/analysis/test_queue.py
+++ b/tests/services/analysis/test_queue.py
@@ -179,7 +179,7 @@ class TestLRCJobProcessing:
         )
 
         # Pre-populate cache with correct composite key
-        cache_key = _compute_lrc_cache_key(request.content_hash, request.lyrics_text)
+        cache_key = _compute_lrc_cache_key(request.content_hash, request.lyrics_text, "en")
         queue.cache_manager.save_lrc_result(
             cache_key,
             {"lrc_url": "s3://bucket/abc123def456/lyrics.lrc", "line_count": 2},

--- a/tests/services/analysis/test_qwen3_asr_pipeline.py
+++ b/tests/services/analysis/test_qwen3_asr_pipeline.py
@@ -255,7 +255,14 @@ async def test_qwen_lrc_alignment_uses_snapped_phrases(tmp_path: Path):
         {"time_seconds": 5.0, "text": "我要看見"},
     ]
 
-    async def fake_llm_align(lyrics_text, phrases, llm_model, max_retries=3, prompt_builder=None):
+    async def fake_llm_align(
+        lyrics_text,
+        phrases,
+        llm_model,
+        max_retries=3,
+        prompt_builder=None,
+        language="zh",
+    ):
         assert [p.text for p in phrases] == [
             "我要看見",
             "如同摩西看見祢的榮耀",


### PR DESCRIPTION
## Summary

This PR implements the English/Chinese title-based LRC language detection plan for the analysis service and admin submission flow. It also includes the branch-local spec documents and the queue logging maintenance change that were already part of this branch before the implementation commit.

The core behavior change is that LRC jobs now accept `language="auto" | "zh" | "en"`, default to `auto`, resolve the effective downstream language once per job from `song_title` and `lyrics_text`, and pass only resolved `zh` or `en` into transcription, transcript selection, prompt builders, and cache keys.

## What Changed

### LRC language request model and resolver
- Added `song_title: str = ""` to `LrcJobRequest` for backward-compatible title-based detection.
- Changed `LrcOptions.language` to a validated `Literal["auto", "zh", "en"]`, defaulting to `auto`.
- Added a shared resolver with the v2 rules:
  - explicit `zh` or `en` wins
  - any CJK in the title resolves to `zh`
  - Latin-only title resolves to `en`
  - ambiguous titles fall back to lyrics inspection
  - fully ambiguous inputs default to `zh`
- Added script-mismatch warnings when resolved language and lyric script strongly disagree.

### Analysis queue integration
- Resolves language once near the start of LRC job processing and logs requested language, resolved language, title, and reason.
- Uses resolved language for:
  - LRC result cache key
  - YouTube transcript path
  - Qwen3 context and cache key
  - Qwen3 alignment prompt
  - Whisper language parameter and initial prompt
  - Whisper transcription cache key
  - main LLM alignment prompt
- Keeps raw persisted request data unmutated; resolved language is only runtime state.

### Prompt and transcription behavior
- Added English-specific Whisper initial prompts for English worship songs.
- Added English-specific main LLM alignment prompt that preserves official English casing, punctuation, contractions, and repeated sung sections.
- Added English-specific Qwen3 ASR context and Qwen3 alignment prompt.
- Kept existing Chinese prompt behavior for resolved `zh` jobs.

### YouTube transcript behavior
- Added language-aware transcript preference ordering:
  - resolved `zh`: Chinese first, then English fallback
  - resolved `en`: English first, then Chinese fallback
- Applies the same preference to direct fetch language codes and list-fallback transcript ranking.
- Added an English transcript correction prompt that preserves official English casing/punctuation and repeated sections.

### Cache and R2 behavior
- Versioned LRC result cache keys with resolved language and a language-aware prompt/cache version.
- Added language-aware Whisper cache keys using content hash, lyrics hash, stem kind, model, language, and prompt version.
- Ensured Qwen3 cache keys use the resolved language and context hash derived from the exact context sent to Qwen3.
- Extended analysis-service R2 LRC upload to accept an object name and now stores generated language/version-specific objects such as `lyrics.en.v2.lrc` or `lyrics.zh.v2.lrc`.

### Admin CLI submission flow
- Updated `AnalysisClient.submit_lrc()` to accept and send `song_title`.
- Changed admin LRC defaults to `language="auto"`.
- Updated single, stdin batch, helper, download/batch, and lost-job resubmission paths to pass `song.title` and avoid hard-coded `zh` except where tests intentionally force it.
- Added CLI validation for `--lang auto|zh|en`.

### Queue logging maintenance included in this branch
- Suppressed empty periodic analysis queue stats logs.
- Kept active queued/processing logs and recent failed-job logs within the existing in-memory retention window.
- Added queue logging regression coverage for empty, completed-only, queued, processing, recent failed, and stale failed states.

### Specs and status reporting
- Added `specs/lrc-pipeline-english-chinese-title-detection.md`.
- Added the full v2 spec at `specs/lrc-pipeline-english-chinese-title-detection-v2.md`.
- Updated `reports/current_impl_status.md` with the latest LRC language-aware pipeline milestone and queue logging maintenance note.

## Why

The old LRC pipeline was Chinese-first throughout: the default language was `zh`, prompts were Chinese-focused, YouTube captions preferred Chinese even for English songs, and several cache keys could reuse Chinese-only prompt outputs for English reruns. That made English worship song LRC generation prone to stale cache reuse and poor transcript/prompt selection.

This branch makes the language decision explicit, deterministic, and logged while preserving backward compatibility for existing jobs and direct clients. It also isolates language-specific cache and R2 outputs so rerunning a recording under a different language mode does not silently reuse or point at overwritten artifacts.

## User / Developer Impact

Admins can keep using `sow-admin audio lrc` without specifying a language. Chinese titles continue to resolve as Chinese, English titles resolve as English, and ambiguous legacy inputs still fall back to Chinese. Explicit `--lang zh` and `--lang en` remain available for exceptions such as pinyin Chinese titles or bad metadata.

For developers, downstream LRC code should now receive only resolved `zh` or `en`; raw `auto` should stay at the request/queue boundary.

## Validation

Ran:

```bash
PYTHONPATH=services/analysis/src:src uv run --python 3.11 --extra app --extra test pytest \
  tests/services/analysis/test_lrc_worker.py \
  tests/services/analysis/test_qwen3_asr_pipeline.py \
  tests/services/analysis/test_models.py \
  services/analysis/tests/test_youtube_transcript.py \
  tests/admin/test_audio_lrc_visibility.py -v
```

Result: `124 passed`.

```bash
PYTHONPATH=services/analysis/src:src uv run --python 3.11 --extra app --extra test pytest \
  tests/services/analysis/test_queue.py -v
```

Result: `15 passed`.

```bash
PYTHONPATH=src uv run --python 3.11 --extra app --extra test pytest \
  tests/admin/test_audio_commands.py \
  tests/admin/test_audio_lrc_visibility.py -v
```

Result: `5 passed, 65 skipped` with the repository's existing skips.

Also ran:

```bash
python -m py_compile \
  services/analysis/src/sow_analysis/models.py \
  services/analysis/src/sow_analysis/workers/lrc.py \
  services/analysis/src/sow_analysis/workers/queue.py \
  services/analysis/src/sow_analysis/workers/youtube_transcript.py \
  services/analysis/src/sow_analysis/storage/r2.py \
  src/stream_of_worship/admin/services/analysis.py \
  src/stream_of_worship/admin/commands/audio.py

git diff --check
```

Both passed.

## Notes

`graphify update .` was run after code changes, but it refused to overwrite the existing graph because the newly extracted graph had far fewer nodes than the checked-in graph. I left graph metadata unchanged rather than forcing a lossy overwrite.