### PR TITLE
[codex] Preserve blank LRC timing in render worker

### DIFF
--- a/services/render-worker/src/sow_render_worker/frame_renderer.py
+++ b/services/render-worker/src/sow_render_worker/frame_renderer.py
@@ -798,6 +798,9 @@ class FrameRenderer:
         width: int,
         height: int,
     ) -> None:
+        if next_alpha <= 0 or not isinstance(next_line.text, str) or not next_line.text.strip():
+            return
+
         text_r, text_g, text_b = self.template.text_color
         next_font_size_target = self.base_font_size
         next_margin = self.get_margin(draw, next_font_size_target)

--- a/services/render-worker/src/sow_render_worker/frame_renderer.py
+++ b/services/render-worker/src/sow_render_worker/frame_renderer.py
@@ -30,6 +30,11 @@ FontFamily = Literal[
 _DEFAULT_FADE_ALPHA_STEPS = 16
 _DEFAULT_MAX_CACHE_ENTRIES = 200
 _DEFAULT_CACHE_ENABLED = True
+_DEFAULT_TEMPO_BPM = 70.0
+_BLANK_PREVIEW_ALPHA = 128
+_BLANK_PREVIEW_FADE_SECONDS = 0.5
+_BLANK_PREVIOUS_HOLD_SECONDS = 2.0
+_BLANK_PREVIOUS_FADE_SECONDS = 4.0
 
 
 def _get_bool_env(name: str, default: bool) -> bool:
@@ -92,6 +97,8 @@ class VisualState:
     current_lyric_index: int
     intro_alpha: int
     fade_alpha: int
+    preview_alpha: int
+    tempo_bpm: float | None
     is_last_lyric_faded: bool
     current_time: float
 
@@ -188,11 +195,15 @@ def _load_font(
         return font
     except (OSError, IOError):
         font = ImageFont.load_default(size=size)
-        logger.warning("No TrueType font found, using default font (size=%d, family=%s)", size, font_family)
+        logger.warning(
+            "No TrueType font found, using default font (size=%d, family=%s)", size, font_family
+        )
         return font
     except TypeError:
         font = ImageFont.load_default()
-        logger.warning("No TrueType font found, using default font (size=%d, family=%s)", size, font_family)
+        logger.warning(
+            "No TrueType font found, using default font (size=%d, family=%s)", size, font_family
+        )
         return font
 
 
@@ -211,8 +222,12 @@ class FrameRenderer:
         self.font_family = font_family
 
         self._cache_enabled = _get_bool_env("SOW_FRAME_CACHE_ENABLED", _DEFAULT_CACHE_ENABLED)
-        self._fade_alpha_steps = min(256, max(2, _get_int_env("SOW_FADE_ALPHA_STEPS", _DEFAULT_FADE_ALPHA_STEPS)))
-        self._max_cache_entries = max(1, _get_int_env("SOW_MAX_CACHE_ENTRIES", _DEFAULT_MAX_CACHE_ENTRIES))
+        self._fade_alpha_steps = min(
+            256, max(2, _get_int_env("SOW_FADE_ALPHA_STEPS", _DEFAULT_FADE_ALPHA_STEPS))
+        )
+        self._max_cache_entries = max(
+            1, _get_int_env("SOW_MAX_CACHE_ENTRIES", _DEFAULT_MAX_CACHE_ENTRIES)
+        )
         self._frame_cache: OrderedDict[tuple, bytes] = OrderedDict()
         self._cache_hits = 0
         self._cache_misses = 0
@@ -221,8 +236,14 @@ class FrameRenderer:
         logger.info(
             "FrameRenderer init: template=%s, font_size=%s, resolution=%dx%d, font_family=%s, "
             "cache_enabled=%s, fade_alpha_steps=%d, max_entries=%d",
-            self.template.name, self.font_size_preset, self.resolution[0], self.resolution[1],
-            self.font_family, self._cache_enabled, self._fade_alpha_steps, self._max_cache_entries,
+            self.template.name,
+            self.font_size_preset,
+            self.resolution[0],
+            self.resolution[1],
+            self.font_family,
+            self._cache_enabled,
+            self._fade_alpha_steps,
+            self._max_cache_entries,
         )
 
     def get_base_font_size(self) -> int:
@@ -331,6 +352,78 @@ class FrameRenderer:
 
         return 255
 
+    def _find_previous_non_blank_index(
+        self,
+        song_lyrics: list[GlobalLRCLine],
+        current_index: int,
+    ) -> int:
+        for i in range(current_index - 1, -1, -1):
+            if song_lyrics[i].text.strip():
+                return i
+        return -1
+
+    def _find_next_non_blank_index(
+        self,
+        song_lyrics: list[GlobalLRCLine],
+        current_index: int,
+    ) -> int:
+        for i in range(current_index + 1, len(song_lyrics)):
+            if song_lyrics[i].text.strip():
+                return i
+        return -1
+
+    def _compute_blank_previous_fade_alpha(
+        self,
+        song_lyrics: list[GlobalLRCLine],
+        current_time: float,
+        current_index: int,
+    ) -> int:
+        if current_index < 0 or current_index >= len(song_lyrics):
+            return 0
+        if song_lyrics[current_index].text.strip():
+            return 0
+        if self._find_previous_non_blank_index(song_lyrics, current_index) < 0:
+            return 0
+
+        elapsed = current_time - song_lyrics[current_index].global_time_seconds
+        if elapsed < _BLANK_PREVIOUS_HOLD_SECONDS:
+            return 255
+
+        fade_elapsed = elapsed - _BLANK_PREVIOUS_HOLD_SECONDS
+        if fade_elapsed >= _BLANK_PREVIOUS_FADE_SECONDS:
+            return 0
+
+        fade_progress = max(0.0, fade_elapsed / _BLANK_PREVIOUS_FADE_SECONDS)
+        return math.floor(255 * (1.0 - math.sqrt(fade_progress)))
+
+    def _compute_blank_preview_alpha(
+        self,
+        song_lyrics: list[GlobalLRCLine],
+        current_time: float,
+        current_index: int,
+        tempo_bpm: float | None,
+    ) -> int:
+        if current_index < 0 or current_index >= len(song_lyrics):
+            return 0
+        if song_lyrics[current_index].text.strip():
+            return 0
+
+        next_index = self._find_next_non_blank_index(song_lyrics, current_index)
+        if next_index < 0:
+            return 0
+
+        bpm = tempo_bpm if tempo_bpm and tempo_bpm > 0 else _DEFAULT_TEMPO_BPM
+        four_beat_window_seconds = 4 * 60 / bpm
+        preview_start = song_lyrics[next_index].global_time_seconds - four_beat_window_seconds
+        if current_time < preview_start:
+            return 0
+
+        preview_elapsed = current_time - preview_start
+        return min(
+            _BLANK_PREVIEW_ALPHA,
+            math.floor(_BLANK_PREVIEW_ALPHA * preview_elapsed / _BLANK_PREVIEW_FADE_SECONDS),
+        )
+
     def _resolve_visual_state(
         self,
         lyrics: list[GlobalLRCLine],
@@ -339,6 +432,7 @@ class FrameRenderer:
     ) -> VisualState:
         current_title = ""
         current_segment: SegmentInfo | None = None
+        tempo_bpm: float | None = None
 
         for segment in segments:
             segment_start = segment.start_time_seconds
@@ -346,6 +440,8 @@ class FrameRenderer:
             if segment_start <= current_time < segment_end:
                 current_title = segment.song_title or "Unknown"
                 current_segment = segment
+                if segment.tempo_bpm and segment.tempo_bpm > 0:
+                    tempo_bpm = segment.tempo_bpm
                 break
 
         lyrics_by_song = group_lyrics_by_song(lyrics)
@@ -361,6 +457,7 @@ class FrameRenderer:
 
         current_lyric_index = -1
         fade_alpha = 255
+        preview_alpha = 0
         is_last_lyric_faded = False
 
         if current_song_lyrics and current_time >= current_song_lyrics[0].global_time_seconds:
@@ -371,14 +468,23 @@ class FrameRenderer:
                     break
 
             if current_lyric_index >= 0:
-                is_last = current_lyric_index == len(current_song_lyrics) - 1
-                if is_last:
-                    fade_alpha = self._compute_last_lyric_fade_alpha(
+                current_line = current_song_lyrics[current_lyric_index]
+                if current_line.text.strip():
+                    is_last = current_lyric_index == len(current_song_lyrics) - 1
+                    if is_last:
+                        fade_alpha = self._compute_last_lyric_fade_alpha(
+                            current_song_lyrics, current_time, current_lyric_index
+                        )
+                        if fade_alpha <= 0:
+                            is_last_lyric_faded = True
+                            current_lyric_index = -1
+                else:
+                    fade_alpha = self._compute_blank_previous_fade_alpha(
                         current_song_lyrics, current_time, current_lyric_index
                     )
-                    if fade_alpha <= 0:
-                        is_last_lyric_faded = True
-                        current_lyric_index = -1
+                    preview_alpha = self._compute_blank_preview_alpha(
+                        current_song_lyrics, current_time, current_lyric_index, tempo_bpm
+                    )
 
         return VisualState(
             segment_id=current_segment.id if current_segment else "",
@@ -388,6 +494,8 @@ class FrameRenderer:
             current_lyric_index=current_lyric_index,
             intro_alpha=intro_alpha,
             fade_alpha=fade_alpha,
+            preview_alpha=preview_alpha,
+            tempo_bpm=tempo_bpm,
             is_last_lyric_faded=is_last_lyric_faded,
             current_time=current_time,
         )
@@ -395,6 +503,9 @@ class FrameRenderer:
     def _compute_cache_key(self, state: VisualState) -> tuple:
         quantized_intro = self._quantize_alpha(state.intro_alpha) if state.intro_alpha > 0 else 0
         quantized_fade = self._quantize_alpha(state.fade_alpha) if state.fade_alpha < 255 else 255
+        quantized_preview = (
+            self._quantize_alpha(state.preview_alpha) if state.preview_alpha > 0 else 0
+        )
 
         return (
             self.font_family,
@@ -403,6 +514,7 @@ class FrameRenderer:
             state.current_lyric_index,
             quantized_intro,
             quantized_fade,
+            quantized_preview,
             state.is_last_lyric_faded,
         )
 
@@ -495,6 +607,7 @@ class FrameRenderer:
                     draw,
                     width,
                     height,
+                    tempo_bpm=state.tempo_bpm,
                 )
 
         return img
@@ -580,6 +693,7 @@ class FrameRenderer:
         draw: ImageDraw.ImageDraw,
         width: int,
         height: int,
+        tempo_bpm: float | None = None,
     ) -> None:
         current_index = -1
         for i, line in enumerate(song_lyrics):
@@ -598,15 +712,54 @@ class FrameRenderer:
         current_line = song_lyrics[current_index]
         is_last_lyric = current_index == len(song_lyrics) - 1
 
+        highlight_r, highlight_g, highlight_b = self.template.highlight_color
+        current_font_size_target = self.base_font_size * 2
+        margin = self.get_margin(draw, current_font_size_target)
+
+        if not current_line.text.strip():
+            previous_index = self._find_previous_non_blank_index(song_lyrics, current_index)
+            previous_alpha = self._compute_blank_previous_fade_alpha(
+                song_lyrics, current_time, current_index
+            )
+            if previous_index >= 0 and previous_alpha > 0:
+                previous_line = song_lyrics[previous_index]
+                previous_font_size = self.fit_text(
+                    draw, previous_line.text, current_font_size_target, width - margin * 2
+                )
+                previous_font = self._get_font(previous_font_size)
+                previous_fill_color = (
+                    int(highlight_r * previous_alpha / 255),
+                    int(highlight_g * previous_alpha / 255),
+                    int(highlight_b * previous_alpha / 255),
+                )
+                draw.text(
+                    (width // 2, int(height * 0.33)),
+                    previous_line.text,
+                    fill=previous_fill_color,
+                    font=previous_font,
+                    anchor="mt",
+                )
+
+            preview_alpha = self._compute_blank_preview_alpha(
+                song_lyrics, current_time, current_index, tempo_bpm
+            )
+            next_index = self._find_next_non_blank_index(song_lyrics, current_index)
+            if next_index >= 0 and preview_alpha > 0:
+                self._render_next_lyric_preview(
+                    song_lyrics[next_index],
+                    preview_alpha,
+                    draw,
+                    width,
+                    height,
+                )
+            return
+
         fade_alpha = self._compute_last_lyric_fade_alpha(song_lyrics, current_time, current_index)
         is_last_lyric_faded = is_last_lyric and fade_alpha <= 0
 
         if is_last_lyric_faded:
             return
 
-        highlight_r, highlight_g, highlight_b = self.template.highlight_color
-        current_font_size_target = self.base_font_size * 2
-        margin = self.get_margin(draw, current_font_size_target)
         current_font_size = self.fit_text(
             draw, current_line.text, current_font_size_target, width - margin * 2
         )
@@ -635,29 +788,39 @@ class FrameRenderer:
                     fade_progress = 1.0 - fade_alpha / 255.0
                     next_alpha = math.floor(128 * (1 - fade_progress))
 
-                text_r, text_g, text_b = self.template.text_color
-                next_font_size_target = self.base_font_size
-                next_margin = self.get_margin(draw, next_font_size_target)
-                next_font_size = self.fit_text(
-                    draw,
-                    next_line.text,
-                    next_font_size_target,
-                    width - next_margin * 2,
-                )
-                next_font = self._get_font(next_font_size)
-                next_fill_color = (
-                    int(text_r * next_alpha / 255),
-                    int(text_g * next_alpha / 255),
-                    int(text_b * next_alpha / 255),
-                )
-                next_y = int(height * 0.33 + 200)
-                draw.text(
-                    (width // 2, next_y),
-                    next_line.text,
-                    fill=next_fill_color,
-                    font=next_font,
-                    anchor="mt",
-                )
+                self._render_next_lyric_preview(next_line, next_alpha, draw, width, height)
+
+    def _render_next_lyric_preview(
+        self,
+        next_line: GlobalLRCLine,
+        next_alpha: int,
+        draw: ImageDraw.ImageDraw,
+        width: int,
+        height: int,
+    ) -> None:
+        text_r, text_g, text_b = self.template.text_color
+        next_font_size_target = self.base_font_size
+        next_margin = self.get_margin(draw, next_font_size_target)
+        next_font_size = self.fit_text(
+            draw,
+            next_line.text,
+            next_font_size_target,
+            width - next_margin * 2,
+        )
+        next_font = self._get_font(next_font_size)
+        next_fill_color = (
+            int(text_r * next_alpha / 255),
+            int(text_g * next_alpha / 255),
+            int(text_b * next_alpha / 255),
+        )
+        next_y = int(height * 0.33 + 200)
+        draw.text(
+            (width // 2, next_y),
+            next_line.text,
+            fill=next_fill_color,
+            font=next_font,
+            anchor="mt",
+        )
 
     def render_title_card(self, config: TitleCardConfig) -> Image.Image:
         width, height = self.resolution

--- a/services/render-worker/src/sow_render_worker/frame_renderer.py
+++ b/services/render-worker/src/sow_render_worker/frame_renderer.py
@@ -372,6 +372,16 @@ class FrameRenderer:
                 return i
         return -1
 
+    def _find_blank_run_start_index(
+        self,
+        song_lyrics: list[GlobalLRCLine],
+        current_index: int,
+    ) -> int:
+        for i in range(current_index - 1, -1, -1):
+            if song_lyrics[i].text.strip():
+                return i + 1
+        return 0
+
     def _compute_blank_previous_fade_alpha(
         self,
         song_lyrics: list[GlobalLRCLine],
@@ -385,7 +395,8 @@ class FrameRenderer:
         if self._find_previous_non_blank_index(song_lyrics, current_index) < 0:
             return 0
 
-        elapsed = current_time - song_lyrics[current_index].global_time_seconds
+        blank_run_start_index = self._find_blank_run_start_index(song_lyrics, current_index)
+        elapsed = current_time - song_lyrics[blank_run_start_index].global_time_seconds
         if elapsed < _BLANK_PREVIOUS_HOLD_SECONDS:
             return 255
 

--- a/services/render-worker/src/sow_render_worker/lrc_parser.py
+++ b/services/render-worker/src/sow_render_worker/lrc_parser.py
@@ -34,8 +34,7 @@ def parse_lrc(lrc_content: str) -> list[LRCLine]:
         milliseconds = int(ms_str.ljust(3, "0")[:3])
         text = match.group(4).strip()
         time_seconds = minutes * 60 + seconds + milliseconds / 1000.0
-        if text:
-            lines.append(LRCLine(time_seconds=time_seconds, text=text))
+        lines.append(LRCLine(time_seconds=time_seconds, text=text))
     lines.sort(key=lambda line: line.time_seconds)
     return lines
 
@@ -63,14 +62,22 @@ def estimate_last_lyric_duration(
     if not song_lyrics:
         return 5.0
 
-    last_lyric = song_lyrics[-1]
+    last_lyric_index = -1
+    for i in range(len(song_lyrics) - 1, -1, -1):
+        if song_lyrics[i].text.strip():
+            last_lyric_index = i
+            break
 
-    for i in range(len(song_lyrics) - 2, -1, -1):
+    if last_lyric_index < 0:
+        return 5.0
+
+    last_lyric = song_lyrics[last_lyric_index]
+
+    for i in range(last_lyric_index - 1, -1, -1):
         if song_lyrics[i].text == last_lyric.text:
             if i + 1 < len(song_lyrics):
                 duration = (
-                    song_lyrics[i + 1].global_time_seconds
-                    - song_lyrics[i].global_time_seconds
+                    song_lyrics[i + 1].global_time_seconds - song_lyrics[i].global_time_seconds
                 )
                 return max(3.0, duration)
 

--- a/services/render-worker/src/sow_render_worker/video_engine.py
+++ b/services/render-worker/src/sow_render_worker/video_engine.py
@@ -159,8 +159,11 @@ class VideoEngine:
 
         logger.info(
             "[%s] generate_video: duration=%.1fs, total_frames=%d, resolution=%s, fps=%d",
-            job_id or "unknown", total_duration_seconds, total_frames,
-            f"{self.resolution[0]}x{self.resolution[1]}", self.fps,
+            job_id or "unknown",
+            total_duration_seconds,
+            total_frames,
+            f"{self.resolution[0]}x{self.resolution[1]}",
+            self.fps,
         )
 
         all_lyrics: list[GlobalLRCLine] = []
@@ -179,9 +182,8 @@ class VideoEngine:
                 continue
 
             local_lyrics = parse_lrc(lrc_content)
-            title = (
-                segment.item.song_title
-                or (str(segment.item.song_id) if segment.item.song_id else f"song-{i}")
+            title = segment.item.song_title or (
+                str(segment.item.song_id) if segment.item.song_id else f"song-{i}"
             )
             global_lyrics = convert_to_global_timeline(
                 local_lyrics, segment.start_time_seconds, title
@@ -208,9 +210,11 @@ class VideoEngine:
                 )
             )
 
-        if not all_lyrics:
+        if not all_lyrics or all(not line.text for line in all_lyrics):
             return self.generate_blank_video(
-                audio_path, output_path, total_duration_seconds,
+                audio_path,
+                output_path,
+                total_duration_seconds,
                 job_id=job_id,
             )
 
@@ -238,7 +242,9 @@ class VideoEngine:
             else:
                 song_titles = [seg.item.song_title for seg in segments if seg.item.song_title]
                 display_name = self.songset_name or "Worship Set"
-                title_lines = tuple([display_name] + song_titles) if song_titles else (display_name,)
+                title_lines = (
+                    tuple([display_name] + song_titles) if song_titles else (display_name,)
+                )
 
             title_card_config = TitleCardConfig(
                 enabled=True,
@@ -262,7 +268,8 @@ class VideoEngine:
 
         logger.info(
             "[%s] generate_video: complete, %d frames encoded",
-            job_id or "unknown", total_frames,
+            job_id or "unknown",
+            total_frames,
         )
 
         return VideoExportResult(
@@ -295,7 +302,10 @@ class VideoEngine:
         ffmpeg_start_ns = time.monotonic_ns()
         logger.info(
             "[%s] encode_video_with_ffmpeg: starting FFmpeg pipe, %d frames (%.1fs at %dfps)",
-            job_id or "unknown", total_frames, total_duration_seconds, self.fps,
+            job_id or "unknown",
+            total_frames,
+            total_duration_seconds,
+            self.fps,
         )
 
         args = [
@@ -334,6 +344,7 @@ class VideoEngine:
         stderr_chunks: list[bytes] = []
         stderr_thread: threading.Thread | None = None
         if process.stderr:
+
             def _drain_stderr(pipe, chunks):
                 try:
                     while True:
@@ -344,7 +355,9 @@ class VideoEngine:
                 except Exception:
                     pass
 
-            stderr_thread = threading.Thread(target=_drain_stderr, args=(process.stderr, stderr_chunks), daemon=True)
+            stderr_thread = threading.Thread(
+                target=_drain_stderr, args=(process.stderr, stderr_chunks), daemon=True
+            )
             stderr_thread.start()
 
         title_card_frame_count = (
@@ -375,7 +388,9 @@ class VideoEngine:
                 else:
                     current_time = frame_count / self.fps
                     t0 = time.monotonic_ns()
-                    frame_bytes = self.frame_renderer.render_frame_bytes(lyrics, segments, current_time)
+                    frame_bytes = self.frame_renderer.render_frame_bytes(
+                        lyrics, segments, current_time
+                    )
                     render_total_ns += time.monotonic_ns() - t0
 
                 try:
@@ -390,19 +405,24 @@ class VideoEngine:
                     if process.returncode == 0:
                         logger.info(
                             "[%s] FFmpeg completed early (stopped reading at frame %d/%d)",
-                            job_id or "unknown", frame_count, total_frames,
+                            job_id or "unknown",
+                            frame_count,
+                            total_frames,
                         )
                         ffmpeg_elapsed = (time.monotonic_ns() - ffmpeg_start_ns) / 1e9
                         logger.info(
                             "[%s] FFmpeg process exited with code 0 in %.1fs",
-                            job_id or "unknown", ffmpeg_elapsed,
+                            job_id or "unknown",
+                            ffmpeg_elapsed,
                         )
                         if progress_callback:
                             progress_callback(total_frames, total_frames)
                         return
                     logger.error(
                         "[%s] FFmpeg pipe broken at frame %d/%d",
-                        job_id or "unknown", frame_count, total_frames,
+                        job_id or "unknown",
+                        frame_count,
+                        total_frames,
                     )
                     stderr_output = b"".join(stderr_chunks).decode("utf-8", errors="replace")
                     stderr_info = (
@@ -433,7 +453,8 @@ class VideoEngine:
                         "[%s] Encoding breakdown at frame %d/%d: "
                         "render=%.1fs (%.1f%%), pipe_write=%.1fs (%.1f%%)%s",
                         job_id or "unknown",
-                        frame_count, total_frames,
+                        frame_count,
+                        total_frames,
                         render_total_ns / 1e9,
                         render_total_ns / elapsed_so_far * 100,
                         write_total_ns / 1e9,
@@ -460,7 +481,11 @@ class VideoEngine:
                 logger.info(
                     "[%s] Frame cache final: %d entries, %d hits, %d misses (%.1f%% hit rate), max=%d",
                     job_id or "unknown",
-                    stats["entries"], stats["hits"], stats["misses"], hit_rate, stats["max_entries"],
+                    stats["entries"],
+                    stats["hits"],
+                    stats["misses"],
+                    hit_rate,
+                    stats["max_entries"],
                 )
             if total_elapsed_ns > 0:
                 logger.info(
@@ -488,7 +513,9 @@ class VideoEngine:
         ffmpeg_elapsed = (time.monotonic_ns() - ffmpeg_start_ns) / 1e9
         logger.info(
             "[%s] FFmpeg process exited with code %d in %.1fs",
-            job_id or "unknown", return_code, ffmpeg_elapsed,
+            job_id or "unknown",
+            return_code,
+            ffmpeg_elapsed,
         )
         stderr_output = b"".join(stderr_chunks).decode("utf-8", errors="replace")
         if return_code != 0:
@@ -515,7 +542,9 @@ class VideoEngine:
 
         logger.info(
             "[%s] generate_blank_video: %.1fs, %s",
-            job_id or "unknown", duration_seconds, output_path,
+            job_id or "unknown",
+            duration_seconds,
+            output_path,
         )
 
         args = [
@@ -567,7 +596,9 @@ class VideoEngine:
     ) -> bool:
         logger.info(
             "[%s] inject_chapters: %d chapters into %s",
-            job_id or "unknown", len(chapters), video_path,
+            job_id or "unknown",
+            len(chapters),
+            video_path,
         )
         try:
             temp_dir = self.asset_fetcher.get_temp_dir()

--- a/services/render-worker/tests/test_frame_renderer.py
+++ b/services/render-worker/tests/test_frame_renderer.py
@@ -579,6 +579,35 @@ class TestRenderLyrics:
         assert list(img_hold.getdata()) != list(blank.getdata())
         assert list(img_faded.getdata()) == list(blank.getdata())
 
+    @pytest.mark.parametrize(
+        ("text", "alpha"),
+        [
+            ("World", 0),
+            ("", 128),
+            ("   ", 128),
+            (None, 128),
+            (123, 128),
+        ],
+    )
+    def test_next_lyric_preview_guard_skips_non_renderable_text(self, text, alpha):
+        renderer = FrameRenderer(template=VIDEO_TEMPLATES["dark"])
+        img = Image.new("RGB", (1920, 1080), VIDEO_TEMPLATES["dark"].background_color)
+        draw = ImageDraw.Draw(img)
+        draw_text = MagicMock()
+        draw.text = draw_text
+        line = GlobalLRCLine(
+            text=text,
+            local_time_seconds=10.0,
+            global_time_seconds=10.0,
+            title="Song",
+        )
+
+        with patch.object(renderer, "fit_text") as fit_text:
+            renderer._render_next_lyric_preview(line, alpha, draw, 1920, 1080)
+
+        fit_text.assert_not_called()
+        draw_text.assert_not_called()
+
 
 class TestRenderTitleCard:
     def test_returns_pil_image(self):

--- a/services/render-worker/tests/test_frame_renderer.py
+++ b/services/render-worker/tests/test_frame_renderer.py
@@ -135,9 +135,7 @@ class TestVideoTemplates:
 
 class TestSegmentInfo:
     def test_frozen_dataclass(self):
-        s = SegmentInfo(
-            id="1", song_id="s1", position=0, song_title="Test"
-        )
+        s = SegmentInfo(id="1", song_id="s1", position=0, song_title="Test")
         with pytest.raises(AttributeError):
             s.id = "2"
 
@@ -203,9 +201,7 @@ class TestFrameRendererInit:
         assert renderer.resolution == (1920, 1080)
 
     def test_custom_resolution(self):
-        renderer = FrameRenderer(
-            template=VIDEO_TEMPLATES["dark"], resolution=(1280, 720)
-        )
+        renderer = FrameRenderer(template=VIDEO_TEMPLATES["dark"], resolution=(1280, 720))
         assert renderer.resolution == (1280, 720)
 
     def test_get_base_font_size(self):
@@ -291,9 +287,7 @@ class TestRenderFrame:
         assert result.size == (1920, 1080)
 
     def test_custom_resolution(self):
-        renderer = FrameRenderer(
-            template=VIDEO_TEMPLATES["dark"], resolution=(1280, 720)
-        )
+        renderer = FrameRenderer(template=VIDEO_TEMPLATES["dark"], resolution=(1280, 720))
         lyrics = _make_lyrics([(5.0, "Hello")])
         segments = [_make_segment(start=0.0, duration=60.0)]
         result = renderer.render_frame(lyrics, segments, 7.0)
@@ -314,9 +308,7 @@ class TestRenderFrame:
     def test_before_first_lyric_shows_intro(self):
         renderer = FrameRenderer(template=VIDEO_TEMPLATES["dark"])
         lyrics = _make_lyrics([(10.0, "Hello")])
-        segment = _make_segment(
-            start=0.0, duration=60.0, composer="Test Composer"
-        )
+        segment = _make_segment(start=0.0, duration=60.0, composer="Test Composer")
         result = renderer.render_frame(lyrics, [segment], 2.0)
         assert isinstance(result, Image.Image)
 
@@ -372,9 +364,7 @@ class TestRenderIntroInfo:
         renderer = FrameRenderer(template=VIDEO_TEMPLATES["dark"])
         img = Image.new("RGB", (1920, 1080))
         draw = ImageDraw.Draw(img)
-        segment = _make_segment(
-            start=0.0, duration=60.0, composer="Test Composer"
-        )
+        segment = _make_segment(start=0.0, duration=60.0, composer="Test Composer")
         result = renderer.render_intro_info(segment, 1.0, 10.0, draw, 1920, 1080)
         assert result == 255
 
@@ -382,9 +372,7 @@ class TestRenderIntroInfo:
         renderer = FrameRenderer(template=VIDEO_TEMPLATES["dark"])
         img = Image.new("RGB", (1920, 1080))
         draw = ImageDraw.Draw(img)
-        segment = _make_segment(
-            start=0.0, duration=60.0, composer="Test Composer"
-        )
+        segment = _make_segment(start=0.0, duration=60.0, composer="Test Composer")
         alpha_start = renderer.render_intro_info(segment, 5.0, 10.0, draw, 1920, 1080)
         alpha_later = renderer.render_intro_info(segment, 8.0, 10.0, draw, 1920, 1080)
         assert alpha_later < alpha_start
@@ -393,9 +381,7 @@ class TestRenderIntroInfo:
         renderer = FrameRenderer(template=VIDEO_TEMPLATES["dark"])
         img = Image.new("RGB", (1920, 1080))
         draw = ImageDraw.Draw(img)
-        segment = _make_segment(
-            start=0.0, duration=60.0, composer="Test Composer"
-        )
+        segment = _make_segment(start=0.0, duration=60.0, composer="Test Composer")
         result = renderer.render_intro_info(segment, 9.5, 10.0, draw, 1920, 1080)
         assert result == 0
 
@@ -436,9 +422,7 @@ class TestRenderIntroInfo:
         img = Image.new("RGB", (1920, 1080))
         draw = ImageDraw.Draw(img)
         segment = _make_segment(start=0.0, duration=60.0, composer="Test")
-        alpha_at_half_fade = renderer.render_intro_info(
-            segment, 6.0, 10.0, draw, 1920, 1080
-        )
+        alpha_at_half_fade = renderer.render_intro_info(segment, 6.0, 10.0, draw, 1920, 1080)
         import math
 
         info_duration = 10.0 - 4.0 - 3.0
@@ -514,6 +498,86 @@ class TestRenderLyrics:
         renderer.render_lyrics(lyrics, 7.0, "Song", draw, 1920, 1080)
         blank = Image.new("RGB", (1920, 1080), bg)
         assert list(img.getdata()) != list(blank.getdata())
+
+    def test_blank_current_line_no_preview_outside_four_beat_window(self):
+        renderer = FrameRenderer(template=VIDEO_TEMPLATES["dark"])
+        bg = VIDEO_TEMPLATES["dark"].background_color
+        img = Image.new("RGB", (1920, 1080), bg)
+        draw = ImageDraw.Draw(img)
+        lyrics = _make_lyrics([(0.0, "Hello"), (10.0, ""), (40.0, "World")])
+
+        with patch.object(renderer, "_render_next_lyric_preview") as mock_preview:
+            renderer.render_lyrics(lyrics, 17.0, "Song", draw, 1920, 1080, tempo_bpm=120.0)
+
+        blank = Image.new("RGB", (1920, 1080), bg)
+        mock_preview.assert_not_called()
+        assert list(img.getdata()) == list(blank.getdata())
+
+    def test_blank_current_line_preview_inside_four_beat_window(self):
+        renderer = FrameRenderer(template=VIDEO_TEMPLATES["dark"])
+        img = Image.new("RGB", (1920, 1080), VIDEO_TEMPLATES["dark"].background_color)
+        draw = ImageDraw.Draw(img)
+        lyrics = _make_lyrics([(0.0, "Hello"), (10.0, ""), (13.0, "World")])
+
+        with patch.object(renderer, "_render_next_lyric_preview") as mock_preview:
+            renderer.render_lyrics(lyrics, 11.25, "Song", draw, 1920, 1080, tempo_bpm=120.0)
+
+        mock_preview.assert_called_once()
+        assert mock_preview.call_args.args[0].text == "World"
+        assert mock_preview.call_args.args[1] == 64
+
+    def test_blank_preview_fade_in_alpha(self):
+        renderer = FrameRenderer(template=VIDEO_TEMPLATES["dark"])
+        lyrics = _make_lyrics([(0.0, "Hello"), (10.0, ""), (13.0, "World")])
+
+        assert renderer._compute_blank_preview_alpha(lyrics, 11.0, 1, 120.0) == 0
+        assert renderer._compute_blank_preview_alpha(lyrics, 11.25, 1, 120.0) == 64
+        assert renderer._compute_blank_preview_alpha(lyrics, 11.5, 1, 120.0) == 128
+
+    def test_blank_preview_skips_future_blank_lines(self):
+        renderer = FrameRenderer(template=VIDEO_TEMPLATES["dark"])
+        lyrics = _make_lyrics([(0.0, "Hello"), (10.0, ""), (12.0, ""), (14.0, "World")])
+
+        assert renderer._compute_blank_preview_alpha(lyrics, 12.25, 1, 120.0) == 64
+
+    def test_blank_preview_uses_default_tempo_fallback(self):
+        renderer = FrameRenderer(template=VIDEO_TEMPLATES["dark"])
+        lyrics = _make_lyrics([(0.0, "Hello"), (10.0, ""), (14.0, "World")])
+
+        assert renderer._compute_blank_preview_alpha(lyrics, 10.55, 1, None) == 0
+        assert renderer._compute_blank_preview_alpha(lyrics, 10.6, 1, 0.0) > 0
+
+    def test_blank_previous_lyric_holds_then_fades(self):
+        renderer = FrameRenderer(template=VIDEO_TEMPLATES["dark"])
+        lyrics = _make_lyrics([(0.0, "Hello"), (10.0, "")])
+
+        assert renderer._compute_blank_previous_fade_alpha(lyrics, 11.0, 1) == 255
+        assert 0 < renderer._compute_blank_previous_fade_alpha(lyrics, 14.0, 1) < 255
+        assert renderer._compute_blank_previous_fade_alpha(lyrics, 16.0, 1) == 0
+
+    def test_blank_previous_and_preview_can_overlap(self):
+        renderer = FrameRenderer(template=VIDEO_TEMPLATES["dark"])
+        lyrics = _make_lyrics([(0.0, "Hello"), (10.0, ""), (13.0, "World")])
+
+        previous_alpha = renderer._compute_blank_previous_fade_alpha(lyrics, 11.25, 1)
+        preview_alpha = renderer._compute_blank_preview_alpha(lyrics, 11.25, 1, 120.0)
+
+        assert previous_alpha == 255
+        assert preview_alpha == 64
+
+    def test_trailing_blank_holds_then_fades_last_sung_line(self):
+        renderer = FrameRenderer(template=VIDEO_TEMPLATES["dark"])
+        bg = VIDEO_TEMPLATES["dark"].background_color
+        lyrics = _make_lyrics([(0.0, "Hello"), (10.0, "")])
+
+        img_hold = Image.new("RGB", (1920, 1080), bg)
+        renderer.render_lyrics(lyrics, 11.0, "Song", ImageDraw.Draw(img_hold), 1920, 1080)
+        img_faded = Image.new("RGB", (1920, 1080), bg)
+        renderer.render_lyrics(lyrics, 16.0, "Song", ImageDraw.Draw(img_faded), 1920, 1080)
+        blank = Image.new("RGB", (1920, 1080), bg)
+
+        assert list(img_hold.getdata()) != list(blank.getdata())
+        assert list(img_faded.getdata()) == list(blank.getdata())
 
 
 class TestRenderTitleCard:
@@ -603,11 +667,13 @@ class TestLoadFont:
 class TestFrameRendererIntegration:
     def test_full_render_pipeline(self):
         renderer = FrameRenderer(template=VIDEO_TEMPLATES["dark"])
-        lyrics = _make_lyrics([
-            (5.0, "First line"),
-            (10.0, "Second line"),
-            (15.0, "Third line"),
-        ])
+        lyrics = _make_lyrics(
+            [
+                (5.0, "First line"),
+                (10.0, "Second line"),
+                (15.0, "Third line"),
+            ]
+        )
         segments = [_make_segment(start=0.0, duration=60.0)]
 
         for t in [0.0, 3.0, 7.0, 12.0, 20.0]:
@@ -645,9 +711,7 @@ class TestFrameRendererIntegration:
         segments = [_make_segment(start=0.0, duration=60.0)]
 
         for preset in ["S", "M", "L", "XL"]:
-            renderer = FrameRenderer(
-                template=VIDEO_TEMPLATES["dark"], font_size_preset=preset
-            )
+            renderer = FrameRenderer(template=VIDEO_TEMPLATES["dark"], font_size_preset=preset)
             result = renderer.render_frame(lyrics, segments, 7.0)
             assert result.size == (1920, 1080)
 
@@ -810,7 +874,26 @@ class TestComputeCacheKey:
         renderer = FrameRenderer(template=VIDEO_TEMPLATES["dark"])
         state = renderer._resolve_visual_state([], [], 0.0)
         key = renderer._compute_cache_key(state)
-        assert key == ("noto_serif_tc", "", "", -1, 0, 255, False)
+        assert key == ("noto_serif_tc", "", "", -1, 0, 255, 0, False)
+
+    def test_blank_preview_alpha_changes_cache_key(self):
+        renderer = FrameRenderer(template=VIDEO_TEMPLATES["dark"])
+        lyrics = _make_lyrics([(0.0, "Hello"), (10.0, ""), (13.0, "World")], title="Test Song")
+        segment = _make_segment(start=0.0, duration=60.0, tempo=120.0)
+
+        state_before = renderer._resolve_visual_state(lyrics, [segment], 10.5)
+        state_fading = renderer._resolve_visual_state(lyrics, [segment], 11.25)
+        state_visible = renderer._resolve_visual_state(lyrics, [segment], 11.5)
+
+        assert state_before.preview_alpha == 0
+        assert state_fading.preview_alpha == 64
+        assert state_visible.preview_alpha == 128
+        assert renderer._compute_cache_key(state_before) != renderer._compute_cache_key(
+            state_fading
+        )
+        assert renderer._compute_cache_key(state_fading) != renderer._compute_cache_key(
+            state_visible
+        )
 
 
 class TestFrameCache:
@@ -900,6 +983,7 @@ class TestFrameCachePerformance:
         renderer.render_frame_bytes(lyrics, segments, 7.0)
 
         import time
+
         start = time.monotonic()
         for _ in range(100):
             renderer.render_frame_bytes(lyrics, segments, 7.0)

--- a/services/render-worker/tests/test_frame_renderer.py
+++ b/services/render-worker/tests/test_frame_renderer.py
@@ -555,6 +555,16 @@ class TestRenderLyrics:
         assert 0 < renderer._compute_blank_previous_fade_alpha(lyrics, 14.0, 1) < 255
         assert renderer._compute_blank_previous_fade_alpha(lyrics, 16.0, 1) == 0
 
+    def test_consecutive_blank_previous_fade_stays_anchored_to_first_blank(self):
+        renderer = FrameRenderer(template=VIDEO_TEMPLATES["dark"])
+        lyrics = _make_lyrics([(0.0, "Hello"), (10.0, ""), (13.0, ""), (20.0, "World")])
+
+        alpha_from_first_blank = renderer._compute_blank_previous_fade_alpha(lyrics, 14.0, 1)
+        alpha_from_later_blank = renderer._compute_blank_previous_fade_alpha(lyrics, 14.0, 2)
+
+        assert 0 < alpha_from_later_blank < 255
+        assert alpha_from_later_blank == alpha_from_first_blank
+
     def test_blank_previous_and_preview_can_overlap(self):
         renderer = FrameRenderer(template=VIDEO_TEMPLATES["dark"])
         lyrics = _make_lyrics([(0.0, "Hello"), (10.0, ""), (13.0, "World")])

--- a/services/render-worker/tests/test_lrc_parser.py
+++ b/services/render-worker/tests/test_lrc_parser.py
@@ -47,11 +47,23 @@ class TestParseLRC:
         assert len(result) == 1
         assert result[0].text == "Hello"
 
-    def test_empty_text_lines_ignored(self):
+    def test_empty_text_lines_preserved(self):
         content = "[00:01.00]\n[00:05.00]Hello"
         result = parse_lrc(content)
-        assert len(result) == 1
-        assert result[0].text == "Hello"
+        assert result == [
+            LRCLine(time_seconds=1.0, text=""),
+            LRCLine(time_seconds=5.0, text="Hello"),
+        ]
+
+    def test_whitespace_only_text_lines_preserved_as_blank(self):
+        content = "[00:01.00]   \n[00:05.00]Hello"
+        result = parse_lrc(content)
+        assert result[0] == LRCLine(time_seconds=1.0, text="")
+
+    def test_blank_lines_sort_by_timestamp(self):
+        content = "[00:10.00]Second\n[00:01.00]\n[00:05.00]First"
+        result = parse_lrc(content)
+        assert [line.text for line in result] == ["", "First", "Second"]
 
     def test_empty_content(self):
         result = parse_lrc("")
@@ -126,9 +138,7 @@ class TestConvertToGlobalTimeline:
 class TestEstimateLastLyricDuration:
     def _make_lyrics(self, times_and_texts):
         return [
-            GlobalLRCLine(
-                text=t, local_time_seconds=ts, global_time_seconds=ts, title="Song"
-            )
+            GlobalLRCLine(text=t, local_time_seconds=ts, global_time_seconds=ts, title="Song")
             for ts, t in times_and_texts
         ]
 
@@ -136,19 +146,23 @@ class TestEstimateLastLyricDuration:
         assert estimate_last_lyric_duration([]) == 5.0
 
     def test_matching_previous_text(self):
-        lyrics = self._make_lyrics([
-            (0.0, "Chorus"),
-            (5.0, "Verse"),
-            (10.0, "Chorus"),
-        ])
+        lyrics = self._make_lyrics(
+            [
+                (0.0, "Chorus"),
+                (5.0, "Verse"),
+                (10.0, "Chorus"),
+            ]
+        )
         result = estimate_last_lyric_duration(lyrics)
         assert result == 5.0
 
     def test_matching_previous_text_minimum_3(self):
-        lyrics = self._make_lyrics([
-            (0.0, "Chorus"),
-            (1.0, "Chorus"),
-        ])
+        lyrics = self._make_lyrics(
+            [
+                (0.0, "Chorus"),
+                (1.0, "Chorus"),
+            ]
+        )
         result = estimate_last_lyric_duration(lyrics)
         assert result == 3.0
 
@@ -182,6 +196,22 @@ class TestEstimateLastLyricDuration:
         lyrics = self._make_lyrics([(0.0, "Only line")])
         result = estimate_last_lyric_duration(lyrics)
         assert result >= 3.0
+
+    def test_skips_trailing_blank_lines(self):
+        lyrics = self._make_lyrics(
+            [
+                (0.0, "Chorus"),
+                (5.0, "Verse"),
+                (10.0, "Chorus"),
+                (14.0, ""),
+            ]
+        )
+        result = estimate_last_lyric_duration(lyrics)
+        assert result == 5.0
+
+    def test_all_blank_lines_return_default(self):
+        lyrics = self._make_lyrics([(0.0, ""), (5.0, "")])
+        assert estimate_last_lyric_duration(lyrics) == 5.0
 
 
 class TestFindCurrentLyricIndex:

--- a/services/render-worker/tests/test_video_engine.py
+++ b/services/render-worker/tests/test_video_engine.py
@@ -324,12 +324,18 @@ class TestEncodeVideoWithFFmpeg:
         engine = VideoEngine(fetcher, fps=24)
 
         lyrics: list[GlobalLRCLine] = [
-            GlobalLRCLine(text="Hello", local_time_seconds=0.0, global_time_seconds=0.0, title="Song"),
+            GlobalLRCLine(
+                text="Hello", local_time_seconds=0.0, global_time_seconds=0.0, title="Song"
+            ),
         ]
         segments = [
             SegmentInfo(
-                id="1", song_id="s1", position=0, song_title="Song",
-                start_time_seconds=0.0, duration_seconds=10.0,
+                id="1",
+                song_id="s1",
+                position=0,
+                song_title="Song",
+                start_time_seconds=0.0,
+                duration_seconds=10.0,
             ),
         ]
 
@@ -452,12 +458,18 @@ class TestEncodeVideoWithFFmpeg:
         engine = VideoEngine(fetcher, fps=24, include_title_card=True)
 
         lyrics: list[GlobalLRCLine] = [
-            GlobalLRCLine(text="Hello", local_time_seconds=0.0, global_time_seconds=0.0, title="Song"),
+            GlobalLRCLine(
+                text="Hello", local_time_seconds=0.0, global_time_seconds=0.0, title="Song"
+            ),
         ]
         segments = [
             SegmentInfo(
-                id="1", song_id="s1", position=0, song_title="Song",
-                start_time_seconds=0.0, duration_seconds=10.0,
+                id="1",
+                song_id="s1",
+                position=0,
+                song_title="Song",
+                start_time_seconds=0.0,
+                duration_seconds=10.0,
             ),
         ]
 
@@ -528,15 +540,23 @@ class TestEncodeVideoWithFFmpeg:
     def test_encode_lyrics_timeline_sync_with_title_card(self, tmp_path):
         output_path = str(tmp_path / "video.mp4")
         fetcher = MockAssetFetcher()
-        engine = VideoEngine(fetcher, fps=24, include_title_card=True, title_card_duration_seconds=5.0)
+        engine = VideoEngine(
+            fetcher, fps=24, include_title_card=True, title_card_duration_seconds=5.0
+        )
 
         lyrics: list[GlobalLRCLine] = [
-            GlobalLRCLine(text="Hello", local_time_seconds=5.0, global_time_seconds=5.0, title="Song"),
+            GlobalLRCLine(
+                text="Hello", local_time_seconds=5.0, global_time_seconds=5.0, title="Song"
+            ),
         ]
         segments = [
             SegmentInfo(
-                id="1", song_id="s1", position=0, song_title="Song",
-                start_time_seconds=0.0, duration_seconds=10.0,
+                id="1",
+                song_id="s1",
+                position=0,
+                song_title="Song",
+                start_time_seconds=0.0,
+                duration_seconds=10.0,
             ),
         ]
 
@@ -561,8 +581,12 @@ class TestEncodeVideoWithFFmpeg:
             render_times.append(current_time)
             return original_render_frame_bytes(lyrics_arg, segments_arg, current_time)
 
-        with patch("sow_render_worker.video_engine.subprocess.Popen") as mock_popen, \
-             patch.object(engine.frame_renderer, "render_frame_bytes", side_effect=capture_render_time):
+        with (
+            patch("sow_render_worker.video_engine.subprocess.Popen") as mock_popen,
+            patch.object(
+                engine.frame_renderer, "render_frame_bytes", side_effect=capture_render_time
+            ),
+        ):
             mock_popen.return_value = mock_process
             engine.encode_video_with_ffmpeg(
                 "/tmp/audio.mp3",
@@ -610,8 +634,10 @@ class TestGenerateVideo:
             fps=24,
         )
 
-        with patch("sow_render_worker.video_engine.get_audio_info", return_value=audio_info), \
-             patch.object(engine, "generate_blank_video", return_value=blank_result) as mock_blank:
+        with (
+            patch("sow_render_worker.video_engine.get_audio_info", return_value=audio_info),
+            patch.object(engine, "generate_blank_video", return_value=blank_result) as mock_blank,
+        ):
             result = engine.generate_video("/tmp/audio.mp3", [], output_path, job_id="test-job")
 
         mock_blank.assert_called_once_with("/tmp/audio.mp3", output_path, 60.0, job_id="test-job")
@@ -630,9 +656,13 @@ class TestGenerateVideo:
             "channels": 2,
         }
 
-        with patch("sow_render_worker.video_engine.get_audio_info", return_value=audio_info), \
-             patch.object(engine, "encode_video_with_ffmpeg") as mock_encode:
-            result = engine.generate_video("/tmp/audio.mp3", [segment], output_path, job_id="test-job")
+        with (
+            patch("sow_render_worker.video_engine.get_audio_info", return_value=audio_info),
+            patch.object(engine, "encode_video_with_ffmpeg") as mock_encode,
+        ):
+            result = engine.generate_video(
+                "/tmp/audio.mp3", [segment], output_path, job_id="test-job"
+            )
 
         mock_encode.assert_called_once()
         call_args = mock_encode.call_args
@@ -642,6 +672,63 @@ class TestGenerateVideo:
         assert result.width == 1920
         assert result.height == 1080
         assert result.fps == 24
+
+    def test_blank_timing_lines_mixed_with_lyrics_encode_video(self, tmp_path):
+        output_path = str(tmp_path / "video.mp4")
+        fetcher = MockAssetFetcher(lrc_content="[00:00.00]Hello\n[00:05.00]\n[00:08.00]World")
+        engine = VideoEngine(fetcher, include_title_card=False)
+
+        segment = _make_segment()
+        audio_info = {
+            "duration_seconds": 180.0,
+            "duration_ms": 180000,
+            "sample_rate": 44100,
+            "channels": 2,
+        }
+
+        with (
+            patch("sow_render_worker.video_engine.get_audio_info", return_value=audio_info),
+            patch.object(engine, "encode_video_with_ffmpeg") as mock_encode,
+            patch.object(engine, "generate_blank_video") as mock_blank,
+        ):
+            engine.generate_video("/tmp/audio.mp3", [segment], output_path, job_id="test-job")
+
+        mock_blank.assert_not_called()
+        mock_encode.assert_called_once()
+
+    def test_all_blank_timing_lines_generate_blank_video(self, tmp_path):
+        output_path = str(tmp_path / "video.mp4")
+        fetcher = MockAssetFetcher(lrc_content="[00:00.00]\n[00:05.00]   ")
+        engine = VideoEngine(fetcher, include_title_card=False)
+
+        segment = _make_segment()
+        audio_info = {
+            "duration_seconds": 180.0,
+            "duration_ms": 180000,
+            "sample_rate": 44100,
+            "channels": 2,
+        }
+        blank_result = VideoExportResult(
+            output_path=output_path,
+            total_frames=4320,
+            duration_seconds=180.0,
+            width=1920,
+            height=1080,
+            fps=24,
+        )
+
+        with (
+            patch("sow_render_worker.video_engine.get_audio_info", return_value=audio_info),
+            patch.object(engine, "generate_blank_video", return_value=blank_result) as mock_blank,
+            patch.object(engine, "encode_video_with_ffmpeg") as mock_encode,
+        ):
+            result = engine.generate_video(
+                "/tmp/audio.mp3", [segment], output_path, job_id="test-job"
+            )
+
+        mock_blank.assert_called_once_with("/tmp/audio.mp3", output_path, 180.0, job_id="test-job")
+        mock_encode.assert_not_called()
+        assert result == blank_result
 
     def test_skips_segment_without_hash_prefix(self, tmp_path):
         output_path = str(tmp_path / "video.mp4")
@@ -657,9 +744,13 @@ class TestGenerateVideo:
             "channels": 2,
         }
 
-        with patch("sow_render_worker.video_engine.get_audio_info", return_value=audio_info), \
-             patch.object(engine, "generate_blank_video") as mock_blank:
-            result = engine.generate_video("/tmp/audio.mp3", [segment], output_path, job_id="test-job")
+        with (
+            patch("sow_render_worker.video_engine.get_audio_info", return_value=audio_info),
+            patch.object(engine, "generate_blank_video") as mock_blank,
+        ):
+            result = engine.generate_video(
+                "/tmp/audio.mp3", [segment], output_path, job_id="test-job"
+            )
 
         mock_blank.assert_called_once()
 
@@ -676,9 +767,13 @@ class TestGenerateVideo:
             "channels": 2,
         }
 
-        with patch("sow_render_worker.video_engine.get_audio_info", return_value=audio_info), \
-             patch.object(engine, "generate_blank_video") as mock_blank:
-            result = engine.generate_video("/tmp/audio.mp3", [segment], output_path, job_id="test-job")
+        with (
+            patch("sow_render_worker.video_engine.get_audio_info", return_value=audio_info),
+            patch.object(engine, "generate_blank_video") as mock_blank,
+        ):
+            result = engine.generate_video(
+                "/tmp/audio.mp3", [segment], output_path, job_id="test-job"
+            )
 
         mock_blank.assert_called_once()
 
@@ -703,8 +798,10 @@ class TestGenerateVideo:
             fps=24,
         )
 
-        with patch("sow_render_worker.video_engine.get_audio_info", return_value=audio_info), \
-             patch.object(engine, "generate_blank_video", return_value=blank_result):
+        with (
+            patch("sow_render_worker.video_engine.get_audio_info", return_value=audio_info),
+            patch.object(engine, "generate_blank_video", return_value=blank_result),
+        ):
             engine.generate_video("/tmp/audio.mp3", [], output_path, job_id="test-job")
 
         assert Path(tmp_path / "subdir").is_dir()
@@ -722,12 +819,20 @@ class TestGenerateVideo:
             "channels": 2,
         }
 
-        with patch("sow_render_worker.video_engine.get_audio_info", return_value=audio_info), \
-             patch.object(engine, "encode_video_with_ffmpeg") as mock_encode:
+        with (
+            patch("sow_render_worker.video_engine.get_audio_info", return_value=audio_info),
+            patch.object(engine, "encode_video_with_ffmpeg") as mock_encode,
+        ):
             engine.generate_video("/tmp/audio.mp3", [segment], output_path, job_id="test-job")
 
         call_kwargs = mock_encode.call_args
-        title_card_config = call_kwargs[1].get("title_card_config") if "title_card_config" in call_kwargs[1] else call_kwargs[0][7] if len(call_kwargs[0]) > 7 else None
+        title_card_config = (
+            call_kwargs[1].get("title_card_config")
+            if "title_card_config" in call_kwargs[1]
+            else call_kwargs[0][7]
+            if len(call_kwargs[0]) > 7
+            else None
+        )
         assert title_card_config is not None
         assert title_card_config.enabled is True
         assert len(title_card_config.lines) >= 1
@@ -761,8 +866,10 @@ class TestInjectChapters:
         mock_result.returncode = 0
         mock_result.stderr = b""
 
-        with patch("sow_render_worker.video_engine.subprocess.run") as mock_run, \
-             patch("sow_render_worker.video_engine.shutil.move"):
+        with (
+            patch("sow_render_worker.video_engine.subprocess.run") as mock_run,
+            patch("sow_render_worker.video_engine.shutil.move"),
+        ):
             mock_run.return_value = mock_result
             result = engine.inject_chapters(video_path, chapters, job_id="test-job")
 
@@ -828,8 +935,10 @@ class TestInjectChapters:
         mock_result.returncode = 0
         mock_result.stderr = b""
 
-        with patch("sow_render_worker.video_engine.subprocess.run") as mock_run, \
-             patch("sow_render_worker.video_engine.shutil.move"):
+        with (
+            patch("sow_render_worker.video_engine.subprocess.run") as mock_run,
+            patch("sow_render_worker.video_engine.shutil.move"),
+        ):
             mock_run.return_value = mock_result
             result = engine.inject_chapters(video_path, chapters, job_id="test-job")
 
@@ -861,8 +970,10 @@ class TestInjectChapters:
         mock_result.returncode = 0
         mock_result.stderr = b""
 
-        with patch("sow_render_worker.video_engine.subprocess.run") as mock_run, \
-             patch("sow_render_worker.video_engine.shutil.move"):
+        with (
+            patch("sow_render_worker.video_engine.subprocess.run") as mock_run,
+            patch("sow_render_worker.video_engine.shutil.move"),
+        ):
             mock_run.return_value = mock_result
             engine.inject_chapters(video_path, chapters, job_id="test-job")
 
@@ -1023,8 +1134,10 @@ class TestFFmpegCommandConstruction:
         mock_result.returncode = 0
         mock_result.stderr = b""
 
-        with patch("sow_render_worker.video_engine.subprocess.run") as mock_run, \
-             patch("sow_render_worker.video_engine.shutil.move"):
+        with (
+            patch("sow_render_worker.video_engine.subprocess.run") as mock_run,
+            patch("sow_render_worker.video_engine.shutil.move"),
+        ):
             mock_run.return_value = mock_result
             engine.inject_chapters(video_path, chapters, job_id="test-job")
 
@@ -1070,16 +1183,20 @@ class TestCheckMemoryPressure:
     def test_raises_at_90_percent(self):
         status_content = "Name: test\nVmRSS: 2900000 kB\nVmSize: 4000000 kB\n"
 
-        with patch.dict("os.environ", {"AWS_LAMBDA_FUNCTION_MEMORY_SIZE": "3072"}), \
-             patch("builtins.open", mock_open(read_data=status_content)):
+        with (
+            patch.dict("os.environ", {"AWS_LAMBDA_FUNCTION_MEMORY_SIZE": "3072"}),
+            patch("builtins.open", mock_open(read_data=status_content)),
+        ):
             with pytest.raises(MemoryError, match="Memory pressure"):
                 _check_memory_pressure()
 
     def test_passes_below_threshold(self):
         status_content = "Name: test\nVmRSS: 1000000 kB\nVmSize: 2000000 kB\n"
 
-        with patch.dict("os.environ", {"AWS_LAMBDA_FUNCTION_MEMORY_SIZE": "3072"}), \
-             patch("builtins.open", mock_open(read_data=status_content)):
+        with (
+            patch.dict("os.environ", {"AWS_LAMBDA_FUNCTION_MEMORY_SIZE": "3072"}),
+            patch("builtins.open", mock_open(read_data=status_content)),
+        ):
             _check_memory_pressure()
 
     def test_noop_without_proc(self):
@@ -1106,8 +1223,10 @@ class TestGCCollect:
         mock_process.stderr = MagicMock()
         mock_process.stderr.read.return_value = b""
 
-        with patch("sow_render_worker.video_engine.subprocess.Popen") as mock_popen, \
-             patch("sow_render_worker.video_engine.gc") as mock_gc:
+        with (
+            patch("sow_render_worker.video_engine.subprocess.Popen") as mock_popen,
+            patch("sow_render_worker.video_engine.gc") as mock_gc,
+        ):
             mock_popen.return_value = mock_process
             engine.encode_video_with_ffmpeg(
                 "/tmp/audio.mp3",

--- a/specs/preserve-blank-lrc-lines-render-worker-v2.md
+++ b/specs/preserve-blank-lrc-lines-render-worker-v2.md
@@ -1,0 +1,125 @@
+# Preserve Blank LRC Lines in Render Worker Lyrics Video
+
+## Summary
+
+The render-worker currently skips timestamped LRC lines whose lyric text is empty after trimming. This means an LRC event such as `[00:10.00]` is not represented in the parsed lyric timeline, so the previous non-empty lyric can remain visible until the next non-empty lyric appears.
+
+The desired behavior is to treat blank timestamped LRC lines as intentional timing events. When the current lyric event is blank, the rendered lyric area should be blank. As the next non-blank lyric approaches, the renderer should show the next-line preview within a four-beat window so worship leaders/congregants get a cue that singing resumes soon.
+
+## Current Behavior
+
+- `services/render-worker/src/sow_render_worker/lrc_parser.py`
+  - `parse_lrc()` extracts text with `match.group(4).strip()`.
+  - It only appends the parsed line when `if text:` is truthy.
+  - Therefore `[00:10.00]` and `[00:10.00]   ` are dropped.
+- `services/render-worker/src/sow_render_worker/video_engine.py`
+  - `VideoEngine.generate_video()` uses `parse_lrc()` before converting lyrics into the global timeline.
+  - Dropped blank lines never reach `FrameRenderer`.
+  - Chapter manifests are built from `local_lyrics` after `parse_lrc()`.
+- `services/render-worker/src/sow_render_worker/frame_renderer.py`
+  - `render_lyrics()` renders the current line and then renders the immediate next line as preview.
+  - If blank lines are preserved, renderer behavior must avoid drawing the immediate next lyric too early during a blank interval.
+  - `_compute_cache_key()` does not include preview visibility, so a fixed `current_lyric_index` during a blank interval would cache one frame for the entire interval.
+
+## Implementation Changes
+
+### 1. LRC Parser (`lrc_parser.py`)
+
+- Update `parse_lrc()` to append every syntactically valid timestamped line, including empty text:
+  - Preserve existing timestamp parsing, millisecond handling, sorting, and whitespace trimming.
+  - Keep ignoring lines without valid LRC timestamps.
+  - Normalize whitespace-only lyric text to `""`.
+
+### 2. Video Engine (`video_engine.py`)
+
+- Update `generate_video()` blank-video fallback logic:
+  - After building `all_lyrics`, if the list is non-empty but **every** line has `text == ""`, fall back to `generate_blank_video()` instead of frame-by-frame rendering.
+  - This avoids wasting Lambda CPU/memory on thousands of visually identical frames.
+- Chapter manifest behavior:
+  - Keep blank entries in chapter `lines` tuples (accepted shared-parser impact).
+  - Do **not** filter blank lines when building `ChapterInfo.lines`.
+
+### 3. Frame Renderer (`frame_renderer.py`)
+
+#### 3a. Blank lyric rendering
+
+- When `current_line.text == ""`, do not draw current lyric text.
+- Do not render the immediate next-line preview by default during a blank interval.
+- Find the next future lyric whose `text` is non-empty after trimming.
+- Render that non-blank next-line preview only when `current_time >= next_non_blank.global_time_seconds - four_beats_seconds`.
+- The preview pops in abruptly at fixed `alpha=128` (matching existing next-line preview behavior).
+
+#### 3b. Four-beat preview window
+
+- `four_beats_seconds = 4 * 60 / tempo_bpm`.
+- Use the current segment tempo from `SegmentInfo.tempo_bpm` when present and positive.
+- Fall back to `70 BPM` when tempo is missing or invalid, matching existing render-worker fallback behavior.
+
+#### 3c. Passing tempo context
+
+- Preferred minimal change: pass the resolved `VisualState` or current `SegmentInfo` into lyric rendering from `_render_frame_impl()`.
+- Keep existing public behavior of `render_frame()` and `render_frame_bytes()` unchanged.
+
+#### 3d. Frame cache key
+
+- Add a boolean `preview_visible` to `_compute_cache_key()`.
+- The value is `True` when the current lyric is blank **and** the next non-blank lyric is within the four-beat preview window.
+- This ensures the cache correctly distinguishes "blank with no preview" from "blank with preview" frames.
+- During non-blank intervals, `preview_visible` is always `False` (or omitted) so existing cache behavior is unchanged.
+
+#### 3e. Title/header rendering
+
+- Blank lyric events should blank only the lyric area.
+- The song title/header may continue to render as it does today.
+
+#### 3f. Last-lyric fade with trailing blanks
+
+- If a song ends with blank timestamped lines after the final non-blank lyric, the fade-out logic applies to the blank line (which is invisible).
+- The last non-blank lyric will cut off abruptly when the first trailing blank line is reached.
+- **This is accepted behavior** — trailing blank lines are intentional end-of-song markers.
+
+## Test Plan
+
+- `services/render-worker/tests/test_lrc_parser.py`
+  - Replace the existing expectation that empty text lines are ignored.
+  - Add coverage that `[00:01.00]` parses to `LRCLine(time_seconds=1.0, text="")`.
+  - Add coverage that whitespace-only text parses to `text == ""`.
+  - Confirm parsed blank lines still sort by timestamp.
+- `services/render-worker/tests/test_frame_renderer.py`
+  - Add a test where the current lyric is blank and the next non-blank lyric is outside the four-beat window; assert no lyric pixels are rendered.
+  - Add a test where the current lyric is blank and the next non-blank lyric is inside the four-beat window; assert preview text is rendered.
+  - Add a test where one or more future blank lines appear before the next non-blank lyric; assert preview timing uses the next non-blank line.
+  - Add a tempo fallback test for missing/invalid tempo using `70 BPM`.
+  - Add a test verifying the cache key differs between "blank no preview" and "blank with preview" states.
+- `services/render-worker/tests/test_video_engine.py`
+  - Add coverage that an LRC containing blank timing lines mixed with non-blank lines is treated as lyric timing data and does not fall back to `generate_blank_video()`.
+  - Add coverage that an LRC containing **only** blank timing lines **does** fall back to `generate_blank_video()`.
+
+Recommended focused test command:
+
+```bash
+PYTHONPATH=src:services/render-worker/src uv run --python 3.11 --extra test pytest \
+  services/render-worker/tests/test_lrc_parser.py \
+  services/render-worker/tests/test_frame_renderer.py \
+  services/render-worker/tests/test_video_engine.py -v
+```
+
+## Acceptance Criteria
+
+- Timestamped blank LRC lines are preserved in parsed lyric data.
+- During a blank lyric interval, the currently displayed lyric text disappears instead of the previous lyric lingering.
+- The next non-blank lyric preview appears only inside the four-beat resume window.
+- Missing or invalid tempo uses a deterministic `70 BPM` fallback.
+- Existing non-blank lyric rendering behavior remains unchanged outside blank intervals.
+- Frame cache correctly distinguishes blank states with and without preview.
+- All-blank LRC files fall back to efficient blank-video generation.
+- Chapter manifests include blank entries (downstream consumers must handle empty `text`).
+
+## Assumptions
+
+- Blank timestamped LRC lines are intentional lyric timing markers, not malformed data.
+- Whitespace-only lyric text should be treated as blank.
+- "Within 4 beats" means four beats before the next non-blank lyric timestamp.
+- The implementation should not add a new render-job option; this becomes the default lyrics renderer behavior.
+- Trailing blank lines after the last non-blank lyric are intentional end-of-song markers; abrupt cutoff of the last sung lyric is acceptable.
+- Next-line preview during blank intervals pops in abruptly at fixed alpha (no fade-in animation).

--- a/specs/preserve-blank-lrc-lines-render-worker-v3.md
+++ b/specs/preserve-blank-lrc-lines-render-worker-v3.md
@@ -1,0 +1,162 @@
+# Preserve Blank LRC Lines in Render Worker Lyrics Video (v3)
+
+## Summary
+
+The render-worker currently skips timestamped LRC lines whose lyric text is empty after trimming. This means an LRC event such as `[00:10.00]` is not represented in the parsed lyric timeline, so the previous non-empty lyric can remain visible until the next non-empty lyric appears.
+
+The desired behavior is to treat blank timestamped LRC lines as intentional timing events. When the current lyric event is blank, the rendered lyric area should transition smoothly: the previous non-blank lyric holds briefly then fades out, and as the next non-blank lyric approaches, a preview fades in within a four-beat window so worship leaders/congregants get a cue that singing resumes soon.
+
+## Current Behavior
+
+- `services/render-worker/src/sow_render_worker/lrc_parser.py`
+  - `parse_lrc()` extracts text with `match.group(4).strip()`.
+  - It only appends the parsed line when `if text:` is truthy.
+  - Therefore `[00:10.00]` and `[00:10.00]   ` are dropped.
+- `services/render-worker/src/sow_render_worker/video_engine.py`
+  - `VideoEngine.generate_video()` uses `parse_lrc()` before converting lyrics into the global timeline.
+  - Dropped blank lines never reach `FrameRenderer`.
+  - Chapter manifests are built from `local_lyrics` after `parse_lrc()`.
+- `services/render-worker/src/sow_render_worker/frame_renderer.py`
+  - `render_lyrics()` renders the current line and then renders the immediate next line as preview.
+  - If blank lines are preserved, renderer behavior must avoid drawing the immediate next lyric too early during a blank interval.
+  - `_compute_cache_key()` does not include preview visibility, so a fixed `current_lyric_index` during a blank interval would cache one frame for the entire interval.
+  - `_compute_last_lyric_fade_alpha()` calls `estimate_last_lyric_duration()` which looks at `song_lyrics[-1]`. If the last entry is blank, the duration estimate will be incorrect.
+
+## Implementation Changes
+
+### 1. LRC Parser (`lrc_parser.py`)
+
+- Update `parse_lrc()` to append every syntactically valid timestamped line, including empty text:
+  - Preserve existing timestamp parsing, millisecond handling, sorting, and whitespace trimming.
+  - Keep ignoring lines without valid LRC timestamps.
+  - Normalize whitespace-only lyric text to `""`.
+
+- Update `estimate_last_lyric_duration()` to skip trailing blank lines:
+  - Search backward from `song_lyrics[-1]` to find the last entry with non-empty `text`.
+  - If all lyrics are blank, return the default `5.0`.
+  - Use the found non-blank lyric as the basis for duration estimation (existing logic applies from that point).
+  - This ensures fade-out timing is computed against the actual last sung line, not a blank marker.
+
+### 2. Video Engine (`video_engine.py`)
+
+- Update `generate_video()` blank-video fallback logic:
+  - After building `all_lyrics`, if the list is non-empty but **every** line has `text == ""`, fall back to `generate_blank_video()` instead of frame-by-frame rendering.
+  - This avoids wasting Lambda CPU/memory on thousands of visually identical frames.
+- Chapter manifest behavior:
+  - Keep blank entries in chapter `lines` tuples (accepted shared-parser impact).
+  - Do **not** filter blank lines when building `ChapterInfo.lines`.
+
+### 3. Frame Renderer (`frame_renderer.py`)
+
+#### 3a. Blank lyric rendering
+
+- When `current_line.text == ""`, do not draw current lyric text.
+- Do not render the immediate next-line preview by default during a blank interval.
+- Find the next future lyric whose `text` is non-empty after trimming.
+- Render that non-blank next-line preview only when `current_time >= next_non_blank.global_time_seconds - four_beat_window_seconds`.
+- The preview fades in linearly from alpha=0 to alpha=128 over 0.5 seconds (see 3b).
+
+#### 3b. Four-beat preview window with fade-in
+
+- `four_beat_window_seconds = 4 * 60 / tempo_bpm`.
+- Use the current segment tempo from `SegmentInfo.tempo_bpm` when present and positive.
+- Fall back to `70 BPM` when tempo is missing or invalid, matching existing render-worker fallback behavior.
+- Preview fade-in: when the current time enters the four-beat window, the preview alpha ramps linearly from 0 to 128 over 0.5 seconds:
+  - `preview_elapsed = current_time - (next_non_blank.global_time_seconds - four_beat_window_seconds)`
+  - `preview_alpha = min(128, floor(128 * preview_elapsed / 0.5))`
+  - After 0.5s within the window, preview holds at alpha=128.
+
+#### 3c. Passing tempo context
+
+- Add `tempo_bpm: float | None` field to `VisualState`.
+- Resolve tempo in `_resolve_visual_state()` from `current_segment.tempo_bpm` when the segment is present and the value is positive; otherwise `None`.
+- `render_lyrics()` reads `state.tempo_bpm` (passed through `_render_frame_impl()`) instead of receiving segment info directly.
+- Keep existing public behavior of `render_frame()` and `render_frame_bytes()` unchanged.
+
+#### 3d. Frame cache key
+
+- Replace the original spec's boolean `preview_visible` with a quantized `preview_alpha` integer in `_compute_cache_key()`.
+- During non-blank intervals, `preview_alpha` is `0` (no preview rendered, existing cache behavior unchanged).
+- During blank intervals:
+  - Before the four-beat window: `preview_alpha = 0`.
+  - During fade-in (0.0–0.5s into window): quantized using the existing `_quantize_alpha()` applied to the 0–128 range, producing ~8 distinct cache entries.
+  - After fade-in complete: `preview_alpha = 128` (quantized to 128).
+- This ensures the cache correctly distinguishes intermediate fade-in states and avoids visual glitches on cache hits.
+
+#### 3e. Title/header rendering
+
+- Blank lyric events should blank only the lyric area.
+- The song title/header may continue to render as it does today.
+
+#### 3f. Previous-lyric hold-and-fade on blank transition
+
+When a blank lyric line follows a non-blank lyric (whether mid-song or trailing), the previous non-blank lyric does **not** vanish instantly. Instead:
+
+1. **Hold phase (2 seconds):** The previous non-blank lyric remains fully visible (alpha=255) for 2 seconds after the blank timestamp fires.
+2. **Fade phase (4 seconds):** After the hold, the previous non-blank lyric fades out over 4 seconds using the existing sqrt-based fade curve (matching intro fade behavior).
+3. **Interaction with preview:** The hold-and-fade of the previous lyric and the fade-in of the next-line preview are independent. Both can be visible simultaneously during the overlap period. The previous lyric renders at its current fade alpha; the preview renders at its fade-in alpha.
+
+This applies consistently to both mid-song blanks and trailing blanks after the last sung lyric.
+
+#### 3g. Interaction with existing last-lyric fade
+
+- The existing `_compute_last_lyric_fade_alpha()` logic applies when `current_index == len(song_lyrics) - 1`.
+- With blank lines preserved, the "last lyric" may be a blank line. The `estimate_last_lyric_duration()` fix (Section 1) ensures the duration is computed against the last non-blank lyric.
+- The hold-and-fade behavior in 3f supersedes the existing last-lyric fade for the case where the current line is blank and follows a non-blank line. The existing fade continues to apply when the current (last) line is non-blank.
+
+## Test Plan
+
+- `services/render-worker/tests/test_lrc_parser.py`
+  - Replace the existing expectation that empty text lines are ignored.
+  - Add coverage that `[00:01.00]` parses to `LRCLine(time_seconds=1.0, text="")`.
+  - Add coverage that whitespace-only text parses to `text == ""`.
+  - Confirm parsed blank lines still sort by timestamp.
+  - Add coverage that `estimate_last_lyric_duration()` skips trailing blank lines and uses the last non-blank lyric for duration estimation.
+  - Add coverage that `estimate_last_lyric_duration()` returns the default when all lyrics are blank.
+- `services/render-worker/tests/test_frame_renderer.py`
+  - Add a test where the current lyric is blank and the next non-blank lyric is outside the four-beat window; assert no preview pixels are rendered.
+  - Add a test where the current lyric is blank and the next non-blank lyric is inside the four-beat window; assert preview text is rendered with appropriate alpha.
+  - Add a test verifying the 0.5s linear fade-in: assert preview alpha increases from 0 toward 128 over the first 0.5s of the window.
+  - Add a test where one or more future blank lines appear before the next non-blank lyric; assert preview timing uses the next non-blank line.
+  - Add a tempo fallback test for missing/invalid tempo using `70 BPM`.
+  - Add a test verifying the cache key differs between different `preview_alpha` states (0, intermediate, 128).
+  - Add a test for the hold-and-fade behavior: when a blank line follows a non-blank line, the previous lyric holds for 2s then fades over 4s.
+  - Add a test that hold-and-fade and preview fade-in can overlap (both visible simultaneously).
+  - Add a test for mid-song blank: previous lyric holds then fades, preview fades in within four-beat window.
+  - Add a test for trailing blank at song end: last sung lyric holds then fades.
+- `services/render-worker/tests/test_video_engine.py`
+  - Add coverage that an LRC containing blank timing lines mixed with non-blank lines is treated as lyric timing data and does not fall back to `generate_blank_video()`.
+  - Add coverage that an LRC containing **only** blank timing lines **does** fall back to `generate_blank_video()`.
+
+Recommended focused test command:
+
+```bash
+PYTHONPATH=src:services/render-worker/src uv run --python 3.11 --extra test pytest \
+  services/render-worker/tests/test_lrc_parser.py \
+  services/render-worker/tests/test_frame_renderer.py \
+  services/render-worker/tests/test_video_engine.py -v
+```
+
+## Acceptance Criteria
+
+- Timestamped blank LRC lines are preserved in parsed lyric data.
+- During a blank lyric interval, the previous non-blank lyric holds for 2 seconds then fades over 4 seconds (sqrt curve) instead of vanishing instantly.
+- The next non-blank lyric preview fades in linearly from alpha=0 to alpha=128 over 0.5 seconds, starting at the four-beat window boundary.
+- Hold-and-fade of the previous lyric and fade-in of the preview can overlap; both render at their respective alphas.
+- Missing or invalid tempo uses a deterministic `70 BPM` fallback.
+- Existing non-blank lyric rendering behavior remains unchanged outside blank intervals.
+- Frame cache correctly distinguishes intermediate preview alpha states via quantized `preview_alpha` in the cache key.
+- All-blank LRC files fall back to efficient blank-video generation.
+- Chapter manifests include blank entries (downstream consumers must handle empty `text`).
+- `estimate_last_lyric_duration()` skips trailing blank lines and computes duration from the last non-blank lyric.
+
+## Assumptions
+
+- Blank timestamped LRC lines are intentional lyric timing markers, not malformed data.
+- Whitespace-only lyric text should be treated as blank.
+- "Within 4 beats" means four beats before the next non-blank lyric timestamp.
+- The implementation should not add a new render-job option; this becomes the default lyrics renderer behavior.
+- Next-line preview during blank intervals fades in linearly over 0.5s to alpha=128.
+- When a blank line follows a non-blank line, the previous lyric holds for 2s then fades over 4s (consistent for both mid-song and trailing blanks).
+- All-blank LRC files produce a fully blank video (no title header overlay).
+- Blank entries in chapter manifests are kept as-is; downstream consumers must handle empty `text`.

--- a/specs/preserve-blank-lrc-lines-render-worker.md
+++ b/specs/preserve-blank-lrc-lines-render-worker.md
@@ -1,0 +1,83 @@
+# Preserve Blank LRC Lines in Render Worker Lyrics Video
+
+## Summary
+
+The render-worker currently skips timestamped LRC lines whose lyric text is empty after trimming. This means an LRC event such as `[00:10.00]` is not represented in the parsed lyric timeline, so the previous non-empty lyric can remain visible until the next non-empty lyric appears.
+
+The desired behavior is to treat blank timestamped LRC lines as intentional timing events. When the current lyric event is blank, the rendered lyric area should be blank. As the next non-blank lyric approaches, the renderer should show the next-line preview within a four-beat window so worship leaders/congregants get a cue that singing resumes soon.
+
+## Current Behavior
+
+- `services/render-worker/src/sow_render_worker/lrc_parser.py`
+  - `parse_lrc()` extracts text with `match.group(4).strip()`.
+  - It only appends the parsed line when `if text:` is truthy.
+  - Therefore `[00:10.00]` and `[00:10.00]   ` are dropped.
+- `services/render-worker/src/sow_render_worker/video_engine.py`
+  - `VideoEngine.generate_video()` uses `parse_lrc()` before converting lyrics into the global timeline.
+  - Dropped blank lines never reach `FrameRenderer`.
+- `services/render-worker/src/sow_render_worker/frame_renderer.py`
+  - `render_lyrics()` renders the current line and then renders the immediate next line as preview.
+  - If blank lines are preserved, renderer behavior must avoid drawing the immediate next lyric too early during a blank interval.
+
+## Implementation Changes
+
+- Update `parse_lrc()` to append every syntactically valid timestamped line, including empty text:
+  - Preserve existing timestamp parsing, millisecond handling, sorting, and whitespace trimming.
+  - Keep ignoring lines without valid LRC timestamps.
+  - Normalize whitespace-only lyric text to `""`.
+- Update frame rendering so blank current lyrics are real lyric states:
+  - When `current_line.text == ""`, do not draw current lyric text.
+  - Do not render the immediate next-line preview by default during a blank interval.
+  - Find the next future lyric whose `text` is non-empty after trimming.
+  - Render that non-blank next-line preview only when `current_time >= next_non_blank.global_time_seconds - four_beats_seconds`.
+- Define the four-beat preview window as:
+  - `four_beats_seconds = 4 * 60 / tempo_bpm`.
+  - Use the current segment tempo from `SegmentInfo.tempo_bpm` when present and positive.
+  - Fall back to `70 BPM` when tempo is missing or invalid, matching existing render-worker fallback behavior.
+- Pass enough context into `render_lyrics()` to calculate the tempo-aware window:
+  - Preferred minimal change: pass the resolved `VisualState` or current `SegmentInfo` into lyric rendering from `_render_frame_impl()`.
+  - Keep existing public behavior of `render_frame()` and `render_frame_bytes()` unchanged.
+- Preserve existing title/header rendering behavior:
+  - Blank lyric events should blank only the lyric area.
+  - The song title/header may continue to render as it does today.
+- Accept shared-parser impact:
+  - Chapter manifests also use `parse_lrc()`, so blank timestamped lines will be preserved in generated chapter lyric metadata.
+
+## Test Plan
+
+- `services/render-worker/tests/test_lrc_parser.py`
+  - Replace the existing expectation that empty text lines are ignored.
+  - Add coverage that `[00:01.00]` parses to `LRCLine(time_seconds=1.0, text="")`.
+  - Add coverage that whitespace-only text parses to `text == ""`.
+  - Confirm parsed blank lines still sort by timestamp.
+- `services/render-worker/tests/test_frame_renderer.py`
+  - Add a test where the current lyric is blank and the next non-blank lyric is outside the four-beat window; assert no lyric pixels are rendered.
+  - Add a test where the current lyric is blank and the next non-blank lyric is inside the four-beat window; assert preview text is rendered.
+  - Add a test where one or more future blank lines appear before the next non-blank lyric; assert preview timing uses the next non-blank line.
+  - Add a tempo fallback test for missing/invalid tempo using `70 BPM`.
+- `services/render-worker/tests/test_video_engine.py`
+  - Add coverage that an LRC containing blank timing lines is treated as lyric timing data and does not fall back to `generate_blank_video()`.
+
+Recommended focused test command:
+
+```bash
+PYTHONPATH=src:services/render-worker/src uv run --python 3.11 --extra test pytest \
+  services/render-worker/tests/test_lrc_parser.py \
+  services/render-worker/tests/test_frame_renderer.py \
+  services/render-worker/tests/test_video_engine.py -v
+```
+
+## Acceptance Criteria
+
+- Timestamped blank LRC lines are preserved in parsed lyric data.
+- During a blank lyric interval, the currently displayed lyric text disappears instead of the previous lyric lingering.
+- The next non-blank lyric preview appears only inside the four-beat resume window.
+- Missing or invalid tempo uses a deterministic `70 BPM` fallback.
+- Existing non-blank lyric rendering behavior remains unchanged outside blank intervals.
+
+## Assumptions
+
+- Blank timestamped LRC lines are intentional lyric timing markers, not malformed data.
+- Whitespace-only lyric text should be treated as blank.
+- "Within 4 beats" means four beats before the next non-blank lyric timestamp.
+- The implementation should not add a new render-job option; this becomes the default lyrics renderer behavior.


### PR DESCRIPTION
## Summary

Implement `specs/preserve-blank-lrc-lines-render-worker-v3.md` for the render worker lyric video path.

## What changed

- Preserve syntactically valid timestamped LRC lines even when their lyric text trims to an empty string.
- Update last-lyric duration estimation to ignore trailing blank markers and compute from the last non-blank sung line.
- Render blank lyric intervals as intentional timing events:
  - current blank markers do not draw empty lyric text;
  - the previous non-blank lyric holds for 2 seconds, then fades out over 4 seconds using the existing sqrt fade curve;
  - the next future non-blank lyric preview fades in from alpha 0 to 128 over 0.5 seconds once the render time enters the four-beat window;
  - future blank markers are skipped when finding preview text;
  - invalid or missing tempo falls back to 70 BPM.
- Add `tempo_bpm` and quantized `preview_alpha` to renderer visual state/cache behavior so blank-interval preview fade frames are cached distinctly.
- Keep chapter manifest lines based on parsed LRC entries, including blank markers.
- Route all-blank LRC timelines to `generate_blank_video()` to avoid expensive frame rendering with no visible lyric content.

## Why

Previously `parse_lrc()` dropped blank timestamped events because it only appended lines with truthy text. That made lyric timing markers such as `[00:10.00]` disappear from the timeline, causing the previous lyric to remain visible until the next non-empty line. Once blank markers are preserved, the renderer also needs explicit blank-interval behavior so it does not preview the immediate next entry too early or reuse stale cached frames during preview fade-in.

## User impact

Worship lyric videos can now intentionally clear the lyric area during instrumental/rest sections while still cueing the next sung line near the correct beat window. All-blank LRC files render efficiently as blank videos with no title/header overlay path triggered by lyric rendering.

## Validation

- `PYTHONPATH=src:services/render-worker/src uv run --python 3.11 --extra test pytest services/render-worker/tests/test_lrc_parser.py services/render-worker/tests/test_frame_renderer.py services/render-worker/tests/test_video_engine.py -v`
  - 234 passed, 20 existing Pillow `getdata()` deprecation warnings.
- `PYTHONPATH=src:services/render-worker/src uv run --python 3.11 --extra test ruff format --check services/render-worker/src/sow_render_worker/lrc_parser.py services/render-worker/src/sow_render_worker/frame_renderer.py services/render-worker/src/sow_render_worker/video_engine.py services/render-worker/tests/test_lrc_parser.py services/render-worker/tests/test_frame_renderer.py services/render-worker/tests/test_video_engine.py`
  - 6 files already formatted.

## Notes

- `graphify update .` was attempted after code changes, but Graphify refused to overwrite the existing graph because the AST-only update produced fewer nodes than the current `graph.json`; no graph files were modified.
- `ruff check` on the touched files currently reports pre-existing unused imports/local variables in the test modules, so it was not used as the final gate for this PR.