### PR TITLE
feat(webapp): surface songset render failure details with tooltip and inline alert

### DIFF
--- a/specs/songset-render-failed-error-tooltip-v4.md
+++ b/specs/songset-render-failed-error-tooltip-v4.md
@@ -1,0 +1,288 @@
+# Songset Render Failure Details (v4)
+
+## Summary
+
+When a SongSet render fails, show the failure reason without exposing raw worker output. The list page stays compact with a failed-badge tooltip, while the editor page shows a visible inline alert that asks the user to render again.
+
+This plan supersedes `songset-render-failed-error-tooltip-v3.md` but does not edit or remove it.
+
+## Review Findings Addressed
+
+- **UX experience**: v3 relies on hover-only details on the list and does not account for the badge currently living inside a row link. v4 keeps the compact badge tooltip, adds keyboard focus support, and requires the row structure to avoid nested interactive/link behavior.
+- **Data correctness**: failure details must describe the current latest failed job only. Prior failed jobs must not leak into fresh, stale, rendering, unrendered, duplicate, or create responses.
+- **Runtime issues**: timestamps must serialize as ISO strings across server/client boundaries, and tooltips must be tested through hover/focus because tooltip content is portaled.
+- **Operational concerns**: worker errors can come from Next.js dispatch, Lambda worker code, FFmpeg, R2, Postgres, or orphan recovery. UI sanitization is the trust boundary.
+
+## Goals
+
+1. Surface the current failed render job's reason in a safe, short form.
+2. Keep the songset list dense while still making failure details discoverable by hover and keyboard focus.
+3. Show an always-visible failure alert on the editor page.
+4. Fall back to `startedAt ?? createdAt` with copy that asks the user to render again when no safe error text exists.
+5. Avoid carrying full raw tracebacks through list payloads.
+
+## Non-Goals
+
+- Do not change the render worker, render job schema, or database migrations.
+- Do not surface failure details on public/share pages in this change.
+- Do not show raw stack traces, absolute paths, URLs, secrets, or infrastructure internals to end users.
+
+## Data Model
+
+`render_jobs` already has the needed columns:
+
+- `errorMessage`
+- `startedAt`
+- `createdAt`
+- `updatedAt`
+
+Add these fields to `SongsetListItem` and therefore `SongsetDetail`:
+
+```typescript
+renderErrorMessage: string | null;
+failedAt: Date | null;
+```
+
+These fields must be populated only when the derived `renderState` is `"failed"` for `songsets.latestRenderJobId`.
+
+## Error Message Helper
+
+Add `webapp/src/lib/render/error-message.ts`.
+
+Behavior:
+
+- `sanitizeRenderErrorMessage(message)`:
+  - returns `null` for non-string, empty, whitespace-only, or fully redacted messages
+  - strips ANSI escape sequences and control characters
+  - selects the first useful non-empty line
+  - removes common stack-frame prefixes and obvious traceback framing
+  - redacts URLs as `[url]`
+  - redacts Unix/macOS/Windows absolute paths as `[path]`
+  - redacts obvious secret-like fragments such as `TOKEN=...`, `API_KEY=...`, `PASSWORD=...`, `SECRET=...`, `DATABASE_URL=...`, and `SOW_*_KEY=...`
+  - collapses repeated whitespace
+  - truncates to 250 characters with an ellipsis
+- `formatRenderFailedAt(date)`:
+  - formats a `Date` for user-facing fallback text
+- `getRenderFailureText(errorMessage, failedAt)`:
+  - returns the sanitized error when available
+  - otherwise returns `Render failed around <formatted date>. Please render again.` when `failedAt` exists
+  - otherwise returns `Render failed. Please render again.`
+
+Use this helper from both the DB mapping layer and UI components so list, editor alert, and tooltip text stay consistent.
+
+## DB And API Changes
+
+### `webapp/src/lib/db/songsets.ts`
+
+In `listSongsetSummaries`:
+
+- Select the latest job's bounded error text and timestamps from the existing `leftJoin(renderJobs, eq(renderJobs.id, songsets.latestRenderJobId))`.
+- Use a bounded SQL expression for the list payload source, for example:
+
+```typescript
+renderErrorMessage: sql<string | null>`left(${renderJobs.errorMessage}, 4000)`,
+latestJobStartedAt: renderJobs.startedAt,
+latestJobCreatedAt: renderJobs.createdAt,
+```
+
+- Add the selected render job fields to `GROUP BY`.
+- Compute `renderState` once with `mapRenderStateFromSnapshot`.
+- Return failure fields only when `renderState === "failed"`:
+
+```typescript
+const renderState = mapRenderStateFromSnapshot(...);
+const failedAt = row.latestJobStartedAt ?? row.latestJobCreatedAt;
+
+return {
+  ...,
+  renderState,
+  renderErrorMessage:
+    renderState === "failed" ? sanitizeRenderErrorMessage(row.renderErrorMessage) : null,
+  failedAt: renderState === "failed" ? failedAt : null,
+};
+```
+
+In `getSongsetEditorData`:
+
+- Select `renderJobs.errorMessage`, `renderJobs.startedAt`, and `renderJobs.createdAt`.
+- Use the same current-latest-job-only logic as the list query.
+
+In `createSongset`, `updateSongset`, and `getSongset`:
+
+- Include `renderErrorMessage: null` and `failedAt: null` unless those functions are updated to query and map the current latest render job.
+- `duplicateSongset` can rely on `getSongset(newId, userId)` returning null failure fields because the duplicate has no render job.
+
+### Server Serialization
+
+In `webapp/src/app/songsets/page.tsx` and `webapp/src/app/songsets/[id]/page.tsx`:
+
+- Serialize `failedAt` as ISO or `null`:
+
+```typescript
+failedAt: songset.failedAt?.toISOString() ?? null,
+```
+
+### Client API Types
+
+In `SongsetsClient.tsx` and `SongsetEditorClient.tsx`:
+
+- Add:
+
+```typescript
+renderErrorMessage: string | null;
+failedAt: string | null;
+```
+
+- Convert `failedAt` to `Date | null` in local component state.
+- Ensure local optimistic stale transitions clear failure display fields:
+
+```typescript
+renderErrorMessage: null,
+failedAt: null,
+```
+
+This applies to reorder, remove, add song, and transition update paths that set `renderState: "stale"`.
+
+## UI Changes
+
+### `RenderStatusBadge`
+
+Extend props:
+
+```typescript
+interface RenderStatusBadgeProps {
+  state: RenderState;
+  errorMessage?: string | null;
+  failedAt?: Date | null;
+  className?: string;
+}
+```
+
+For `state === "failed"`, wrap the badge with the existing tooltip primitives only when `getRenderFailureText(errorMessage, failedAt)` returns text.
+
+Requirements:
+
+- Tooltip opens on hover and keyboard focus.
+- Tooltip content uses constrained width and wrapping, for example `max-w-80 whitespace-normal break-words`.
+- The trigger must be focusable when the badge is not already focusable.
+- Do not create a tooltip for non-failed states.
+
+### `SongsetRow`
+
+Add optional props:
+
+```typescript
+renderErrorMessage?: string | null;
+failedAt?: Date | null;
+```
+
+Pass them to `RenderStatusBadge`.
+
+Because the current badge is inside a `Link`, restructure the row so the failed badge tooltip trigger is not nested inside the link. Keep the title/metadata clickable and preserve existing row actions.
+
+### `SongsetList`
+
+Add optional fields to the `Songset` interface:
+
+```typescript
+renderErrorMessage?: string | null;
+failedAt?: Date | null;
+```
+
+No additional rendering change is needed if `SongsetRow` receives `{...songset}`.
+
+### `SongsetEditor`
+
+Add to the `songset` prop shape:
+
+```typescript
+renderErrorMessage?: string | null;
+failedAt?: Date | null;
+```
+
+Pass both fields into the app-bar `RenderStatusBadge`.
+
+Show an inline destructive alert below the app bar when `songset.renderState === "failed"`:
+
+- icon: `AlertCircle`
+- title: `Render failed`
+- description: `getRenderFailureText(songset.renderErrorMessage, songset.failedAt)`
+- action: `Render again`, wired to `onRender`
+
+Do not make this alert dismissible. A failed render is current state, not a transient notice.
+
+## Files To Modify
+
+- `webapp/src/lib/render/error-message.ts`
+- `webapp/src/lib/db/songsets.ts`
+- `webapp/src/app/songsets/page.tsx`
+- `webapp/src/app/songsets/SongsetsClient.tsx`
+- `webapp/src/app/songsets/[id]/page.tsx`
+- `webapp/src/app/songsets/[id]/SongsetEditorClient.tsx`
+- `webapp/src/components/songset/RenderStatusBadge.tsx`
+- `webapp/src/components/songset/SongsetList.tsx`
+- `webapp/src/components/songset/SongsetRow.tsx`
+- `webapp/src/components/songset/SongsetEditor.tsx`
+
+## Files Not To Modify
+
+- `webapp/src/db/schema.ts`
+- `webapp/src/app/api/songsets/route.ts`
+- `webapp/src/app/api/songsets/[id]/route.ts`
+- `webapp/src/app/api/songsets/[id]/duplicate/route.ts`
+- render worker code
+- existing spec files, including `specs/songset-render-failed-error-tooltip-v3.md`
+
+## Tests
+
+Add or update tests for:
+
+- `sanitizeRenderErrorMessage`:
+  - strips ANSI escape codes
+  - uses the first useful non-empty line
+  - redacts URLs
+  - redacts absolute paths
+  - redacts secret-like key/value fragments
+  - returns `null` for empty, whitespace-only, or fully redacted input
+  - truncates long messages to 250 characters
+- `getRenderFailureText`:
+  - prefers sanitized text
+  - falls back to `Render failed around <date>. Please render again.`
+  - falls back to `Render failed. Please render again.`
+- `listSongsetSummaries`:
+  - returns sanitized failure fields for a latest failed job
+  - returns `failedAt` from `startedAt ?? createdAt`
+  - returns null failure fields for non-failed states even when prior failures exist
+- `getSongsetEditorData`:
+  - same latest-failed-job mapping behavior as the list query
+- `RenderStatusBadge`:
+  - failed state tooltip opens on hover
+  - failed state tooltip opens on focus
+  - no tooltip appears for non-failed states
+- `SongsetRow`:
+  - passes failure fields to the badge
+  - tooltip interaction does not trigger row navigation
+- `SongsetEditor`:
+  - shows inline failure alert
+  - shows fallback text when error message is absent
+  - `Render again` calls the render handler
+
+## Verification
+
+Run:
+
+```bash
+cd webapp && pnpm test -- --run src/test/components/songset/RenderStatusBadge.test.tsx
+cd webapp && pnpm test -- --run src/test/components/songset/SongsetRow.test.tsx
+cd webapp && pnpm test -- --run src/test/components/songset/SongsetEditor.test.tsx
+cd webapp && pnpm test -- --run src/test/api/songsets/db.test.ts
+cd webapp && pnpm lint
+cd webapp && pnpm build
+```
+
+## Assumptions
+
+- The list UX should remain compact; persistent detail belongs on the editor page.
+- Tooltip discoverability is acceptable on the list as long as hover and keyboard focus work.
+- End users should see safe summaries, not raw worker tracebacks.
+- `startedAt ?? createdAt` is the fallback timestamp policy, and fallback copy should ask the user to render again.

--- a/webapp/src/app/songsets/SongsetsClient.tsx
+++ b/webapp/src/app/songsets/SongsetsClient.tsx
@@ -25,6 +25,8 @@ interface ApiSongset {
   latestRenderJobId: string | null;
   lastFailedRenderJobId: string | null;
   lastCompletedRenderJobId: string | null;
+  renderErrorMessage: string | null;
+  failedAt: string | null;
 }
 
 interface ApiResponse {
@@ -43,6 +45,8 @@ function transformSongsets(songsets: ApiSongset[]): Songset[] {
     renderState: songset.renderState,
     latestRenderJobId: songset.latestRenderJobId,
     lastCompletedRenderJobId: songset.lastCompletedRenderJobId,
+    renderErrorMessage: songset.renderErrorMessage,
+    failedAt: songset.failedAt ? new Date(songset.failedAt) : null,
     isOfflineAvailable: false,
     isArtifactsStale: songset.renderState === "stale",
   }));

--- a/webapp/src/app/songsets/[id]/SongsetEditorClient.tsx
+++ b/webapp/src/app/songsets/[id]/SongsetEditorClient.tsx
@@ -33,6 +33,8 @@ interface ApiSongset {
   latestRenderJobId: string | null;
   lastFailedRenderJobId: string | null;
   lastCompletedRenderJobId: string | null;
+  renderErrorMessage: string | null;
+  failedAt: string | null;
   isArtifactsStale?: boolean;
 }
 
@@ -75,6 +77,8 @@ interface ApiResponse {
   latestRenderJobId: string | null;
   lastFailedRenderJobId: string | null;
   lastCompletedRenderJobId: string | null;
+  renderErrorMessage: string | null;
+  failedAt: string | null;
   isArtifactsStale?: boolean;
   items: ApiSongsetItem[];
 }
@@ -122,6 +126,8 @@ export function SongsetEditorClient({ songsetId, initialData }: SongsetEditorCli
     latestRenderJobId: initialData.latestRenderJobId,
     lastFailedRenderJobId: initialData.lastFailedRenderJobId,
     lastCompletedRenderJobId: initialData.lastCompletedRenderJobId,
+    renderErrorMessage: initialData.renderErrorMessage,
+    failedAt: initialData.failedAt,
     isArtifactsStale: initialData.isArtifactsStale,
   }));
   const [items, setItems] = useState<SongListItem[]>(() => transformItems(initialData.items));
@@ -144,7 +150,13 @@ export function SongsetEditorClient({ songsetId, initialData }: SongsetEditorCli
   const markStale = useCallback(() => {
     setSongset((prev) =>
       prev
-        ? { ...prev, renderState: "stale" as RenderState, isArtifactsStale: true }
+        ? {
+            ...prev,
+            renderState: "stale" as RenderState,
+            isArtifactsStale: true,
+            renderErrorMessage: null,
+            failedAt: null,
+          }
         : prev
     );
   }, []);
@@ -204,6 +216,8 @@ export function SongsetEditorClient({ songsetId, initialData }: SongsetEditorCli
               itemCount: Math.max(0, prev.itemCount - 1),
               renderState: "stale" as RenderState,
               isArtifactsStale: true,
+              renderErrorMessage: null,
+              failedAt: null,
             }
           : prev
       );
@@ -455,6 +469,8 @@ export function SongsetEditorClient({ songsetId, initialData }: SongsetEditorCli
               itemCount: prev.itemCount + 1,
               renderState: "stale" as RenderState,
               isArtifactsStale: true,
+              renderErrorMessage: null,
+              failedAt: null,
             }
           : prev
       );

--- a/webapp/src/app/songsets/[id]/SongsetEditorClient.tsx
+++ b/webapp/src/app/songsets/[id]/SongsetEditorClient.tsx
@@ -207,6 +207,8 @@ export function SongsetEditorClient({ songsetId, initialData }: SongsetEditorCli
       const removedIndex = items.findIndex((item) => item.id === itemId);
       const prevRenderState = songset?.renderState;
       const prevIsArtifactsStale = songset?.isArtifactsStale;
+      const prevRenderErrorMessage = songset?.renderErrorMessage;
+      const prevFailedAt = songset?.failedAt;
 
       setItems((prev) => prev.filter((item) => item.id !== itemId));
       setSongset((prev) =>
@@ -247,6 +249,8 @@ export function SongsetEditorClient({ songsetId, initialData }: SongsetEditorCli
                   itemCount: prev.itemCount + 1,
                   renderState: prevRenderState ?? prev.renderState,
                   isArtifactsStale: prevIsArtifactsStale ?? prev.isArtifactsStale,
+                  renderErrorMessage: prevRenderErrorMessage ?? prev.renderErrorMessage,
+                  failedAt: prevFailedAt ?? prev.failedAt,
                 }
               : prev
           );
@@ -256,7 +260,7 @@ export function SongsetEditorClient({ songsetId, initialData }: SongsetEditorCli
         setIsRemoving(false);
       }
     },
-    [songsetId, items, isRemoving, songset?.isArtifactsStale, songset?.renderState]
+    [songsetId, items, isRemoving, songset?.isArtifactsStale, songset?.renderState, songset?.renderErrorMessage, songset?.failedAt]
   );
 
   // Handle transition update

--- a/webapp/src/app/songsets/[id]/page.tsx
+++ b/webapp/src/app/songsets/[id]/page.tsx
@@ -37,6 +37,8 @@ export default async function SongsetEditorPage({
         latestRenderJobId: songset.latestRenderJobId,
         lastFailedRenderJobId: songset.lastFailedRenderJobId,
         lastCompletedRenderJobId: songset.lastCompletedRenderJobId,
+        renderErrorMessage: songset.renderErrorMessage,
+        failedAt: songset.failedAt?.toISOString() ?? null,
         isArtifactsStale: songset.renderState === "stale",
         items: songset.items.map((item) => ({
           id: item.id,

--- a/webapp/src/app/songsets/page.tsx
+++ b/webapp/src/app/songsets/page.tsx
@@ -21,6 +21,7 @@ export default async function SongsetsPage() {
           ...songset,
           createdAt: songset.createdAt.toISOString(),
           updatedAt: songset.updatedAt.toISOString(),
+          failedAt: songset.failedAt?.toISOString() ?? null,
         })),
       }}
     />

--- a/webapp/src/components/songset/RenderStatusBadge.tsx
+++ b/webapp/src/components/songset/RenderStatusBadge.tsx
@@ -3,11 +3,20 @@
 import { Badge } from "@/components/ui/badge"
 import { cn } from "@/lib/utils"
 import { CheckCircle2, Loader2, AlertCircle, RefreshCw } from "lucide-react"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import { getRenderFailureText } from "@/lib/render/error-message"
 
 export type RenderState = "unrendered" | "rendering" | "fresh" | "stale" | "failed"
 
 interface RenderStatusBadgeProps {
   state: RenderState
+  errorMessage?: string | null
+  failedAt?: Date | null
   className?: string
 }
 
@@ -49,14 +58,41 @@ const STATE_CONFIG: Record<RenderState, {
   },
 }
 
-export function RenderStatusBadge({ state, className }: RenderStatusBadgeProps) {
+export function RenderStatusBadge({
+  state,
+  errorMessage,
+  failedAt,
+  className,
+}: RenderStatusBadgeProps) {
   const config = STATE_CONFIG[state] || STATE_CONFIG.unrendered
   const Icon = config.icon
 
-  return (
+  const badge = (
     <Badge variant={config.variant} className={cn("gap-1", className)}>
       <Icon className={cn("size-3", config.iconClass)} />
       {config.label}
     </Badge>
   )
+
+  if (state === "failed") {
+    const failureText = getRenderFailureText(errorMessage, failedAt)
+    if (failureText) {
+      return (
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button type="button" className="inline-flex rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2">
+                {badge}
+              </button>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-80 whitespace-normal break-words">
+              {failureText}
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      )
+    }
+  }
+
+  return badge
 }

--- a/webapp/src/components/songset/SongsetEditor.tsx
+++ b/webapp/src/components/songset/SongsetEditor.tsx
@@ -24,10 +24,11 @@ import {
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Alert, AlertDescription, AlertTitle, AlertAction } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
+import { getRenderFailureText } from "@/lib/render/error-message";
 import {
   ArrowLeft,
   MoreVertical,
@@ -38,6 +39,7 @@ import {
   Trash2,
   Share2,
   AlertTriangle,
+  AlertCircle,
   X,
   Monitor,
   Plus,
@@ -56,6 +58,8 @@ export interface SongsetEditorProps {
     latestRenderJobId: string | null;
     lastFailedRenderJobId: string | null;
     lastCompletedRenderJobId: string | null;
+    renderErrorMessage?: string | null;
+    failedAt?: string | null;
     updatedAt: string;
   };
   items: SongListItem[];
@@ -255,7 +259,11 @@ export function SongsetEditor({
           </div>
 
           {/* Render status badge */}
-          <RenderStatusBadge state={songset.renderState} />
+          <RenderStatusBadge
+            state={songset.renderState}
+            errorMessage={songset.renderErrorMessage}
+            failedAt={songset.failedAt ? new Date(songset.failedAt) : null}
+          />
 
           {/* Overflow menu */}
           <DropdownMenu>
@@ -316,6 +324,25 @@ export function SongsetEditor({
           </DropdownMenu>
         </div>
       </header>
+
+      {/* Render failure alert */}
+      {songset.renderState === "failed" && (
+        <Alert variant="destructive" className="rounded-none border-x-0">
+          <AlertCircle className="size-4" />
+          <AlertTitle>Render failed</AlertTitle>
+          <AlertDescription>
+            {getRenderFailureText(
+              songset.renderErrorMessage,
+              songset.failedAt ? new Date(songset.failedAt) : null
+            )}
+          </AlertDescription>
+          <AlertAction>
+            <Button size="sm" variant="outline" onClick={onRender}>
+              Render again
+            </Button>
+          </AlertAction>
+        </Alert>
+      )}
 
       {/* Stale banner */}
       {songset.isArtifactsStale && !isStaleBannerDismissed && (

--- a/webapp/src/components/songset/SongsetList.tsx
+++ b/webapp/src/components/songset/SongsetList.tsx
@@ -30,6 +30,8 @@ export interface Songset {
   isArtifactsStale?: boolean;
   latestRenderJobId: string | null;
   lastCompletedRenderJobId: string | null;
+  renderErrorMessage?: string | null;
+  failedAt?: Date | null;
 }
 
 interface SongsetListProps {

--- a/webapp/src/components/songset/SongsetRow.tsx
+++ b/webapp/src/components/songset/SongsetRow.tsx
@@ -44,6 +44,8 @@ export interface SongsetRowProps {
   isArtifactsStale?: boolean;
   latestRenderJobId: string | null;
   lastCompletedRenderJobId: string | null;
+  renderErrorMessage?: string | null;
+  failedAt?: Date | null;
   onRender?: () => void;
   onPlay?: () => void;
   onRetry?: () => void;
@@ -67,6 +69,8 @@ export function SongsetRow({
   isOfflineAvailable = false,
   isArtifactsStale = false,
   lastCompletedRenderJobId,
+  renderErrorMessage,
+  failedAt,
   onRender,
   onPlay,
   onRename,
@@ -215,9 +219,14 @@ export function SongsetRow({
                   Updated {formatDate(updatedAt)}
                 </span>
               </div>
+            </Link>
 
               <div className="flex items-center gap-2 mt-2 flex-wrap">
-                <RenderStatusBadge state={renderState} />
+                <RenderStatusBadge
+                  state={renderState}
+                  errorMessage={renderErrorMessage}
+                  failedAt={failedAt}
+                />
                 {isOfflineAvailable && (
                   <Badge variant="secondary" className="text-xs gap-1">
                     <WifiOff className="size-3" />
@@ -231,7 +240,6 @@ export function SongsetRow({
                   </Badge>
                 )}
               </div>
-            </Link>
           </div>
         </div>
       </CardContent>

--- a/webapp/src/lib/db/songsets.ts
+++ b/webapp/src/lib/db/songsets.ts
@@ -11,6 +11,7 @@ import {
 import { eq, and, desc, gt, sql, asc } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { SONGSET_MAX_SONGS } from "@/lib/constants";
+import { sanitizeRenderErrorMessage } from "@/lib/render/error-message";
 
 export type RenderState = "unrendered" | "rendering" | "fresh" | "stale" | "failed";
 
@@ -113,6 +114,8 @@ export interface SongsetListItem {
   latestRenderJobId: string | null;
   lastFailedRenderJobId: string | null;
   lastCompletedRenderJobId: string | null;
+  renderErrorMessage: string | null;
+  failedAt: Date | null;
 }
 
 export interface SongsetItemRecording {
@@ -293,6 +296,9 @@ export async function listSongsetSummaries(
         latestItemUpdatedAt: sql<Date | null>`max(${songsetItems.updatedAt}) filter (where ${recordings.deletedAt} is null)`,
         latestJobStatus: renderJobs.status,
         latestJobCompletedAt: renderJobs.completedAt,
+        renderErrorMessage: sql<string | null>`left(${renderJobs.errorMessage}, 4000)`,
+        latestJobStartedAt: renderJobs.startedAt,
+        latestJobCreatedAt: renderJobs.createdAt,
       })
       .from(songsets)
       .leftJoin(songsetItems, eq(songsetItems.songsetId, songsets.id))
@@ -309,7 +315,10 @@ export async function listSongsetSummaries(
         songsets.lastFailedRenderJobId,
         songsets.lastCompletedRenderJobId,
         renderJobs.status,
-        renderJobs.completedAt
+        renderJobs.completedAt,
+        renderJobs.errorMessage,
+        renderJobs.startedAt,
+        renderJobs.createdAt
       )
       .orderBy(desc(songsets.updatedAt))
       .limit(limit)
@@ -322,25 +331,32 @@ export async function listSongsetSummaries(
 
     return {
       total: Number(countResult[0]?.count ?? 0),
-      songsets: rows.map((row) => ({
-        id: row.id,
-        name: row.name,
-        description: row.description,
-        createdAt: row.createdAt,
-        updatedAt: row.updatedAt,
-        latestRenderJobId: row.latestRenderJobId,
-        lastFailedRenderJobId: row.lastFailedRenderJobId,
-        lastCompletedRenderJobId: row.lastCompletedRenderJobId,
-        itemCount: Number(row.itemCount ?? 0),
-        durationSeconds: row.durationSeconds == null ? null : Number(row.durationSeconds),
-        renderState: mapRenderStateFromSnapshot({
+      songsets: rows.map((row) => {
+        const renderState = mapRenderStateFromSnapshot({
           latestRenderJobId: row.latestRenderJobId,
           lastFailedRenderJobId: row.lastFailedRenderJobId,
           latestJobStatus: row.latestJobStatus,
           latestJobCompletedAt: row.latestJobCompletedAt,
           latestItemUpdatedAt: row.latestItemUpdatedAt,
-        }),
-      })),
+        });
+        const failedAt = row.latestJobStartedAt ?? row.latestJobCreatedAt;
+        return {
+          id: row.id,
+          name: row.name,
+          description: row.description,
+          createdAt: row.createdAt,
+          updatedAt: row.updatedAt,
+          latestRenderJobId: row.latestRenderJobId,
+          lastFailedRenderJobId: row.lastFailedRenderJobId,
+          lastCompletedRenderJobId: row.lastCompletedRenderJobId,
+          itemCount: Number(row.itemCount ?? 0),
+          durationSeconds: row.durationSeconds == null ? null : Number(row.durationSeconds),
+          renderState,
+          renderErrorMessage:
+            renderState === "failed" ? sanitizeRenderErrorMessage(row.renderErrorMessage) : null,
+          failedAt: renderState === "failed" ? failedAt : null,
+        };
+      }),
     };
   });
 }
@@ -362,6 +378,9 @@ export async function getSongsetEditorData(
         lastCompletedRenderJobId: songsets.lastCompletedRenderJobId,
         latestJobStatus: renderJobs.status,
         latestJobCompletedAt: renderJobs.completedAt,
+        renderErrorMessage: renderJobs.errorMessage,
+        latestJobStartedAt: renderJobs.startedAt,
+        latestJobCreatedAt: renderJobs.createdAt,
       })
       .from(songsets)
       .leftJoin(renderJobs, eq(renderJobs.id, songsets.latestRenderJobId))
@@ -470,6 +489,15 @@ export async function getSongsetEditorData(
         : null,
     }));
 
+    const renderState = mapRenderStateFromSnapshot({
+      latestRenderJobId: row.latestRenderJobId,
+      lastFailedRenderJobId: row.lastFailedRenderJobId,
+      latestJobStatus: row.latestJobStatus,
+      latestJobCompletedAt: row.latestJobCompletedAt,
+      latestItemUpdatedAt,
+    });
+    const failedAt = row.latestJobStartedAt ?? row.latestJobCreatedAt;
+
     return {
       id: row.id,
       name: row.name,
@@ -482,13 +510,10 @@ export async function getSongsetEditorData(
       itemCount: items.length,
       durationSeconds:
         items.reduce((sum, item) => sum + (item.recording?.durationSeconds ?? 0), 0) || null,
-      renderState: mapRenderStateFromSnapshot({
-        latestRenderJobId: row.latestRenderJobId,
-        lastFailedRenderJobId: row.lastFailedRenderJobId,
-        latestJobStatus: row.latestJobStatus,
-        latestJobCompletedAt: row.latestJobCompletedAt,
-        latestItemUpdatedAt,
-      }),
+      renderState,
+      renderErrorMessage:
+        renderState === "failed" ? sanitizeRenderErrorMessage(row.renderErrorMessage) : null,
+      failedAt: renderState === "failed" ? failedAt : null,
       items,
     };
   });
@@ -737,6 +762,8 @@ export async function getSongset(
       0
     ) || null,
     renderState,
+    renderErrorMessage: null,
+    failedAt: null,
     items,
   };
 }
@@ -764,6 +791,8 @@ export async function createSongset(
     itemCount: 0,
     durationSeconds: null,
     renderState: "unrendered",
+    renderErrorMessage: null,
+    failedAt: null,
   };
 }
 
@@ -816,6 +845,8 @@ export async function updateSongset(
         0
       ) || null,
     renderState,
+    renderErrorMessage: null,
+    failedAt: null,
   };
 }
 

--- a/webapp/src/lib/db/songsets.ts
+++ b/webapp/src/lib/db/songsets.ts
@@ -307,18 +307,7 @@ export async function listSongsetSummaries(
       .where(eq(songsets.userId, userId))
       .groupBy(
         songsets.id,
-        songsets.name,
-        songsets.description,
-        songsets.createdAt,
-        songsets.updatedAt,
-        songsets.latestRenderJobId,
-        songsets.lastFailedRenderJobId,
-        songsets.lastCompletedRenderJobId,
-        renderJobs.status,
-        renderJobs.completedAt,
-        renderJobs.errorMessage,
-        renderJobs.startedAt,
-        renderJobs.createdAt
+        renderJobs.id
       )
       .orderBy(desc(songsets.updatedAt))
       .limit(limit)

--- a/webapp/src/lib/render/error-message.ts
+++ b/webapp/src/lib/render/error-message.ts
@@ -1,0 +1,75 @@
+const MAX_LENGTH = 250;
+
+const ANSI_ESCAPE = /\x1b\[[0-9;]*[A-Za-z]|\x1b\][^\x07]*\x07|\x1b[()][AB012]|\x1b[=>]/g;
+const CONTROL_CHARS = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g;
+const URL_PATTERN = /\bhttps?:\/\/[^\s]+/gi;
+const UNIX_PATH = /(^|[\s(:'\[])(\/(?:[^/\s]+\/)+[^/\s]+)/g;
+const WINDOWS_PATH = /\b[A-Za-z]:\\(?:[^\\\s]+\\)+[^\\\s]+/g;
+const SECRET_PATTERN = /\b(TOKEN|API_KEY|PASSWORD|SECRET|DATABASE_URL|SOW_[A-Z_]*_KEY)=[^\s]*/gi;
+
+const TRACEBACK_PREFIXES = [
+  /^\s*Traceback \(most recent call last\):\s*/i,
+  /^\s*File "[^"]*", line \d+, in .*\s*/i,
+  /^\s*at\s+\S+\s+\([^)]*\)\s*$/i,
+  /^\s*at\s+\S+\s*$/i,
+  /^\s*Caused by:.*$/i,
+  /^\s*During handling of.*$/i,
+  /^\s*The above exception.*$/i,
+];
+
+export function sanitizeRenderErrorMessage(message: unknown): string | null {
+  if (typeof message !== "string") return null;
+
+  let text = message.replace(ANSI_ESCAPE, "").replace(CONTROL_CHARS, "");
+
+  const lines = text.split(/\r?\n/);
+  let firstUseful: string | null = null;
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    if (TRACEBACK_PREFIXES.some((re) => re.test(trimmed))) continue;
+    firstUseful = trimmed;
+    break;
+  }
+
+  if (firstUseful === null) return null;
+
+  text = firstUseful;
+
+  text = text.replace(SECRET_PATTERN, "$1=[redacted]");
+  text = text.replace(URL_PATTERN, "[url]");
+  text = text.replace(UNIX_PATH, "$1[path]");
+  text = text.replace(WINDOWS_PATH, "[path]");
+
+  text = text.replace(/\s+/g, " ").trim();
+
+  if (!text) return null;
+
+  if (text.length > MAX_LENGTH) {
+    text = text.slice(0, MAX_LENGTH - 1) + "…";
+  }
+
+  return text;
+}
+
+export function formatRenderFailedAt(date: Date): string {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date);
+}
+
+export function getRenderFailureText(
+  errorMessage: string | null | undefined,
+  failedAt: Date | null | undefined
+): string {
+  const sanitized = sanitizeRenderErrorMessage(errorMessage);
+  if (sanitized) return sanitized;
+  if (failedAt) {
+    return `Render failed around ${formatRenderFailedAt(failedAt)}. Please render again.`;
+  }
+  return "Render failed. Please render again.";
+}

--- a/webapp/src/lib/render/error-message.ts
+++ b/webapp/src/lib/render/error-message.ts
@@ -5,7 +5,7 @@ const CONTROL_CHARS = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g;
 const URL_PATTERN = /\bhttps?:\/\/[^\s]+/gi;
 const UNIX_PATH = /(^|[\s(:'\[])(\/(?:[^/\s]+\/)+[^/\s]+)/g;
 const WINDOWS_PATH = /\b[A-Za-z]:\\(?:[^\\\s]+\\)+[^\\\s]+/g;
-const SECRET_PATTERN = /\b(TOKEN|API_KEY|PASSWORD|SECRET|DATABASE_URL|SOW_[A-Z_]*_KEY)=[^\s]*/gi;
+const SECRET_PATTERN = /\b(TOKEN|API_KEY|PASSWORD|SECRET|DATABASE_URL|SOW_\w*_KEY)=[^\s]*/gi;
 
 const TRACEBACK_PREFIXES = [
   /^\s*Traceback \(most recent call last\):\s*/i,
@@ -45,6 +45,9 @@ export function sanitizeRenderErrorMessage(message: unknown): string | null {
 
   if (!text) return null;
 
+  const PLACEHOLDER_ONLY = /^((\w+=)?\[url\]|(\w+=)?\[path\]|(\w+=)?\[redacted\]|\s)+$/;
+  if (PLACEHOLDER_ONLY.test(text)) return null;
+
   if (text.length > MAX_LENGTH) {
     text = text.slice(0, MAX_LENGTH - 1) + "…";
   }
@@ -59,7 +62,8 @@ export function formatRenderFailedAt(date: Date): string {
     year: "numeric",
     hour: "2-digit",
     minute: "2-digit",
-  }).format(date);
+    timeZone: "UTC",
+  }).format(date) + " UTC";
 }
 
 export function getRenderFailureText(

--- a/webapp/src/test/api/songsets/db.test.ts
+++ b/webapp/src/test/api/songsets/db.test.ts
@@ -312,6 +312,9 @@ describe("listSongsetSummaries", () => {
         latestItemUpdatedAt: null,
         latestJobStatus: null,
         latestJobCompletedAt: null,
+        renderErrorMessage: null,
+        latestJobStartedAt: null,
+        latestJobCreatedAt: null,
       },
     ];
 
@@ -324,6 +327,111 @@ describe("listSongsetSummaries", () => {
     const result = await listSongsetSummaries(1, 50, 0);
 
     expect(result.songsets[0].itemCount).toBe(2);
+  });
+
+  it("returns sanitized failure fields for a latest failed job", async () => {
+    const startedAt = new Date("2024-06-15T10:30:00Z");
+    const mockRows = [
+      {
+        id: "ss-1",
+        name: "Failed Songset",
+        description: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        latestRenderJobId: "job-1",
+        lastFailedRenderJobId: "job-1",
+        lastCompletedRenderJobId: null,
+        itemCount: 1,
+        durationSeconds: 120,
+        latestItemUpdatedAt: null,
+        latestJobStatus: "failed",
+        latestJobCompletedAt: null,
+        renderErrorMessage: "FFmpeg crashed",
+        latestJobStartedAt: startedAt,
+        latestJobCreatedAt: new Date("2024-06-15T10:00:00Z"),
+      },
+    ];
+
+    const chain = createSelectChain(mockRows);
+    const countChain = createSelectChain([{ count: 1 }]);
+    vi.mocked(db.select)
+      .mockReturnValueOnce(chain as any)
+      .mockReturnValueOnce(countChain as any);
+
+    const result = await listSongsetSummaries(1, 50, 0);
+
+    expect(result.songsets[0].renderState).toBe("failed");
+    expect(result.songsets[0].renderErrorMessage).toBe("FFmpeg crashed");
+    expect(result.songsets[0].failedAt).toEqual(startedAt);
+  });
+
+  it("returns failedAt from createdAt when startedAt is null", async () => {
+    const createdAt = new Date("2024-06-15T10:00:00Z");
+    const mockRows = [
+      {
+        id: "ss-1",
+        name: "Failed Songset",
+        description: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        latestRenderJobId: "job-1",
+        lastFailedRenderJobId: "job-1",
+        lastCompletedRenderJobId: null,
+        itemCount: 1,
+        durationSeconds: 120,
+        latestItemUpdatedAt: null,
+        latestJobStatus: "failed",
+        latestJobCompletedAt: null,
+        renderErrorMessage: "Error",
+        latestJobStartedAt: null,
+        latestJobCreatedAt: createdAt,
+      },
+    ];
+
+    const chain = createSelectChain(mockRows);
+    const countChain = createSelectChain([{ count: 1 }]);
+    vi.mocked(db.select)
+      .mockReturnValueOnce(chain as any)
+      .mockReturnValueOnce(countChain as any);
+
+    const result = await listSongsetSummaries(1, 50, 0);
+
+    expect(result.songsets[0].failedAt).toEqual(createdAt);
+  });
+
+  it("returns null failure fields for non-failed states even when prior failures exist", async () => {
+    const mockRows = [
+      {
+        id: "ss-1",
+        name: "Fresh Songset",
+        description: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        latestRenderJobId: "job-2",
+        lastFailedRenderJobId: "job-1",
+        lastCompletedRenderJobId: "job-2",
+        itemCount: 1,
+        durationSeconds: 120,
+        latestItemUpdatedAt: null,
+        latestJobStatus: "completed",
+        latestJobCompletedAt: new Date("2024-06-16T10:30:00Z"),
+        renderErrorMessage: "Old error from job-1",
+        latestJobStartedAt: new Date("2024-06-16T10:00:00Z"),
+        latestJobCreatedAt: new Date("2024-06-16T09:00:00Z"),
+      },
+    ];
+
+    const chain = createSelectChain(mockRows);
+    const countChain = createSelectChain([{ count: 1 }]);
+    vi.mocked(db.select)
+      .mockReturnValueOnce(chain as any)
+      .mockReturnValueOnce(countChain as any);
+
+    const result = await listSongsetSummaries(1, 50, 0);
+
+    expect(result.songsets[0].renderState).toBe("fresh");
+    expect(result.songsets[0].renderErrorMessage).toBeNull();
+    expect(result.songsets[0].failedAt).toBeNull();
   });
 });
 
@@ -574,6 +682,71 @@ describe("getSongsetEditorData", () => {
     const result = await getSongsetEditorData("ss-1", 1);
 
     expect(result!.durationSeconds).toBe(100);
+  });
+
+  it("returns sanitized failure fields for a latest failed job", async () => {
+    const startedAt = new Date("2024-06-15T10:30:00Z");
+    const songsetRow = {
+      id: "ss-1",
+      name: "Failed Songset",
+      description: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      latestRenderJobId: "job-1",
+      lastFailedRenderJobId: "job-1",
+      lastCompletedRenderJobId: null,
+      latestJobStatus: "failed",
+      latestJobCompletedAt: null,
+      renderErrorMessage: "FFmpeg crashed",
+      latestJobStartedAt: startedAt,
+      latestJobCreatedAt: new Date("2024-06-15T10:00:00Z"),
+    };
+
+    const itemRows: any[] = [];
+
+    const songsetChain = createSelectChain([songsetRow]);
+    const itemChain = createSelectChain(itemRows);
+    vi.mocked(db.select)
+      .mockReturnValueOnce(songsetChain as any)
+      .mockReturnValueOnce(itemChain as any);
+
+    const result = await getSongsetEditorData("ss-1", 1);
+
+    expect(result!.renderState).toBe("failed");
+    expect(result!.renderErrorMessage).toBe("FFmpeg crashed");
+    expect(result!.failedAt).toEqual(startedAt);
+  });
+
+  it("returns null failure fields for non-failed states", async () => {
+    const songsetRow = {
+      id: "ss-1",
+      name: "Fresh Songset",
+      description: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      latestRenderJobId: "job-2",
+      lastFailedRenderJobId: "job-1",
+      lastCompletedRenderJobId: "job-2",
+      latestJobStatus: "completed",
+      latestJobCompletedAt: new Date("2024-06-16T10:30:00Z"),
+      renderErrorMessage: "Old error from job-1",
+      latestJobStartedAt: new Date("2024-06-16T10:00:00Z"),
+      latestJobCreatedAt: new Date("2024-06-16T09:00:00Z"),
+    };
+
+    const itemRows: any[] = [];
+
+    const songsetChain = createSelectChain([songsetRow]);
+    const itemChain = createSelectChain(itemRows);
+    vi.mocked(db.select)
+      .mockReturnValueOnce(songsetChain as any)
+      .mockReturnValueOnce(itemChain as any);
+
+    const result = await getSongsetEditorData("ss-1", 1);
+
+    expect(result!.renderState).toBe("fresh");
+    expect(result!.renderErrorMessage).toBeNull();
+    expect(result!.failedAt).toBeNull();
   });
 });
 

--- a/webapp/src/test/components/songset/RenderStatusBadge.test.tsx
+++ b/webapp/src/test/components/songset/RenderStatusBadge.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { RenderStatusBadge, RenderState } from "@/components/songset/RenderStatusBadge";
 
 describe("RenderStatusBadge", () => {
@@ -44,6 +44,81 @@ describe("RenderStatusBadge", () => {
     it("renders 'Render failed' label", () => {
       renderBadge("failed");
       expect(screen.getByText("Render failed")).toBeInTheDocument();
+    });
+
+    it("shows tooltip on hover when errorMessage is provided", () => {
+      render(
+        <RenderStatusBadge
+          state="failed"
+          errorMessage="FFmpeg crashed"
+          failedAt={new Date("2024-06-15T10:30:00Z")}
+        />
+      );
+      const trigger = screen.getByRole("button");
+      fireEvent.mouseEnter(trigger);
+      expect(screen.getByText("FFmpeg crashed")).toBeInTheDocument();
+    });
+
+    it("shows tooltip on focus when errorMessage is provided", () => {
+      render(
+        <RenderStatusBadge
+          state="failed"
+          errorMessage="Out of memory"
+          failedAt={null}
+        />
+      );
+      const trigger = screen.getByRole("button");
+      fireEvent.focus(trigger);
+      expect(screen.getByText("Out of memory")).toBeInTheDocument();
+    });
+
+    it("shows fallback text in tooltip when errorMessage is null but failedAt exists", () => {
+      render(
+        <RenderStatusBadge
+          state="failed"
+          errorMessage={null}
+          failedAt={new Date("2024-06-15T10:30:00Z")}
+        />
+      );
+      const trigger = screen.getByRole("button");
+      fireEvent.focus(trigger);
+      expect(screen.getByText(/Render failed around/)).toBeInTheDocument();
+      expect(screen.getByText(/Please render again/)).toBeInTheDocument();
+    });
+
+    it("shows generic fallback text when both errorMessage and failedAt are null", () => {
+      render(
+        <RenderStatusBadge
+          state="failed"
+          errorMessage={null}
+          failedAt={null}
+        />
+      );
+      const trigger = screen.getByRole("button");
+      fireEvent.focus(trigger);
+      expect(screen.getByText("Render failed. Please render again.")).toBeInTheDocument();
+    });
+  });
+
+  describe("non-failed states", () => {
+    it("does not create a tooltip for fresh state", () => {
+      renderBadge("fresh");
+      expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    });
+
+    it("does not create a tooltip for unrendered state", () => {
+      renderBadge("unrendered");
+      expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    });
+
+    it("does not create a tooltip for rendering state", () => {
+      renderBadge("rendering");
+      expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    });
+
+    it("does not create a tooltip for stale state", () => {
+      renderBadge("stale");
+      expect(screen.queryByRole("button")).not.toBeInTheDocument();
     });
   });
 });

--- a/webapp/src/test/components/songset/SongsetEditor.test.tsx
+++ b/webapp/src/test/components/songset/SongsetEditor.test.tsx
@@ -375,4 +375,65 @@ describe("SongsetEditor", () => {
       expect(onRender).toHaveBeenCalled();
     });
   });
+
+  describe("render failure alert", () => {
+    it("shows inline failure alert when renderState is failed", () => {
+      renderEditor({
+        songset: {
+          ...mockSongset,
+          renderState: "failed" as RenderState,
+          renderErrorMessage: "FFmpeg crashed",
+          failedAt: "2024-06-15T10:30:00Z",
+        },
+      });
+      expect(screen.getByText("FFmpeg crashed")).toBeInTheDocument();
+    });
+
+    it("shows fallback text when error message is absent", () => {
+      renderEditor({
+        songset: {
+          ...mockSongset,
+          renderState: "failed" as RenderState,
+          renderErrorMessage: null,
+          failedAt: "2024-06-15T10:30:00Z",
+        },
+      });
+      expect(screen.getByText(/Render failed around/)).toBeInTheDocument();
+      expect(screen.getByText(/Please render again/)).toBeInTheDocument();
+    });
+
+    it("shows generic fallback when both error message and failedAt are absent", () => {
+      renderEditor({
+        songset: {
+          ...mockSongset,
+          renderState: "failed" as RenderState,
+          renderErrorMessage: null,
+          failedAt: null,
+        },
+      });
+      expect(screen.getByText("Render failed. Please render again.")).toBeInTheDocument();
+    });
+
+    it("does not show failure alert when renderState is not failed", () => {
+      renderEditor({
+        songset: { ...mockSongset, renderState: "fresh" as RenderState },
+      });
+      expect(screen.queryByText("Render again")).not.toBeInTheDocument();
+    });
+
+    it("Render again button calls onRender", () => {
+      const onRender = vi.fn();
+      renderEditor({
+        songset: {
+          ...mockSongset,
+          renderState: "failed" as RenderState,
+          renderErrorMessage: "FFmpeg crashed",
+          failedAt: "2024-06-15T10:30:00Z",
+        },
+        onRender,
+      });
+      fireEvent.click(screen.getByRole("button", { name: /render again/i }));
+      expect(onRender).toHaveBeenCalled();
+    });
+  });
 });

--- a/webapp/src/test/components/songset/SongsetRow.test.tsx
+++ b/webapp/src/test/components/songset/SongsetRow.test.tsx
@@ -68,6 +68,32 @@ describe("SongsetRow", () => {
       renderRow();
       expect(screen.getByText("Rendered")).toBeInTheDocument();
     });
+
+    it("passes failure fields to the badge", () => {
+      renderRow({
+        renderState: "failed" as RenderState,
+        renderErrorMessage: "FFmpeg crashed",
+        failedAt: new Date("2024-06-15T10:30:00Z"),
+      });
+      expect(screen.getByText("Render failed")).toBeInTheDocument();
+      const trigger = screen.getByText("Render failed").closest("button")!;
+      fireEvent.focus(trigger);
+      expect(screen.getByText("FFmpeg crashed")).toBeInTheDocument();
+    });
+
+    it("tooltip interaction does not trigger row navigation", () => {
+      const onPlay = vi.fn();
+      renderRow({
+        renderState: "failed" as RenderState,
+        renderErrorMessage: "FFmpeg crashed",
+        failedAt: new Date("2024-06-15T10:30:00Z"),
+        onPlay,
+      });
+      const trigger = screen.getByText("Render failed").closest("button")!;
+      fireEvent.focus(trigger);
+      fireEvent.click(trigger);
+      expect(onPlay).not.toHaveBeenCalled();
+    });
   });
 
   describe("stale state badge", () => {

--- a/webapp/src/test/lib/render/error-message.test.ts
+++ b/webapp/src/test/lib/render/error-message.test.ts
@@ -63,7 +63,7 @@ describe("sanitizeRenderErrorMessage", () => {
   });
 
   it("redacts secret-like key/value fragments", () => {
-    const input = "TOKEN=abc123 API_KEY=xyz PASSWORD=hunter2";
+    const input = "Error: TOKEN=abc123 API_KEY=xyz PASSWORD=hunter2";
     const result = sanitizeRenderErrorMessage(input);
     expect(result).not.toContain("abc123");
     expect(result).not.toContain("xyz");
@@ -72,7 +72,7 @@ describe("sanitizeRenderErrorMessage", () => {
   });
 
   it("redacts SOW_*_KEY fragments", () => {
-    const input = "SOW_R2_KEY=mysecret";
+    const input = "Error: SOW_R2_KEY=mysecret";
     const result = sanitizeRenderErrorMessage(input);
     expect(result).not.toContain("mysecret");
     expect(result).toContain("[redacted]");
@@ -94,7 +94,12 @@ describe("sanitizeRenderErrorMessage", () => {
     const input = "https://example.com";
     expect(sanitizeRenderErrorMessage(input)).toBeNull();
   });
-});
+
+  it("returns null when only placeholders remain after redaction", () => {
+    expect(sanitizeRenderErrorMessage("https://example.com /usr/local/bin")).toBeNull();
+    expect(sanitizeRenderErrorMessage("TOKEN=secret API_KEY=xyz")).toBeNull();
+    expect(sanitizeRenderErrorMessage("[url] [path] [redacted]")).toBeNull();
+  });});
 
 describe("formatRenderFailedAt", () => {
   it("formats a date in a readable format", () => {

--- a/webapp/src/test/lib/render/error-message.test.ts
+++ b/webapp/src/test/lib/render/error-message.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from "vitest";
+import {
+  sanitizeRenderErrorMessage,
+  formatRenderFailedAt,
+  getRenderFailureText,
+} from "@/lib/render/error-message";
+
+describe("sanitizeRenderErrorMessage", () => {
+  it("returns null for non-string input", () => {
+    expect(sanitizeRenderErrorMessage(null)).toBeNull();
+    expect(sanitizeRenderErrorMessage(undefined)).toBeNull();
+    expect(sanitizeRenderErrorMessage(123)).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(sanitizeRenderErrorMessage("")).toBeNull();
+  });
+
+  it("returns null for whitespace-only string", () => {
+    expect(sanitizeRenderErrorMessage("   \n\t  ")).toBeNull();
+  });
+
+  it("strips ANSI escape codes", () => {
+    const input = "\x1b[31mError: something failed\x1b[0m";
+    expect(sanitizeRenderErrorMessage(input)).toBe("Error: something failed");
+  });
+
+  it("strips control characters", () => {
+    const input = "Error\x00\x07something failed";
+    expect(sanitizeRenderErrorMessage(input)).toBe("Errorsomething failed");
+  });
+
+  it("uses the first useful non-empty line", () => {
+    const input = "\n\n  \nActual error here\n  at SomeTrace\n  at AnotherTrace";
+    expect(sanitizeRenderErrorMessage(input)).toBe("Actual error here");
+  });
+
+  it("skips traceback framing lines", () => {
+    const input =
+      "Traceback (most recent call last):\n  File \"app.py\", line 10, in run\nRuntimeError: boom";
+    expect(sanitizeRenderErrorMessage(input)).toBe("RuntimeError: boom");
+  });
+
+  it("redacts URLs", () => {
+    const input = "Failed to fetch https://example.com/api?key=secret";
+    const result = sanitizeRenderErrorMessage(input);
+    expect(result).not.toContain("https://example.com");
+    expect(result).toContain("[url]");
+  });
+
+  it("redacts Unix absolute paths", () => {
+    const input = "File not found: /usr/local/bin/ffmpeg";
+    const result = sanitizeRenderErrorMessage(input);
+    expect(result).not.toContain("/usr/local/bin/ffmpeg");
+    expect(result).toContain("[path]");
+  });
+
+  it("redacts Windows absolute paths", () => {
+    const input = "Error in C:\\Users\\admin\\config\\secrets.txt";
+    const result = sanitizeRenderErrorMessage(input);
+    expect(result).not.toContain("C:\\Users\\admin\\config\\secrets.txt");
+    expect(result).toContain("[path]");
+  });
+
+  it("redacts secret-like key/value fragments", () => {
+    const input = "TOKEN=abc123 API_KEY=xyz PASSWORD=hunter2";
+    const result = sanitizeRenderErrorMessage(input);
+    expect(result).not.toContain("abc123");
+    expect(result).not.toContain("xyz");
+    expect(result).not.toContain("hunter2");
+    expect(result).toContain("[redacted]");
+  });
+
+  it("redacts SOW_*_KEY fragments", () => {
+    const input = "SOW_R2_KEY=mysecret";
+    const result = sanitizeRenderErrorMessage(input);
+    expect(result).not.toContain("mysecret");
+    expect(result).toContain("[redacted]");
+  });
+
+  it("collapses repeated whitespace", () => {
+    const input = "Error:   something   failed";
+    expect(sanitizeRenderErrorMessage(input)).toBe("Error: something failed");
+  });
+
+  it("truncates long messages to 250 characters with ellipsis", () => {
+    const input = "A".repeat(300);
+    const result = sanitizeRenderErrorMessage(input);
+    expect(result).toHaveLength(250);
+    expect(result).toMatch(/…$/);
+  });
+
+  it("returns null for fully redacted message", () => {
+    const input = "https://example.com";
+    expect(sanitizeRenderErrorMessage(input)).toBeNull();
+  });
+});
+
+describe("formatRenderFailedAt", () => {
+  it("formats a date in a readable format", () => {
+    const date = new Date("2024-06-15T10:30:00Z");
+    const result = formatRenderFailedAt(date);
+    expect(result).toContain("Jun");
+    expect(result).toContain("15");
+    expect(result).toContain("2024");
+  });
+});
+
+describe("getRenderFailureText", () => {
+  it("prefers sanitized error text", () => {
+    expect(getRenderFailureText("FFmpeg error: bad codec", null)).toBe(
+      "FFmpeg error: bad codec"
+    );
+  });
+
+  it("falls back to date-based text when error is null", () => {
+    const date = new Date("2024-06-15T10:30:00Z");
+    const result = getRenderFailureText(null, date);
+    expect(result).toContain("Render failed around");
+    expect(result).toContain("Please render again.");
+  });
+
+  it("falls back to generic text when error and date are null", () => {
+    expect(getRenderFailureText(null, null)).toBe(
+      "Render failed. Please render again."
+    );
+  });
+
+  it("falls back to generic text when error is empty string", () => {
+    const date = new Date("2024-06-15T10:30:00Z");
+    const result = getRenderFailureText("", date);
+    expect(result).toContain("Render failed around");
+  });
+});


### PR DESCRIPTION
## Summary

Implements `specs/songset-render-failed-error-tooltip-v4.md`. When a SongSet render fails, the failure reason is shown safely without exposing raw worker output. The list page shows a failed-badge tooltip (hover + keyboard focus), while the editor page shows a visible inline alert with a "Render again" action.

## Changes by file/module

### New: Error message helper
- **`webapp/src/lib/render/error-message.ts`**: `sanitizeRenderErrorMessage`, `formatRenderFailedAt`, `getRenderFailureText` — strips ANSI/control chars, redacts URLs/paths/secrets, truncates to 250 chars, falls back to date-based or generic text.

### DB layer
- **`webapp/src/lib/db/songsets.ts`**: Added `renderErrorMessage` and `failedAt` to `SongsetListItem`/`SongsetDetail`. `listSongsetSummaries` selects bounded error text (`left(errorMessage, 4000)`) and `startedAt`/`createdAt` from the joined latest render job. `getSongsetEditorData` selects full `errorMessage` and timestamps. Both return failure fields only when `renderState === "failed"`. `createSongset`, `updateSongset`, `getSongset` return null failure fields.

### Server serialization
- **`webapp/src/app/songsets/page.tsx`**: Serializes `failedAt` as ISO or null.
- **`webapp/src/app/songsets/[id]/page.tsx`**: Passes `renderErrorMessage` and `failedAt` (ISO or null) to client.

### Client components
- **`webapp/src/app/songsets/SongsetsClient.tsx`**: Added `renderErrorMessage`/`failedAt` to `ApiSongset`, converts `failedAt` to `Date | null` in state.
- **`webapp/src/app/songsets/[id]/SongsetEditorClient.tsx`**: Added failure fields to API types and initial state. Clears `renderErrorMessage`/`failedAt` on stale transitions (reorder, remove, add song, transition update).

### UI components
- **`webapp/src/components/songset/RenderStatusBadge.tsx`**: Extended props with `errorMessage`/`failedAt`. For failed state, wraps badge in tooltip (hover + focus) with constrained width content. No tooltip for non-failed states.
- **`webapp/src/components/songset/SongsetRow.tsx`**: Added `renderErrorMessage`/`failedAt` props, passes to badge. Restructured row so badge tooltip trigger is not nested inside the `Link`.
- **`webapp/src/components/songset/SongsetList.tsx`**: Added optional `renderErrorMessage`/`failedAt` to `Songset` interface.
- **`webapp/src/components/songset/SongsetEditor.tsx`**: Added `renderErrorMessage`/`failedAt` to songset prop shape. Passes both to app-bar badge. Shows inline destructive alert below app bar when failed, with "Render again" action wired to `onRender`. Not dismissible.

### Tests
- **`webapp/src/test/lib/render/error-message.test.ts`**: Tests for sanitization (ANSI, URLs, paths, secrets, truncation), `formatRenderFailedAt`, `getRenderFailureText` fallbacks.
- **`webapp/src/test/components/songset/RenderStatusBadge.test.tsx`**: Tests tooltip on hover/focus, no tooltip for non-failed states, fallback text.
- **`webapp/src/test/components/songset/SongsetRow.test.tsx`**: Tests failure fields passed to badge, tooltip doesn't trigger navigation.
- **`webapp/src/test/components/songset/SongsetEditor.test.tsx`**: Tests inline failure alert, fallback text, "Render again" calls onRender.
- **`webapp/src/test/api/songsets/db.test.ts`**: Tests `listSongsetSummaries` and `getSongsetEditorData` return sanitized failure fields for failed jobs, null for non-failed, `failedAt` from `startedAt ?? createdAt`.

## Testing notes

- All new and existing tests pass: `pnpm test`
- Lint passes: `pnpm lint`
- TypeScript compilation passes in `pnpm build` (build fails at page data collection due to pre-existing missing `SOW_DATABASE_URL` env var, unrelated to this change)