### PR TITLE
fix(render-worker): require R2 ffmpeg for deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -115,6 +115,7 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: sow-render-worker
           IMAGE_TAG: ${{ github.sha }}
+          FFMPEG_VERSION: "7.0.2"
           R2_BUCKET: ${{ secrets.SOW_R2_BUCKET }}
           R2_ENDPOINT_URL: ${{ secrets.SOW_R2_ENDPOINT_URL }}
           R2_ACCESS_KEY_ID: ${{ secrets.SOW_R2_ACCESS_KEY_ID }}
@@ -122,23 +123,24 @@ jobs:
         run: |
           set -euo pipefail
           BUILD_LOG="$(mktemp)"
+          # R2 creds must be present in a deployed build; validate before
+          # Docker can fall through to the flaky johnvansickle fallback.
+          for k in R2_BUCKET R2_ENDPOINT_URL R2_ACCESS_KEY_ID R2_SECRET_ACCESS_KEY; do
+            [ -n "${!k}" ] || { echo "::error::Secret $k is empty; refusing to deploy without R2-sourced FFmpeg."; exit 1; }
+          done
+
           # --progress=plain is load-bearing: BuildKit only streams RUN stdout
           # (our 'Downloaded ffmpeg from R2' marker) in plain mode; the
           # progress-bar mode buffers/discards it, which would break the grep.
           docker build \
             --progress=plain \
+            --build-arg FFMPEG_VERSION="$FFMPEG_VERSION" \
             --build-arg R2_BUCKET="$R2_BUCKET" \
             --build-arg R2_ENDPOINT_URL="$R2_ENDPOINT_URL" \
             --build-arg R2_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID" \
             --build-arg R2_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY" \
+            --build-arg REQUIRE_R2_FFMPEG=true \
             -t "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" . 2>&1 | tee "$BUILD_LOG"
-
-          # R2 creds must be present in a deployed build; an empty secret would
-          # mean we silently fall back to the flaky johnvansickle primary the
-          # v2 spec set out to eliminate.
-          for k in R2_BUCKET R2_ENDPOINT_URL R2_ACCESS_KEY_ID R2_SECRET_ACCESS_KEY; do
-            [ -n "${!k}" ] || { echo "::error::Secret $k is empty; refusing to deploy a fallback-built image."; exit 1; }
-          done
 
           if ! grep -q "Downloaded ffmpeg from R2" "$BUILD_LOG"; then
             echo "::error::FFmpeg was NOT fetched from R2 - build fell back to johnvansickle.com. Aborting deploy to surface the issue (see log for 'R2 download failed:' cause)."

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,4 +1,4 @@
-# Graph Report - stream_of_worship  (2026-06-17)
+# Graph Report - stream_of_worship  (2026-06-18)
 
 ## Corpus Check
 - 370 files · ~263,808 words

--- a/services/render-worker/Dockerfile
+++ b/services/render-worker/Dockerfile
@@ -13,10 +13,11 @@ ARG R2_BUCKET
 ARG R2_ENDPOINT_URL
 ARG R2_ACCESS_KEY_ID
 ARG R2_SECRET_ACCESS_KEY
+ARG REQUIRE_R2_FFMPEG=false
 
 COPY scripts/download-ffmpeg.sh /tmp/download-ffmpeg.sh
 RUN chmod +x /tmp/download-ffmpeg.sh \
-    && /tmp/download-ffmpeg.sh "${FFMPEG_VERSION}" "${R2_BUCKET}" "${R2_ENDPOINT_URL}" "${R2_ACCESS_KEY_ID}" "${R2_SECRET_ACCESS_KEY}" \
+    && /tmp/download-ffmpeg.sh "${FFMPEG_VERSION}" "${R2_BUCKET}" "${R2_ENDPOINT_URL}" "${R2_ACCESS_KEY_ID}" "${R2_SECRET_ACCESS_KEY}" "${REQUIRE_R2_FFMPEG}" \
     && rm -f /tmp/download-ffmpeg.sh
 
 COPY requirements.txt ${LAMBDA_TASK_ROOT}/

--- a/services/render-worker/Dockerfile.dev
+++ b/services/render-worker/Dockerfile.dev
@@ -13,10 +13,11 @@ ARG R2_BUCKET
 ARG R2_ENDPOINT_URL
 ARG R2_ACCESS_KEY_ID
 ARG R2_SECRET_ACCESS_KEY
+ARG REQUIRE_R2_FFMPEG=false
 
 COPY scripts/download-ffmpeg.sh /tmp/download-ffmpeg.sh
 RUN chmod +x /tmp/download-ffmpeg.sh \
-    && /tmp/download-ffmpeg.sh "${FFMPEG_VERSION}" "${R2_BUCKET}" "${R2_ENDPOINT_URL}" "${R2_ACCESS_KEY_ID}" "${R2_SECRET_ACCESS_KEY}" \
+    && /tmp/download-ffmpeg.sh "${FFMPEG_VERSION}" "${R2_BUCKET}" "${R2_ENDPOINT_URL}" "${R2_ACCESS_KEY_ID}" "${R2_SECRET_ACCESS_KEY}" "${REQUIRE_R2_FFMPEG}" \
     && rm -f /tmp/download-ffmpeg.sh
 
 COPY requirements.txt ${LAMBDA_TASK_ROOT}/

--- a/services/render-worker/docker-compose.dev.yml
+++ b/services/render-worker/docker-compose.dev.yml
@@ -4,6 +4,7 @@ services:
       context: .
       dockerfile: Dockerfile.dev
       args:
+        FFMPEG_VERSION: ${FFMPEG_VERSION:-7.0.2}
         R2_BUCKET: ${SOW_R2_BUCKET}
         R2_ENDPOINT_URL: ${SOW_R2_ENDPOINT_URL}
         R2_ACCESS_KEY_ID: ${SOW_R2_ACCESS_KEY_ID}

--- a/services/render-worker/docker-compose.yml
+++ b/services/render-worker/docker-compose.yml
@@ -4,6 +4,7 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
+        FFMPEG_VERSION: ${FFMPEG_VERSION:-7.0.2}
         R2_BUCKET: ${SOW_R2_BUCKET}
         R2_ENDPOINT_URL: ${SOW_R2_ENDPOINT_URL}
         R2_ACCESS_KEY_ID: ${SOW_R2_ACCESS_KEY_ID}

--- a/services/render-worker/scripts/download-ffmpeg.sh
+++ b/services/render-worker/scripts/download-ffmpeg.sh
@@ -27,11 +27,15 @@ import sys, hashlib, boto3
 
 bucket, endpoint, access_key, secret_key, key, checksum_key, archive, checksum_path = sys.argv[1:]
 
-s3 = boto3.client('s3',
-    endpoint_url=endpoint,
-    aws_access_key_id=access_key,
-    aws_secret_access_key=secret_key,
-    region_name='auto')
+try:
+    s3 = boto3.client('s3',
+        endpoint_url=endpoint,
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+        region_name='auto')
+except Exception as e:
+    print(f'R2 client creation failed: {e}', file=sys.stderr)
+    sys.exit(2)
 
 try:
     s3.download_file(bucket, key, archive)

--- a/services/render-worker/scripts/download-ffmpeg.sh
+++ b/services/render-worker/scripts/download-ffmpeg.sh
@@ -6,19 +6,26 @@ R2_BUCKET="${2:-}"
 R2_ENDPOINT_URL="${3:-}"
 R2_ACCESS_KEY_ID="${4:-}"
 R2_SECRET_ACCESS_KEY="${5:-}"
+REQUIRE_R2="${6:-false}"
 
 ARCHIVE="/tmp/ffmpeg.tar.xz"
 CHECKSUM="/tmp/ffmpeg.tar.xz.sha256"
+R2_KEY="build-dependencies/ffmpeg/ffmpeg-release-amd64-static-${FFMPEG_VERSION}.tar.xz"
+R2_CHECKSUM_KEY="${R2_KEY}.sha256"
 
 downloaded_from=""
+
+print_expected_r2_keys() {
+    echo "Expected R2 objects:"
+    echo "  s3://${R2_BUCKET:-<SOW_R2_BUCKET>}/${R2_KEY}"
+    echo "  s3://${R2_BUCKET:-<SOW_R2_BUCKET>}/${R2_CHECKSUM_KEY}"
+}
 
 if [ -n "${R2_BUCKET}" ] && [ -n "${R2_ENDPOINT_URL}" ] && [ -n "${R2_ACCESS_KEY_ID}" ] && [ -n "${R2_SECRET_ACCESS_KEY}" ]; then
     if python3 -c "
 import sys, hashlib, boto3
 
-version, bucket, endpoint, access_key, secret_key, archive, checksum_path = sys.argv[1:]
-key = f'build-dependencies/ffmpeg/ffmpeg-release-amd64-static-{version}.tar.xz'
-checksum_key = f'{key}.sha256'
+bucket, endpoint, access_key, secret_key, key, checksum_key, archive, checksum_path = sys.argv[1:]
 
 s3 = boto3.client('s3',
     endpoint_url=endpoint,
@@ -62,22 +69,33 @@ try:
 except Exception as e:
     print(f'ERROR: Checksum verification failed: {e}', file=sys.stderr)
     sys.exit(1)
-" "${FFMPEG_VERSION}" "${R2_BUCKET}" "${R2_ENDPOINT_URL}" "${R2_ACCESS_KEY_ID}" "${R2_SECRET_ACCESS_KEY}" "${ARCHIVE}" "${CHECKSUM}"; then
+" "${R2_BUCKET}" "${R2_ENDPOINT_URL}" "${R2_ACCESS_KEY_ID}" "${R2_SECRET_ACCESS_KEY}" "${R2_KEY}" "${R2_CHECKSUM_KEY}" "${ARCHIVE}" "${CHECKSUM}"; then
         downloaded_from="r2"
         rm -f "${CHECKSUM}"
     else
         rc=$?
         if [ "$rc" -eq 2 ]; then
+            if [ "${REQUIRE_R2}" = "true" ]; then
+                echo "ERROR: R2 FFmpeg download is required for this build; refusing johnvansickle fallback."
+                print_expected_r2_keys
+                exit 1
+            fi
             echo "Falling back to johnvansickle.com"
             curl --max-time 60 -fsSL -o "${ARCHIVE}" \
               https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz
             downloaded_from="johnvansickle"
         else
             echo "ERROR: R2 download succeeded but verification failed. Aborting build."
+            print_expected_r2_keys
             exit 1
         fi
     fi
 else
+    if [ "${REQUIRE_R2}" = "true" ]; then
+        echo "ERROR: R2 credentials not fully provided and R2 FFmpeg download is required."
+        print_expected_r2_keys
+        exit 1
+    fi
     echo "R2 credentials not fully provided. Falling back to johnvansickle.com"
     curl --max-time 60 -fsSL -o "${ARCHIVE}" \
       https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz

--- a/services/render-worker/tests/test_docker.py
+++ b/services/render-worker/tests/test_docker.py
@@ -1,8 +1,11 @@
 import importlib
 import os
+from pathlib import Path
 import subprocess
 
 import pytest
+
+RENDER_WORKER_DIR = Path(__file__).resolve().parent.parent
 
 
 @pytest.mark.skipif(os.environ.get("SKIP_DOCKER_TESTS") == "1", reason="Docker tests disabled")
@@ -135,3 +138,28 @@ class TestHandlerImportable:
     def test_pipeline_module_importable(self):
         mod = importlib.import_module("sow_render_worker.pipeline")
         assert hasattr(mod, "execute_render_pipeline")
+
+
+class TestDockerConfiguration:
+    def test_deploy_requires_r2_ffmpeg_build_arg(self):
+        workflow = (RENDER_WORKER_DIR.parent.parent / ".github/workflows/deploy.yml").read_text()
+
+        assert 'FFMPEG_VERSION: "7.0.2"' in workflow
+        assert '--build-arg FFMPEG_VERSION="$FFMPEG_VERSION"' in workflow
+        assert "--build-arg REQUIRE_R2_FFMPEG=true" in workflow
+        assert "refusing to deploy without R2-sourced FFmpeg" in workflow
+
+    def test_dockerfiles_pass_require_r2_flag_to_download_script(self):
+        for dockerfile_name in ("Dockerfile", "Dockerfile.dev"):
+            dockerfile = (RENDER_WORKER_DIR / dockerfile_name).read_text()
+
+            assert "ARG REQUIRE_R2_FFMPEG=false" in dockerfile
+            assert '"${REQUIRE_R2_FFMPEG}"' in dockerfile
+
+    def test_download_script_has_required_r2_mode(self):
+        script = (RENDER_WORKER_DIR / "scripts/download-ffmpeg.sh").read_text()
+
+        assert 'REQUIRE_R2="${6:-false}"' in script
+        assert "R2 FFmpeg download is required" in script
+        assert "Expected R2 objects:" in script
+        assert "Falling back to johnvansickle.com" in script

--- a/services/render-worker/tests/test_docker.py
+++ b/services/render-worker/tests/test_docker.py
@@ -161,5 +161,7 @@ class TestDockerConfiguration:
 
         assert 'REQUIRE_R2="${6:-false}"' in script
         assert "R2 FFmpeg download is required" in script
+        assert "R2 client creation failed" in script
+        assert "sys.exit(2)" in script
         assert "Expected R2 objects:" in script
         assert "Falling back to johnvansickle.com" in script


### PR DESCRIPTION
## Summary
- require deploy builds to source FFmpeg from R2 instead of silently falling back to johnvansickle.com
- validate R2 secrets before Docker build and pass explicit `FFMPEG_VERSION=7.0.2`
- add a deploy-only `REQUIRE_R2_FFMPEG` Docker build arg and static regression tests

## Root Cause
The render-worker deploy Docker build could fall through to the johnvansickle fallback when R2 was missing or unavailable. If that fallback returned an HTTP error, Docker surfaced a generic `curl` exit code 22 at the FFmpeg install step instead of clearly reporting the R2 artifact/secret problem.

## Validation
- `bash -n services/render-worker/scripts/download-ffmpeg.sh`
- `bash services/render-worker/scripts/download-ffmpeg.sh 7.0.2 '' '' '' '' true` confirms required-R2 failures print expected R2 object keys
- `SKIP_DOCKER_TESTS=1 PYTHONPATH=src uv run --python 3.11 pytest tests/test_docker.py -v`