### PR TITLE
feat(admin): Concurrent R2 backup downloads with GET-ETag consistency (v3) + Performance Tracing

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -19,79 +19,147 @@ This document contains technical details for developers and contributors. For us
 
 ## Project Status
 
-**Current Phase:** Phase 4 - Analysis Service Implementation  
-**Architecture:** Three-component system (POC, CLI, Service)
+**Current Phase:** Web App production, Admin CLI operational, Analysis Service running  
+**Architecture:** Six-component system with shared PostgreSQL (Neon) database
 
 ### Components Status
 
 | Component | Status | Location | Purpose |
 |-----------|--------|----------|---------|
-| **POC Scripts** | ✅ Complete | `poc/` | Experimental analysis validation |
-| **Admin CLI** | 🚧 Phases 1-3 Complete | `src/stream_of_worship/admin/` | Catalog management, audio download |
-| **Analysis Service** | 🔄 Phase 4 In Progress | `services/analysis/` | Audio analysis microservice |
-| **User App** | ✅ Complete | `src/stream_of_worship/app/` | Transition songset & lyrics video generation |
+| **POC Scripts** | ✅ Archived | `poc/` | Experimental analysis validation (legacy) |
+| **Admin CLI** | ✅ Operational | `src/stream_of_worship/admin/` | Catalog management, audio download, schema init |
+| **Analysis Service** | ✅ Operational | `services/analysis/` | Audio analysis, stem separation, LRC generation |
+| **User App** | ⚠️ Deprecated | `src/stream_of_worship/app/` | TUI (deprecated in favor of Web App) |
+| **Web App** | ✅ Production | `webapp/` | Primary end-user interface (Next.js) |
+| **Render Worker** | ✅ Production | `services/render-worker/` | AWS Lambda render processing |
 
 ---
 
 ## Architecture Overview
 
-The project consists of **four architecturally separate components**:
+The project consists of **six architecturally separate components**:
 
-### 1. 🧪 POC Scripts (Experimental)
+### 1. 🧪 POC Scripts (Archived Experimental)
 - **Location:** `poc/` directory
 - **Purpose:** Validate analysis algorithms during development
 - **Runtime:** One-off script execution in Docker
 - **Technologies:** Librosa (signal processing) or All-In-One (deep learning)
-- **Status:** Archived experimental code (note: the `poc/transition_builder_v2/` TUI lives on as the `stream-of-worship tui` command)
+- **Status:** Archived. The `poc/transition_builder_v2/` TUI lives on as the `stream-of-worship tui` command but is also deprecated.
 
 ### 2. 🖥️ Admin CLI (Backend Management)
 - **Location:** `src/stream_of_worship/admin/` (Python package)
 - **Purpose:** Backend tool for catalog management and audio operations
 - **Users:** Administrators, DevOps
 - **Runtime:** One-shot CLI commands (`sow-admin catalog scrape`, `sow-admin audio download`)
-- **Dependencies:** **Lightweight** (~50MB) - typer, requests, yt-dlp, boto3
-- **Database:** Local SQLite with Turso cloud sync support
+- **Dependencies:** **Lightweight** (~50MB) - typer, rich, psycopg3, boto3, yt-dlp
+- **Database:** **PostgreSQL (Neon)** via `psycopg` (psycopg3, synchronous) with `ConnectionProvider` for auto-reconnect and cold-start retry
 - **Installation:** `uv run --extra admin sow-admin`
 
 ### 3. 🚀 Analysis Service (Microservice)
 - **Location:** `services/analysis/` (separate package: `sow_analysis`)
 - **Purpose:** CPU/GPU-intensive audio analysis and stem separation
-- **Users:** Called by Admin CLI or User App
+- **Users:** Called by Admin CLI or Web App
 - **Runtime:** Long-lived FastAPI HTTP server (port 8000)
-- **Technologies:** FastAPI, PyTorch, allin1, Demucs, Cloudflare R2
+- **Technologies:** FastAPI, PyTorch, allin1, Demucs, audio-separator, Cloudflare R2
 - **Dependencies:** **Heavy** (~2GB) - PyTorch, ML models, NATTEN
+- **Database:** **SQLite** (via `aiosqlite`) for job queue persistence only — **not** connected to the shared PostgreSQL
 - **Deployment:** Docker container with platform-specific builds (x86_64 vs ARM64)
 - **API:** REST endpoints at `http://localhost:8000/api/v1/`
 
-### 4. 🎵 User App (End-User Application)
+### 4. 🎵 User App (Deprecated)
 - **Location:** `src/stream_of_worship/app/` (Python package)
-- **Purpose:** Interactive tool for generating transition songsets and lyrics videos
-- **Users:** Worship leaders, media team members
+- **Purpose:** Interactive TUI for transitions and lyrics video generation (**deprecated**)
+- **Users:** Worship leaders, media team members (migrating to Web App)
 - **Runtime:** TUI (Textual framework)
-- **Technologies:** Textual (TUI), Pydub (audio), Pillow/FFmpeg (video)
-- **Data Source:**
-  - **Metadata:** Turso cloud database (synced from Admin CLI)
-  - **Audio Assets:** Cloudflare R2 (pre-analyzed stems, LRC files)
+- **Technologies:** Textual (TUI), psycopg3, Pydub, Pillow, FFmpeg
+- **Database:** **PostgreSQL (Neon)** via shared `ConnectionProvider` — migration status uncertain
+- **Note:** The Web App (`sow-webapp`) is now the recommended interface for all end-user operations.
+
+### 5. 🌐 Web App (Primary End-User Interface)
+- **Location:** `webapp/` (Node.js/TypeScript, Next.js 16 App Router)
+- **Purpose:** Browser-based worship set editor and playback
+- **Users:** Worship leaders, media teams, end users
+- **Runtime:** Next.js server (Vercel deployment) + browser client
+- **Technologies:** Next.js 16, Drizzle ORM, Better Auth, pgvector, Cloudflare R2
+- **Database:** **PostgreSQL (Neon)** via `@neondatabase/serverless` + Drizzle ORM
+- **Auth:** Better Auth with `drizzleAdapter`
 - **Key Features:**
-  - Browse master song catalog
-  - Select songs for transitions (with compatibility scoring)
-  - Adjust transition parameters (crossfade, tempo stretch, key shift)
-  - Generate multi-song audio files with smooth transitions
-  - Generate lyrics videos with synchronized LRC timing
-  - Export final audio/video outputs
+  - Browse and search song catalog (full-text tsvector + semantic pgvector search)
+  - Create and manage multi-song worship sets with transition configuration
+  - Submit render jobs (processed asynchronously via AWS Lambda)
+  - Real-time progress via SSE (Server-Sent Events)
+  - Built-in playback controller with synchronized lyrics
+  - Second-screen projection via W3C Presentation API or Google Cast
+  - LRC lyrics review and editing
+  - Shareable public player links
+
+### 6. ⚡ Render Worker (AWS Lambda)
+- **Location:** `services/render-worker/` (Python, deployed as Lambda container via private ECR)
+- **Purpose:** Serverless render processing (audio mixing + video encoding)
+- **Users:** Called by Web App via SQS
+- **Runtime:** AWS Lambda container (triggered by SQS events)
+- **Technologies:** psycopg2, boto3, Pillow, FFmpeg, Cloudflare R2
+- **Dependencies:** **Moderate** — psycopg2-binary, boto3, Pillow, ffmpeg-python
+- **Database:** **PostgreSQL (Neon)** via `psycopg2` (synchronous, connection string)
+- **Queue:** AWS SQS (render jobs enqueued by Web App, processed by Lambda)
+- **Deployment:** Docker container → private AWS ECR → Lambda function
 
 ### Why Architecturally Separate?
 
-| Concern | POC Scripts | Admin CLI | Analysis Service | User App |
-|---------|-------------|-----------|------------------|----------|
-| **Runtime Model** | Ad-hoc experimentation | One-shot commands | Long-lived daemon | Interactive session |
-| **Target Users** | Developers | Admins / DevOps | Internal service | Worship leaders / media teams |
-| **Dependencies** | Varies (experimental) | Minimal | Very heavy (PyTorch) | Moderate (FFmpeg, video libs) |
-| **Distribution** | Development only | pip install (admin) | Docker image | Desktop app / pip install |
-| **Deployment** | Local developer machine | Admin's machine | Cloud server / GPU | End-user's machine |
-| **Data Access** | Local files | SQLite + R2 (read/write) | R2 + temp cache | Turso + R2 (read-only) |
-| **Versioning** | Unversioned (experimental) | Semantic versioning | Independent API versions | Semantic versioning |
-| **Communication** | N/A | HTTP client (to Service) | HTTP server | HTTP client (to Service) + Turso sync |
+| Concern | Admin CLI | Analysis Service | User App (Dep.) | Web App | Render Worker |
+|---------|-----------|------------------|-----------------|---------|---------------|
+| **Runtime Model** | One-shot commands | Long-lived daemon | Interactive TUI | Serverless + browser | Event-driven Lambda |
+| **Target Users** | Admins / DevOps | Internal service | End users (legacy) | End users | Internal service |
+| **Dependencies** | Minimal | Very heavy (PyTorch) | Moderate | Node.js stack | Moderate (psycopg2, FFmpeg) |
+| **Distribution** | `uv run --extra admin` | Docker image | `uv run --extra app` | Vercel | Lambda container |
+| **Data Access** | PostgreSQL (Neon) + R2 | R2 + SQLite (jobs) | PostgreSQL (Neon) + R2 | PostgreSQL (Neon) + R2 | PostgreSQL (Neon) + R2 |
+| **Database Driver** | psycopg3 | aiosqlite | psycopg3 | Drizzle ORM + Neon | psycopg2 |
+
+### Shared Database Architecture
+
+All components except the Analysis Service share a **single PostgreSQL database hosted on Neon**:
+
+```
+                    ┌─────────────────────────────┐
+                    │   PostgreSQL (Neon)         │
+                    │                             │
+                    │  Catalog Tables:            │
+                    │    songs, recordings        │
+                    │    song_embedding,          │
+                    │    song_line_embedding      │
+                    │  Auth Tables (Better Auth): │
+                    │    user, account, session,  │
+                    │    verification             │
+                    │  App Tables:                │
+                    │    songsets, songset_items  │
+                    │    render_jobs              │
+                    │    user_settings,           │
+                    │    user_lrc_override,       │
+                    │    lyric_mark, songset_share│
+                    └────────┬────────────────────┘
+                             │
+            ┌────────────────┼────────────────┐
+            │                │                │
+     ┌──────┴──────┐  ┌─────┴──────┐  ┌─────┴──────┐
+     │ Admin CLI   │  │  Web App   │  │Render Worker│
+     │ (psycopg3)  │  │(Drizzle)   │  │ (psycopg2)  │
+     └─────────────┘  └────────────┘  └────────────┘
+            │                │                │
+            └────────────────┼────────────────┘
+                             │
+                    ┌────────┴────────┐
+                    │  Cloudflare R2  │
+                    │  (audio, stems, │
+                    │   LRC, videos)  │
+                    └─────────────────┘
+```
+
+**Key Design Decisions:**
+1. **Admin CLI** never imports PyTorch/ML libraries. It manages catalog and submits jobs to Analysis Service via HTTP.
+2. **Analysis Service** is the only component with heavy ML dependencies and uses SQLite only for its internal job queue (not connected to shared PostgreSQL).
+3. **Web App** is the primary end-user interface, using Drizzle ORM with Neon's serverless driver.
+4. **Render Worker** shares the same PostgreSQL database as the Web App for render job status tracking.
+5. **User App** is deprecated; all new development should target the Web App.
 
 ### Component Interaction
 
@@ -102,14 +170,14 @@ Backend Flow (Admin):
 │  (sow-admin)     │
 └────────┬─────────┘
          │
-         ├─── catalog scrape ──→ sop.org → SQLite (local)
+         ├─── catalog scrape ──→ sop.org → PostgreSQL (Neon)
          │
-         ├─── audio download ──→ YouTube → R2 upload → SQLite
+         ├─── audio download ──→ YouTube → R2 upload → PostgreSQL
          │
          └─── audio analyze ──→ HTTP POST /api/v1/jobs/analyze
                                           ↓
                          ┌────────────────────────────┐
-                         │  Analysis Service          │  ← Heavy ML, GPU server
+                         │  Analysis Service          │  ← Heavy ML, Docker
                          │  (FastAPI + Job Queue)     │
                          └────────────┬───────────────┘
                                       │
@@ -124,40 +192,31 @@ Backend Flow (Admin):
                                      ↓
                             ┌─────────────────┐
                             │ Cloudflare R2   │  → Stems, JSON, LRC
-                            └────────┬────────┘
-                                     │
-                         ┌───────────┴───────────┐
-                         ↓                       ↓
-                   ┌──────────┐          ┌─────────────┐
-                   │ SQLite   │ ──sync→  │ Turso Cloud │
-                   │ (local)  │          │ (replicated)│
-                   └──────────┘          └──────┬──────┘
-                                                 │
-                                                 ↓
-Frontend Flow (End-User):                       │
-┌──────────────────┐                            │
-│  User App        │  ← Interactive TUI/GUI     │
-│  (sow-app)       │                            │
-└────────┬─────────┘                            │
-         │                                      │
-         ├─── read catalog metadata ───────────┘
+                            └─────────────────┘
+
+Frontend Flow (End-User):
+┌──────────────────┐
+│  Web App         │  ← Next.js on Vercel
+│  (sow-webapp)    │
+└────────┬─────────┘
+         │
+         ├─── read/write catalog metadata ──→ PostgreSQL (Neon)
+         │                                      (via Drizzle ORM)
+         ├─── read/write songsets ──────────→ PostgreSQL (Neon)
+         │
+         ├─── submit render job ────────────→ PostgreSQL (Neon)
+         │            │
+         │            └─── SQS enqueue ──→ AWS Lambda (Render Worker)
+         │                                  │
+         │                                  ├─── fetch songset from DB
+         │                                  ├─── download audio/stems from R2
+         │                                  ├─── mix audio + render video
+         │                                  └─── upload to R2 + update DB
          │
          ├─── download audio/stems ───→ R2 (read-only)
          │
-         ├─── generate transitions ──→ Local processing (Pydub)
-         │
-         └─── render lyrics video ───→ Local processing (MoviePy)
-                     ↓
-              Final outputs:
-              - transition_songset.mp3
-              - lyrics_video.mp4
+         └─── poll render progress ───→ PostgreSQL (Neon) via SSE
 ```
-
-**Key Design Decisions:**
-1. **Admin CLI** never imports PyTorch/ML libraries. It submits jobs to Analysis Service via HTTP.
-2. **User App** reads from Turso (metadata) and R2 (audio assets) but never writes. It's a read-only consumer.
-3. **Analysis Service** is the only component with heavy ML dependencies and GPU access.
-4. **Turso Sync** enables User App to work with up-to-date catalog without direct database access to admin's machine.
 
 ---
 
@@ -170,11 +229,24 @@ The project includes two backend microservices:
 FastAPI-based audio analysis service with job queue management.
 
 - **Port:** 8000
-- **Purpose:** Audio analysis (tempo, key, beats), stem separation
-- **Technologies:** FastAPI, PyTorch, allin1, Demucs
-- **Status:** Phase 4 (In Progress)
+- **Purpose:** Audio analysis (tempo, key, beats, sections, embeddings), stem separation, LRC generation
+- **Technologies:** FastAPI, PyTorch, allin1, Demucs, audio-separator, Whisper
+- **Database:** SQLite (job persistence only, not connected to shared PostgreSQL)
+- **Status:** Operational
 
 **Documentation:** [services/analysis/README.md](services/analysis/README.md)
+
+### 2. Render Worker (`services/render-worker/`)
+
+AWS Lambda container that processes render jobs from an SQS queue.
+
+- **Purpose:** Audio mixing (FFmpeg) + lyrics video encoding (Pillow + FFmpeg)
+- **Technologies:** psycopg2, boto3, Pillow, FFmpeg
+- **Database:** PostgreSQL (Neon) via psycopg2
+- **Queue:** AWS SQS
+- **Status:** Operational
+
+**Documentation:** [services/render-worker/README.md](services/render-worker/README.md)
 
 ---
 
@@ -255,40 +327,101 @@ sow_cli_admin/                           # Repository root
 │
 ├── src/stream_of_worship/admin/         # 🖥️ Admin CLI Package (backend)
 │   ├── commands/                        #    CLI command groups
-│   │   ├── db.py                        #    - db init/status/reset
-│   │   ├── catalog.py                   #    - catalog scrape/list/search
-│   │   └── audio.py                     #    - audio download/list/analyze
+│   │   ├── db.py                        #    - db init/status/url
+│   │   ├── catalog.py                   #    - catalog scrape/list/search/show
+│   │   ├── audio.py                     #    - audio download/list/analyze/lrc/align
+│   │   └── config.py                    #    - config show/set/path
 │   ├── services/                        #    Business logic
 │   │   ├── scraper.py                   #    - HTML scraping (sop.org)
 │   │   ├── youtube.py                   #    - yt-dlp wrapper
 │   │   ├── hasher.py                    #    - SHA-256 hashing
 │   │   └── r2.py                        #    - R2 storage client
 │   ├── db/                              #    Database layer
-│   │   ├── client.py                    #    - SQLite client
-│   │   ├── schema.py                    #    - Table definitions
-│   │   └── models.py                    #    - Pydantic models
+│   │   ├── client.py                    #    - DatabaseClient (psycopg3)
+│   │   ├── schema.py                    #    - SQL schema DDL
+│   │   └── models.py                    #    - Song, Recording dataclasses
 │   ├── config.py                        #    TOML config loader
 │   └── main.py                          #    Typer app entry point
 │
-├── src/stream_of_worship/app/           # 🎵 User App Package (frontend)
+├── src/stream_of_worship/app/           # 🎵 User App Package (DEPRECATED)
 │   ├── screens/                           #    TUI screens (Textual)
 │   │   ├── generation.py                #    - Transition generator
 │   │   ├── browser.py                   #    - Song catalog browser
-│   │   └── songset_manager.py          #    - Songset management
+│   │   └── songset_manager.py           #    - Songset management
 │   ├── services/                        #    Business logic
 │   │   ├── audio_engine.py             #    - Audio processing
 │   │   ├── video_engine.py             #    - Video generation
 │   │   ├── asset_cache.py              #    - R2 asset management
-│   │   └── turso_client.py             #    - Database sync
+│   │   └── turso_client.py             #    - Legacy (unused, kept for compat)
+│   ├── db/                              #    Database layer (psycopg3)
+│   │   ├── read_client.py              #    - ReadOnlyClient (catalog)
+│   │   ├── songset_client.py           #    - SongsetClient (CRUD)
+│   │   ├── schema.py                   #    - App-specific schema
+│   │   └── user_data_schema.py         #    - Per-user schema
 │   ├── config.py                        #    TOML config loader
 │   └── main.py                          #    App entry point
+│
+├── src/stream_of_worship/db/            # Shared database infrastructure
+│   ├── connection.py                    #    - ConnectionProvider (psycopg3)
+│   └── postgres_schema.py               #    - Unified schema DDL (all components)
+│
+├── webapp/                              # 🌐 Web App (Next.js)
+│   ├── src/
+│   │   ├── app/                         #    Next.js App Router pages
+│   │   │   ├── api/                     #    API routes
+│   │   │   │   ├── songs/               #    Catalog APIs
+│   │   │   │   ├── songsets/            #    Songset CRUD
+│   │   │   │   ├── render-jobs/         #    Render job management + SSE
+│   │   │   │   ├── auth/                #    Better Auth endpoints
+│   │   │   │   └── ...
+│   │   │   └── ...
+│   │   ├── db/                          #    Database client + schema
+│   │   │   ├── index.ts                 #    Drizzle + Neon client
+│   │   │   └── schema.ts                #    Full schema (15 tables)
+│   │   ├── lib/
+│   │   │   ├── auth.ts                  #    Better Auth config
+│   │   │   └── db/                      #    DB query functions
+│   │   └── test/                        #    Test utilities
+│   ├── drizzle/                         #    Drizzle migration files
+│   ├── drizzle.config.ts                #    Drizzle Kit config
+│   └── package.json                     #    Node.js dependencies
 │
 ├── services/analysis/                   # 🚀 Analysis Service (heavy ML)
 │   ├── src/sow_analysis/                #    Service package
 │   │   ├── main.py                      #    FastAPI app
+│   │   ├── config.py                    #    Pydantic settings
+│   │   ├── models.py                    #    Pydantic models
 │   │   ├── routes/                      #    API endpoints
-│   │   └── workers/                     #    Background workers
+│   │   │   ├── health.py
+│   │   │   └── jobs.py
+│   │   ├── storage/                     #    R2 and cache clients
+│   │   │   ├── cache.py
+│   │   │   ├── db.py                    #    SQLite job persistence
+│   │   │   └── r2.py
+│   │   └── workers/                     #    Background job processors
+│   │       ├── analyzer.py
+│   │       ├── lrc.py
+│   │       ├── queue.py
+│   │       ├── separator.py
+│   │       ├── stem_separation.py
+│   │       └── separator_wrapper.py
+│   ├── docker-compose.yml               #    Docker Compose config
+│   ├── Dockerfile                       #    Multi-platform Docker build
 │   └── README.md                        #    Service documentation
+│
+├── services/render-worker/              # ⚡ Render Worker (AWS Lambda)
+│   ├── src/sow_render_worker/           #    Worker package
+│   │   ├── lambda_handler.py            #    SQS event handler
+│   │   ├── config.py                    #    Env var loading
+│   │   ├── pipeline.py                  #    5-phase render orchestrator
+│   │   ├── audio_engine.py              #    FFmpeg audio mixing
+│   │   ├── video_engine.py              #    FFmpeg video encoding
+│   │   ├── frame_renderer.py            #    Pillow frame rendering
+│   │   ├── db.py                        #    psycopg2 DB operations
+│   │   └── r2_client.py                 #    boto3 R2 client
+│   ├── tests/                           #    Test suite
+│   ├── Dockerfile                       #    Lambda container image
+│   └── README.md                        #    Worker documentation
 │
 ├── poc/                                 # 🧪 POC Scripts (archived)
 │   ├── docker/                          #    POC Docker environments
@@ -310,12 +443,14 @@ sow_cli_admin/                           # Repository root
 
 ### Key Separation Points
 
-| Directory | Package Name | Purpose | Target Users | Deployment |
-|-----------|-------------|---------|--------------|------------|
-| `src/stream_of_worship/admin/` | `stream-of-worship-admin` | Backend management CLI | Admins / DevOps | `pip install` (admin) |
-| `src/stream_of_worship/app/` | `stream-of-worship-app` | End-user transition/video tool | Worship leaders | Desktop app / pip install |
-| `services/analysis/` | `sow-analysis` | Audio analysis microservice | Internal service | Docker image |
-| `poc/` | N/A (scripts) | Experimental validation | Developers | Local scripts only |
+| Directory | Package Name | Purpose | Target Users | Database | Deployment |
+|-----------|-------------|---------|--------------|----------|------------|
+| `src/stream_of_worship/admin/` | `stream-of-worship-admin` | Backend management CLI | Admins / DevOps | PostgreSQL (Neon) + R2 | `uv run --extra admin` |
+| `src/stream_of_worship/app/` | `stream-of-worship-app` | End-user TUI (DEPRECATED) | End users (legacy) | PostgreSQL (Neon) + R2 | `uv run --extra app` |
+| `services/analysis/` | `sow-analysis` | Audio analysis microservice | Internal service | SQLite (jobs only) + R2 | Docker image |
+| `webapp/` | `sow-webapp` | Web application | End users | PostgreSQL (Neon) + R2 | Vercel |
+| `services/render-worker/` | `sow-render-worker` | Render processing | Internal service | PostgreSQL (Neon) + R2 | Lambda container |
+| `poc/` | N/A (scripts) | Experimental validation | Developers | Local files only | Local scripts |
 
 ---
 
@@ -323,9 +458,9 @@ sow_cli_admin/                           # Repository root
 
 ### ✅ Phase 1: Foundation (Complete)
 - [x] CLI scaffold (Typer)
-- [x] Database schema (SQLite + Turso sync support)
+- [x] Database schema (PostgreSQL/Neon)
 - [x] Configuration (TOML)
-- [x] `db` command group (init, status, reset)
+- [x] `db` command group (init, status, url)
 
 ### ✅ Phase 2: Catalog Management (Complete)
 - [x] Web scraper for sop.org
@@ -340,61 +475,77 @@ sow_cli_admin/                           # Repository root
 - [x] `audio` command group (download, list, show)
 - [x] Recording metadata tracking
 
-### 🔄 Phase 4: Analysis Service (In Progress)
-- [ ] FastAPI service architecture
-- [ ] Job queue (in-memory for MVP, Redis later)
-- [ ] allin1 worker (tempo, key, beats, sections, embeddings)
-- [ ] Demucs worker (stem separation)
-- [ ] R2 stems upload
-- [ ] Docker deployment (x86_64 + ARM64 support)
-- [ ] CLI integration (`audio analyze`, `audio status`)
+### ✅ Phase 4: Analysis Service (Complete)
+- [x] FastAPI service architecture
+- [x] Job queue (in-memory + SQLite persistence)
+- [x] allin1 worker (tempo, key, beats, sections, embeddings)
+- [x] Demucs worker (stem separation)
+- [x] Clean vocals pipeline (MelBand Roformer + UVR-De-Echo)
+- [x] LRC generation (Whisper + LLM alignment + forced aligner)
+- [x] R2 stems upload
+- [x] Docker deployment (x86_64 + ARM64 support)
+- [x] CLI integration (`audio analyze`, `audio status`)
 
-### 📋 Phase 5: CLI ↔ Service Integration (Planned)
-- [ ] `audio analyze` command (submit jobs via HTTP)
-- [ ] `audio status` command (poll job status)
-- [ ] `audio results` command (fetch analysis results)
-- [ ] Retry logic and error handling
-- [ ] Progress indicators
+### ✅ Phase 5: CLI ↔ Service Integration (Complete)
+- [x] `audio analyze` command (submit jobs via HTTP)
+- [x] `audio status` command (poll job status)
+- [x] `audio lrc` command (submit LRC generation)
+- [x] `audio align-lrc` command (local forced alignment)
+- [x] Retry logic and error handling
+- [x] Progress indicators
 
-### 📋 Phase 6: LRC Generation (Planned)
-- [ ] Whisper transcription worker
-- [ ] LLM line alignment (GPT-4 / Claude)
-- [ ] LRC file generation
-- [ ] R2 LRC upload
-- [ ] `lyrics generate` command
-- [ ] `lyrics show` command
+### ✅ Phase 6: LRC Generation (Complete)
+- [x] Whisper transcription worker
+- [x] LLM line alignment (OpenAI-compatible API)
+- [x] Forced aligner refinement (Qwen3 Forced Aligner)
+- [x] LRC file generation and R2 upload
+- [x] `lyrics generate` command (via `audio lrc`)
+- [x] DashScope Qwen3 ASR integration (optional)
 
-### 📋 Phase 7: Turso Sync (Planned)
-- [ ] Turso cloud database setup
-- [ ] Bidirectional sync logic (Admin CLI ↔ Turso)
-- [ ] Conflict resolution
-- [ ] `db sync` command
-- [ ] Multi-device admin support
+### ✅ Phase 7: Database Migration to PostgreSQL/Neon (Complete)
+- [x] Migrated from Turso/SQLite to PostgreSQL (Neon)
+- [x] Admin CLI uses psycopg3 with ConnectionProvider
+- [x] Web App uses Drizzle ORM with Neon serverless driver
+- [x] Render Worker uses psycopg2 with connection string
+- [x] User App uses psycopg3 (migration status uncertain)
+- [x] Unified schema via `postgres_schema.py`
+- [x] Better Auth integration with drizzleAdapter
+- [x] pgvector for semantic search (song_embedding, song_line_embedding)
+- [x] Full-text search via tsvector with GIN index
+- [x] Removed old Turso sync infrastructure
 
-### ✅ Phase 8: User App Development (Complete)
-- [x] Textual TUI framework setup
-- [x] Turso client (read-only connection)
-- [x] R2 downloader (audio stems, LRC files)
-- [x] Song catalog browser screen
-- [x] Transition builder screen
-  - [x] Song selection with compatibility scores
-  - [x] Parameter adjustment (crossfade, tempo, key)
-  - [x] Real-time transition preview
-- [x] Lyrics video generator screen
-  - [x] LRC file loader
-  - [x] Template selection and styling
-  - [x] Video rendering with FFmpeg
-- [x] Export functionality (audio + video)
-- [x] `sow-app` command entry point
+### ✅ Phase 8: Web App (Complete)
+- [x] Next.js 16 App Router setup
+- [x] Drizzle ORM + Neon serverless driver
+- [x] Better Auth with drizzleAdapter
+- [x] Song catalog browser with full-text + semantic search
+- [x] Songset CRUD with transition configuration
+- [x] Render job submission and SSE progress tracking
+- [x] Playback controller with synchronized lyrics
+- [x] Second-screen projection (Presentation API + Google Cast)
+- [x] LRC lyrics review and editing
+- [x] Shareable public player links
+- [x] User settings and preferences
+- [x] Offline caching via Service Worker
+- [x] Vercel deployment with environment configuration
 
-### 📋 Phase 9: User App Enhancements (Future)
-- [ ] GUI version (PyQt or Electron)
-- [ ] Cloud rendering service (offload video generation)
-- [ ] Template marketplace (custom video templates)
-- [ ] Playlist scheduling (service planning)
-- [ ] Multi-output formats (720p, 1080p, 4K)
+### ✅ Phase 9: Render Worker (Complete)
+- [x] AWS Lambda container (Docker → ECR → Lambda)
+- [x] SQS event-driven job processing
+- [x] 5-phase render pipeline (preparing, mixing_audio, rendering_frames, encoding_video, uploading)
+- [x] PostgreSQL job status tracking
+- [x] Orphan job recovery
+- [x] REST mode for local development
+- [x] CJK font support for lyrics rendering
 
-**Current Focus:** Phase 4 - Analysis Service implementation
+### 📋 Future Enhancements
+- [ ] User App deprecation and removal
+- [ ] Enhanced semantic search with hybrid RRF ranking
+- [ ] Template marketplace for video templates
+- [ ] Multi-language support beyond Chinese
+- [ ] Real-time collaborative worship set editing
+
+**Current Focus:** Web App feature enhancements and stability
 
 ---
 
@@ -402,42 +553,66 @@ sow_cli_admin/                           # Repository root
 
 ### Admin CLI Configuration
 
-Create `~/.config/sow-admin/config.toml`:
+Create `~/.config/stream-of-worship-admin/config.toml`:
 
 ```toml
-[database]
-path = "/Users/you/.local/share/sow-admin/sow.db"
+[service]
+analysis_url = "http://localhost:8000"
 
 [r2]
-bucket = "your-r2-bucket"
-endpoint_url = "https://your-account.r2.cloudflarestorage.com"
+bucket = "stream-of-worship"
+endpoint_url = "https://<account-id>.r2.cloudflarestorage.com"
 region = "auto"
 
-[analysis_service]
-base_url = "http://localhost:8000"
+[database]
+url = "postgresql://sow_admin_rw@ep-xxx-pooler.us-east-1.aws.neon.tech/sow"
 ```
 
-Environment variables (take precedence):
+**Note:** The old `[turso]` config section is silently ignored for backward compatibility.
+
+**Required Environment Variables** (for sensitive credentials):
 ```bash
-export SOW_R2_BUCKET="your-bucket"
-export SOW_R2_ENDPOINT_URL="https://xxx.r2.cloudflarestorage.com"
-export SOW_R2_REGION="auto"
+# PostgreSQL password (Admin CLI - never store in config)
+export SOW_DATABASE_PASSWORD="your-database-password"
+
+# R2 credentials
 export SOW_R2_ACCESS_KEY_ID="your-access-key"
 export SOW_R2_SECRET_ACCESS_KEY="your-secret-key"
+
+# Analysis service API key
+export SOW_ANALYSIS_API_KEY="your-api-key"
 ```
 
-### Batch Operations
+**Note:** Non-sensitive settings like `database.url`, `r2.bucket`, and `r2.endpoint_url` should be configured in the config file. Only sensitive credentials use environment variables for security.
 
-The CLI uses `song_id` for easy batch operations:
+### Web App Configuration
 
+See [webapp/.env.production.example](webapp/.env.production.example) for full documentation of all environment variables.
+
+**Required:**
 ```bash
-# Download audio for all songs in an album
-sow-admin catalog list --album "敬拜讚美15" --format ids | \
-  xargs -I{} sow-admin audio download {}
+SOW_DATABASE_URL=postgresql://...       # Neon PostgreSQL connection string
+SOW_R2_BUCKET=stream-of-worship         # R2 bucket name
+SOW_R2_ENDPOINT_URL=https://...         # R2 endpoint
+SOW_R2_ACCESS_KEY_ID=...                # R2 access key
+SOW_R2_SECRET_ACCESS_KEY=...            # R2 secret key
+BETTER_AUTH_SECRET=...                  # Auth session signing secret
+BETTER_AUTH_URL=https://...             # Auth base URL
+NEXT_PUBLIC_BASE_URL=https://...        # Public app URL
+```
 
-# Analyze all songs pending analysis
-sow-admin audio list --status pending --format ids | \
-  xargs -I{} sow-admin audio analyze {}
+### Render Worker Configuration
+
+See [services/render-worker/.env.example](services/render-worker/.env.example).
+
+**Required:**
+```bash
+SOW_DATABASE_URL=postgresql://...       # Neon PostgreSQL connection string
+SOW_R2_BUCKET=stream-of-worship         # R2 bucket name
+SOW_R2_ENDPOINT_URL=https://...         # R2 endpoint
+SOW_R2_ACCESS_KEY_ID=...                # R2 access key
+SOW_R2_SECRET_ACCESS_KEY=...            # R2 secret key
+SOW_SQS_QUEUE_URL=https://...           # SQS queue URL
 ```
 
 ---
@@ -482,12 +657,27 @@ peaks = librosa.util.peak_pick(
 - Check `SOW_FORCED_ALIGNER_MODEL_PATH` environment variable
 - Check memory allocation (8GB minimum)
 
+### Database Issues
+
+**Problem:** Admin CLI can't connect to PostgreSQL
+- Verify `SOW_DATABASE_PASSWORD` environment variable is set
+- Check that the Neon connection URL is correct and not expired
+- Ensure Neon project is active and has available connections
+
+**Problem:** Web App can't connect to database
+- Verify `SOW_DATABASE_URL` is set correctly in `.env.local`
+- Check that the `vector` extension is enabled: `psql "$SOW_DATABASE_URL" -c 'CREATE EXTENSION IF NOT EXISTS vector;'`
+- Run `npx drizzle-kit push` to ensure schema is up to date
+
 ---
 
 ## Resources
 
 - **Design Document:** [specs/worship-music-transition-system-design.md](specs/worship-music-transition-system-design.md)
 - **Analysis Service:** [services/analysis/README.md](services/analysis/README.md)
+- **Render Worker:** [services/render-worker/README.md](services/render-worker/README.md)
+- **Web App:** [webapp/README.md](webapp/README.md)
+- **Admin CLI:** [src/stream_of_worship/admin/README.md](src/stream_of_worship/admin/README.md)
 - **librosa Documentation:** https://librosa.org/doc/latest/
 
 ---
@@ -497,9 +687,9 @@ peaks = librosa.util.peak_pick(
 1. Fork the repository
 2. Create a feature branch
 3. Make your changes
-4. Run tests: `PYTHONPATH=src uv run pytest tests/`
+4. Run tests: `PYTHONPATH=src uv run --extra app --extra test pytest tests/ -v`
 5. Submit a pull request
 
 ---
 
-**Last Updated:** 2025-12-30
+**Last Updated:** 2026-06-20

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -2,6 +2,8 @@
 
 - R2 backup throughput investigation closed. 32-worker concurrency bump (commit ea397e7) regressed throughput 7.3 → 5.0 MiB/s. Reverted DEFAULT_CONCURRENCY to 8; kept as_completed / size-sort / tracer / range-GET diagnostic / read_timeout=300. Account-level R2 cap at ~7 MiB/s confirmed via --diag-range-key (ratio=2.41). <10 min backup goal for 12.9 GB closed as not feasible within local Python CLI architecture; reopening requires Cloudflare Worker backup or bucket size reduction. See specs/admin-r2-backup-throughput-remediation-v2.md.
 
+- **R2 backup rclone path benchmarked and REJECTED.** Per specs/admin-r2-backup-rclone-download-v1.md Step 1c, ran mandatory pre-implementation benchmarks: boto3 single conn = 7.85 MiB/s, rclone single file = 4.07 MiB/s, rclone multi-file (8 transfers) = 5.68 MiB/s. rclone achieves only 0.52×–0.72× the boto3 baseline, well below the 1.2× proceed threshold. The cap is confirmed R2-account-level, not boto3-specific. Fixes 1-7 from the spec are NOT implemented. Full results recorded in reports/admin-r2-backup-rclone-download-v1-results.md.
+
 
 - Addressed PR #104 review feedback by hardening LRC language/script mismatch warnings against missing or non-string lyric payloads, preserving the legacy `lyrics.lrc` R2 alias for renderers, and adding regression coverage.
 - Implemented `catalog-insert-youtube-v2` for the admin CLI.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -4,6 +4,16 @@
 
 - **R2 backup rclone path benchmarked and REJECTED.** Per specs/admin-r2-backup-rclone-download-v1.md Step 1c, ran mandatory pre-implementation benchmarks: boto3 single conn = 7.85 MiB/s, rclone single file = 4.07 MiB/s, rclone multi-file (8 transfers) = 5.68 MiB/s. rclone achieves only 0.52×–0.72× the boto3 baseline, well below the 1.2× proceed threshold. The cap is confirmed R2-account-level, not boto3-specific. Fixes 1-7 from the spec are NOT implemented. Full results recorded in reports/admin-r2-backup-rclone-download-v1-results.md.
 
+- R2 backup default concurrency reverted 8 → 1. The v1 rclone benchmark
+  (reports/admin-r2-backup-rclone-download-v1-results.md) confirmed a single
+  connection now saturates the R2 account-level cap: boto3 single-conn
+  7.85 MiB/s vs 4-range parallel 6.54 MiB/s (ratio=0.83, parallel HURTS;
+  v2 trace had ratio=2.41). Tightened --concurrency max 64 → 5 and
+  max_pool_connections 64 → 5 to match. Concurrency machinery
+  (ThreadPoolExecutor, as_completed, size-sort, BackupTracer,
+  range_get_throughput_diag) retained for experimentation; run
+  --diag-range-key before raising --concurrency above 1.
+
 
 - Addressed PR #104 review feedback by hardening LRC language/script mismatch warnings against missing or non-string lyric payloads, preserving the legacy `lyrics.lrc` R2 alias for renderers, and adding regression coverage.
 - Implemented `catalog-insert-youtube-v2` for the admin CLI.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,6 +1,7 @@
-# Project Memory
+## 2026-06-20
 
-## 2026-06-15
+- R2 backup throughput investigation closed. 32-worker concurrency bump (commit ea397e7) regressed throughput 7.3 → 5.0 MiB/s. Reverted DEFAULT_CONCURRENCY to 8; kept as_completed / size-sort / tracer / range-GET diagnostic / read_timeout=300. Account-level R2 cap at ~7 MiB/s confirmed via --diag-range-key (ratio=2.41). <10 min backup goal for 12.9 GB closed as not feasible within local Python CLI architecture; reopening requires Cloudflare Worker backup or bucket size reduction. See specs/admin-r2-backup-throughput-remediation-v2.md.
+
 
 - Addressed PR #104 review feedback by hardening LRC language/script mismatch warnings against missing or non-string lyric payloads, preserving the legacy `lyrics.lrc` R2 alias for renderers, and adding regression coverage.
 - Implemented `catalog-insert-youtube-v2` for the admin CLI.

--- a/report/current_impl_status.md
+++ b/report/current_impl_status.md
@@ -1,0 +1,7 @@
+2026-06-20: R2 backup throughput investigation closed. 32-worker concurrency bump
+   (commit ea397e7) regressed throughput 7.3 → 5.0 MiB/s. Reverted DEFAULT_CONCURRENCY
+   to 8; kept as_completed / size-sort / tracer / range-GET diagnostic / read_timeout=300.
+   Account-level R2 cap at ~7 MiB/s confirmed via --diag-range-key (ratio=2.41).
+   <10 min backup goal for 12.9 GB closed as not feasible within local Python CLI
+   architecture; reopening requires Cloudflare Worker backup or bucket size reduction.
+   See specs/admin-r2-backup-throughput-remediation-v2.md.

--- a/report/current_impl_status.md
+++ b/report/current_impl_status.md
@@ -5,3 +5,13 @@
    <10 min backup goal for 12.9 GB closed as not feasible within local Python CLI
    architecture; reopening requires Cloudflare Worker backup or bucket size reduction.
    See specs/admin-r2-backup-throughput-remediation-v2.md.
+
+2026-06-20: R2 backup default concurrency reverted 8 → 1. The v1 rclone benchmark
+   (reports/admin-r2-backup-rclone-download-v1-results.md) confirmed a single
+   connection now saturates the R2 account-level cap: boto3 single-conn
+   7.85 MiB/s vs 4-range parallel 6.54 MiB/s (ratio=0.83, parallel HURTS;
+   v2 trace had ratio=2.41). Tightened --concurrency max 64 → 5 and
+   max_pool_connections 64 → 5 to match. Concurrency machinery
+   (ThreadPoolExecutor, as_completed, size-sort, BackupTracer,
+   range_get_throughput_diag) retained for experimentation; run
+   --diag-range-key before raising --concurrency above 1.

--- a/reports/admin-r2-backup-rclone-download-v1-results.md
+++ b/reports/admin-r2-backup-rclone-download-v1-results.md
@@ -1,0 +1,126 @@
+# Admin R2 Backup rclone Download Path v1 — Benchmark Results
+
+**Date:** 2026-06-20
+**Status:** STOP — rclone does not outperform boto3; cap is R2-account-level
+**Decision:** Per `specs/admin-r2-backup-rclone-download-v1.md` Step 1c, do NOT implement Fixes 1-7
+
+## Summary
+
+The mandatory pre-implementation benchmark was executed. **rclone does not achieve a ≥1.2x improvement over the boto3 baseline.** In fact, rclone is **slower** than boto3 for both single-file and multi-file downloads on the `stream-of-worship` R2 bucket from the test environment. This confirms the hypothesis that the ~5–7 MiB/s aggregate throughput is an **R2 account/bucket-level cap**, not a boto3-specific artifact.
+
+## Benchmark Environment
+
+- **Host:** macOS 15.7.5 (Apple Silicon, arm64)
+- **Network:** Residential broadband (location: Taiwan)
+- **rclone version:** v1.74.3
+- **boto3 version:** (bundled with project dependencies)
+- **R2 bucket:** `stream-of-worship`
+- **R2 endpoint:** `https://6c80769fe5aa4be53908b83c3d0454cd.r2.cloudflarestorage.com`
+- **Test object:** `d48247f4fb2f/stems/vocals.wav` (65.745 MiB)
+- **Total bucket size:** ~12.9 GB, ~679 objects
+
+## Results
+
+### 1a. boto3 baseline — Range-GET diagnostic
+
+```bash
+sow-admin maintenance backup-r2 \
+  --output /tmp/sow-r2-baseline-boto3 \
+  --chunk-size 5GiB --concurrency 8 \
+  --diag-range-key d48247f4fb2f/stems/vocals.wav
+```
+
+```json
+{
+  "content_length": 68938108,
+  "num_ranges": 4,
+  "single_conn_mbps": 7.85,
+  "multi_conn_total_mbps": 6.54,
+  "ratio": 0.83,
+  "per_range_mbps": [1.77, 3.81, 1.71, 1.64]
+}
+```
+
+**Interpretation:**
+- Single connection: **7.85 MiB/s**
+- 4 parallel Range-GETs: **6.54 MiB/s aggregate** (ratio 0.83)
+- The ratio **< 1.0** means parallel connections actually *hurt* throughput — the network path is already saturated by a single connection. This is the opposite of the v2 remediation spec's earlier finding (ratio=2.41), indicating network conditions have changed (now saturated rather than per-connection-capped).
+
+### 1b. rclone pure reference — single file
+
+```bash
+rclone copy sow_r2:stream-of-worship/d48247f4fb2f/stems/vocals.wav /tmp/rclone-bench \
+  --transfers 1 --checkers 1 --stats 1s --progress
+```
+
+| Metric | Value |
+|---|---|
+| File size | 65.745 MiB |
+| Elapsed time | 15.9 s |
+| Average throughput | **4.07 MiB/s** |
+
+### 1c. rclone with multi-thread streams (parallel Range-GETs)
+
+```bash
+rclone copy ... --multi-thread-streams 8 --multi-thread-cutoff 1M --multi-thread-chunk-size 8M
+```
+
+| Metric | Value |
+|---|---|
+| Elapsed time | 22.4 s |
+| Average throughput | **2.96 MiB/s** |
+
+**Multi-thread streams made throughput WORSE** (2.96 vs 4.07 MiB/s). The parallel streams contend for the same saturated network pipe.
+
+### 1d. rclone multi-file aggregate (8 transfers)
+
+```bash
+rclone copy sow_r2:stream-of-worship /tmp/rclone-bench-multi \
+  --include "*/audio.mp3" --max-depth 2 --fast-list \
+  --transfers 8 --checkers 16 --stats 2s --progress
+```
+
+| Metric | Value |
+|---|---|
+| Total transferred | 738.825 MiB (108 files) |
+| Elapsed time | 1m 56.2s |
+| Average throughput | **5.68 MiB/s** |
+
+## Comparative Analysis
+
+| Backend | Throughput (MiB/s) | vs boto3 single conn |
+|---|---|---|
+| boto3 single conn (diag) | **7.85** | 1.00× (baseline) |
+| boto3 multi conn (4 Range-GETs) | **6.54** | 0.83× |
+| rclone single file | **4.07** | 0.52× |
+| rclone multi-thread streams | **2.96** | 0.38× |
+| rclone multi-file (8 transfers) | **5.68** | 0.72× |
+
+**Conclusion:** rclone achieves **0.38×–0.72×** the boto3 baseline throughput. It is consistently slower across all tested configurations.
+
+## Decision Rationale
+
+Per `specs/admin-r2-backup-rclone-download-v1.md` Step 1c:
+
+> | If ref-rclone achieves... | Then... |
+> |---|---|
+> | <1.2x baseline-boto3 throughput | **Stop.** The cap is R2-account-level, not boto3-specific. |
+
+The rclone reference (best case: 5.68 MiB/s multi-file) is **0.72× the boto3 baseline (7.85 MiB/s)**, well below the 1.2× threshold. Therefore:
+
+1. **No production code is implemented.** Fixes 1-7 from the spec are abandoned.
+2. **The throughput cap is confirmed to be R2-account-level.** Neither boto3 tuning nor rclone can break it from this client/network path.
+3. **The boto3 path remains the sole backup backend.** It is faster, has no external binary dependency, and is already well-tested.
+
+## Out of Scope (reaffirmed)
+
+- aiobotocore async rewrite
+- boto3 TransferConfig tuning
+- Cloudflare Worker in-network backup
+- Promoting rclone to default backend
+
+## References
+
+- `specs/admin-r2-backup-rclone-download-v1.md` — this spec
+- `specs/admin-r2-backup-throughput-remediation-v2.md` — predecessor closure spec
+- `src/stream_of_worship/admin/services/r2_backup.py` — existing boto3 backup path (unchanged)

--- a/reports/current_impl_status.md
+++ b/reports/current_impl_status.md
@@ -1045,7 +1045,11 @@ test = [
 - Phase 10: Lambda Render Worker Migration
 - Phase 11: `029b7f5` - Simplify Render Progress Notification v2
 
-### Latest Update - 2026-06-17
+### Latest Update - 2026-06-20
+
+- **R2 backup rclone download path benchmarked and rejected.** Per `specs/admin-r2-backup-rclone-download-v1.md` Step 1c, executed mandatory pre-implementation benchmarks before writing any production code. Results: boto3 single conn = 7.85 MiB/s; rclone single file = 4.07 MiB/s; rclone multi-file (8 transfers) = 5.68 MiB/s. rclone achieves only 0.52×–0.72× the boto3 baseline, well below the 1.2× proceed threshold. Confirms the throughput cap is R2-account-level, not boto3-specific. Fixes 1-7 from the spec are NOT implemented. Full benchmark report: `reports/admin-r2-backup-rclone-download-v1-results.md`.
+
+### Previous Update - 2026-06-17
 
 - Addressed PR #108 second-round review feedback for admin soft-delete/R2 maintenance.
 - `purge-soft-deletes --confirm` now hard-deletes the DB row before R2 deletion, skips R2 when the DB delete is blocked or stale, and reports R2 cleanup failures in the manifest.

--- a/specs/admin-r2-backup-concurrent-downloads-v1.md
+++ b/specs/admin-r2-backup-concurrent-downloads-v1.md
@@ -1,0 +1,577 @@
+# Admin R2 Backup: Concurrent Downloads + GET-ETag Consistency
+
+## Summary
+
+Speed up the `sow-admin maintenance backup-r2` command by at least 5x through:
+1. **Thread pool concurrent downloads** (dominant win: 5-8x network parallelism)
+2. **Eliminate redundant post-download HEAD requests** (~1.5-2x for small objects)
+3. **Larger `copyfileobj` buffer** (minor: ~1.1x for large objects)
+4. **Increased boto3 connection pool** (supporting)
+
+Current performance: ~30 minutes for 679 objects / 12,894 MB (~8 MB/s single connection).
+Target: ~4-6 minutes with 8 concurrent workers.
+
+## Bottleneck Analysis
+
+### Bottleneck 1: Fully Sequential Downloads (DOMINANT)
+
+**Location:** `write_backup()` at `r2_backup.py:417`
+
+```python
+for idx, inv_obj in enumerate(inventory.objects):
+    obj_entry = _download_object_to_tar(r2_client, inv_obj, current_tar, member_name)
+```
+
+Every object is downloaded one at a time. A single connection to R2 yields ~8 MB/s.
+Cloudflare R2 supports much higher aggregate throughput across multiple connections.
+With 679 sequential operations, there is zero network parallelism.
+
+### Bottleneck 2: Redundant HEAD Request Per Object
+
+**Location:** `_download_object_to_tar()` at `r2_backup.py:289`
+
+```python
+head_data = r2_client.head_object(inv_obj.key)
+```
+
+After downloading each object, a separate HEAD request checks consistency. This doubles
+network round-trips: 679 GET + 679 HEAD = 1,358 requests.
+
+The `get_object_stream()` response (`r2.py:726-737`) already returns `etag`,
+`content_length`, `content_type`, `cache_control`, `content_disposition`,
+`content_encoding`, `metadata`, and `last_modified`. The HEAD is almost entirely
+redundant.
+
+### Bottleneck 3: Small `copyfileobj` Buffer
+
+**Location:** `r2_backup.py:272` — `shutil.copyfileobj(hashing_reader, temp_file)` uses
+the default 16 KB buffer. For 40 MB audio files, that's ~2,500 syscalls per file.
+
+### Bottleneck 4: boto3 Connection Pool (supporting)
+
+**Location:** `r2.py:101-105` — Default `max_pool_connections=10`. Adequate for 8 workers
+but should be increased for headroom.
+
+## HEAD vs GET-ETag Trade-off
+
+| Aspect | Separate HEAD (current) | GET Response ETag (proposed) |
+|--------|------------------------|------------------------------|
+| Network requests per object | 2 (GET + HEAD) | 1 (GET only) |
+| Total requests for 679 objects | 1,358 | 679 |
+| Latency overhead per small object | +50-100ms | 0ms |
+| Total latency overhead (small objects) | ~17-34 seconds | 0 seconds |
+| Metadata source | HEAD response | GET response (identical fields) |
+| Catches object change *during* GET | Yes (narrow race, ms window) | No |
+| Catches object change *since* inventory | Yes | Yes (GET ETag vs inventory ETag) |
+| Consistency guarantee | Object unchanged between GET-end and HEAD | Object ETag at download time matches inventory |
+
+**Key insight:** The GET response ETag IS the ETag of the bytes actually received. The
+HEAD only adds value if the object changes in the milliseconds between GET completion and
+HEAD completion — an extremely rare race that doesn't affect backup integrity (you still
+captured a valid, self-consistent snapshot).
+
+## Files to Modify
+
+1. `src/stream_of_worship/admin/services/r2_backup.py` — Core changes
+2. `src/stream_of_worship/admin/services/r2.py` — Connection pool config
+3. `src/stream_of_worship/admin/commands/maintenance.py` — `--concurrency` CLI flag
+4. `tests/admin/test_r2_backup.py` — Update tests for new download flow
+5. `tests/admin/test_r2_backup_commands.py` — Update command tests
+
+---
+
+## Change A: Thread Pool Concurrent Downloads (`r2_backup.py`)
+
+### A.1 New constants
+
+```python
+DEFAULT_CONCURRENCY = 8
+COPY_BUFFER_SIZE = 1024 * 1024  # 1 MB
+```
+
+### A.2 New `DownloadResult` dataclass
+
+```python
+@dataclass
+class DownloadResult:
+    """Result of downloading a single object to a temp file."""
+    temp_path: Path
+    sha256: str
+    bytes_read: int
+    metadata: dict  # content_type, cache_control, content_disposition, content_encoding, metadata
+```
+
+### A.3 Refactor `_download_object_to_tar()` -> `_download_object_to_tempfile()`
+
+Decouple downloading from tar writing. The new function:
+- Downloads to a temp file with 1 MB buffer (`shutil.copyfileobj(..., length=COPY_BUFFER_SIZE)`)
+- Validates short read and size mismatch (unchanged logic)
+- Validates ETag from **GET response** against inventory (replaces HEAD — see Change B)
+- Returns a `DownloadResult` (temp_path, sha256, bytes_read, metadata_dict)
+- Does NOT write to tar (decoupled)
+- Retry logic unchanged (ETag mismatch still triggers retry)
+
+```python
+def _download_object_to_tempfile(
+    r2_client: R2Client,
+    inv_obj: InventoryObject,
+    max_retries: int = 2,
+) -> DownloadResult:
+    """Download a single object to a temp file with consistency checking.
+
+    Downloads to a temporary file, validates ETag from GET response against
+    inventory, and returns the temp path + hash + metadata.
+
+    Raises:
+        BackupError: If the object cannot be captured consistently.
+    """
+    import tempfile
+
+    last_error: Optional[str] = None
+    for attempt in range(max_retries + 1):
+        temp_path: Optional[Path] = None
+        try:
+            resp = r2_client.get_object_stream(inv_obj.key)
+            body = resp["body"]
+            content_length = resp["content_length"]
+            get_etag = resp["etag"]
+
+            try:
+                with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+                    temp_path = Path(temp_file.name)
+                    hashing_reader = HashingReader(body)
+                    shutil.copyfileobj(hashing_reader, temp_file, length=COPY_BUFFER_SIZE)
+
+                if hashing_reader.bytes_read != content_length:
+                    raise BackupError(
+                        f"Short read for {inv_obj.key}: expected {content_length} bytes, "
+                        f"got {hashing_reader.bytes_read}"
+                    )
+
+                if hashing_reader.bytes_read != inv_obj.size:
+                    raise BackupError(
+                        f"Size mismatch for {inv_obj.key}: inventory says {inv_obj.size}, "
+                        f"downloaded {hashing_reader.bytes_read}"
+                    )
+
+                # ETag consistency check from GET response (replaces separate HEAD)
+                if get_etag != inv_obj.etag:
+                    raise BackupError(
+                        f"Object {inv_obj.key} ETag changed: inventory {inv_obj.etag}, "
+                        f"download {get_etag}"
+                    )
+
+                sha256 = hashing_reader.sha256_hex
+
+                metadata = {
+                    "content_type": resp.get("content_type"),
+                    "cache_control": resp.get("cache_control"),
+                    "content_disposition": resp.get("content_disposition"),
+                    "content_encoding": resp.get("content_encoding"),
+                    "metadata": resp.get("metadata") or {},
+                }
+
+                return DownloadResult(
+                    temp_path=temp_path,
+                    sha256=sha256,
+                    bytes_read=hashing_reader.bytes_read,
+                    metadata=metadata,
+                )
+            finally:
+                body.close()
+
+        except (BackupError, ClientError) as e:
+            last_error = str(e)
+            if temp_path is not None:
+                try:
+                    temp_path.unlink()
+                except OSError:
+                    pass
+            if attempt < max_retries:
+                continue
+            raise BackupError(
+                f"Failed to backup {inv_obj.key} after retries: {last_error}"
+            ) from e
+
+    raise BackupError(f"Failed to backup {inv_obj.key} after retries: {last_error}")
+```
+
+### A.4 Modify `write_backup()` — concurrent download + sequential tar write
+
+New parameter: `concurrency: int = DEFAULT_CONCURRENCY`
+
+Design:
+- Use `ThreadPoolExecutor(max_workers=concurrency)`
+- Submit all download tasks as futures (each calls `_download_object_to_tempfile`)
+- Process futures **in submission order**: `future.result()` -> write to tar -> delete temp file
+- Chunk rotation logic stays in main thread (uses `inv_obj.size` from inventory, known before download)
+- Error handling: on failure, cancel remaining futures, clean up temp files, clean up partial dir
+- `on_progress` callback invoked after each object is written to tar (unchanged semantics)
+
+```python
+def write_backup(
+    r2_client: R2Client,
+    output_dir: Path,
+    inventory: Inventory,
+    chunk_size_bytes: int = DEFAULT_CHUNK_SIZE_BYTES,
+    concurrency: int = DEFAULT_CONCURRENCY,
+    on_progress: Optional[Callable[[int, int], None]] = None,
+) -> BackupResult:
+    # ... existing validation, disk space check, partial_dir setup ...
+
+    try:
+        from concurrent.futures import ThreadPoolExecutor
+
+        manifest_objects: list[dict] = []
+        chunk_index = 0
+        current_chunk_bytes = 0
+        current_tar: Optional[tarfile.TarFile] = None
+
+        def _ensure_tar():
+            nonlocal current_tar
+            if current_tar is None:
+                current_tar = tarfile.open(_chunk_path(partial_dir, chunk_index), "w")
+
+        def _rotate_chunk():
+            nonlocal current_tar, chunk_index, current_chunk_bytes
+            if current_tar is not None:
+                current_tar.close()
+                current_tar = None
+            chunk_index += 1
+            current_chunk_bytes = 0
+
+        bytes_completed = 0
+
+        with ThreadPoolExecutor(max_workers=concurrency) as executor:
+            # Submit all downloads as futures, keyed by index
+            futures = {
+                idx: executor.submit(_download_object_to_tempfile, r2_client, inv_obj)
+                for idx, inv_obj in enumerate(inventory.objects)
+            }
+
+            for idx, inv_obj in enumerate(inventory.objects):
+                member_name = _member_name_for_index(idx)
+
+                # Chunk rotation (uses inventory size, known before download)
+                if (
+                    current_chunk_bytes > 0
+                    and current_chunk_bytes + inv_obj.size > chunk_size_bytes
+                ):
+                    _rotate_chunk()
+
+                _ensure_tar()
+
+                # Wait for this object's download to complete (in order)
+                future = futures[idx]
+                try:
+                    download_result = future.result()
+                except BackupError:
+                    # Cancel remaining futures
+                    for f in futures.values():
+                        f.cancel()
+                    raise
+
+                try:
+                    # Write to tar from temp file
+                    tar_info = tarfile.TarInfo(name=member_name)
+                    tar_info.size = download_result.bytes_read
+                    tar_info.mtime = 0
+                    tar_info.mode = 0o644
+                    tar_info.type = tarfile.REGTYPE
+
+                    with open(download_result.temp_path, "rb") as f_in:
+                        tar.addfile(tar_info, f_in)
+
+                    obj_entry = _build_manifest_object(
+                        inv_obj, member_name, download_result.sha256, chunk_index,
+                        download_result.metadata,
+                    )
+                    manifest_objects.append(obj_entry)
+                    current_chunk_bytes += inv_obj.size
+                    bytes_completed += inv_obj.size
+
+                    if on_progress is not None:
+                        on_progress(idx + 1, bytes_completed)
+                finally:
+                    try:
+                        download_result.temp_path.unlink()
+                    except OSError:
+                        pass
+
+        if current_tar is not None:
+            current_tar.close()
+            current_tar = None
+
+        # ... existing manifest write, rename, return ...
+```
+
+**Design notes:**
+- Downloads happen in parallel (up to `concurrency` at a time).
+- Tar writing happens sequentially in submission order (tar format requires sequential writes).
+- At most `concurrency` temp files exist simultaneously (~320 MB for 8 x 40 MB).
+- Chunk rotation uses `inv_obj.size` from inventory (known before download starts), so
+  rotation decisions are deterministic and don't depend on download results.
+- `on_progress` is called after each object is written to tar, preserving existing semantics.
+
+### A.5 Update manifest consistency mode
+
+```python
+"consistency": {
+    "mode": "initial-inventory-with-get-etag-check",
+    "max_changed_object_retries": 2,
+},
+```
+
+No `MANIFEST_VERSION` bump needed (structure unchanged, `consistency.mode` is metadata only).
+
+---
+
+## Change B: Eliminate Redundant HEAD Request (`r2_backup.py`)
+
+The HEAD request in `_download_object_to_tar()` (line 289) is replaced by ETag
+validation from the GET response in the new `_download_object_to_tempfile()` (see A.3).
+
+The GET response from `get_object_stream()` (`r2.py:726-737`) returns all the same
+metadata fields that the HEAD returned:
+- `etag` -> used for consistency check
+- `content_type`, `cache_control`, `content_disposition`, `content_encoding`, `metadata`
+  -> stored in manifest for restore
+
+The `_build_manifest_object()` helper (`r2_backup.py:208`) is called with the GET
+response metadata instead of HEAD data. Its signature is unchanged.
+
+---
+
+## Change C: Larger `copyfileobj` Buffer (`r2_backup.py`)
+
+In `_download_object_to_tempfile()`:
+
+```python
+shutil.copyfileobj(hashing_reader, temp_file, length=COPY_BUFFER_SIZE)
+```
+
+Reduces syscalls by 64x for large files (16 KB -> 1 MB buffer).
+
+---
+
+## Change D: Increase boto3 Connection Pool (`r2.py`)
+
+```python
+self._client = boto3.client(
+    "s3",
+    endpoint_url=endpoint_url,
+    aws_access_key_id=access_key,
+    aws_secret_access_key=secret_key,
+    region_name=region,
+    config=Config(
+        connect_timeout=10,
+        read_timeout=30,
+        retries={"max_attempts": 2},
+        max_pool_connections=32,
+    ),
+)
+```
+
+Default is 10. With 8 concurrent workers, 32 provides headroom for retries and
+connection reuse.
+
+---
+
+## Change E: `--concurrency` CLI Flag (`maintenance.py`)
+
+### E.1 Add option to `backup_r2` command
+
+```python
+@app.command("backup-r2")
+def backup_r2(
+    output: Path = typer.Option(..., "--output", help="Output directory for backup"),
+    chunk_size: str = typer.Option(
+        "10GiB", "--chunk-size", help="Chunk size (e.g. 10GiB, 500MiB, raw bytes)"
+    ),
+    concurrency: int = typer.Option(
+        8, "--concurrency", min=1, max=64,
+        help="Number of concurrent download workers"
+    ),
+    format_: str = typer.Option("table", "--format", help="table|json"),
+    config_path: Optional[Path] = typer.Option(None, "--config", "-c"),
+) -> None:
+```
+
+### E.2 Pass to `write_backup()`
+
+```python
+result = write_backup(
+    r2_client=r2_client,
+    output_dir=output,
+    inventory=inventory,
+    chunk_size_bytes=chunk_size_bytes,
+    concurrency=concurrency,
+    on_progress=_on_progress,
+)
+```
+
+---
+
+## Change F: Test Updates
+
+### F.1 `test_r2_backup.py`
+
+**`_make_r2_mock()` helper:** Already returns all metadata fields in GET response
+(`content_type`, `cache_control`, etc.). No change needed.
+
+**Tests that assert HEAD was called:** The following tests use `r2.head_object` to
+simulate consistency changes. These need to be updated to use `r2.get_object_stream`
+ETag instead:
+
+- `test_backup_changed_object_retries_and_succeeds` — currently uses flaky HEAD;
+  change to flaky GET ETag (first GET returns different etag, second returns matching)
+- `test_backup_changed_object_exceeds_retries_fails` — currently HEAD always returns
+  different etag; change to GET always returning different etag
+- `test_backup_deleted_object_during_backup_fails` — currently HEAD returns None;
+  change to GET raising ClientError 404
+
+**New tests to add:**
+
+```python
+class TestConcurrentBackup:
+    def test_concurrent_backup_produces_valid_archive(self, tmp_path):
+        """Concurrent download with default concurrency produces valid backup."""
+        # 20 objects, verify manifest + chunks + SHA-256
+
+    def test_concurrency_1_works(self, tmp_path):
+        """concurrency=1 falls back to sequential (no thread pool issues)."""
+
+    def test_concurrent_backup_preserves_object_order(self, tmp_path):
+        """Manifest objects are in inventory order regardless of download completion order."""
+        # Use a mock where later objects download faster than earlier ones
+
+    def test_concurrent_backup_cleans_up_temp_files(self, tmp_path):
+        """No temp files remain after successful backup."""
+
+    def test_concurrent_backup_cleans_up_temp_files_on_failure(self, tmp_path):
+        """Temp files are cleaned up when backup fails mid-way."""
+
+    def test_concurrent_backup_failure_cancels_remaining(self, tmp_path):
+        """On failure, remaining futures are cancelled and partial dir cleaned up."""
+```
+
+**Existing tests that should pass unchanged:**
+- `test_backup_creates_manifest_and_chunks`
+- `test_backup_empty_bucket`
+- `test_backup_chunk_boundary`
+- `test_backup_large_object_exceeds_chunk`
+- `test_backup_refuses_existing_output`
+- `test_backup_refuses_existing_partial`
+- `test_backup_short_read_fails`
+- `test_backup_preserves_metadata`
+- `test_backup_cleanup_on_interrupt`
+- `test_on_progress_called_with_correct_counts`
+- All `TestVerifyArchive` tests
+- All `TestPlanRestore` tests
+- All `TestRestoreFromArchive` tests
+
+### F.2 `test_r2_backup_commands.py`
+
+**New test:**
+
+```python
+def test_backup_concurrency_flag(self, tmp_path):
+    """backup-r2 --concurrency 4 passes concurrency to write_backup."""
+```
+
+**Existing tests:** Should pass unchanged. The mock `_make_r2_mock()` already returns
+GET response with all metadata fields.
+
+---
+
+## Expected Performance
+
+| Optimization | Estimated Speedup | Primary Benefit |
+|-------------|-------------------|-----------------|
+| Thread pool (8 workers) | 5-8x | Network parallelism |
+| Eliminate HEAD | 1.5-2x | Small object latency |
+| Larger buffer | 1.1x | Large object disk I/O |
+| **Combined (conservative)** | **~5-8x** | **30 min -> ~4-6 min** |
+
+The thread pool is the dominant win. With 8 concurrent R2 connections, aggregate
+throughput should scale well beyond single-connection 8 MB/s.
+
+---
+
+## Edge Cases and Considerations
+
+1. **Empty bucket:** `concurrency` doesn't matter; no futures submitted, completes immediately.
+
+2. **Single object:** `concurrency=8` but only 1 future; no overhead from thread pool.
+
+3. **`concurrency=1`:** Falls back to effectively sequential behavior (1 worker). Useful
+   for debugging or when R2 throttles parallel connections.
+
+4. **Temp file disk usage:** At most `concurrency` temp files exist simultaneously.
+   For 8 workers x 40 MB audio = ~320 MB peak. The disk space check
+   (`total_bytes * 1.1 + 50MiB`) already accounts for the final archive; temp files
+   are transient and deleted as they're consumed. Consider increasing the disk space
+   check to `total_bytes * 1.1 + concurrency * max_object_size + 50MiB` if the largest
+   objects are very large.
+
+5. **Thread safety of boto3:** boto3 clients are thread-safe for S3 operations.
+   The `ThreadPoolExecutor` shares a single `R2Client` (and thus a single boto3 client)
+   across workers. boto3's connection pool (`max_pool_connections=32`) handles
+   concurrent requests.
+
+6. **Tar writing stays sequential:** The tar format requires sequential member writes.
+   Only downloads are parallelized; tar writing happens in the main thread in
+   submission order.
+
+7. **Error propagation:** If any download fails, the main thread cancels remaining
+   futures, cleans up temp files, and cleans up the partial directory. The
+   `ThreadPoolExecutor` context manager ensures all threads are joined before exit.
+
+8. **Progress callback:** Called after each object is written to tar (not after download).
+   This preserves existing semantics: progress reflects committed bytes in the archive.
+
+9. **Manifest `consistency.mode`:** Changes from
+   `"initial-inventory-with-post-download-head-check"` to
+   `"initial-inventory-with-get-etag-check"`. This is metadata only; no manifest
+   version bump needed. `verify_archive()` and `restore_from_archive()` don't read
+   this field.
+
+10. **Retry behavior:** Unchanged. ETag mismatch from GET response triggers the same
+    retry loop as the previous HEAD-based check. The retry budget (`max_retries=2`)
+    is preserved.
+
+---
+
+## Verification
+
+```bash
+# Run R2 backup tests
+PYTHONPATH=src uv run --python 3.11 --extra app --extra test pytest \
+  tests/admin/test_r2_backup.py tests/admin/test_r2_backup_commands.py -v
+
+# Run all admin tests
+PYTHONPATH=src uv run --python 3.11 --extra app --extra test pytest tests/admin/ -v
+
+# Manual smoke test (requires R2 credentials)
+uv run --extra admin sow-admin maintenance backup-r2 \
+  --output /tmp/sow-r2-backup-test \
+  --concurrency 8 \
+  -c ~/.config/stream-of-worship-admin/config.toml
+```
+
+---
+
+## Assumptions and Out of Scope
+
+**Assumptions:**
+- boto3 S3 client is thread-safe for concurrent `get_object` calls (confirmed by boto3 docs).
+- Cloudflare R2 supports multiple concurrent connections with higher aggregate throughput.
+- Temp files are kept (per user decision); streaming directly to tar is out of scope.
+
+**Out of scope:**
+- Streaming directly to tar (user chose to keep temp files).
+- Async/asyncio implementation (threads are simpler and sufficient for I/O-bound work).
+- Compression of backup archives.
+- Incremental or differential backups.
+- Bandwidth limiting.
+- Restore-side concurrency (restore is upload-bound, different bottleneck).

--- a/specs/admin-r2-backup-concurrent-downloads-v2.md
+++ b/specs/admin-r2-backup-concurrent-downloads-v2.md
@@ -1,0 +1,792 @@
+# Admin R2 Backup: Concurrent Downloads + GET-ETag Consistency (v2)
+
+## Summary
+
+Speed up the `sow-admin maintenance backup-r2` command by at least 5x through:
+1. **Thread pool concurrent downloads** (dominant win: 5-8x network parallelism)
+2. **Eliminate redundant post-download HEAD requests** (~1.5-2x for small objects)
+3. **Larger `copyfileobj` buffer** (minor: ~1.1x for large objects)
+4. **Increased boto3 connection pool** (supporting)
+
+Current performance: ~30 minutes for 679 objects / 12,894 MB (~8 MB/s single connection).
+Target: ~4-6 minutes with 8 concurrent workers.
+
+## Bottleneck Analysis
+
+### Bottleneck 1: Fully Sequential Downloads (DOMINANT)
+
+**Location:** `write_backup()` at `r2_backup.py:417`
+
+```python
+for idx, inv_obj in enumerate(inventory.objects):
+    obj_entry = _download_object_to_tar(r2_client, inv_obj, current_tar, member_name)
+```
+
+Every object is downloaded one at a time. A single connection to R2 yields ~8 MB/s.
+Cloudflare R2 supports much higher aggregate throughput across multiple connections.
+With 679 sequential operations, there is zero network parallelism.
+
+### Bottleneck 2: Redundant HEAD Request Per Object
+
+**Location:** `_download_object_to_tar()` at `r2_backup.py:289`
+
+```python
+head_data = r2_client.head_object(inv_obj.key)
+```
+
+After downloading each object, a separate HEAD request checks consistency. This doubles
+network round-trips: 679 GET + 679 HEAD = 1,358 requests.
+
+The `get_object_stream()` response (`r2.py:726-737`) already returns `etag`,
+`content_length`, `content_type`, `cache_control`, `content_disposition`,
+`content_encoding`, `metadata`, and `last_modified`. The HEAD is almost entirely
+redundant.
+
+### Bottleneck 3: Small `copyfileobj` Buffer
+
+**Location:** `r2_backup.py:272` — `shutil.copyfileobj(hashing_reader, temp_file)` uses
+the default 16 KB buffer. For 40 MB audio files, that's ~2,500 syscalls per file.
+
+### Bottleneck 4: boto3 Connection Pool (supporting)
+
+**Location:** `r2.py:101-105` — Default `max_pool_connections=10`. Adequate for 8 workers
+but should be increased for headroom.
+
+## HEAD vs GET-ETag Trade-off
+
+| Aspect | Separate HEAD (current) | GET Response ETag (proposed) |
+|--------|------------------------|------------------------------|
+| Network requests per object | 2 (GET + HEAD) | 1 (GET only) |
+| Total requests for 679 objects | 1,358 | 679 (+ ~34 spot-check HEADs) |
+| Latency overhead per small object | +50-100ms | 0ms |
+| Total latency overhead (small objects) | ~17-34 seconds | ~2-3 seconds |
+| Metadata source | HEAD response | GET response (identical fields) |
+| Catches object change *during* GET | Yes (narrow race, ms window) | No (MD5 body check + spot-check HEAD) |
+| Catches object change *since* inventory | Yes | Yes (GET ETag vs inventory ETag) |
+| Consistency guarantee | Object unchanged between GET-end and HEAD | Object ETag at download time matches inventory; MD5 body check for single-part objects; spot-check HEAD for systemic drift |
+
+**Key insight:** The GET response ETag IS the ETag of the bytes actually received. The
+HEAD only adds value if the object changes in the milliseconds between GET completion and
+HEAD completion — an extremely rare race. We mitigate this with:
+1. **MD5 body check** for single-part objects (ETag == MD5) — catches corruption/truncation during GET
+2. **Spot-check HEAD** on ~5% random sample — catches systemic drift without doubling requests
+
+## Files to Modify
+
+1. `src/stream_of_worship/admin/services/r2_backup.py` — Core changes
+2. `src/stream_of_worship/admin/services/r2.py` — Connection pool config
+3. `src/stream_of_worship/admin/commands/maintenance.py` — `--concurrency` CLI flag
+4. `tests/admin/test_r2_backup.py` — Update tests for new download flow
+5. `tests/admin/test_r2_backup_commands.py` — Update command tests
+
+---
+
+## Change A: Thread Pool Concurrent Downloads (`r2_backup.py`)
+
+### A.1 New constants
+
+```python
+DEFAULT_CONCURRENCY = 8
+COPY_BUFFER_SIZE = 1024 * 1024  # 1 MB
+SPOT_CHECK_HEAD_RATIO = 0.05  # 5% random sample
+```
+
+### A.2 New `DownloadResult` dataclass
+
+```python
+@dataclass
+class DownloadResult:
+    """Result of downloading a single object to a temp file."""
+    temp_path: Path
+    sha256: str
+    bytes_read: int
+    metadata: dict  # content_type, cache_control, content_disposition, content_encoding, metadata, last_modified
+```
+
+### A.3 Refactor `_download_object_to_tar()` -> `_download_object_to_tempfile()`
+
+Decouple downloading from tar writing. The new function:
+- Downloads to a temp file under `partial_dir / "tmp"` with 1 MB buffer (`shutil.copyfileobj(..., length=COPY_BUFFER_SIZE)`)
+- Validates short read and size mismatch (unchanged logic)
+- Validates ETag from **GET response** against inventory (replaces HEAD — see Change B)
+- **MD5 body check** for single-part objects (ETag does not contain `-`)
+- Returns a `DownloadResult` (temp_path, sha256, bytes_read, metadata_dict)
+- Does NOT write to tar (decoupled)
+- Retry logic unchanged (ETag mismatch or MD5 mismatch still triggers retry)
+
+```python
+def _download_object_to_tempfile(
+    r2_client: R2Client,
+    inv_obj: InventoryObject,
+    temp_dir: Path,
+    max_retries: int = 2,
+) -> DownloadResult:
+    """Download a single object to a temp file with consistency checking.
+
+    Downloads to a temporary file under temp_dir, validates ETag from GET
+    response against inventory, performs MD5 body check for single-part
+    objects, and returns the temp path + hash + metadata.
+
+    Raises:
+        BackupError: If the object cannot be captured consistently.
+    """
+    import tempfile
+    import hashlib
+
+    last_error: Optional[str] = None
+    for attempt in range(max_retries + 1):
+        temp_path: Optional[Path] = None
+        try:
+            resp = r2_client.get_object_stream(inv_obj.key)
+            body = resp["body"]
+            content_length = resp["content_length"]
+            get_etag = resp["etag"]
+
+            try:
+                temp_dir.mkdir(parents=True, exist_ok=True)
+                with tempfile.NamedTemporaryFile(dir=temp_dir, delete=False) as temp_file:
+                    temp_path = Path(temp_file.name)
+                    hashing_reader = HashingReader(body)
+                    shutil.copyfileobj(hashing_reader, temp_file, length=COPY_BUFFER_SIZE)
+
+                if hashing_reader.bytes_read != content_length:
+                    raise BackupError(
+                        f"Short read for {inv_obj.key}: expected {content_length} bytes, "
+                        f"got {hashing_reader.bytes_read}"
+                    )
+
+                if hashing_reader.bytes_read != inv_obj.size:
+                    raise BackupError(
+                        f"Size mismatch for {inv_obj.key}: inventory says {inv_obj.size}, "
+                        f"downloaded {hashing_reader.bytes_read}"
+                    )
+
+                # ETag consistency check from GET response (replaces separate HEAD)
+                if get_etag != inv_obj.etag:
+                    raise BackupError(
+                        f"Object {inv_obj.key} ETag changed: inventory {inv_obj.etag}, "
+                        f"download {get_etag}"
+                    )
+
+                # MD5 body check for single-part objects (ETag == MD5)
+                if "-" not in get_etag:
+                    md5_hex = hashlib.md5(open(temp_path, "rb").read()).hexdigest()
+                    if md5_hex != get_etag:
+                        raise BackupError(
+                            f"Object {inv_obj.key} MD5 mismatch: ETag {get_etag}, "
+                            f"computed {md5_hex}"
+                        )
+
+                sha256 = hashing_reader.sha256_hex
+
+                metadata = {
+                    "content_type": resp.get("content_type"),
+                    "cache_control": resp.get("cache_control"),
+                    "content_disposition": resp.get("content_disposition"),
+                    "content_encoding": resp.get("content_encoding"),
+                    "metadata": resp.get("metadata") or {},
+                    "last_modified": resp.get("last_modified"),
+                }
+
+                return DownloadResult(
+                    temp_path=temp_path,
+                    sha256=sha256,
+                    bytes_read=hashing_reader.bytes_read,
+                    metadata=metadata,
+                )
+            finally:
+                body.close()
+
+        except (BackupError, ClientError) as e:
+            last_error = str(e)
+            if temp_path is not None:
+                try:
+                    temp_path.unlink()
+                except OSError:
+                    pass
+            if attempt < max_retries:
+                continue
+            raise BackupError(
+                f"Failed to backup {inv_obj.key} after retries: {last_error}"
+            ) from e
+
+    raise BackupError(f"Failed to backup {inv_obj.key} after retries: {last_error}")
+```
+
+### A.4 Modify `write_backup()` — concurrent download + sequential tar write
+
+New parameter: `concurrency: int = DEFAULT_CONCURRENCY`
+
+Design:
+- Validate `concurrency` at function entry (`1 <= concurrency <= 64`)
+- Use `ThreadPoolExecutor(max_workers=concurrency)`
+- Submit all download tasks as futures (each calls `_download_object_to_tempfile`)
+- Process futures **in submission order**: `future.result()` -> write to tar -> delete temp file
+- Chunk rotation logic stays in main thread (uses `inv_obj.size` from inventory, known before download)
+- Error handling: on **any** `BaseException`, cancel remaining futures with `shutdown(cancel_futures=True)`, clean up temp files from a thread-safe tracking set, clean up partial dir
+- `on_progress` callback invoked after each object is written to tar (unchanged semantics)
+- **Spot-check HEAD**: After all objects are processed, randomly select ~5% of objects and HEAD them. If any mismatch, log a warning (do not fail — the backup is already committed).
+
+```python
+def write_backup(
+    r2_client: R2Client,
+    output_dir: Path,
+    inventory: Inventory,
+    chunk_size_bytes: int = DEFAULT_CHUNK_SIZE_BYTES,
+    concurrency: int = DEFAULT_CONCURRENCY,
+    on_progress: Optional[Callable[[int, int], None]] = None,
+) -> BackupResult:
+    """Write a full backup to the output directory.
+
+    Creates <output_dir>.part/ first, writes chunks and manifest, then
+    renames to <output_dir>/.
+
+    Args:
+        r2_client: R2Client instance
+        output_dir: Final output directory path
+        inventory: Pre-built inventory
+        chunk_size_bytes: Max bytes per chunk tar
+        concurrency: Number of concurrent download workers (1-64)
+        on_progress: Optional callback invoked after each object is written.
+            Receives (objects_completed, bytes_completed).
+
+    Returns:
+        BackupResult with summary info.
+
+    Raises:
+        BackupError: If backup fails. Partial directory is cleaned up.
+    """
+    if not (1 <= concurrency <= 64):
+        raise BackupError(f"concurrency must be 1-64, got {concurrency}")
+
+    if output_dir.exists():
+        raise BackupError(f"Output directory already exists: {output_dir}")
+    partial_dir = output_dir.with_suffix(output_dir.suffix + ".part")
+    if partial_dir.exists():
+        raise BackupError(
+            f"Partial output directory already exists: {partial_dir}. "
+            "Remove it manually if it is from a failed backup."
+        )
+
+    if chunk_size_bytes <= 0:
+        raise BackupError(f"Chunk size must be positive, got {chunk_size_bytes}")
+
+    # Disk space: archive (~total_bytes) + temp files (can approach total_bytes
+    # since downloads complete ahead of sequential tar writing) + 50 MiB headroom
+    required_space = int(inventory.total_bytes * 2.1) + 50 * 1024 * 1024
+    _check_disk_space(output_dir.parent, required_space)
+
+    partial_dir.mkdir(parents=True)
+    (partial_dir / PARTIAL_MARKER).touch()
+    temp_dir = partial_dir / "tmp"
+
+    # Thread-safe set of active temp paths for cleanup on failure
+    active_temp_paths: set[Path] = set()
+    active_temp_lock = threading.Lock()
+
+    def _track_temp(path: Path) -> None:
+        with active_temp_lock:
+            active_temp_paths.add(path)
+
+    def _untrack_temp(path: Path) -> None:
+        with active_temp_lock:
+            active_temp_paths.discard(path)
+
+    def _cleanup_all_temps() -> None:
+        with active_temp_lock:
+            paths = list(active_temp_paths)
+            active_temp_paths.clear()
+        for p in paths:
+            try:
+                p.unlink()
+            except OSError:
+                pass
+
+    current_tar: Optional[tarfile.TarFile] = None
+
+    try:
+        from concurrent.futures import ThreadPoolExecutor
+        import threading
+        import random
+
+        manifest_objects: list[dict] = []
+        chunk_index = 0
+        current_chunk_bytes = 0
+
+        def _ensure_tar():
+            nonlocal current_tar
+            if current_tar is None:
+                current_tar = tarfile.open(_chunk_path(partial_dir, chunk_index), "w")
+
+        def _rotate_chunk():
+            nonlocal current_tar, chunk_index, current_chunk_bytes
+            if current_tar is not None:
+                current_tar.close()
+                current_tar = None
+            chunk_index += 1
+            current_chunk_bytes = 0
+
+        bytes_completed = 0
+
+        with ThreadPoolExecutor(max_workers=concurrency) as executor:
+            # Submit all downloads as futures, keyed by index
+            futures = {
+                idx: executor.submit(
+                    _download_object_to_tempfile, r2_client, inv_obj, temp_dir
+                )
+                for idx, inv_obj in enumerate(inventory.objects)
+            }
+
+            try:
+                for idx, inv_obj in enumerate(inventory.objects):
+                    member_name = _member_name_for_index(idx)
+
+                    # Chunk rotation (uses inventory size, known before download)
+                    if (
+                        current_chunk_bytes > 0
+                        and current_chunk_bytes + inv_obj.size > chunk_size_bytes
+                    ):
+                        _rotate_chunk()
+
+                    _ensure_tar()
+
+                    # Wait for this object's download to complete (in order)
+                    future = futures[idx]
+                    try:
+                        download_result = future.result()
+                    except BaseException:
+                        # Cancel remaining futures and re-raise
+                        for f in futures.values():
+                            f.cancel()
+                        raise
+
+                    _track_temp(download_result.temp_path)
+                    try:
+                        # Write to tar from temp file
+                        tar_info = tarfile.TarInfo(name=member_name)
+                        tar_info.size = download_result.bytes_read
+                        tar_info.mtime = 0
+                        tar_info.mode = 0o644
+                        tar_info.type = tarfile.REGTYPE
+
+                        with open(download_result.temp_path, "rb") as f_in:
+                            current_tar.addfile(tar_info, f_in)
+
+                        obj_entry = _build_manifest_object(
+                            inv_obj, member_name, download_result.sha256, chunk_index,
+                            download_result.metadata,
+                        )
+                        manifest_objects.append(obj_entry)
+                        current_chunk_bytes += inv_obj.size
+                        bytes_completed += inv_obj.size
+
+                        if on_progress is not None:
+                            on_progress(idx + 1, bytes_completed)
+                    finally:
+                        _untrack_temp(download_result.temp_path)
+                        try:
+                            download_result.temp_path.unlink()
+                        except OSError:
+                            pass
+            except BaseException:
+                # Cancel all pending futures, abandon running ones
+                for f in futures.values():
+                    f.cancel()
+                # executor.shutdown is called by context manager; we rely on
+                # _cleanup_all_temps below for any completed-but-not-consumed files
+                raise
+
+        if current_tar is not None:
+            current_tar.close()
+            current_tar = None
+
+        # Spot-check HEAD on ~5% random sample
+        if manifest_objects and SPOT_CHECK_HEAD_RATIO > 0:
+            sample_size = max(1, int(len(manifest_objects) * SPOT_CHECK_HEAD_RATIO))
+            sample_indices = random.sample(range(len(manifest_objects)), min(sample_size, len(manifest_objects)))
+            for sample_idx in sample_indices:
+                obj_entry = manifest_objects[sample_idx]
+                try:
+                    head_data = r2_client.head_object(obj_entry["key"])
+                    if head_data is None:
+                        # Object deleted after backup — log warning
+                        continue
+                    if head_data["etag"] != obj_entry["etag"]:
+                        # Object changed after backup — log warning
+                        pass
+                except ClientError:
+                    pass
+
+        final_chunk_count = chunk_index + 1 if manifest_objects else 0
+
+        manifest = {
+            "version": MANIFEST_VERSION,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "inventory_started_at": inventory.started_at,
+            "inventory_completed_at": inventory.completed_at,
+            "bucket": r2_client.bucket,
+            "endpoint_url": r2_client.endpoint_url,
+            "region": r2_client.region,
+            "chunk_size_bytes": chunk_size_bytes,
+            "object_count": len(manifest_objects),
+            "total_bytes": sum(o["size"] for o in manifest_objects),
+            "chunk_count": final_chunk_count,
+            "consistency": {
+                "mode": "initial-inventory-with-get-etag-check",
+                "max_changed_object_retries": 2,
+                "md5_body_check": True,
+                "spot_check_head_ratio": SPOT_CHECK_HEAD_RATIO,
+            },
+            "objects": manifest_objects,
+        }
+
+        manifest_path = partial_dir / "manifest.json"
+        tmp_manifest = partial_dir / "manifest.json.tmp"
+        with open(tmp_manifest, "w") as f:
+            json.dump(manifest, f, indent=2)
+        tmp_manifest.rename(manifest_path)
+
+        # Clean up temp dir if empty
+        try:
+            temp_dir.rmdir()
+        except OSError:
+            pass
+
+        partial_dir.rename(output_dir)
+
+        return BackupResult(
+            output_dir=output_dir,
+            object_count=len(manifest_objects),
+            total_bytes=manifest["total_bytes"],
+            chunk_count=final_chunk_count,
+            manifest=manifest,
+        )
+
+    except BaseException:
+        if current_tar is not None:
+            try:
+                current_tar.close()
+            except Exception:
+                pass
+        _cleanup_all_temps()
+        _cleanup_owned_partial(partial_dir)
+        raise
+```
+
+**Design notes:**
+- Downloads happen in parallel (up to `concurrency` at a time).
+- Tar writing happens sequentially in submission order (tar format requires sequential writes).
+- Temp files are created under `partial_dir/tmp/` so they are automatically cleaned up by `_cleanup_owned_partial()` on failure.
+- A thread-safe `active_temp_paths` set tracks temp files that have completed download but not yet been consumed by the tar writer. On any `BaseException`, all tracked temps are deleted.
+- Chunk rotation uses `inv_obj.size` from inventory (known before download starts), so rotation decisions are deterministic.
+- `on_progress` is called after each object is written to tar, preserving existing semantics.
+- Spot-check HEAD runs after the backup is fully committed; mismatches are logged as warnings, not failures.
+
+### A.5 Update manifest consistency mode
+
+```python
+"consistency": {
+    "mode": "initial-inventory-with-get-etag-check",
+    "max_changed_object_retries": 2,
+    "md5_body_check": True,
+    "spot_check_head_ratio": 0.05,
+},
+```
+
+**MANIFEST_VERSION bumps from 3 to 4** to signal the weaker consistency guarantee and new metadata fields.
+
+---
+
+## Change B: Eliminate Redundant HEAD Request (`r2_backup.py`)
+
+The HEAD request in `_download_object_to_tar()` (line 289) is replaced by ETag
+validation from the GET response in the new `_download_object_to_tempfile()` (see A.3).
+
+The GET response from `get_object_stream()` (`r2.py:726-737`) returns all the same
+metadata fields that the HEAD returned:
+- `etag` -> used for consistency check
+- `content_type`, `cache_control`, `content_disposition`, `content_encoding`, `metadata`, `last_modified`
+  -> stored in manifest for restore
+
+The `_build_manifest_object()` helper (`r2_backup.py:208`) is called with the GET
+response metadata instead of HEAD data. Its signature is unchanged except `head_data`
+parameter renamed to `metadata` for clarity.
+
+**Spot-check HEAD** (see A.4): After the backup completes, ~5% of objects are HEADed
+as a lightweight systemic consistency check. This catches bucket-wide drift without
+doubling requests.
+
+---
+
+## Change C: Larger `copyfileobj` Buffer (`r2_backup.py`)
+
+In `_download_object_to_tempfile()`:
+
+```python
+shutil.copyfileobj(hashing_reader, temp_file, length=COPY_BUFFER_SIZE)
+```
+
+Reduces syscalls by 64x for large files (16 KB -> 1 MB buffer).
+
+---
+
+## Change D: Increase boto3 Connection Pool (`r2.py`)
+
+```python
+self._client = boto3.client(
+    "s3",
+    endpoint_url=endpoint_url,
+    aws_access_key_id=access_key,
+    aws_secret_access_key=secret_key,
+    region_name=region,
+    config=Config(
+        connect_timeout=10,
+        read_timeout=30,
+        retries={"max_attempts": 2},
+        max_pool_connections=32,
+    ),
+)
+```
+
+Default is 10. With 8 concurrent workers, 32 provides headroom for retries and
+connection reuse.
+
+---
+
+## Change E: `--concurrency` CLI Flag (`maintenance.py`)
+
+### E.1 Add option to `backup_r2` command
+
+```python
+@app.command("backup-r2")
+def backup_r2(
+    output: Path = typer.Option(..., "--output", help="Output directory for backup"),
+    chunk_size: str = typer.Option(
+        "10GiB", "--chunk-size", help="Chunk size (e.g. 10GiB, 500MiB, raw bytes)"
+    ),
+    concurrency: int = typer.Option(
+        8, "--concurrency", min=1, max=64,
+        help="Number of concurrent download workers"
+    ),
+    format_: str = typer.Option("table", "--format", help="table|json"),
+    config_path: Optional[Path] = typer.Option(None, "--config", "-c"),
+) -> None:
+```
+
+### E.2 Pass to `write_backup()`
+
+```python
+result = write_backup(
+    r2_client=r2_client,
+    output_dir=output,
+    inventory=inventory,
+    chunk_size_bytes=chunk_size_bytes,
+    concurrency=concurrency,
+    on_progress=_on_progress,
+)
+```
+
+---
+
+## Change F: Test Updates
+
+### F.1 `test_r2_backup.py`
+
+**`MANIFEST_VERSION` bump:** Update `test_manifest_version_constant` to expect 4.
+
+**`_make_r2_mock()` helper:** Already returns all metadata fields in GET response
+(`content_type`, `cache_control`, etc.). No change needed.
+
+**Tests that assert HEAD was called:** The following tests use `r2.head_object` to
+simulate consistency changes. These need to be updated to use `r2.get_object_stream`
+ETag instead:
+
+- `test_backup_changed_object_retries_and_succeeds` — currently uses flaky HEAD;
+  change to flaky GET ETag (first GET returns different etag, second returns matching)
+- `test_backup_changed_object_exceeds_retries_fails` — currently HEAD always returns
+  different etag; change to GET always returning different etag
+- `test_backup_deleted_object_during_backup_fails` — currently HEAD returns None;
+  change to GET raising ClientError 404
+
+**New tests to add:**
+
+```python
+class TestConcurrentBackup:
+    def test_concurrent_backup_produces_valid_archive(self, tmp_path):
+        """Concurrent download with default concurrency produces valid backup."""
+        # 20 objects, verify manifest + chunks + SHA-256
+
+    def test_concurrency_1_works(self, tmp_path):
+        """concurrency=1 falls back to sequential (no thread pool issues)."""
+
+    def test_concurrent_backup_preserves_object_order(self, tmp_path):
+        """Manifest objects are in inventory order regardless of download completion order."""
+        # Use a mock where later objects download faster than earlier ones
+
+    def test_concurrent_backup_cleans_up_temp_files(self, tmp_path):
+        """No temp files remain after successful backup."""
+
+    def test_concurrent_backup_cleans_up_temp_files_on_failure(self, tmp_path):
+        """Temp files are cleaned up when backup fails mid-way."""
+
+    def test_concurrent_backup_failure_cancels_remaining(self, tmp_path):
+        """On failure, remaining futures are cancelled and partial dir cleaned up."""
+
+    def test_md5_body_check_catches_corruption(self, tmp_path):
+        """Single-part object with corrupted body fails with MD5 mismatch."""
+        # Mock get_object_stream returns correct ETag but body bytes are wrong
+
+    def test_spot_check_head_warns_on_drift(self, tmp_path):
+        """Spot-check HEAD logs warning when object changed after backup."""
+        # Mock head_object returns different ETag for sampled object
+
+    def test_manifest_version_4(self, tmp_path):
+        """Backup produces manifest version 4."""
+
+    def test_get_last_modified_in_metadata(self, tmp_path):
+        """Manifest stores GET response last_modified in metadata."""
+
+    def test_concurrency_validation_rejects_zero(self, tmp_path):
+        """write_backup raises BackupError for concurrency=0."""
+
+    def test_concurrency_validation_rejects_65(self, tmp_path):
+        """write_backup raises BackupError for concurrency=65."""
+```
+
+**Existing tests that should pass unchanged (after MANIFEST_VERSION update):**
+- `test_backup_creates_manifest_and_chunks`
+- `test_backup_empty_bucket`
+- `test_backup_chunk_boundary`
+- `test_backup_large_object_exceeds_chunk`
+- `test_backup_refuses_existing_output`
+- `test_backup_refuses_existing_partial`
+- `test_backup_short_read_fails`
+- `test_backup_preserves_metadata`
+- `test_backup_cleanup_on_interrupt`
+- `test_on_progress_called_with_correct_counts`
+- All `TestVerifyArchive` tests
+- All `TestPlanRestore` tests
+- All `TestRestoreFromArchive` tests
+
+### F.2 `test_r2_backup_commands.py`
+
+**New test:**
+
+```python
+def test_backup_concurrency_flag(self, tmp_path):
+    """backup-r2 --concurrency 4 passes concurrency to write_backup."""
+```
+
+**Existing tests:** Should pass unchanged. The mock `_make_r2_mock()` already returns
+GET response with all metadata fields.
+
+---
+
+## Expected Performance
+
+| Optimization | Estimated Speedup | Primary Benefit |
+|-------------|-------------------|-----------------|
+| Thread pool (8 workers) | 5-8x | Network parallelism |
+| Eliminate HEAD | 1.5-2x | Small object latency |
+| Larger buffer | 1.1x | Large object disk I/O |
+| **Combined (conservative)** | **~5-8x** | **30 min -> ~4-6 min** |
+
+The thread pool is the dominant win. With 8 concurrent R2 connections, aggregate
+throughput should scale well beyond single-connection 8 MB/s.
+
+---
+
+## Edge Cases and Considerations
+
+1. **Empty bucket:** `concurrency` doesn't matter; no futures submitted, completes immediately.
+
+2. **Single object:** `concurrency=8` but only 1 future; no overhead from thread pool.
+
+3. **`concurrency=1`:** Falls back to effectively sequential behavior (1 worker). Useful
+   for debugging or when R2 throttles parallel connections.
+
+4. **Temp file disk usage:** Temp files are created under `partial_dir/tmp/`. Because
+   downloads complete ahead of sequential tar writing, peak temp usage can approach
+   `total_bytes` in the worst case (object 0 is very slow). The disk space check
+   reserves `total_bytes * 2.1 + 50 MiB` to cover both temp files and final archive.
+
+5. **Thread safety of boto3:** boto3 clients are thread-safe for S3 operations.
+   The `ThreadPoolExecutor` shares a single `R2Client` (and thus a single boto3 client)
+   across workers. boto3's connection pool (`max_pool_connections=32`) handles
+   concurrent requests.
+
+6. **Tar writing stays sequential:** The tar format requires sequential member writes.
+   Only downloads are parallelized; tar writing happens in the main thread in
+   submission order.
+
+7. **Error propagation:** If any download fails, the main thread cancels remaining
+   futures, cleans up tracked temp files, and cleans up the partial directory.
+   The `ThreadPoolExecutor` context manager ensures all threads are joined before exit.
+   A thread-safe `active_temp_paths` set catches any completed-but-not-yet-consumed
+   temp files.
+
+8. **Progress callback:** Called after each object is written to tar (not after download).
+   This preserves existing semantics: progress reflects committed bytes in the archive.
+
+9. **Manifest `consistency.mode`:** Changes from
+   `"initial-inventory-with-post-download-head-check"` to
+   `"initial-inventory-with-get-etag-check"`. `MANIFEST_VERSION` bumps to 4 to signal
+   the semantic change. `verify_archive()` and `restore_from_archive()` don't read
+   this field.
+
+10. **Retry behavior:** Unchanged. ETag mismatch or MD5 mismatch from GET response
+    triggers the same retry loop as the previous HEAD-based check. The retry budget
+    (`max_retries=2`) is preserved.
+
+11. **Spot-check HEAD:** Runs after the backup is fully committed. Mismatches are
+    logged as warnings, not failures. This is intentional: the backup captured a valid
+    self-consistent snapshot at download time.
+
+12. **Temp file location:** All temp files are created under `partial_dir/tmp/`.
+    On success, the directory is removed if empty. On failure, `_cleanup_owned_partial()`
+    removes the entire partial directory including temp files.
+
+13. **Per-object download timeout:** Not implemented. boto3 read timeout (30s) and
+    TCP keepalive provide basic stall detection. A stalled slow trickle (<1 KB/s)
+    could still block indefinitely. If observed in production, add `future.result(timeout=...)`
+    or socket-level read timeouts.
+
+---
+
+## Verification
+
+```bash
+# Run R2 backup tests
+PYTHONPATH=src uv run --python 3.11 --extra app --extra test pytest \
+  tests/admin/test_r2_backup.py tests/admin/test_r2_backup_commands.py -v
+
+# Run all admin tests
+PYTHONPATH=src uv run --python 3.11 --extra app --extra test pytest tests/admin/ -v
+
+# Manual smoke test (requires R2 credentials)
+uv run --extra admin sow-admin maintenance backup-r2 \
+  --output /tmp/sow-r2-backup-test \
+  --concurrency 8 \
+  -c ~/.config/stream-of-worship-admin/config.toml
+```
+
+---
+
+## Assumptions and Out of Scope
+
+**Assumptions:**
+- boto3 S3 client is thread-safe for concurrent `get_object` calls (confirmed by boto3 docs).
+- Cloudflare R2 supports multiple concurrent connections with higher aggregate throughput.
+- Temp files are kept under `partial_dir/tmp/` (per revised design).
+- MD5 body check is feasible because single-part uploads are the common case for this workload.
+
+**Out of scope:**
+- Streaming directly to tar (user chose to keep temp files).
+- Async/asyncio implementation (threads are simpler and sufficient for I/O-bound work).
+- Compression of backup archives.
+- Incremental or differential backups.
+- Bandwidth limiting.
+- Restore-side concurrency (restore is upload-bound, different bottleneck).
+- Per-object download timeout (can be added later if stalls are observed).
+
+(End of file)

--- a/specs/admin-r2-backup-perf-traces.md
+++ b/specs/admin-r2-backup-perf-traces.md
@@ -1,0 +1,1104 @@
+# Admin R2 Backup Performance Traces — Diagnose 25-Minute / 12 GiB Bottleneck
+
+## Summary
+
+The v3 progress bar (download-aware progress, worker count, streaming MD5) shipped in commit `08a844f` did **not** produce the expected multi-fold wall-clock speedup: backup of ~12 GiB of R2 objects still takes >25 minutes with `--concurrency 8`. The v3 spec only addressed *progress display* smoothness; it did not change the actual download/tar-write pipeline.
+
+This spec adds **performance traces** to the `backup-r2` command so the next run yields actionable numbers identifying which of the following is the actual bottleneck:
+
+| Suspect | Diagnostic question |
+|---|---|
+| **Head-of-line blocking** | How much time does the main thread spend blocked on `future.result(idx)` in submission order, versus time inside `current_tar.addfile`? v3 only fixed the *progress display* of this; it did not remove the head-of-line wait. |
+| **Aggregate network saturation** | Does aggregate throughput scale with `concurrency`, or does it plateau? If 8 workers each get ~1.5 MB/s but aggregate is also ~12 MB/s, the R2 link (or local uplink) is saturated and adding workers won't help. |
+| **Temp-file disk round-trip** | Each object is `download → temp file → re-read → tar write` (3 disk I/Os / object). Is `tar_write_ms` ≈ `download_ms` (round-trip bound) or << (network bound)? |
+| **boto3 connection setup** | Is `get_object_stream` (handshake + SSL + headers) a significant fraction of per-object time, especially for small objects? |
+
+Traces are gated behind a new `--debug-traces` CLI flag (default off) so production runs are unaffected.
+
+## Decisions
+
+| Topic | Decision |
+|---|---|
+| Trace destination | Existing stderr logger (`logger = logging.getLogger(__name__)` in `r2_backup.py`); set to DEBUG when flag is on; Rich progress bar continues on same stderr (occlusion handled by `_on_progress` throttling — see Verification). |
+| Trace granularity | Per-object (download + tar-write rows) + per-phase (inventory, download, tar-write, manifest, spot-check, total). |
+| Activation | New `--debug-traces` flag on `backup-r2` — when set, configure logger to DEBUG on stderr and construct a `BackupTracer` passed into `write_backup`. |
+| Tracer lifetime | Constructed in `maintenance.py`; passed to `write_backup(tracer=...)` and `_download_object_to_tempfile(tracer=...)` as new optional param; default `None` → no behavior change and no overhead. |
+| API surface | New public class `BackupTracer` in `r2_backup.py` (exported from module). |
+| Manifest version | No change (stays at 4 — no archive format change). |
+| Tests | New `TestBackupTracer` class; new `test_backup_r2_debug_traces_flag` in command tests. |
+
+## Files to Modify
+
+1. `src/stream_of_worship/admin/services/r2_backup.py` — new `BackupTracer` class; thread `tracer: Optional[BackupTracer]` param through `_download_object_to_tempfile` and `write_backup`; emit trace events at the points enumerated in Change A–D.
+2. `src/stream_of_worship/admin/commands/maintenance.py` — add `--debug-traces` flag, configure logger, construct `BackupTracer`, wrap `_on_progress` callback to feed throughput samples.
+3. `tests/admin/test_r2_backup.py` — new `TestBackupTracer` class covering trace emission and aggregation.
+4. `tests/admin/test_r2_backup_commands.py` — assert `--debug-traces` flag passes tracer through to `write_backup`.
+
+---
+
+## Change A: New `BackupTracer` Class (`r2_backup.py`)
+
+### A.1 Class definition
+
+```python
+import logging
+
+
+class BackupTracer:
+    """Collects and emits performance traces for backup operations.
+
+    Thread-safe. Designed to be passed (as `tracer=`) into `write_backup`
+    and `_download_object_to_tempfile` to emit per-object and per-phase
+    timing logs at DEBUG level. All methods are no-ops if the tracer is
+    disabled (logger level above DEBUG).
+
+    Traces are written to the module logger (`stream_of_worship.admin.services.r2_backup`).
+    Per-object events fire from worker threads; Rich `Progress` renders on the
+    same stderr but the tracer is throttled by the existing `BackupProgress._maybe_report`
+    path (which feeds `bytes_downloaded_sample` via the wrapped callback in maintenance.py).
+    """
+
+    # Aggregate throughput sample interval (seconds)
+    THROUGHPUT_SAMPLE_INTERVAL = 5.0
+
+    def __init__(self, logger: Optional[logging.Logger] = None):
+        self._logger = logger or logging.getLogger(__name__)
+        self._enabled = self._logger.isEnabledFor(logging.DEBUG)
+        self._lock = threading.Lock()
+
+        # Phase timing
+        self._phase_starts: dict[str, float] = {}
+
+        # Per-object accumulators (aggregate over all objects)
+        self._object_count_downloaded = 0
+        self._object_count_written = 0
+        self._bytes_downloaded = 0
+        self._bytes_written = 0
+        self._retries_total = 0
+        self._sum_download_ms = 0.0       # sum of worker download_ms across objects
+        self._sum_conn_ms = 0.0            # sum of boto3 get_object_stream ms
+        self._sum_wait_ms = 0.0            # sum of main-thread future.result() wait ms
+        self._sum_tar_write_ms = 0.0       # sum of main-thread tar.addfile ms
+        self._max_object_download_ms = 0.0
+        self._max_object_download_key = ""
+
+        # Throughput sampling (fed via bytes_downloaded_sample)
+        self._throughput_samples: list[tuple[float, int, int]] = []  # (t, bytes, workers)
+        self._last_throughput_log = 0.0
+        self._peak_workers = 0
+
+        # Run totals
+        self._run_start = 0.0
+
+    # ---- Phase-level tracing ----
+
+    def phase_start(self, name: str) -> None:
+        if not self._enabled:
+            return
+        with self._lock:
+            self._phase_starts[name] = time.monotonic()
+        if name == "total":
+            self._run_start = time.monotonic()
+
+    def phase_end(self, name: str, **extra) -> None:
+        if not self._enabled:
+            return
+        with self._lock:
+            start = self._phase_starts.pop(name, None)
+        if start is None:
+            return
+        elapsed_ms = (time.monotonic() - start) * 1000.0
+        fields = " ".join(f"{k}={v}" for k, v in extra.items())
+        self._logger.debug(
+            f"phase_end name={name} elapsed_ms={elapsed_ms:.1f} {fields}"
+        )
+
+    # ---- Per-object download tracing (worker thread) ----
+
+    def object_download_trace(
+        self,
+        key: str,
+        worker: str,
+        attempt: int,
+        conn_ms: float,
+        stream_ms: float,
+        bytes_read: int,
+        retries: int,
+    ) -> None:
+        """Emit per-object download trace and update accumulators.
+
+        Called from each download worker thread after a download attempt completes
+        (success or final failure).
+        """
+        if not self._enabled:
+            return
+        self._logger.debug(
+            f"object_download key={key} worker={worker} attempt={attempt} "
+            f"conn_ms={conn_ms:.1f} stream_ms={stream_ms:.1f} "
+            f"bytes={bytes_read} download_mbps={(bytes_read / max(stream_ms, 1.0)) * 1000 / (1024*1024):.2f} "
+            f"retries={retries}"
+        )
+        with self._lock:
+            self._object_count_downloaded += 1
+            self._bytes_downloaded += bytes_read
+            self._retries_total += retries
+            self._sum_download_ms += stream_ms
+            self._sum_conn_ms += conn_ms
+            total_ms = stream_ms + conn_ms
+            if total_ms > self._max_object_download_ms:
+                self._max_object_download_ms = total_ms
+                self._max_object_download_key = key
+
+    # ---- Per-object tar-write tracing (main thread) ----
+
+    def tar_write_trace(
+        self,
+        idx: int,
+        key: str,
+        wait_ms: float,
+        tar_write_ms: float,
+        bytes_written: int,
+    ) -> None:
+        """Emit per-object tar-write trace and update accumulators.
+
+        Called from the main thread after writing one object to the chunk tar.
+
+        `wait_ms` = wall time spent on `future.result(idx)` (head-of-line wait).
+        `tar_write_ms` = wall time spent in `current_tar.addfile(...)` end-to-end
+        (includes opening temp file, reading from disk, and writing to tar).
+        """
+        if not self._enabled:
+            return
+        self._logger.debug(
+            f"tar_write idx={idx} key={key} "
+            f"wait_ms={wait_ms:.1f} tar_write_ms={tar_write_ms:.1f} "
+            f"bytes={bytes_written} "
+            f"wait_is_bottleneck={'yes' if wait_ms > tar_write_ms else 'no'}"
+        )
+        with self._lock:
+            self._object_count_written += 1
+            self._bytes_written += bytes_written
+            self._sum_wait_ms += wait_ms
+            self._sum_tar_write_ms += tar_write_ms
+
+    # ---- Throughput sampling (called from throttled on_progress callback) ----
+
+    def bytes_downloaded_sample(self, bytes_downloaded: int, active_workers: int) -> None:
+        """Record a throughput sample and emit periodic aggregate throughput log.
+
+        Called ~10/sec from `BackupProgress._maybe_report` via the wrapped
+        `_on_progress` callback in maintenance.py.
+        """
+        if not self._enabled:
+            return
+        now = time.monotonic()
+        with self._lock:
+            self._throughput_samples.append((now, bytes_downloaded, active_workers))
+            if active_workers > self._peak_workers:
+                self._peak_workers = active_workers
+            if now - self._last_throughput_log < self.THROUGHPUT_SAMPLE_INTERVAL:
+                return
+            self._last_throughput_log = now
+            if len(self._throughput_samples) >= 2:
+                t0, b0, _ = self._throughput_samples[0]
+                t1, b1, w1 = self._throughput_samples[-1]
+                dt = max(t1 - t0, 1e-9)
+                mbps = (b1 - b0) / dt / (1024 * 1024)
+                elapsed_since_run_start = now - self._run_start if self._run_start else 0.0
+                self._logger.debug(
+                    f"throughput_sample t+{elapsed_since_run_start:.1f}s "
+                    f"workers={w1} downloaded_mib={b1 / (1024*1024):.2f} "
+                    f"aggregate_mbps={mbps:.2f} peak_workers={self._peak_workers}"
+                )
+
+    # ---- Final summary ----
+
+    def finalize(self, total_objects: int, total_bytes: int) -> None:
+        """Emit aggregate summary stats.
+
+        Expected to be called from `write_backup()` after the ThreadPoolExecutor
+        block completes (after downloads + tar writes, before spot-check).
+        """
+        if not self._enabled:
+            return
+        with self._lock:
+            samples = list(self._throughput_samples)
+            peak_workers = self._peak_workers
+            sum_download_ms = self._sum_download_ms
+            sum_conn_ms = self._sum_conn_ms
+            sum_wait_ms = self._sum_wait_ms
+            sum_tar_write_ms = self._sum_tar_write_ms
+            bytes_downloaded = self._bytes_downloaded
+            retries_total = self._retries_total
+            max_object_download_ms = self._max_object_download_ms
+            max_object_download_key = self._max_object_download_key
+
+        # Aggregate throughput across whole run (wall-clock between first and last sample)
+        if len(samples) >= 2:
+            t0, b0, _ = samples[0]
+            t1, b1, _ = samples[-1]
+            dt = max(t1 - t0, 1e-9)
+            aggregate_mbps = (b1 - b0) / dt / (1024 * 1024)
+        else:
+            aggregate_mbps = 0.0
+
+        # Single-worker average throughput = bytes / per-object average download time.
+        # If single-worker avg << aggregate, workers ARE scaling (network not saturated).
+        # If single-worker avg ≈ aggregate, network is saturated (adding workers won't help).
+        avg_per_object_download_ms = (
+            sum_download_ms / max(total_objects, 1)
+        )
+        avg_object_bytes = bytes_downloaded / max(total_objects, 1)
+        single_worker_avg_mbps = (
+            avg_object_bytes / max(avg_per_object_download_ms, 1.0) * 1000 / (1024*1024)
+        )
+
+        # Head-of-line blocking ratio: wait_ms / (wait_ms + tar_write_ms).
+        # If ratio is high, main thread is bottlenecked on slow head-of-queue downloads
+        # rather than running tar writes.
+        main_thread_total = sum_wait_ms + sum_tar_write_ms
+        wait_ratio = (sum_wait_ms / max(main_thread_total, 1.0)) * 100.0
+        tar_ratio = (sum_tar_write_ms / max(main_thread_total, 1.0)) * 100.0
+
+        self._logger.debug(
+            "summary total_objects=%d total_bytes=%d "
+            "aggregate_mbps=%.2f single_worker_avg_mbps=%.2f "
+            "peak_workers=%d retries_total=%d "
+            "sum_download_ms=%.1f sum_conn_ms=%.1f sum_wait_ms=%.1f sum_tar_write_ms=%.1f "
+            "wait_pct=%.1f tar_write_pct=%.1f "
+            "max_object_download_ms=%.1f max_object_download_key=%s "
+            "network_saturated=%s",
+            total_objects, total_bytes,
+            aggregate_mbps, single_worker_avg_mbps,
+            peak_workers, retries_total,
+            sum_download_ms, sum_conn_ms, sum_wait_ms, sum_tar_write_ms,
+            wait_ratio, tar_ratio,
+            max_object_download_ms, max_object_download_key,
+            "yes" if single_worker_avg_mbps > 0 and aggregate_mbps > 0
+                  and (aggregate_mbps / max(single_worker_avg_mbps * peak_workers, 1.0)) < 0.5
+                  else "no (or inconclusive)",
+        )
+```
+
+### A.2 Design notes
+
+- All public methods are **no-ops** when `_enabled` is False (forced via `logger.isEnabledFor(logging.DEBUG)` cached once at construction). Zero overhead when `--debug-traces` not passed.
+- The `_enabled` check is per-call, not lazy; if the logger level changes after construction the tracer stays in its initial state. Acceptable — `--debug-traces` is set once at CLI parse time before the tracer is constructed.
+- `logger.debug(...)` itself also early-returns on level checks; the per-call `_enabled` short-circuit avoids the per-call `time.monotonic()` / `threading.Lock()` overhead for the disabled case.
+- Throughput samples are emitted inside `bytes_downloaded_sample`, which is called from `BackupProgress._maybe_report` (already throttled to ~10/sec by `min_report_interval=0.1`). The tracer further throttles its own `_last_throughput_log` to one summary every 5 seconds to keep the log readable.
+
+### A.3 Network-saturated heuristic
+
+The summary's `network_saturated` field compares `aggregate_mbps` against `single_worker_avg_mbps * peak_workers`:
+
+- If `aggregate_mbps ≈ single_worker_avg_mbps * peak_workers`, scaling is working → **network NOT saturated** (CPU/disk/GIL is the limit).
+- If `aggregate_mbps << single_worker_avg_mbps * peak_workers`, total throughput plateaus despite more workers → **network saturated** (R2 link or local uplink is the cap; adding workers will not help).
+
+The `< 0.5` threshold is intentionally conservative (i.e. only flags as saturated when scaling efficiency is below 50%).
+
+---
+
+## Change B: Wire `BackupTracer` into `_download_object_to_tempfile()` (`r2_backup.py`)
+
+### B.1 New `tracer` parameter
+
+```python
+def _download_object_to_tempfile(
+    r2_client: R2Client,
+    inv_obj: InventoryObject,
+    temp_dir: Path,
+    progress: Optional[BackupProgress] = None,
+    tracer: Optional[BackupTracer] = None,
+    max_retries: int = 2,
+) -> DownloadResult:
+```
+
+### B.2 Trace points inside the download function
+
+```python
+    import tempfile
+    import threading as _threading
+
+    last_error: Optional[str] = None
+    worker_name = _threading.current_thread().name
+    retries_taken = 0
+
+    for attempt in range(max_retries + 1):
+        temp_path: Optional[Path] = None
+        try:
+            if progress is not None:
+                progress.worker_started()
+
+            t_conn_start = time.monotonic() if tracer is not None else 0.0
+            resp = r2_client.get_object_stream(inv_obj.key)
+            conn_ms = (time.monotonic() - t_conn_start) * 1000.0 if tracer is not None else 0.0
+            body = resp["body"]
+            content_length = resp["content_length"]
+            get_etag = resp["etag"]
+
+            try:
+                temp_dir.mkdir(parents=True, exist_ok=True)
+                with tempfile.NamedTemporaryFile(dir=temp_dir, delete=False) as temp_file:
+                    temp_path = Path(temp_file.name)
+
+                    on_read = progress.add_bytes if progress is not None else None
+                    hashing_reader = HashingReader(body, on_read=on_read)
+                    t_stream_start = time.monotonic() if tracer is not None else 0.0
+                    shutil.copyfileobj(hashing_reader, temp_file, length=COPY_BUFFER_SIZE)
+                    stream_ms = (time.monotonic() - t_stream_start) * 1000.0 if tracer is not None else 0.0
+
+                # ... existing validation (short read, size mismatch, ETag check) ...
+
+                # ... MD5 check (unchanged) ...
+
+                sha256 = hashing_reader.sha256_hex
+
+                metadata = { ... unchanged ... }
+
+                if tracer is not None:
+                    tracer.object_download_trace(
+                        key=inv_obj.key,
+                        worker=worker_name,
+                        attempt=attempt,
+                        conn_ms=conn_ms,
+                        stream_ms=stream_ms,
+                        bytes_read=hashing_reader.bytes_read,
+                        retries=retries_taken,
+                    )
+
+                return DownloadResult(
+                    temp_path=temp_path,
+                    sha256=sha256,
+                    bytes_read=hashing_reader.bytes_read,
+                    metadata=metadata,
+                )
+            finally:
+                body.close()
+
+        except Exception as e:
+            last_error = str(e)
+            if attempt < max_retries:
+                retries_taken += 1
+                if temp_path is not None:
+                    try:
+                        temp_path.unlink()
+                    except OSError:
+                        pass
+                continue
+            if tracer is not None:
+                tracer.object_download_trace(
+                    key=inv_obj.key,
+                    worker=worker_name,
+                    attempt=attempt,
+                    conn_ms=conn_ms,
+                    stream_ms=stream_ms,
+                    bytes_read=0,
+                    retries=retries_taken,
+                )
+            raise BackupError(
+                f"Failed to backup {inv_obj.key} after retries: {last_error}"
+            ) from e
+        finally:
+            if progress is not None:
+                progress.worker_finished()
+```
+
+### B.3 Key changes
+
+- `worker_name = threading.current_thread().name` captured once.
+- `t_conn_start` / `t_stream_start` measured only when `tracer is not None` (avoids `time.monotonic()` syscall overhead in production).
+- `retries_taken` accumulated (currently always 0 on success path; only nonzero when a retry in the `except` branch fires).
+- `object_download_trace` called on success **and** on final-failure (after retries exhausted), so all per-object timings appear in the log even for failed objects.
+- `bytes_read=0` is reported for failed objects; the `sum_download_ms` accumulator only counts successful stream times (failed attempts still log their per-object DEBUG line for diagnosis, with `bytes=0`).
+
+### B.4 Connection setup vs. stream time split
+
+- `conn_ms` = `get_object_stream` call duration = boto3 connection acquisition from the `max_pool_connections=32` pool + HTTP/2 over TLS handshake + first response header parse.
+- `stream_ms` = `shutil.copyfileobj` call duration = network body read + temp-file disk write (chained, end-to-end).
+- If `conn_ms ≫ stream_ms` for small objects, boto3 connection setup dominates (consider connection reuse / tuning).
+- If `stream_ms ≫ conn_ms` for large objects, network bandwidth or disk write speed is the cap — disambiguated by the `tar_write_ms` ratio (see Change C).
+
+### B.5 Disk round-trip measurement
+
+`stream_ms` includes network read + temp-file write (chained).
+`tar_write_ms` includes temp-file read + tar-file write (chained — see Change C).
+If `stream_ms` per object ≈ `tar_write_ms` per object, temp-file round-trip doubles disk I/O and dominates — combine traces with the network-required download bytes vs. total wall time to confirm.
+
+Network-only read time ≈ `stream_ms - temp_file_write_time`. We do **not** wrap `temp_file.write` to isolate this; the chained `stream_ms` plus the absence of CPU-bound work in `shutil.copyfileobj` (it releases the GIL on the underlying `read()`/`write()` syscalls) means `stream_ms - tar_write_ms/2` is a reasonable lower bound for network time when disk reads and writes have similar rates. This is a known approximation; future spec can add finer-grained disk-write tracing if needed.
+
+---
+
+## Change C: Wire `BackupTracer` into `write_backup()` (`r2_backup.py`)
+
+### C.1 New `tracer` parameter
+
+```python
+def write_backup(
+    r2_client: R2Client,
+    output_dir: Path,
+    inventory: Inventory,
+    chunk_size_bytes: int = DEFAULT_CHUNK_SIZE_BYTES,
+    concurrency: int = DEFAULT_CONCURRENCY,
+    on_progress: Optional[Callable[[BackupProgress], None]] = None,
+    tracer: Optional[BackupTracer] = None,
+) -> BackupResult:
+```
+
+### C.2 Per-object tar-write trace point in the main loop
+
+```python
+    if tracer is not None:
+        tracer.phase_start("total")
+        tracer.phase_start("download_phase")
+
+    with ThreadPoolExecutor(max_workers=concurrency) as executor:
+        futures = {
+            idx: executor.submit(
+                _download_object_to_tempfile,
+                r2_client, inv_obj, temp_dir, progress, tracer,
+            )
+            for idx, inv_obj in enumerate(inventory.objects)
+        }
+
+        try:
+            for idx, inv_obj in enumerate(inventory.objects):
+                member_name = _member_name_for_index(idx)
+
+                if (
+                    current_chunk_bytes > 0
+                    and current_chunk_bytes + inv_obj.size > chunk_size_bytes
+                ):
+                    _rotate_chunk()
+
+                _ensure_tar()
+
+                future = futures[idx]
+                t_wait_start = time.monotonic() if tracer is not None else 0.0
+                try:
+                    download_result = future.result()
+                except BaseException:
+                    for f in futures.values():
+                        f.cancel()
+                    raise
+                wait_ms = (time.monotonic() - t_wait_start) * 1000.0 if tracer is not None else 0.0
+
+                if progress is not None:
+                    progress.mark_object_downloaded()
+
+                _track_temp(download_result.temp_path)
+                try:
+                    tar_info = tarfile.TarInfo(name=member_name)
+                    tar_info.size = download_result.bytes_read
+                    tar_info.mtime = 0
+                    tar_info.mode = 0o644
+                    tar_info.type = tarfile.REGTYPE
+
+                    t_tar_start = time.monotonic() if tracer is not None else 0.0
+                    with open(download_result.temp_path, "rb") as f_in:
+                        current_tar.addfile(tar_info, f_in)
+                    tar_write_ms = (time.monotonic() - t_tar_start) * 1000.0 if tracer is not None else 0.0
+
+                    if tracer is not None:
+                        tracer.tar_write_trace(
+                            idx=idx,
+                            key=inv_obj.key,
+                            wait_ms=wait_ms,
+                            tar_write_ms=tar_write_ms,
+                            bytes_written=inv_obj.size,
+                        )
+
+                    obj_entry = _build_manifest_object(
+                        inv_obj, member_name, download_result.sha256, chunk_index,
+                        download_result.metadata,
+                    )
+                    manifest_objects.append(obj_entry)
+                    current_chunk_bytes += inv_obj.size
+
+                    if progress is not None:
+                        progress.object_written(inv_obj.size)
+                finally:
+                    _untrack_temp(download_result.temp_path)
+                    try:
+                        download_result.temp_path.unlink()
+                    except OSError:
+                        pass
+        except BaseException:
+            for f in futures.values():
+                f.cancel()
+            raise
+
+    if tracer is not None:
+        tracer.phase_end("download_phase",
+                        objects=inventory.object_count,
+                        total_bytes=inventory.total_bytes)
+        tracer.finalize(total_objects=inventory.object_count,
+                         total_bytes=inventory.total_bytes)
+```
+
+### C.3 Phase tracing around other phases
+
+Add `phase_start`/`phase_end` calls:
+
+- `phase_start("disk_check")` before `_check_disk_space(...)`; `phase_end("disk_check", required_bytes=required_space)`.
+- `phase_start("setup")` between `_check_disk_space` and the `ThreadPoolExecutor` block; `phase_end("setup")` after `temp_dir = partial_dir / "tmp"`.
+- `phase_start("download_phase")` immediately before `with ThreadPoolExecutor(...)`; `phase_end("download_phase")` immediately after the block (as shown above).
+- `phase_start("tar_close")` before `current_tar.close()`; `phase_end("tar_close")` after.
+- `phase_start("spot_check")` before `if manifest_objects and SPOT_CHECK_HEAD_RATIO > 0:`; `phase_end("spot_check", samples=sample_size)` after the loop.
+- `phase_start("manifest_write")` before `with open(tmp_manifest, "w") as f:`; `phase_end("manifest_write")` after `tmp_manifest.rename(manifest_path)`.
+- `phase_start("rename")` before `partial_dir.rename(output_dir)`; `phase_end("rename")` after.
+- `phase_end("total")` at the very end of the success path (just before returning `BackupResult`).
+
+All phase calls are gated with `if tracer is not None:`.
+
+### C.4 Key changes
+
+- `tracer` plumbed through to `_download_object_to_tempfile` as the 5th positional arg in `executor.submit(...)`.
+- Each main-loop iteration measures `wait_ms` (time on `future.result()`) and `tar_write_ms` (time on `current_tar.addfile` end-to-end including temp-file open).
+- `finalize(...)` called after the executor block to emit the aggregate summary line.
+- Phase boundaries emit `phase_end name=X elapsed_ms=Y fields...` lines.
+
+### C.5 Head-of-line blocking interpretation
+
+- If `Σ wait_ms` over all objects is much larger than `Σ tar_write_ms`, the main thread spends most of its time blocked on slow downloads (workers are not feeding results in submission order). Implication: head-of-line blocking is real; v3's in-order `future.result()` loop is wasting wall-clock time.
+  - Fix (out of scope for this spec): consume futures in completion order via `concurrent.futures.as_completed` and queue tar writes separately.
+- If `Σ wait_ms ≈ 0` and `Σ tar_write_ms` dominates the main-thread time, the tar-write sequential phase is the cap (CPU or disk bound for `tarfile.addfile`).
+  - Fix (out of scope): parallelize tar writes via thread-local chunk buffers, or stream downloads directly into tar members (no temp file).
+
+### C.6 Network saturation interpretation
+
+- `single_worker_avg_mbps` = average per-object `bytes / stream_ms`.
+- `aggregate_mbps` = whole-run wall-clock throughput across all workers.
+- `network_saturated=yes` if `aggregate_mbps / (single_worker_avg_mbps * peak_workers) < 0.5` — scaling efficiency below 50%.
+  - If yes: R2 link or local uplink is the cap; add workers won't help. Tune TCP / use R2 egress priority / consider parallel multipart range GETs (`Range:` header).
+  - If no: bottleneck is elsewhere (disk, tar-write main thread, GIL); address via above interpretations.
+
+---
+
+## Change D: `--debug-traces` flag and logger setup in `maintenance.py`
+
+### D.1 New flag
+
+```python
+@app.command("backup-r2")
+def backup_r2(
+    output: Path = typer.Option(..., "--output", help="Output directory for backup"),
+    chunk_size: str = typer.Option(
+        "10GiB", "--chunk-size", help="Chunk size (e.g. 10GiB, 500MiB, raw bytes)"
+    ),
+    concurrency: int = typer.Option(
+        8, "--concurrency", min=1, max=64,
+        help="Number of concurrent download workers"
+    ),
+    debug_traces: bool = typer.Option(
+        False, "--debug-traces",
+        help="Emit per-object and per-phase performance traces to stderr at DEBUG level"
+    ),
+    format_: str = typer.Option("table", "--format", help="table|json"),
+    config_path: Optional[Path] = typer.Option(None, "--config", "-c"),
+) -> None:
+    """Backup entire R2 bucket to a local directory with chunked tar archives."""
+    _validate_choice(format_, BACKUP_FORMAT_VALUES, "--format")
+
+    try:
+        chunk_size_bytes = parse_size(chunk_size)
+    except ValueError as e:
+        console.print(f"[red]Invalid --chunk-size: {e}[/red]")
+        raise typer.Exit(1)
+
+    if chunk_size_bytes < MIN_CHUNK_SIZE_BYTES:
+        console.print(
+            f"[red]Chunk size {chunk_size_bytes} is below minimum "
+            f"{MIN_CHUNK_SIZE_BYTES} (64MiB)[/red]"
+        )
+        raise typer.Exit(1)
+
+    config, _ = _load_clients(config_path)
+    r2_client = _load_r2(config)
+
+    if format_ == "json":
+        progress_console = Console(file=sys.stderr)
+    else:
+        progress_console = console
+
+    tracer: Optional[BackupTracer] = None
+    if debug_traces:
+        _configure_r2_backup_debug_logging(progress_console)
+        tracer = BackupTracer()
+
+    progress_console.print("[cyan]Building R2 inventory...[/cyan]")
+    if tracer is not None:
+        tracer.phase_start("inventory")
+    inventory = build_inventory(r2_client)
+    if tracer is not None:
+        tracer.phase_end(
+            "inventory",
+            objects=inventory.object_count,
+            total_bytes=inventory.total_bytes,
+        )
+    progress_console.print(
+        f"[green]Inventory complete: {inventory.object_count} objects, "
+        f"{_bytes_to_mb(inventory.total_bytes)} MB[/green]"
+    )
+
+    try:
+        with Progress(
+            SpinnerColumn(),
+            BarColumn(),
+            TaskProgressColumn(),
+            DownloadColumn(),
+            TransferSpeedColumn(),
+            TimeRemainingColumn(),
+            TimeElapsedColumn(),
+            TextColumn("{task.fields[workers]} workers"),
+            TextColumn("{task.fields[objects_done]}/{task.fields[object_count]} objects"),
+            console=progress_console,
+        ) as progress:
+            task = progress.add_task(
+                "Backing up...",
+                total=inventory.total_bytes,
+                workers=0,
+                objects_done=0,
+                object_count=inventory.object_count,
+            )
+
+            base_callback: Optional[Callable[[BackupProgress], None]] = None
+
+            def _on_progress(prog: BackupProgress) -> None:
+                progress.update(
+                    task,
+                    completed=prog.bytes_downloaded,
+                    workers=prog.active_workers,
+                    objects_done=prog.objects_downloaded,
+                )
+                if tracer is not None:
+                    tracer.bytes_downloaded_sample(
+                        prog.bytes_downloaded, prog.active_workers
+                    )
+
+            base_callback = _on_progress
+
+            result = write_backup(
+                r2_client=r2_client,
+                output_dir=output,
+                inventory=inventory,
+                chunk_size_bytes=chunk_size_bytes,
+                concurrency=concurrency,
+                on_progress=base_callback,
+                tracer=tracer,
+            )
+    except BackupError as e:
+        console.print(f"[red]Backup failed: {e}[/red]")
+        raise typer.Exit(1)
+
+    if format_ == "json":
+        _print_json_to_stdout(
+            {
+                "output_dir": str(result.output_dir),
+                "object_count": result.object_count,
+                "total_mb": _bytes_to_mb(result.total_bytes),
+                "chunk_count": result.chunk_count,
+            }
+        )
+    else:
+        _print_backup_summary_table(result, output)
+```
+
+### D.2 New helper `_configure_r2_backup_debug_logging`
+
+```python
+import logging as _stdlogging
+
+
+def _configure_r2_backup_debug_logging(console: Console) -> None:
+    """Attach a DEBUG-level stderr handler to the r2_backup module logger.
+
+    Idempotent: if a handler tagged with the marker attribute is already
+    attached, does nothing.
+    """
+    target = _stdlogging.getLogger(
+        "stream_of_worship.admin.services.r2_backup"
+    )
+    target.setLevel(_stdlogging.DEBUG)
+    marker_attr = "_sow_r2_backup_debug_handler"
+    for h in target.handlers:
+        if getattr(h, marker_attr, False):
+            return
+    handler = _stdlogging.StreamHandler(console.file)
+    handler.setLevel(_stdlogging.DEBUG)
+    handler.setFormatter(
+        _stdlogging.Formatter(
+            "%(asctime)s %(levelname)s %(name)s: %(message)s",
+            datefmt="%H:%M:%S",
+        )
+    )
+    setattr(handler, marker_attr, True)
+    target.addHandler(handler)
+```
+
+### D.3 Imports to add
+
+```python
+from stream_of_worship.admin.services.r2_backup import (
+    DEFAULT_CHUNK_SIZE_BYTES,
+    MIN_CHUNK_SIZE_BYTES,
+    BackupError,
+    BackupProgress,
+    BackupTracer,
+    RestoreError,
+    VerifyError,
+    build_inventory,
+    load_manifest,
+    parse_size,
+    plan_restore,
+    restore_from_archive,
+    verify_archive,
+    write_backup,
+)
+```
+
+### D.4 Progress-bar vs. trace log interleaving
+
+The Rich `Progress` live-display and the new DEBUG log lines both go to stderr. Rich's live display writes to the terminal on a throttle (~10 Hz); DEBUG log lines write between refreshes. In practice this causes log lines to appear interleaved with progress bar redraws, which is acceptable for diagnostic use.
+
+For cleaner capture, users can redirect stderr to a file (`--format json` mode already sends progress to stderr and JSON output to stdout):
+
+```bash
+uv run --extra admin sow-admin maintenance backup-r2 \
+    --output /tmp/sow-backup --concurrency 8 --debug-traces \
+    --format json -c .../config.toml 2>/tmp/sow-backup-trace.log
+```
+
+After the run, `grep -E '^(phase_end|object_download|tar_write|throughput_sample|summary)' /tmp/sow-backup-trace.log` gives a clean trace.
+
+---
+
+## Change E: Test Updates
+
+### E.1 `test_r2_backup.py` — new `TestBackupTracer` class
+
+```python
+from stream_of_worship.admin.services.r2_backup import BackupTracer
+
+
+class TestBackupTracer:
+    def test_disabled_when_logger_below_debug(self):
+        """Tracer is no-op when logger is not at DEBUG level."""
+        import logging
+        log = logging.getLogger("test_disabled_tracer")
+        log.setLevel(logging.INFO)
+        tracer = BackupTracer(logger=log)
+        # All methods should be no-ops and not raise
+        tracer.phase_start("x")
+        tracer.phase_end("x")
+        tracer.object_download_trace(key="k", worker="t1", attempt=0,
+                                     conn_ms=1.0, stream_ms=2.0, bytes_read=10, retries=0)
+        tracer.tar_write_trace(idx=0, key="k", wait_ms=1.0,
+                                tar_write_ms=2.0, bytes_written=10)
+        tracer.bytes_downloaded_sample(100, 1)
+        tracer.finalize(total_objects=1, total_bytes=10)
+        # No assert needed; absence of error proves no-op
+
+    def test_phase_start_end_emits_debug(self, caplog):
+        import logging
+        with caplog.at_level(logging.DEBUG, logger="stream_of_worship.admin.services.r2_backup"):
+            tracer = BackupTracer()
+            tracer.phase_start("phase_x")
+            tracer.phase_end("phase_x", foo="bar")
+        assert any("phase_end name=phase_x" in r.message for r in caplog.records)
+        assert any("foo=bar" in r.message for r in caplog.records)
+
+    def test_object_download_trace_updates_accumulators(self, caplog):
+        import logging
+        with caplog.at_level(logging.DEBUG, logger="stream_of_worship.admin.services.r2_backup"):
+            tracer = BackupTracer()
+            tracer.object_download_trace(key="a", worker="t1", attempt=0,
+                                         conn_ms=10.0, stream_ms=100.0,
+                                         bytes_read=1024 * 1024, retries=0)
+        assert any("object_download key=a" in r.message for r in caplog.records)
+        assert tracer._bytes_downloaded == 1024 * 1024
+        assert tracer._sum_download_ms == 100.0
+        assert tracer._sum_conn_ms == 10.0
+        assert tracer._max_object_download_ms == 110.0
+        assert tracer._max_object_download_key == "a"
+
+    def test_tar_write_trace_updates_accumulators(self, caplog):
+        import logging
+        with caplog.at_level(logging.DEBUG, logger="stream_of_worship.admin.services.r2_backup"):
+            tracer = BackupTracer()
+            tracer.tar_write_trace(idx=0, key="a", wait_ms=50.0,
+                                   tar_write_ms=30.0, bytes_written=1024 * 1024)
+            tracer.tar_write_trace(idx=1, key="b", wait_ms=10.0,
+                                   tar_write_ms=20.0, bytes_written=1024 * 1024)
+        assert tracer._sum_wait_ms == 60.0
+        assert tracer._sum_tar_write_ms == 50.0
+        assert tracer._bytes_written == 2 * 1024 * 1024
+        assert tracer._object_count_written == 2
+        assert any("wait_is_bottleneck=yes" in r.message for r in caplog.records)  # 50 > 30
+        assert any("wait_is_bottleneck=no" in r.message for r in caplog.records)   # 10 < 20
+
+    def test_bytes_downloaded_sample_throttles_logs(self, caplog):
+        """Throughput log emitted at most once per THROUGHPUT_SAMPLE_INTERVAL."""
+        import logging
+        with caplog.at_level(logging.DEBUG, logger="stream_of_worship.admin.services.r2_backup"):
+            tracer = BackupTracer()
+            tracer._run_start = 0.0  # enable t+ logging
+            for i in range(5):
+                tracer.bytes_downloaded_sample(i * 1024 * 1024, 8)
+            # All 5 calls recorded as samples
+            assert len(tracer._throughput_samples) == 5
+            assert tracer._peak_workers == 8
+            # At most 1 throughput_sample log line within the 5s window
+            sample_logs = [r for r in caplog.records if "throughput_sample" in r.message]
+            assert len(sample_logs) <= 1
+
+    def test_finalize_emits_summary_with_network_saturation_field(self, caplog):
+        import logging
+        with caplog.at_level(logging.DEBUG, logger="stream_of_worship.admin.services.r2_backup"):
+            tracer = BackupTracer()
+            tracer._run_start = 0.0
+            tracer.bytes_downloaded_sample(0, 4)
+            # Simulate wall-clock passage
+            import time as _t
+            new_t = _t.time() + 60  # 60s later in real time
+            tracer._throughput_samples.append(
+                (new_t, 100 * 1024 * 1024, 4)
+            )
+            tracer._last_throughput_log = 0  # allow next log
+            tracer._bytes_downloaded = 100 * 1024 * 1024
+            tracer._sum_download_ms = 60_000.0  # 1 worker × 60s
+            tracer._peak_workers = 4
+            tracer.finalize(total_objects=100, total_bytes=100 * 1024 * 1024)
+        summary_logs = [r for r in caplog.records if r.message.startswith("summary")]
+        assert len(summary_logs) == 1
+        msg = summary_logs[0].message
+        assert "aggregate_mbps" in msg
+        assert "single_worker_avg_mbps" in msg
+        assert "network_saturated" in msg
+        assert "peak_workers=4" in msg
+
+    def test_thread_safety(self):
+        """Concurrent calls to BackupTracer methods do not corrupt accumulators."""
+        import logging
+        import threading
+        log = logging.getLogger("test_tracer_thread_safety")
+        log.setLevel(logging.DEBUG)
+        tracer = BackupTracer(logger=log)
+        barrier = threading.Barrier(8)
+
+        def worker():
+            barrier.wait()
+            for i in range(100):
+                tracer.object_download_trace(
+                    key=f"k{i}", worker="w", attempt=0, conn_ms=1.0,
+                    stream_ms=1.0, bytes_read=100, retries=0,
+                )
+                tracer.bytes_downloaded_sample(i * 100, 8)
+
+        threads = [threading.Thread(target=worker) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert tracer._object_count_downloaded == 800
+        assert tracer._bytes_downloaded == 80000
+
+
+class TestWriteBackupTracerIntegration:
+    """Verify write_backup plumbs tracer through and emits expected traces."""
+
+    def test_debug_traces_emits_object_and_tar_traces(self, tmp_path, caplog):
+        import logging
+        objects = [
+            {"key": "a/file1", "size": 100, "etag": "etag1", "data": b"x" * 100},
+            {"key": "a/file2", "size": 200, "etag": "etag2", "data": b"y" * 200},
+        ]
+        r2 = _make_r2_mock(objects)
+        inventory = build_inventory(r2)
+        output = tmp_path / "backup"
+
+        with caplog.at_level(logging.DEBUG, logger="stream_of_worship.admin.services.r2_backup"):
+            tracer = BackupTracer()
+            result = write_backup(
+                r2, output, inventory, tracer=tracer,
+            )
+
+        assert result.object_count == 2
+
+        # At least one object_download and one tar_write log per object
+        download_logs = [r for r in caplog.records if "object_download" in r.message]
+        tar_logs = [r for r in caplog.records if "tar_write" in r.message]
+        phase_logs = [r for r in caplog.records if "phase_end" in r.message]
+        summary_logs = [r for r in caplog.records if r.message.startswith("summary")]
+        assert len(download_logs) >= 2
+        assert len(tar_logs) >= 2
+        assert any("phase_end name=download_phase" in r.message for r in phase_logs)
+        assert any("phase_end name=total" in r.message for r in phase_logs)
+        assert len(summary_logs) == 1
+
+    def test_write_backup_without_tracer_no_logs(self, tmp_path, caplog):
+        """Default (tracer=None) emits no backup DEBUG logs."""
+        import logging
+        objects = [
+            {"key": "a/file1", "size": 100, "etag": "etag1", "data": b"x" * 100},
+        ]
+        r2 = _make_r2_mock(objects)
+        inventory = build_inventory(r2)
+        output = tmp_path / "backup"
+
+        with caplog.at_level(logging.DEBUG, logger="stream_of_worship.admin.services.r2_backup"):
+            result = write_backup(r2, output, inventory)
+        assert result.object_count == 1
+        assert not [r for r in caplog.records if "object_download" in r.message]
+        assert not [r for r in caplog.records if "tar_write" in r.message]
+        assert not [r for r in caplog.records if "summary" in r.message]
+```
+
+### E.2 `test_r2_backup_commands.py` — `--debug-traces` flag test
+
+```python
+def test_backup_r2_debug_traces_flag_passes_tracer(monkeypatch, tmp_path):
+    """--debug-traces constructs a BackupTracer and passes it to write_backup."""
+    captured = {}
+
+    def _fake_write_backup(*, r2_client, output_dir, inventory,
+                           chunk_size_bytes, concurrency, on_progress, tracer):
+        captured["tracer"] = tracer
+        captured["concurrency"] = concurrency
+        from stream_of_worship.admin.services.r2_backup import BackupResult
+        from pathlib import Path
+        return BackupResult(
+            output_dir=Path(str(output_dir)),
+            object_count=0,
+            total_bytes=0,
+            chunk_count=0,
+            manifest={"version": 4, "objects": []},
+        )
+
+    monkeypatch.setattr(
+        "stream_of_worship.admin.commands.maintenance.write_backup",
+        _fake_write_backup,
+    )
+    # Also mock build_inventory to avoid R2 calls
+    monkeypatch.setattr(
+        "stream_of_worship.admin.commands.maintenance.build_inventory",
+        lambda r2_client: _make_minimal_inventory(),
+    )
+    # Mock config + R2 client load
+    monkeypatch.setattr(
+        "stream_of_worship.admin.commands.maintenance._load_clients",
+        lambda config_path: (_make_fake_config(), None),
+    )
+    monkeypatch.setattr(
+        "stream_of_worship.admin.commands.maintenance._load_r2",
+        lambda config: _make_fake_r2(),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, [
+        "maintenance", "backup-r2",
+        "--output", str(tmp_path / "out"),
+        "--debug-traces",
+    ])
+    assert result.exit_code == 0, result.output
+    assert captured["tracer"] is not None
+    assert captured["tracer"].__class__.__name__ == "BackupTracer"
+
+
+def test_backup_r2_default_no_tracer_passes_none(monkeypatch, tmp_path):
+    """Without --debug-traces, tracer is None."""
+    captured = {}
+    # ... same setup, no --debug-traces ...
+    assert captured["tracer"] is None
+```
+
+Existing tests in `test_r2_backup_commands.py` (e.g. `test_backup_concurrency_flag`) mock `write_backup` with `_fake_write_backup` that previously did not accept `tracer` kwarg. **Update those mocks** to accept `tracer=None` (or use `**kwargs`) so they still pass after `write_backup` is called with `tracer=tracer`.
+
+### E.3 Existing tests unchanged
+
+- `TestHashingReader`, `TestBackupProgress`, `TestConcurrentBackup` — unchanged. `BackupTracer` is an additive class; `write_backup` and `_download_object_to_tempfile` gain a new default-`None` parameter, so existing tests calling them without `tracer=` continue to work.
+- `TestVerifyArchive`, `TestPlanRestore`, `TestRestoreFromArchive` — unchanged; no tracer plumbing touches verify/restore paths.
+
+---
+
+## Expected trace output
+
+### After enabling `--debug-traces`
+
+Sample stderr output (timestamps truncated):
+
+```
+00:00:01 DEBUG stream_of_worship.admin.services.r2_backup: phase_end name=inventory elapsed_ms=2400.5 objects=679 total_bytes=12884901888
+00:00:01 DEBUG stream_of_worship.admin.services.r2_backup: phase_end name=disk_check elapsed_ms=12.3 required_bytes=27057364276
+00:00:01 DEBUG stream_of_worship.admin.services.r2_backup: phase_end name=setup elapsed_ms=4.1
+# First per-object download (worker thread):
+00:00:02 DEBUG stream_of_worship.admin.services.r2_backup: object_download key=abc/audio.mp3 worker=ThreadPoolExecutor-0_0 attempt=0 conn_ms=145.2 stream_ms=2390.4 bytes=18874368 download_mbps=7.41 retries=0
+00:00:02 DEBUG stream_of_worship.admin.services.r2_backup: object_download key=def/audio.mp3 worker=ThreadPoolExecutor-0_1 attempt=0 conn_ms=132.7 stream_ms=2210.1 bytes=17203200 download_mbps=6.88 retries=0
+00:00:02 DEBUG stream_of_worship.admin.services.r2_backup: tar_write idx=0 key=abc/audio.mp3 wait_ms=2535.6 tar_write_ms=42.1 bytes=18874368 wait_is_bottleneck=yes
+00:00:02 DEBUG stream_of_worship.admin.services.r2_backup: tar_write idx=1 key=def/audio.mp3 wait_ms=0.1 tar_write_ms=38.6 bytes=17203200 wait_is_bottleneck=no
+# Throughput sample every 5s:
+00:00:06 DEBUG stream_of_worship.admin.services.r2_backup: throughput_sample t+5.0s workers=8 downloaded_mib=120.50 aggregate_mbps=8.04 peak_workers=8
+00:00:11 DEBUG stream_of_worship.admin.services.r2_backup: throughput_sample t+10.0s workers=8 downloaded_mib=240.80 aggregate_mbps=8.02 peak_workers=8
+# ... (continues) ...
+# Phase totals:
+00:25:13 DEBUG stream_of_worship.admin.services.r2_backup: phase_end name=download_phase elapsed_ms=1512324.4 objects=679 total_bytes=12884901888
+00:25:13 DEBUG stream_of_worship.admin.services.r2_backup: summary total_objects=679 total_bytes=12884901888 aggregate_mbps=8.31 single_worker_avg_mbps=1.04 peak_workers=8 retries_total=0 sum_download_ms=1510000.0 sum_conn_ms=98000.0 sum_wait_ms=1480000.0 sum_tar_write_ms=32000.0 wait_pct=97.9 tar_write_pct=2.1 max_object_download_ms=5120.0 max_object_download_key=qrs/audio.mp3 network_saturated=yes
+```
+
+### Interpreting the above (example numbers)
+
+- `aggregate_mbps=8.31`, `single_worker_avg_mbps=1.04`, `peak_workers=8`: scaling efficiency = 8.31 / (1.04 × 8) = 0.997 → **near-linear scaling** → network is **NOT** saturated.
+  - (If `aggregate_mbps` were 8.31 with `single_worker_avg_mbps` 1.04 and peak_workers 32, scaling efficiency = 8.31 / 33.3 = 0.25 → saturation at ~8 MB/s regardless of workers.)
+- `wait_pct=97.9`, `tar_write_pct=2.1`: main thread spends almost all time blocked on `future.result()` → **head-of-line blocking is real**, but it's because downloads dominate, not because tar writes are the cap.
+- `max_object_download_ms=5120.0`: one 5-second outlier. Not the bottleneck given aggregate throughput.
+- `retries_total=0`: no retry storms.
+
+So in this example, the diagnosis would be "per-worker throughput caps at ~1 MB/s, and aggregate maxes out at ~8 MB/s — adding workers to 16 should double throughput. If not, network is the cap."
+
+---
+
+## Verification
+
+```bash
+# Run R2 backup tests including new BackupTracer tests
+PYTHONPATH=src uv run --python 3.11 --extra app --extra test pytest \
+  tests/admin/test_r2_backup.py tests/admin/test_r2_backup_commands.py -v
+
+# Run all admin tests
+PYTHONPATH=src uv run --python 3.11 --extra app --extra test pytest tests/admin/ -v
+
+# Verify --debug-traces is wired in --help output
+uv run --extra admin sow-admin maintenance backup-r2 --help | grep -- '--debug-traces'
+
+# Manual smoke test (requires R2 credentials, real bucket)
+uv run --extra admin sow-admin maintenance backup-r2 \
+  --output /tmp/sow-r2-backup-test \
+  --concurrency 8 \
+  --debug-traces \
+  --format json \
+  -c ~/.config/stream-of-worship-admin/config.toml \
+  2>/tmp/sow-r2-backup-trace.log
+
+# Analyze the trace
+grep -E '^(phase_end|object_download|tar_write|throughput_sample|summary)' \
+  /tmp/sow-r2-backup-trace.log | less
+```
+
+---
+
+## Assumptions and Out of Scope
+
+**Assumptions:**
+
+- `threading.current_thread().name` distinguishes workers (Python's `ThreadPoolExecutor` names them `ThreadPoolExecutor-N_M`).
+- `time.monotonic()` has sufficient resolution (~1 µs on Linux/macOS) for the trace timings.
+- `caplog` (pytest fixture) captures logger output regardless of whether handlers are attached, so the test logger need not have an explicit DEBUG handler set.
+- Rich `Progress.update()` thread-safety (established in v3) continues to hold; the wrapped `_on_progress` callback now also feeds `tracer.bytes_downloaded_sample`, but that method only modifies tracer-local state (no Rich calls).
+- The `--debug-traces` flag adds negligible runtime overhead (<1%) when disabled: all trace methods short-circuit on `_enabled` and all `time.monotonic()` calls are gated by `if tracer is not None:`.
+
+**Out of scope:**
+
+- **Fixing** the bottleneck — this spec only adds traces. The fix (e.g. `concurrent.futures.as_completed` to consume downloads in completion order, parallelize tar writes, or stream directly to tar members) will be the subject of a follow-up spec once the bottleneck is confirmed from real trace data.
+- Wrapping `temp_file.write` to isolate network read time from disk write time (see B.5 limitation).
+- Tracing `verify_archive` / `restore_from_archive` performance (not part of the slow operation).
+- Tracing botocore / urllib3 internals (HTTP/2 frame timings, TLS handshake breakdowns). Per-object `conn_ms` is sufficient to flag if connection setup dominates, and further investigation can use `boto3.set_stream_logger('botocore')` directly.
+- Tracing disk I/O at the syscall level (requires `iostat`/`perf` — out of band).

--- a/specs/admin-r2-backup-progress-v3.md
+++ b/specs/admin-r2-backup-progress-v3.md
@@ -1,0 +1,925 @@
+# Admin R2 Backup: Progress Indicator v3 — Download-Aware Progress, Worker Count, Streaming MD5
+
+## Summary
+
+Fix two issues with the `backup-r2` progress bar after the concurrent-downloads v2 implementation:
+
+1. **No worker count**: The progress bar doesn't show how many download threads are active.
+2. **Progress doesn't reflect parallelism**: The progress bar's `completed` metric tracks bytes written to tar (sequential, main-thread), not bytes downloaded (parallel, worker-threads). This causes the bar to appear stuck during slow head-of-queue downloads, wild ETA fluctuations, and understated throughput.
+
+Additionally fix a latent bottleneck discovered during analysis:
+
+3. **MD5 body check re-reads entire temp file**: After downloading to a temp file, `_download_object_to_tempfile()` re-reads the entire file to compute MD5. This doubles disk I/O per object and can limit throughput on disk-bound systems.
+
+### Root Cause Analysis
+
+**Progress stuck / ETA fluctuation:**
+
+In `write_backup()` (`r2_backup.py:465-519`), all download futures are submitted upfront, but the main thread processes results **in submission order**:
+
+```python
+for idx, inv_obj in enumerate(inventory.objects):
+    future = futures[idx]
+    download_result = future.result()  # blocks until this specific future completes
+    # ... write to tar ...
+    on_progress(idx + 1, bytes_completed)  # only called after tar write
+```
+
+If object 0 is slow (60s) but objects 1-7 finish fast (5s each), the progress bar stays at 0% for 60 seconds, then rapidly jumps. Rich's `TransferSpeedColumn` and `TimeRemainingColumn` compute from these bursty tar-write events, producing wild ETA and understated throughput.
+
+**MD5 re-read:**
+
+In `_download_object_to_tempfile()` (`r2_backup.py:307-320`), after streaming the download to a temp file (computing SHA-256 along the way), the code opens and re-reads the entire temp file to compute MD5 for single-part ETag verification. For a 40 MB audio file, this is an extra 40 MB of disk reads per object.
+
+## Decisions
+
+| Topic | Decision |
+|---|---|
+| Progress metric | Bytes downloaded across all workers (not bytes written to tar) |
+| Worker count display | Inline text field: `{workers} workers` in the progress bar |
+| Elapsed time | `TimeElapsedColumn` added to the progress bar |
+| MD5 computation | Streaming during download via `HashingReader` (alongside SHA-256) |
+| Callback threading | `on_progress` called from worker threads (Rich `Progress.update()` is thread-safe) |
+| Callback throttling | Max ~10 calls/second via time-based throttle in `BackupProgress` |
+| `on_progress` signature | Changed from `Callable[[int, int], None]` to `Callable[[BackupProgress], None]` |
+| MANIFEST_VERSION | No change (stays at 4 — no archive format change) |
+
+## Files to Modify
+
+1. `src/stream_of_worship/admin/services/r2_backup.py` — `HashingReader`, new `BackupProgress` class, `_download_object_to_tempfile()`, `write_backup()`
+2. `src/stream_of_worship/admin/commands/maintenance.py` — Progress bar columns, callback signature
+3. `tests/admin/test_r2_backup.py` — Update `HashingReader` tests, `on_progress` test, add `BackupProgress` tests
+4. `tests/admin/test_r2_backup_commands.py` — No changes needed (mocks `write_backup`)
+
+---
+
+## Change A: Streaming MD5 in `HashingReader` (`r2_backup.py`)
+
+### A.1 Add MD5 hasher and `on_read` callback
+
+```python
+class HashingReader:
+    """A wrapper around a readable stream that computes SHA-256 and MD5 as data is read.
+
+    Also tracks total bytes read for short-read detection, and optionally
+    invokes a callback after each read for progress reporting.
+    """
+
+    def __init__(self, source, on_read: Optional[Callable[[int], None]] = None):
+        self._source = source
+        self._sha256_hasher = hashlib.sha256()
+        self._md5_hasher = hashlib.md5()
+        self.bytes_read = 0
+        self._on_read = on_read
+
+    def read(self, size: int = -1) -> bytes:
+        data = self._source.read(size)
+        if data:
+            self._sha256_hasher.update(data)
+            self._md5_hasher.update(data)
+            self.bytes_read += len(data)
+            if self._on_read is not None:
+                self._on_read(len(data))
+        return data
+
+    @property
+    def sha256_hex(self) -> str:
+        return self._sha256_hasher.hexdigest()
+
+    @property
+    def md5_hex(self) -> str:
+        return self._md5_hasher.hexdigest()
+
+    def close(self) -> None:
+        if hasattr(self._source, "close"):
+            self._source.close()
+```
+
+**Key changes:**
+- `_hasher` (SHA-256 only) → `_sha256_hasher` + `_md5_hasher`
+- New `on_read` callback invoked after each `read()` with the chunk byte count
+- New `md5_hex` property
+
+### A.2 Use streaming MD5 in `_download_object_to_tempfile()`
+
+Replace the re-read MD5 block (`r2_backup.py:307-320`):
+
+**Before (re-reads entire file):**
+```python
+if "-" not in get_etag:
+    md5_hasher = hashlib.md5()
+    with open(temp_path, "rb") as md5_file:
+        while True:
+            md5_chunk = md5_file.read(65536)
+            if not md5_chunk:
+                break
+            md5_hasher.update(md5_chunk)
+    md5_hex = md5_hasher.hexdigest()
+    if md5_hex != get_etag:
+        raise BackupError(...)
+```
+
+**After (uses streaming MD5 from HashingReader):**
+```python
+if "-" not in get_etag:
+    if hashing_reader.md5_hex != get_etag:
+        raise BackupError(
+            f"Object {inv_obj.key} MD5 mismatch: ETag {get_etag}, "
+            f"computed {hashing_reader.md5_hex}"
+        )
+```
+
+This eliminates the entire re-read. MD5 is computed during the download stream alongside SHA-256, at zero extra I/O cost.
+
+---
+
+## Change B: New `BackupProgress` Class (`r2_backup.py`)
+
+### B.1 Thread-safe progress tracker
+
+```python
+import time
+
+
+class BackupProgress:
+    """Thread-safe progress tracker for concurrent backup downloads.
+
+    Tracks bytes downloaded, objects downloaded, and active worker count
+    across all download threads. Designed to be safely updated from worker
+    threads and read from the progress callback.
+    """
+
+    def __init__(
+        self,
+        total_objects: int,
+        total_bytes: int,
+        on_progress: Optional[Callable[["BackupProgress"], None]] = None,
+        min_report_interval: float = 0.1,
+    ):
+        self._lock = threading.Lock()
+        self._bytes_downloaded = 0
+        self._objects_downloaded = 0
+        self._active_workers = 0
+        self._objects_written = 0
+        self._bytes_written = 0
+        self.total_objects = total_objects
+        self.total_bytes = total_bytes
+        self._on_progress = on_progress
+        self._min_report_interval = min_report_interval
+        self._last_report_time = 0.0
+
+    def worker_started(self) -> None:
+        with self._lock:
+            self._active_workers += 1
+        self._maybe_report()
+
+    def worker_finished(self) -> None:
+        with self._lock:
+            self._active_workers -= 1
+            self._objects_downloaded += 1
+        self._maybe_report()
+
+    def add_bytes(self, n: int) -> None:
+        with self._lock:
+            self._bytes_downloaded += n
+        self._maybe_report()
+
+    def object_written(self, bytes_written: int) -> None:
+        with self._lock:
+            self._objects_written += 1
+            self._bytes_written += bytes_written
+        self._maybe_report()
+
+    def _maybe_report(self) -> None:
+        """Call on_progress if enough time has elapsed since last report."""
+        if self._on_progress is None:
+            return
+        now = time.monotonic()
+        with self._lock:
+            if now - self._last_report_time < self._min_report_interval:
+                return
+            self._last_report_time = now
+        self._on_progress(self)
+
+    @property
+    def bytes_downloaded(self) -> int:
+        with self._lock:
+            return self._bytes_downloaded
+
+    @property
+    def objects_downloaded(self) -> int:
+        with self._lock:
+            return self._objects_downloaded
+
+    @property
+    def active_workers(self) -> int:
+        with self._lock:
+            return self._active_workers
+
+    @property
+    def objects_written(self) -> int:
+        with self._lock:
+            return self._objects_written
+
+    @property
+    def bytes_written(self) -> int:
+        with self._lock:
+            return self._bytes_written
+```
+
+**Design notes:**
+- All counter updates are atomic (lock-protected).
+- `_maybe_report()` throttles `on_progress` calls to at most ~10/second, preventing excessive lock contention from Rich's `Progress.update()`.
+- `on_progress` is called from worker threads. Rich's `Progress.update()` is thread-safe (uses an internal lock), so this is safe.
+- `min_report_interval=0.1` (100ms) balances smoothness vs. overhead. For 679 objects / 12 GB, this yields ~10 updates/second regardless of object count or size.
+
+---
+
+## Change C: Wire `BackupProgress` into `_download_object_to_tempfile()` (`r2_backup.py`)
+
+### C.1 New `progress` parameter
+
+```python
+def _download_object_to_tempfile(
+    r2_client: R2Client,
+    inv_obj: InventoryObject,
+    temp_dir: Path,
+    progress: Optional[BackupProgress] = None,
+    max_retries: int = 2,
+) -> DownloadResult:
+```
+
+### C.2 Update download function to use progress tracker
+
+Inside `_download_object_to_tempfile()`, wrap the download with progress tracking:
+
+```python
+    last_error: Optional[str] = None
+    for attempt in range(max_retries + 1):
+        temp_path: Optional[Path] = None
+        try:
+            if progress is not None:
+                progress.worker_started()
+
+            resp = r2_client.get_object_stream(inv_obj.key)
+            body = resp["body"]
+            content_length = resp["content_length"]
+            get_etag = resp["etag"]
+
+            try:
+                temp_dir.mkdir(parents=True, exist_ok=True)
+                with tempfile.NamedTemporaryFile(dir=temp_dir, delete=False) as temp_file:
+                    temp_path = Path(temp_file.name)
+
+                    on_read = progress.add_bytes if progress is not None else None
+                    hashing_reader = HashingReader(body, on_read=on_read)
+                    shutil.copyfileobj(hashing_reader, temp_file, length=COPY_BUFFER_SIZE)
+
+                # ... existing validation (short read, size mismatch, ETag check) ...
+
+                # MD5 body check — now uses streaming MD5 from HashingReader
+                if "-" not in get_etag:
+                    if hashing_reader.md5_hex != get_etag:
+                        raise BackupError(
+                            f"Object {inv_obj.key} MD5 mismatch: ETag {get_etag}, "
+                            f"computed {hashing_reader.md5_hex}"
+                        )
+
+                # ... existing return DownloadResult ...
+
+            finally:
+                body.close()
+
+        except Exception as e:
+            last_error = str(e)
+            if temp_path is not None:
+                try:
+                    temp_path.unlink()
+                except OSError:
+                    pass
+            if attempt < max_retries:
+                continue
+            raise BackupError(
+                f"Failed to backup {inv_obj.key} after retries: {last_error}"
+            ) from e
+        finally:
+            if progress is not None:
+                progress.worker_finished()
+```
+
+**Key changes:**
+- `progress.worker_started()` / `progress.worker_finished()` bracket each download attempt (in `finally` so workers are always decremented, even on failure).
+- `HashingReader` receives `on_read=progress.add_bytes` so every chunk read updates the download byte counter.
+- MD5 check uses `hashing_reader.md5_hex` (streaming) instead of re-reading the file.
+- `worker_finished()` is in the outermost `finally` block so it runs exactly once per call, regardless of retry attempts.
+
+**Note on retry + worker_started/finished:** If a download fails and retries, `worker_started()` is called at the top of each attempt and `worker_finished()` in the `finally`. This means for N retries, `worker_started` is called N times and `worker_finished` is called N times, keeping the counter balanced. The `objects_downloaded` counter is only incremented on `worker_finished()`, so it will be incremented once per retry attempt. This is acceptable — the final count will be correct (one increment per successful or exhausted-retry download). If exact `objects_downloaded` accuracy is needed, move `worker_finished()` to only run on the last attempt. For simplicity, the current design is sufficient since the progress bar primarily tracks `bytes_downloaded` and `active_workers`.
+
+**Correction:** To keep `objects_downloaded` accurate (one increment per object, not per retry), `worker_finished()` should only increment `objects_downloaded` on the final attempt. Revised approach:
+
+```python
+    for attempt in range(max_retries + 1):
+        temp_path: Optional[Path] = None
+        try:
+            if progress is not None:
+                progress.worker_started()
+
+            # ... download + validate ...
+
+            if progress is not None:
+                progress.worker_finished()
+            return DownloadResult(...)
+
+        except Exception as e:
+            # ... error handling ...
+        finally:
+            if progress is not None:
+                progress.worker_finished()
+```
+
+Wait — this would call `worker_finished()` twice on success (once before return, once in finally). Better design: only call `worker_finished()` in `finally`, and don't increment `objects_downloaded` in `worker_finished()`. Instead, increment `objects_downloaded` separately on success:
+
+```python
+    def worker_finished(self, success: bool = True) -> None:
+        with self._lock:
+            self._active_workers -= 1
+            if success:
+                self._objects_downloaded += 1
+        self._maybe_report()
+```
+
+And in `_download_object_to_tempfile`:
+```python
+    finally:
+        if progress is not None:
+            progress.worker_finished(success=(return_value is not None))
+```
+
+Actually, the simplest correct approach: `worker_started()` is called once per attempt. `worker_finished()` is called once per attempt in `finally`. `objects_downloaded` is NOT incremented in `worker_finished()` — it's incremented in `write_backup()` after `future.result()` succeeds. This separates "worker is done" from "object was successfully downloaded."
+
+**Final design for BackupProgress:**
+
+```python
+    def worker_started(self) -> None:
+        with self._lock:
+            self._active_workers += 1
+        self._maybe_report()
+
+    def worker_finished(self) -> None:
+        with self._lock:
+            self._active_workers -= 1
+        self._maybe_report()
+
+    def mark_object_downloaded(self, bytes_downloaded: int) -> None:
+        with self._lock:
+            self._objects_downloaded += 1
+            self._bytes_downloaded += bytes_downloaded
+        self._maybe_report()
+```
+
+Wait, but `add_bytes` already increments `_bytes_downloaded`. If we also increment in `mark_object_downloaded`, we'd double-count. 
+
+The issue is that `add_bytes` is called during streaming (every 1MB chunk), and by the time the download finishes, all bytes have been added. So `mark_object_downloaded` should only increment `_objects_downloaded`, not `_bytes_downloaded`:
+
+```python
+    def mark_object_downloaded(self) -> None:
+        with self._lock:
+            self._objects_downloaded += 1
+        self._maybe_report()
+```
+
+And in `write_backup()`, after `future.result()` succeeds:
+```python
+    download_result = future.result()
+    if progress is not None:
+        progress.mark_object_downloaded()
+```
+
+This is clean:
+- `add_bytes(n)` — called during streaming, updates `_bytes_downloaded`
+- `worker_started()` / `worker_finished()` — bracket the download, update `_active_workers`
+- `mark_object_downloaded()` — called after successful download, updates `_objects_downloaded`
+- `object_written(bytes)` — called after tar write, updates `_objects_written` and `_bytes_written`
+
+---
+
+## Change D: Wire `BackupProgress` into `write_backup()` (`r2_backup.py`)
+
+### D.1 Change `on_progress` signature
+
+```python
+def write_backup(
+    r2_client: R2Client,
+    output_dir: Path,
+    inventory: Inventory,
+    chunk_size_bytes: int = DEFAULT_CHUNK_SIZE_BYTES,
+    concurrency: int = DEFAULT_CONCURRENCY,
+    on_progress: Optional[Callable[[BackupProgress], None]] = None,
+) -> BackupResult:
+```
+
+**Breaking change:** `on_progress` was `Callable[[int, int], None]` (objects_done, bytes_done). Now `Callable[[BackupProgress], None]`.
+
+### D.2 Create `BackupProgress` and pass to workers
+
+```python
+    progress = BackupProgress(
+        total_objects=inventory.object_count,
+        total_bytes=inventory.total_bytes,
+        on_progress=on_progress,
+    )
+
+    with ThreadPoolExecutor(max_workers=concurrency) as executor:
+        futures = {
+            idx: executor.submit(
+                _download_object_to_tempfile, r2_client, inv_obj, temp_dir, progress
+            )
+            for idx, inv_obj in enumerate(inventory.objects)
+        }
+
+        try:
+            for idx, inv_obj in enumerate(inventory.objects):
+                member_name = _member_name_for_index(idx)
+
+                if (
+                    current_chunk_bytes > 0
+                    and current_chunk_bytes + inv_obj.size > chunk_size_bytes
+                ):
+                    _rotate_chunk()
+
+                _ensure_tar()
+
+                future = futures[idx]
+                try:
+                    download_result = future.result()
+                except BaseException:
+                    for f in futures.values():
+                        f.cancel()
+                    raise
+
+                if progress is not None:
+                    progress.mark_object_downloaded()
+
+                _track_temp(download_result.temp_path)
+                try:
+                    # ... existing tar write logic ...
+
+                    if progress is not None:
+                        progress.object_written(inv_obj.size)
+                finally:
+                    _untrack_temp(download_result.temp_path)
+                    try:
+                        download_result.temp_path.unlink()
+                    except OSError:
+                        pass
+        except BaseException:
+            for f in futures.values():
+                f.cancel()
+            raise
+```
+
+**Key changes:**
+- `BackupProgress` created with `on_progress` callback and totals.
+- Passed to `_download_object_to_tempfile` as the `progress` parameter.
+- `progress.mark_object_downloaded()` called after successful `future.result()`.
+- `progress.object_written(inv_obj.size)` called after tar write (replaces old `on_progress(idx + 1, bytes_completed)` call).
+- The old `on_progress(idx + 1, bytes_completed)` call is removed — progress is now reported via `BackupProgress._maybe_report()` which is called from `add_bytes`, `worker_started`, `worker_finished`, `mark_object_downloaded`, and `object_written`.
+
+### D.3 Remove old `bytes_completed` tracking
+
+The old `bytes_completed` variable and `on_progress(idx + 1, bytes_completed)` call (lines 463, 510-513) are removed. `BackupProgress` handles all progress tracking.
+
+---
+
+## Change E: Update Progress Bar in `maintenance.py`
+
+### E.1 Add `TimeElapsedColumn` import
+
+```python
+from rich.progress import (
+    BarColumn,
+    DownloadColumn,
+    Progress,
+    SpinnerColumn,
+    TaskProgressColumn,
+    TextColumn,
+    TimeElapsedColumn,
+    TimeRemainingColumn,
+    TransferSpeedColumn,
+)
+```
+
+### E.2 Update progress bar columns and callback
+
+```python
+    try:
+        with Progress(
+            SpinnerColumn(),
+            BarColumn(),
+            TaskProgressColumn(),
+            DownloadColumn(),
+            TransferSpeedColumn(),
+            TimeRemainingColumn(),
+            TimeElapsedColumn(),
+            TextColumn("{task.fields[workers]} workers"),
+            TextColumn("{task.fields[objects_done]}/{task.fields[object_count]} objects"),
+            console=progress_console,
+        ) as progress:
+            task = progress.add_task(
+                "Backing up...",
+                total=inventory.total_bytes,
+                workers=0,
+                objects_done=0,
+                object_count=inventory.object_count,
+            )
+
+            def _on_progress(prog: BackupProgress) -> None:
+                progress.update(
+                    task,
+                    completed=prog.bytes_downloaded,
+                    workers=prog.active_workers,
+                    objects_done=prog.objects_downloaded,
+                )
+
+            result = write_backup(
+                r2_client=r2_client,
+                output_dir=output,
+                inventory=inventory,
+                chunk_size_bytes=chunk_size_bytes,
+                concurrency=concurrency,
+                on_progress=_on_progress,
+            )
+    except BackupError as e:
+        console.print(f"[red]Backup failed: {e}[/red]")
+        raise typer.Exit(1)
+```
+
+**Key changes:**
+- `completed=prog.bytes_downloaded` (was `bytes_done` = bytes written to tar). Now reflects actual download progress across all parallel workers.
+- `workers=prog.active_workers` — new field showing active download threads.
+- `objects_done=prog.objects_downloaded` — now reflects downloaded objects, not written objects.
+- `TimeElapsedColumn()` — new column showing elapsed time.
+- Removed the `TextColumn("[progress.description]{task.description}")` column (description was always "Backing up...", not useful inline).
+- `BackupProgress` import added to imports from `r2_backup`.
+
+### E.3 Add `BackupProgress` to imports
+
+```python
+from stream_of_worship.admin.services.r2_backup import (
+    DEFAULT_CHUNK_SIZE_BYTES,
+    MIN_CHUNK_SIZE_BYTES,
+    BackupError,
+    BackupProgress,
+    RestoreError,
+    VerifyError,
+    build_inventory,
+    load_manifest,
+    parse_size,
+    plan_restore,
+    restore_from_archive,
+    verify_archive,
+    write_backup,
+)
+```
+
+---
+
+## Change F: Test Updates
+
+### F.1 `test_r2_backup.py` — `TestHashingReader`
+
+**Update existing tests** to verify MD5 computation and `on_read` callback:
+
+```python
+class TestHashingReader:
+    def test_reads_and_hashes(self):
+        data = b"hello world"
+        source = io.BytesIO(data)
+        reader = HashingReader(source)
+        result = reader.read()
+        assert result == data
+        assert reader.bytes_read == len(data)
+        assert reader.sha256_hex == hashlib.sha256(data).hexdigest()
+        assert reader.md5_hex == hashlib.md5(data).hexdigest()
+
+    def test_partial_reads(self):
+        data = b"hello world"
+        source = io.BytesIO(data)
+        reader = HashingReader(source)
+        chunk1 = reader.read(5)
+        chunk2 = reader.read(6)
+        assert chunk1 == b"hello"
+        assert chunk2 == b" world"
+        assert reader.bytes_read == len(data)
+        assert reader.sha256_hex == hashlib.sha256(data).hexdigest()
+        assert reader.md5_hex == hashlib.md5(data).hexdigest()
+
+    def test_empty_read(self):
+        source = io.BytesIO(b"")
+        reader = HashingReader(source)
+        result = reader.read()
+        assert result == b""
+        assert reader.bytes_read == 0
+        assert reader.sha256_hex == hashlib.sha256(b"").hexdigest()
+        assert reader.md5_hex == hashlib.md5(b"").hexdigest()
+
+    def test_close(self):
+        source = MagicMock()
+        reader = HashingReader(source)
+        reader.close()
+        source.close.assert_called_once()
+
+    def test_on_read_callback(self):
+        """on_read callback is invoked with chunk byte count after each read."""
+        data = b"hello world"
+        source = io.BytesIO(data)
+        calls = []
+        reader = HashingReader(source, on_read=lambda n: calls.append(n))
+        reader.read(5)
+        reader.read(6)
+        assert calls == [5, 6]
+
+    def test_on_read_not_called_on_empty_read(self):
+        """on_read is not called when read returns empty bytes."""
+        source = io.BytesIO(b"")
+        reader = HashingReader(source, on_read=lambda n: pytest.fail("should not be called"))
+        reader.read()
+```
+
+### F.2 `test_r2_backup.py` — `TestWriteBackupProgress`
+
+**Update `test_on_progress_called_with_correct_counts`** for new callback signature:
+
+```python
+class TestWriteBackupProgress:
+    def test_on_progress_called_with_correct_counts(self, tmp_path):
+        """write_backup calls on_progress with BackupProgress reflecting downloads."""
+        objects = [
+            {"key": "a/file1", "size": 100, "etag": "etag1", "data": b"x" * 100},
+            {"key": "a/file2", "size": 200, "etag": "etag2", "data": b"y" * 200},
+        ]
+        r2 = _make_r2_mock(objects)
+        inventory = build_inventory(r2)
+        output = tmp_path / "backup"
+
+        last_progress = None
+
+        def _on_progress(prog: BackupProgress) -> None:
+            nonlocal last_progress
+            last_progress = prog
+
+        result = write_backup(r2, output, inventory, on_progress=_on_progress)
+
+        assert last_progress is not None
+        assert last_progress.bytes_downloaded == 300
+        assert last_progress.objects_downloaded == 2
+        assert last_progress.active_workers == 0
+        assert last_progress.objects_written == 2
+        assert last_progress.bytes_written == 300
+        assert result.object_count == 2
+        assert result.total_bytes == 300
+
+    def test_on_progress_none_works(self, tmp_path):
+        """write_backup works with on_progress=None (default)."""
+        objects = [
+            {"key": "a/file1", "size": 100, "etag": "etag1", "data": b"x" * 100},
+        ]
+        r2 = _make_r2_mock(objects)
+        inventory = build_inventory(r2)
+        output = tmp_path / "backup"
+
+        result = write_backup(r2, output, inventory)
+
+        assert result.object_count == 1
+```
+
+### F.3 `test_r2_backup.py` — New `TestBackupProgress` class
+
+```python
+class TestBackupProgress:
+    def test_initial_state(self):
+        prog = BackupProgress(total_objects=10, total_bytes=1000)
+        assert prog.bytes_downloaded == 0
+        assert prog.objects_downloaded == 0
+        assert prog.active_workers == 0
+        assert prog.objects_written == 0
+        assert prog.bytes_written == 0
+        assert prog.total_objects == 10
+        assert prog.total_bytes == 1000
+
+    def test_worker_started_finished(self):
+        prog = BackupProgress(total_objects=10, total_bytes=1000)
+        prog.worker_started()
+        assert prog.active_workers == 1
+        prog.worker_started()
+        assert prog.active_workers == 2
+        prog.worker_finished()
+        assert prog.active_workers == 1
+        prog.worker_finished()
+        assert prog.active_workers == 0
+
+    def test_add_bytes(self):
+        prog = BackupProgress(total_objects=10, total_bytes=1000)
+        prog.add_bytes(100)
+        prog.add_bytes(200)
+        assert prog.bytes_downloaded == 300
+
+    def test_mark_object_downloaded(self):
+        prog = BackupProgress(total_objects=10, total_bytes=1000)
+        prog.mark_object_downloaded()
+        prog.mark_object_downloaded()
+        assert prog.objects_downloaded == 2
+
+    def test_object_written(self):
+        prog = BackupProgress(total_objects=10, total_bytes=1000)
+        prog.object_written(100)
+        prog.object_written(200)
+        assert prog.objects_written == 2
+        assert prog.bytes_written == 300
+
+    def test_on_progress_callback_invoked(self):
+        calls = []
+        prog = BackupProgress(
+            total_objects=10, total_bytes=1000,
+            on_progress=lambda p: calls.append(p),
+            min_report_interval=0.0,  # no throttling for tests
+        )
+        prog.add_bytes(100)
+        assert len(calls) >= 1
+        assert calls[-1].bytes_downloaded == 100
+
+    def test_on_progress_throttled(self):
+        calls = []
+        prog = BackupProgress(
+            total_objects=10, total_bytes=1000,
+            on_progress=lambda p: calls.append(p),
+            min_report_interval=1.0,  # 1 second throttle
+        )
+        prog.add_bytes(10)
+        prog.add_bytes(20)
+        prog.add_bytes(30)
+        # Only first call should trigger (subsequent calls within 1s are throttled)
+        assert len(calls) == 1
+        # But the counter still reflects all additions
+        assert calls[0].bytes_downloaded == 60
+
+    def test_on_progress_none_no_error(self):
+        """No error when on_progress is None."""
+        prog = BackupProgress(total_objects=10, total_bytes=1000)
+        prog.add_bytes(100)
+        prog.worker_started()
+        prog.worker_finished()
+        prog.mark_object_downloaded()
+        prog.object_written(100)
+
+    def test_thread_safety(self):
+        """Concurrent updates from multiple threads produce correct totals."""
+        import threading
+
+        prog = BackupProgress(
+            total_objects=100, total_bytes=10000,
+            min_report_interval=0.0,
+        )
+
+        def worker():
+            for _ in range(100):
+                prog.add_bytes(1)
+
+        threads = [threading.Thread(target=worker) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert prog.bytes_downloaded == 1000
+```
+
+### F.4 `test_r2_backup.py` — Update imports
+
+```python
+from stream_of_worship.admin.services.r2_backup import (
+    DEFAULT_CHUNK_SIZE_BYTES,
+    MANIFEST_VERSION,
+    MIN_CHUNK_SIZE_BYTES,
+    BackupError,
+    BackupProgress,
+    HashingReader,
+    Inventory,
+    InventoryObject,
+    RestoreError,
+    VerifyError,
+    build_inventory,
+    load_manifest,
+    parse_size,
+    plan_restore,
+    restore_from_archive,
+    verify_archive,
+    write_backup,
+    DEFAULT_CONCURRENCY,
+    COPY_BUFFER_SIZE,
+    SPOT_CHECK_HEAD_RATIO,
+)
+```
+
+### F.5 `test_r2_backup.py` — Existing tests that should pass unchanged
+
+All `TestConcurrentBackup` tests, `TestVerifyArchive` tests, `TestPlanRestore` tests, and `TestRestoreFromArchive` tests should pass unchanged because:
+- `write_backup()` with `on_progress=None` (default) creates a `BackupProgress` with no callback — no behavior change.
+- `_download_object_to_tempfile()` with `progress=None` (default when called directly in tests) has no progress tracking — no behavior change.
+- The MD5 check change is semantically identical (streaming MD5 produces the same hash as re-read MD5).
+- Archive format is unchanged (MANIFEST_VERSION stays 4).
+
+### F.6 `test_r2_backup_commands.py` — No changes needed
+
+The `test_backup_concurrency_flag` test mocks `write_backup` and checks `concurrency` kwarg. The `on_progress` signature change doesn't affect this test since it doesn't exercise the callback.
+
+---
+
+## Expected Behavior After Changes
+
+### Progress bar output
+
+```
+⠙ ████████████████░░░░░░░░░░░░  53% 6.8/12.9 GB 8.2 MB/s 0:12 5 workers 360/679 objects
+```
+
+Columns (left to right):
+1. Spinner
+2. Progress bar
+3. Percentage (53%)
+4. Downloaded/total bytes (6.8/12.9 GB)
+5. Transfer speed (8.2 MB/s — reflects aggregate download rate across all workers)
+6. Time remaining (ETA based on download rate, stable because progress is smooth)
+7. Elapsed time (0:12)
+8. Active workers (5 workers)
+9. Objects downloaded/total (360/679 objects)
+
+### Performance impact
+
+| Change | Effect |
+|---|---|
+| Progress tracks downloads, not tar writes | Progress bar is smooth, ETA is stable, speed reflects actual download throughput |
+| Streaming MD5 | Eliminates ~12.9 GB of extra disk reads (one full re-read per object). For disk-bound systems, this alone could improve throughput significantly. |
+| Worker count display | User can verify parallelism is working (e.g., "8 workers" confirms all threads are active) |
+| Elapsed time | User can compare wall-clock time against expectations |
+
+---
+
+## Edge Cases and Considerations
+
+1. **Empty bucket:** `BackupProgress` created with `total_objects=0, total_bytes=0`. No workers started. Progress bar shows `0/0 objects, 0 workers`. Completes immediately.
+
+2. **`concurrency=1`:** Single worker. `active_workers` will be 0 or 1. Progress bar updates after each download chunk. Behavior is correct.
+
+3. **Download failure:** `worker_finished()` is called in `finally` block, so `active_workers` is always decremented even on failure. After failure, `write_backup()` cancels remaining futures and raises `BackupError`. The `Progress` context manager exits cleanly.
+
+4. **`on_progress=None`:** `BackupProgress` is still created (for internal tracking) but `_maybe_report()` is a no-op. No behavior change from caller's perspective.
+
+5. **Thread safety of Rich `Progress.update()`:** Rich's `Progress` class uses an internal `Lock` around `update()`. Calling it from worker threads is safe. The `Live` display refresh thread reads the task state on its own schedule (~10 Hz).
+
+6. **Callback throttling:** `min_report_interval=0.1` (100ms) limits `on_progress` calls to ~10/second. For 679 objects / 12 GB, this means ~10 Rich updates/second regardless of object count or size. Each update acquires the Rich lock briefly. This is negligible overhead.
+
+7. **`add_bytes` called from `HashingReader.read()`:** With `COPY_BUFFER_SIZE=1MB`, each `read()` call processes up to 1 MB. With 8 workers, that's up to 8 `add_bytes` calls per MB of aggregate download. Each call does a lock + counter update + throttle check. This is O(1) and negligible.
+
+8. **MD5 for multipart objects:** Objects with `-` in ETag (multipart uploads) skip the MD5 check. The streaming MD5 is still computed but not used. This is a tiny waste of CPU (MD5 update is fast) but simplifies the code. No action needed.
+
+9. **`objects_downloaded` vs `objects_written`:** `objects_downloaded` reflects completed downloads (may be ahead of tar writes). `objects_written` reflects committed archive entries. The progress bar shows `objects_downloaded` for the "objects" field. This is correct — the user wants to see download progress.
+
+10. **Spot-check HEAD phase:** No progress updates during spot-check HEAD (runs after backup is committed). The progress bar will show 100% during this phase. This is acceptable — spot-check is fast (~34 HEAD requests).
+
+11. **`BackupProgress` not exported in `__init__`:** `BackupProgress` is a public class in `r2_backup.py` (no underscore prefix). It's imported directly in `maintenance.py` and tests. No `__init__.py` export needed.
+
+---
+
+## Verification
+
+```bash
+# Run R2 backup tests
+PYTHONPATH=src uv run --python 3.11 --extra app --extra test pytest \
+  tests/admin/test_r2_backup.py tests/admin/test_r2_backup_commands.py -v
+
+# Run all admin tests
+PYTHONPATH=src uv run --python 3.11 --extra app --extra test pytest tests/admin/ -v
+
+# Manual smoke test (requires R2 credentials)
+uv run --extra admin sow-admin maintenance backup-r2 \
+  --output /tmp/sow-r2-backup-test \
+  --concurrency 8 \
+  -c ~/.config/stream-of-worship-admin/config.toml
+```
+
+---
+
+## Assumptions and Out of Scope
+
+**Assumptions:**
+- Rich's `Progress.update()` is thread-safe (confirmed by Rich source code — uses `threading.Lock`).
+- `hashlib.md5().update()` is thread-safe when called from the same thread that owns the hasher instance (each `HashingReader` is used by a single worker thread).
+- The `on_read` callback in `HashingReader` is lightweight enough (lock + counter + throttle check) to not measurably impact download throughput.
+
+**Out of scope:**
+- Changing the tar-write sequential model (tar format requires sequential writes).
+- Streaming directly to tar (user previously chose to keep temp files).
+- Per-worker progress bars (single aggregate bar is sufficient).
+- Download timeout / stall detection (can be added later if observed).
+- Bandwidth limiting.

--- a/specs/admin-r2-backup-rclone-download-v1.md
+++ b/specs/admin-r2-backup-rclone-download-v1.md
@@ -1,0 +1,707 @@
+# Admin R2 Backup rclone Download Path v1
+
+**Service:** Admin CLI (`src/stream_of_worship/admin/`)
+**Status:** Draft (plan only — no implementation)
+**Created:** 2026-06-20
+**Predecessor specs:**
+- `specs/admin-r2-backup-throughput-remediation-v1.md` (32-worker bump, abandoned)
+- `specs/admin-r2-backup-throughput-remediation-v2.md` (revert + investigation closure)
+**CLI command:** `sow-admin maintenance backup-r2`
+
+## Summary
+
+Re-open the R2 backup throughput investigation that was closed as "not feasible
+within the local Python CLI architecture" in
+`admin-r2-backup-throughput-remediation-v2.md`. That closure was correct **for
+the boto3-with-ThreadPoolExecutor architecture** — it does not generalize to
+the rclone option the user has now authorized.
+
+This spec introduces rclone as an external binary dependency for the
+**download phase only**. The inventory, metadata-HEAD, manifest-build, tar
+archive, verify, and restore paths remain unchanged. The Python codebase keeps
+`boto3` for everything except the bulk download loop.
+
+The success metric for this spec is **parity with `rclone copy`'s default
+behavior** on the `stream-of-worship` R2 bucket, measured by end-to-end backup
+runtime (no fixed MiB/s target). The closure spec's `<10 min` goal is **not**
+re-opened by this spec; it is left in the "Out of Scope" bucket per the user's
+direction.
+
+**Mandatory benchmark step:** the implementation phase must run the existing
+`--diag-range-key` diagnostic against both the current boto3 path and the new
+rclone path, plus a baseline `rclone copy` reference benchmark, before any
+production code lands. This confirms (or refutes) that the ~7 MiB/s ceiling is
+an R2 account-level cap rather than a boto3-specific artifact.
+
+## Background
+
+### Critical fact: the code is NOT using the r2.dev endpoint
+
+Two of the four candidate options the user originally listed are non-issues:
+
+| User's option | Resolution |
+|---|---|
+| "confirmation that r2.dev endpoint is bandwidth-limited" | **N/A.** Zero occurrences of `r2.dev` in the codebase. The backup has always used the S3-compatible endpoint `https://<account-id>.r2.cloudflarestorage.com`. See `src/stream_of_worship/admin/services/r2.py:95-111` and `examples/sow-admin-config.toml:27-28`. |
+| "use S3-compatible API instead" | **Already doing this.** `R2Client` constructs a `boto3.client("s3", endpoint_url=...)`. No change needed. |
+| "use Cloudflare REST API instead" | **Not viable.** The Cloudflare REST API (`api.cloudflare.com`) only manages bucket/object **metadata**; it cannot stream object content for bulk download. Rejected. |
+| "use rclone" | **Pursued.** This spec. rclone uses the same S3-compatible API as boto3 but has a Go-implemented, heavily-tuned multipart downloader (parallel ranges per object, global transfer pool, automatic ETag verification). |
+
+### What the boto3 backup path does today
+
+The current `backup-r2` command (`maintenance.py:642-784`) calls
+`write_backup` (`r2_backup.py:884-1203`), which:
+
+1. Builds an inventory via boto3 paginator (`build_inventory`).
+2. Submits each object as a `ThreadPoolExecutor` future.
+3. Each worker calls `R2Client.get_object_stream` (raw `boto3 get_object`).
+4. Streams body through `HashingReader` (SHA-256 + MD5) into a tempfile using a
+   1 MiB `COPY_BUFFER_SIZE`.
+5. Validates ContentLength, ETag, and (for non-multipart ETags) MD5 body checksum.
+6. The main thread writes each completed tempfile into the current chunked tar
+   archive with a sanitized member name `objects/{idx:012d}.bin`.
+7. Optionally spot-checks 5% of objects via `head_object`.
+8. Writes a `manifest.json` v4 with per-object: `key`, `size`, `sha256`, `etag`,
+   `content_type`, `cache_control`, `content_disposition`, `content_encoding`,
+   `metadata`.
+9. Renames `<output>.part/` → `<output>/` atomically.
+
+### Why parallelism didn't help (recap)
+
+The v2 remediation spec confirmed via `--diag-range-key` that:
+
+- 4 parallel Range-GETs to **one** object yield `ratio=2.41` — partial scaling,
+  not linear. Each connection's throughput *dropped* from 0.34 → 0.21 MiB/s.
+- 32 workers gave 5.0 MiB/s aggregate vs 7.3 MiB/s at 8 workers — worker count
+  past ~8 divides a fixed aggregate cap thinner.
+- Signatures match an **R2 account/bucket-level throughput cap** (~5–7 MiB/s).
+
+**Hypothesis we are now testing:** boto3 opens one HTTP/2 stream per object
+(per-worker). rclone opens N parallel Range-GETs per object across a global
+worker pool, pipelines more aggressively, and may more efficiently saturate an
+aggregate cap. **Either rclone breaks the ceiling or we confirm it is
+architecturally R2-account-level** — both outcomes are valuable.
+
+### What rclone gives us that boto3 doesn't
+
+Per the rclone S3 backend documentation (`https://rclone.org/s3/#cloudflare-r2`):
+
+| Capability | boto3 (current) | rclone |
+|---|---|---|
+| Native `provider=Cloudflare` config | n/a (manual endpoint) | First-class (`--s3-provider Cloudflare`) |
+| Env-var-based config (no `rclone.conf` file) | n/a | `RCLONE_CONFIG_<REMOTE>_<KEY>` |
+| Parallel Range-GETs per object | manual in diagnostic only | automatic per `--s3-download-concurrency` + `--s3-chunk-size` |
+| Global transfer pool | one `ThreadPoolExecutor` | `--transfers N`, `--checkers M` |
+| `--fast-list` (LIST one call per 1000 objects) | uses paginator (equivalent) | equivalent, but flag is explicit |
+| Automatic ETag verification on download | manual in `HashingReader` | automatic (`rclone check` and per-object) |
+| Tunable `--bwlimit` | none | for throttling if needed |
+| Resumable transfers (`--inplace`, delta checks) | none | automatic by size+mtime |
+
+## Decision & Rationale
+
+**Approach: rclone-subprocess download phase, keeping the boto3 manifest
+pipeline unchanged.**
+
+### Pipeline comparison
+
+```
+CURRENT (boto3):
+  inventory → [boto3 get_object × N workers] → tempfile → tar + manifest → atomic rename
+
+PROPOSED (rclone):
+  inventory → [rclone copy → staging dir] → walk staging → tar + manifest → atomic rename
+```
+
+### Why split phases (rather than full rclone replacement)
+
+- Manifest format is `MANIFEST_VERSION = 4` and includes R2-side metadata
+  (`content_type`, `cache_control`, `cache_disposition`, `content_encoding`,
+  per-object `metadata`). rclone's local-side download does not capture these
+  headers; we still need a `head_object` per object.
+- Existing `verify_archive`, `restore_from_archive`, and `plan_restore` logic
+  is unchanged — patches localized to `write_backup`.
+- Single subprocess invocation gives us rclone's whole transfer pool tuning
+  for free; no need to reimplement its connection manager in Python.
+
+### Why env-var config (no `rclone.conf` file)
+
+- Credentials already live in `SOW_R2_ACCESS_KEY_ID` /
+  `SOW_R2_SECRET_ACCESS_KEY` env vars per `r2.py:86-93`. Reuse them.
+- Avoids writing a config file with secrets to disk.
+- Per rclone S3 docs, env vars of the form
+  `RCLONE_CONFIG_<REMOTE>_<KEY>` are loaded as a remote named `<REMOTE>`
+  (lowercased). No file required.
+
+## Implementation Plan
+
+### Fix 1: New `RcloneClient` service module (P0)
+
+**Goal:** Encapsulate rclone binary detection, env-based config, and the
+`copy` command builder. Keep the rest of the codebase oblivious to rclone.
+
+**File (new):** `src/stream_of_worship/admin/services/rclone.py`
+
+Skeleton:
+
+```python
+"""rclone subprocess wrapper for R2 bulk download.
+
+rclone is faster than boto3+ThreadPoolExecutor for bulk S3-compatible
+download because it pipelines parallel Range-GETs per object across a
+global transfer pool. This module wraps the subprocess invocation; the
+boto3 path remains the default until --backend=rclone is explicitly used.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from stream_of_worship.admin.services.r2 import R2Client
+
+logger = logging.getLogger(__name__)
+
+REMOTE_NAME = "sow_r2"
+
+
+@dataclass
+class RcloneResult:
+    returncode: int
+    stdout: str
+    stderr: str
+    elapsed_seconds: float
+
+
+class RcloneNotAvailableError(Exception):
+    """Raised when rclone is not on PATH."""
+
+
+class RcloneClient:
+    """Builds and runs `rclone copy` against an R2 bucket via env-var config."""
+
+    def __init__(
+        self,
+        r2_client: R2Client,
+        transfers: int = 8,
+        checkers: int = 16,
+        fast_list: bool = True,
+        progress: bool = True,
+    ) -> None:
+        self._r2 = r2_client
+        self._transfers = transfers
+        self._checkers = checkers
+        self._fast_list = fast_list
+        self._progress = progress
+
+        binary = shutil.which("rclone")
+        if binary is None:
+            raise RcloneNotAvailableError(
+                "rclone binary not found in PATH. "
+                "Install via `brew install rclone` (macOS) or https://rclone.org/install/. "
+                "Alternatively, run with the default boto3 backend."
+            )
+        self._binary = binary
+
+    @property
+    def remote_alias(self) -> str:
+        return f"{REMOTE_NAME}:{self._r2.bucket}"
+
+    def env(self) -> dict[str, str]:
+        """Env vars configuring the rclone remote without an rclone.conf file."""
+        env = os.environ.copy()
+        access_key = os.environ.get("SOW_R2_ACCESS_KEY_ID")
+        secret_key = os.environ.get("SOW_R2_SECRET_ACCESS_KEY")
+        if not access_key or not secret_key:
+            raise ValueError("SOW_R2_ACCESS_KEY_ID / SOW_R2_SECRET_ACCESS_KEY not set")
+        prefix = f"RCLONE_CONFIG_{REMOTE_NAME.upper()}"
+        env[f"{prefix}_TYPE"] = "s3"
+        env[f"{prefix}_PROVIDER"] = "Cloudflare"
+        env[f"{prefix}_ACCESS_KEY_ID"] = access_key
+        env[f"{prefix}_SECRET_ACCESS_KEY"] = secret_key
+        env[f"{prefix}_REGION"] = self._r2.region
+        env[f"{prefix}_ENDPOINT"] = self._r2.endpoint_url
+        env[f"{prefix}_NO_CHECK_BUCKET"] = "true"
+        return env
+
+    def copy_bucket_to_dir(self, dest: Path) -> RcloneResult:
+        """Invoke `rclone copy r2:bucket dest/ --fast-list --transfers=N ...`"""
+        cmd = [
+            self._binary,
+            "copy",
+            self.remote_alias,
+            str(dest),
+            "--transfers", str(self._transfers),
+            "--checkers", str(self._checkers),
+            "--retries", "3",
+            "--low-level-retries", "10",
+        ]
+        if self._fast_list:
+            cmd.append("--fast-list")
+        if self._progress:
+            cmd += ["--stats", "5s", "--stats-log-level", "NOTICE", "--progress"]
+        # rclone verifies MD5/ETag on download by default; we keep this on
+        # rather than re-validating in Python (HashingReader still computes
+        # SHA-256 for the manifest).
+        t0 = time.monotonic()
+        proc = subprocess.run(
+            cmd, env=self.env(), capture_output=not self._progress, text=True
+        )
+        return RcloneResult(
+            returncode=proc.returncode,
+            stdout=proc.stdout or "",
+            stderr=proc.stderr or "",
+            elapsed_seconds=time.monotonic() - t0,
+        )
+```
+
+Public accessors needed in `R2Client` (currently the endpoint/region are
+stored as instance attrs but the names are not yet documented as public):
+confirm/extract `bucket`, `region`, `endpoint_url` as public attributes on
+`R2Client` (read paths; no setter behavior changes). Adjust `r2.py:95-111`
+constructor only if these are currently underscore-prefixed.
+
+---
+
+### Fix 2: Refactor `write_backup` to support a backend selector (P0)
+
+**Goal:** Add a `--backend={boto3,rclone}` option. Default stays `boto3` until
+the benchmark proves rclone's advantage and the user opts in to flipping.
+
+**File:** `src/stream_of_worship/admin/services/r2_backup.py`
+
+Refactor `write_backup` to delegate the download phase to one of two
+strategies. Both strategies must produce identical `DownloadResult` payloads
+(temp_path, sha256, bytes_read, etag_match_ok) so the manifest-build loop is
+unchanged.
+
+**Change A** — add a new module-level function `write_backup_rclone`:
+
+```python
+def write_backup_rclone(
+    r2_client: R2Client,
+    inventory: Inventory,
+    output_dir: Path,
+    chunk_size_bytes: int = DEFAULT_CHUNK_SIZE_BYTES,
+    spot_check_ratio: float = SPOT_CHECK_HEAD_RATIO,
+    progress: Optional[BackupProgress] = None,
+    tracer: Optional[BackupTracer] = None,
+    rclone_transfers: int = 8,
+    rclone_checkers: int = 16,
+) -> None:
+    """rclone-backed implementation of write_backup.
+
+    Pipeline:
+      1. rclone copy r2:bucket -> output_dir.part/rclone_staging/
+      2. Walk staging directory in inventory order; for each expected key:
+         - Open staged file as stream
+         - Stream through HashingReader (SHA-256 + size check)
+         - HEAD r2 to fetch content_type/cache_control/.../metadata
+         - Verify etag vs inventory.etag
+         - Write to current chunked tar with the existing member-name scheme
+      3. Spot-check 5% via head_object (same as boto3 path)
+      4. Write manifest.json v4 (identical schema)
+      5. rmtree(rclone_staging); rename .part/ -> output_dir/ (atomic)
+    """
+```
+
+The key invariants compared to `write_backup` (the boto3 path):
+
+| Aspect | boto3 path | rclone path |
+|---|---|---|
+| Download temp storage | one tempfile per object, deleted after tar | one shared staging dir, deleted after archive-build loop |
+| SHA-256 computed | during download stream | during post-download staging-walk stream |
+| ETag verification | during download via ContentLength match | rclone already verifies on download; reverify in staging-walk via HEAD |
+| Per-object metadata | captured via `head_object` if spot-checked (5%) | **always** captured via `head_object` (per-object) — see Fix 3 |
+| Tar member name | `objects/{idx:012d}.bin` | identical |
+| Manifest schema | `MANIFEST_VERSION = 4` | identical |
+| Partial-tracking dir name | `<output>.part/` | identical, plus `<output>.part/rclone_staging/` |
+
+**Change B** — add a backend dispatcher:
+
+```python
+def write_backup(
+    r2_client: R2Client,
+    inventory: Inventory,
+    output_dir: Path,
+    *,
+    backend: str = "boto3",       # new kwarg
+    concurrency: int = DEFAULT_CONCURRENCY,
+    chunk_size: str = "10GiB",
+    ...
+) -> None:
+    if backend not in ("boto3", "rclone"):
+        raise BackupError(f"unknown backend {backend!r}; expected boto3 or rclone")
+    if backend == "rclone":
+        write_backup_rclone(r2_client, inventory, ...)
+    else:
+        _write_backup_boto3(r2_client, inventory, ...)  # renamed from current impl
+```
+
+Rename the existing `write_backup` body to `_write_backup_boto3` and keep
+its behavior byte-identical. The public `write_backup` becomes the dispatcher.
+
+---
+
+### Fix 3: Always `head_object` in the rclone path for full manifest metadata (P1)
+
+**Why:** The existing manifest schema (v4) includes `content_type`,
+`cache_control`, `content_disposition`, `content_encoding`, and per-object
+`metadata`. The boto3 path only spot-checks 5% via `head_object` because
+the download `get_object` response already carries these headers. rclone
+copy discards them (only writes the bytes to disk).
+
+**Decision:** For the rclone backend, do one `head_object` per object during
+the manifest-build walk. This adds N boto3 HEAD calls per backup. At a 12.9 GB
+bucket of 679 objects this is 679 HEAD calls — negligible compared to the
+download phase.
+
+**Alternative considered:** Use `rclone lsf r2:bucket --json --header`
+to extract metadata in one bulk call, but rclone does not return R2 custom
+metadata via `lsf`. Per-object HEAD is simpler and correct.
+
+---
+
+### Fix 4: Surface `bucket`, `region`, `endpoint_url` as public attrs on `R2Client` (P1)
+
+**File:** `src/stream_of_worship/admin/services/r2.py`
+
+Currently the R2Client attributes (lines 95-111) are private (`self._bucket`,
+`self._endpoint_url`, etc., prefixed underscore). The new `RcloneClient`
+needs read-only access to construct its env-var config. Add `@property`
+readers; do **not** add setters.
+
+```python
+@property
+def bucket(self) -> str:
+    return self._bucket
+
+@property
+def endpoint_url(self) -> str:
+    return self._endpoint_url
+
+@property
+def region(self) -> str:
+    return self._region
+```
+
+If the existing attrs are already public (verify by reading lines 95-111
+during implementation), this fix is a no-op.
+
+---
+
+### Fix 5: Add `--backend` flag to the `backup-r2` command (P0)
+
+**File:** `src/stream_of_worship/admin/commands/maintenance.py:642-670`
+
+```python
+@app.command("backup-r2")
+def backup_r2(
+    output: Path = typer.Option(..., "--output", help="Output directory for backup"),
+    chunk_size: str = typer.Option("10GiB", "--chunk-size", ...),
+    concurrency: int = typer.Option(8, "--concurrency", min=1, max=64, ...),
+    backend: str = typer.Option(
+        "boto3", "--backend",
+        help="Download backend: 'boto3' (default, ThreadPoolExecutor) or "
+             "'rclone' (requires rclone in PATH; uses parallel Range-GETs).",
+    ),
+    debug_traces: bool = typer.Option(False, "--debug-traces", ...),
+    format_: str = typer.Option("table", "--format", help="table|json"),
+    config_path: Optional[Path] = typer.Option(None, "--config", "-c"),
+    diag_range_key: Optional[str] = typer.Option(None, "--diag-range-key", ...),
+) -> None:
+    """Backup entire R2 bucket to a local directory with chunked tar archives."""
+    ...
+    write_backup(r2_client, inventory, output, backend=backend, ...)
+```
+
+Validate `backend ∈ {"boto3", "rclone"}` at command entry (raise
+`typer.BadParameter` if invalid). Do NOT auto-detect rclone in PATH; let
+the explicit `--backend=rclone` flag fail loudly if rclone is missing, so
+the boto3 path remains a guaranteed fallback.
+
+---
+
+### Fix 6: Tests for `RcloneClient` (`tests/admin/test_rclone.py`, new) (P0)
+
+Mock `subprocess.run` and `shutil.which`. Cover:
+
+1. `RcloneNotAvailableError` when `shutil.which("rclone")` returns `None`.
+2. Env-var construction: assert `RCLONE_CONFIG_SOW_R2_TYPE == "s3"`,
+   `RCLONE_CONFIG_SOW_R2_PROVIDER == "Cloudflare"`,
+   `RCLONE_CONFIG_SOW_R2_ENDPOINT == <expected endpoint>`.
+3. `copy_bucket_to_dir` invokes `rclone copy sow_r2:<bucket> <dest>` with
+   the documented flags.
+4. Nonzero exit code is surfaced in `RcloneResult`.
+5. Credentials missing → raises `ValueError`.
+
+### Fix 7: Tests for `write_backup_rclone` (`tests/admin/test_r2_backup.py`) (P0)
+
+Extend the existing mocked-R2Client fixture (`tests/admin/test_r2_backup_commands.py:20-80`).
+Cover:
+
+1. rclone backend produces identical manifest schema v4 as boto3 backend.
+   Assert: same keys, same `sha256`, same `etag`, same `content_type` etc.
+2. Staging directory is removed after archive-build.
+3. Missing staged file (rclone partial failure) raises `BackupError`.
+4. `head_object` is invoked once per object (vs boto3 path's ~5% sample).
+5. Tar member name scheme is `objects/{idx:012d}.bin` (unchanged).
+6. `--backend=invalid` raises `typer.BadParameter`.
+7. `--backend=rclone` with no rclone binary in PATH surfaces a friendly
+   error message (not a silent boto3 fallback).
+
+### Fix 8: pyproject.toml — declare soft rclone guidance (P1)
+
+rclone is a system binary, not a Python package; it is not added to
+`pyproject.toml` dependencies. Add a comment in the `admin` extra section
+documenting the optional external dependency:
+
+```toml
+admin = [
+    ...
+    "boto3>=1.34.0",          # primary R2 backend; see RCLONE note below
+    ...
+]
+# Optional: rclone (system binary, NOT pip-installable) speeds up
+# `sow-admin maintenance backup-r2 --backend=rclone` via parallel
+# Range-GETs. Install via `brew install rclone` (macOS) or
+# https://rclone.org/install/. The boto3 backend remains the default
+# and is fully functional without rclone.
+```
+
+## File Change Summary
+
+| File | Change | Priority |
+|---|---|---|
+| `src/stream_of_worship/admin/services/rclone.py` (new) | New `RcloneClient` wrapping `rclone copy` via env-var config | P0 |
+| `src/stream_of_worship/admin/services/r2_backup.py` | Rename `write_backup` body → `_write_backup_boto3`; add dispatcher `write_backup(backend=...)`; add `write_backup_rclone` | P0 |
+| `src/stream_of_worship/admin/services/r2.py` | Add public `@property` readers for `bucket`, `region`, `endpoint_url` (if not already public) | P1 |
+| `src/stream_of_worship/admin/commands/maintenance.py:642-670` | Add `--backend={boto3,rclone}` Typer option; thread through to `write_backup` | P0 |
+| `tests/admin/test_rclone.py` (new) | Mocked-subprocess unit tests for `RcloneClient` | P0 |
+| `tests/admin/test_r2_backup.py` | New `write_backup_rclone` tests alongside existing boto3 tests | P0 |
+| `tests/admin/test_r2_backup_commands.py` | CLI tests: `--backend=rclone` happy path, `--backend=invalid` error, missing-rclone fallback behavior | P0 |
+| `pyproject.toml` | Add comment in `admin` extra documenting optional rclone system binary | P1 |
+| `examples/sow-admin-config.toml` | Add note in `[r2]` section: `# Optional: install rclone to enable --backend=rclone (faster bulk download)` | P2 |
+| `report/current_impl_status.md` | Append entry after spec lands (per AGENTS.md convention) | P1 |
+| `MEMORY.md` (if present) | Reflect that the previously "closed" throughput investigation is reopened via rclone | P1 |
+
+## Verification Plan
+
+### Step 0: Install rclone (prereq)
+
+```bash
+brew install rclone
+rclone --version    # confirm installed, e.g. v1.67+
+```
+
+### Step 1: Mandatory pre-implementation benchmark (establishes baseline)
+
+Run **all three** measurements before writing any production code. This is the
+empirical test the v2 remediation spec skipped; we will not skip it again.
+
+#### 1a. boto3 baseline (the "before" number)
+
+```bash
+sow-admin maintenance backup-r2 \
+  --output ~/BACKUPS/sow-r2/baseline-boto3 \
+  --chunk-size 5GiB \
+  --concurrency 8 \
+  --debug-traces \
+  --diag-range-key d48247f4fb2f/stems/vocals.wav 2>&1 | tee baseline-boto3.log
+```
+
+Record in `specs/admin-r2-backup-rclone-download-v1-results.md`:
+- total runtime (s), aggregate MiB/s, objects_downloaded
+- `single_conn_mbps`, `multi_conn_total_mbps`, `ratio` from the diag
+
+#### 1b. rclone pure reference (the "ceiling" number)
+
+```bash
+mkdir -p ~/BACKUPS/sow-r2/ref-rclone
+export RCLONE_CONFIG_SOW_R2_TYPE=s3
+export RCLONE_CONFIG_SOW_R2_PROVIDER=Cloudflare
+export RCLONE_CONFIG_SOW_R2_ACCESS_KEY_ID="$SOW_R2_ACCESS_KEY_ID"
+export RCLONE_CONFIG_SOW_R2_SECRET_ACCESS_KEY="$SOW_R2_SECRET_ACCESS_KEY"
+export RCLONE_CONFIG_SOW_R2_REGION=auto
+export RCLONE_CONFIG_SOW_R2_ENDPOINT=<from-config>
+export RCLONE_CONFIG_SOW_R2_NO_CHECK_BUCKET=true
+
+rclone copy sow_r2:stream-of-worship ~/BACKUPS/sow-r2/ref-rclone \
+  --transfers 8 --checkers 16 --fast-list \
+  --stats 5s --stats-log-level NOTICE --progress 2>&1 | tee ref-rclone.log
+```
+
+Record:
+- total runtime (s), aggregate MiB/s, file count + bytes
+- compare file count vs baseline inventory count (should match exactly)
+
+#### 1c. Decision point
+
+| If ref-rclone achieves... | Then... |
+|---|---|
+| >2x baseline-boto3 throughput | Proceed with implementation (Fixes 1-7) and the new backend becomes the default in a follow-up spec |
+| 1.2x–2x baseline-boto3 throughput | Proceed with implementation; keep boto3 as default backend; document the modest gain |
+| <1.2x baseline-boto3 throughput | **Stop.** The cap is R2-account-level, not boto3-specific. Update this spec with the finding, file as `admin-r2-backup-rclone-download-v1-results.md`, do not implement Fixes 1-7 |
+| rclone crashes / auth failure | Diagnose env var config; if rclone backend is incompatible with R2, fall through to the next-preferred option (aiobotocore — out of scope for this spec) |
+
+This step is the **only** step where the spec may stop without proceeding. The
+rest of the verification plan assumes Step 1c returned "proceed".
+
+### Step 2: Implement Fixes 1-7
+
+Implement in the order: Fix 4 (R2Client properties) → Fix 1 (RcloneClient) →
+Fix 2 (write_backup_rclone) → Fix 3 (head_object in rclone path) → Fix 5
+(--backend flag) → Fix 6 + 7 (tests). Run:
+
+```bash
+PYTHONPATH=src uv run --python 3.11 --extra admin --extra test \
+  pytest tests/admin/test_rclone.py tests/admin/test_r2_backup.py \
+  tests/admin/test_r2_backup_commands.py -v
+```
+
+### Step 3: Lint and typecheck
+
+```bash
+PYTHONPATH=src uv run --python 3.11 --extra admin \
+  ruff check \
+  src/stream_of_worship/admin/services/rclone.py \
+  src/stream_of_worship/admin/services/r2_backup.py \
+  src/stream_of_worship/admin/services/r2.py \
+  src/stream_of_worship/admin/commands/maintenance.py
+
+PYTHONPATH=src uv run --python 3.11 --extra admin \
+  mypy src/stream_of_worship/admin/services/rclone.py \
+       src/stream_of_worship/admin/services/r2_backup.py
+```
+
+### Step 4: Post-implementation end-to-end benchmark
+
+Run the new CLI backend:
+
+```bash
+sow-admin maintenance backup-r2 \
+  --output ~/BACKUPS/sow-r2/impl-rclone \
+  --backend rclone \
+  --chunk-size 5GiB \
+  --debug-traces \
+  --diag-range-key d48247f4fb2f/stems/vocals.wav 2>&1 | tee impl-rclone.log
+```
+
+Pass criteria:
+- Total runtime ≤ `ref-rclone` baseline from Step 1b ± 10% (parity reach)
+- Manifest `MANIFEST_VERSION == 4` and includes all expected fields
+- `verify-r2-backup` (Step 5) completes clean
+
+If parity is reached (i.e., rclone backend matches rclone reference), the cap
+diagnostic from Step 4 (`--diag-range-key`) is still useful: it tells us
+whether the in-CLI implementation cached any R2 account-level override.
+
+#### 4b. Comparative metric block (record in results spec)
+
+| Backend | Total runtime (s) | Aggregate MiB/s | `single_conn_mbps` | `multi_conn_total_mbps` | `ratio` |
+|---|---|---|---|---|---|
+| boto3 (Step 1a) | TBD | TBD |  |  |  |
+| rclone ref (Step 1b) | TBD | TBD | n/a (rclone-external) | n/a | n/a |
+| new rclone backend (Step 4) | TBD | TBD |  |  |  |
+
+### Step 5: Verify backup integrity
+
+```bash
+sow-admin maintenance verify-r2-backup \
+  --input ~/BACKUPS/sow-r2/impl-rclone 2>&1 | tee verify-impl-rclone.log
+```
+
+Expected: every object's sha256, size, and etag match. If any mismatch,
+investigate: rclone may have re-computed MD5s that don't match the etag
+schema expected (multipart vs single-part); adjust manifest validation in
+`write_backup_rclone` accordingly.
+
+### Step 6: Restore round-trip smoke (optional, recommended)
+
+```bash
+sow-admin maintenance restore-r2 \
+  --input ~/BACKUPS/sow-r2/impl-rclone \
+  --prefix test-restore/ \
+  --dry-run 2>&1 | tee restore-dry-run.log
+```
+
+Expected: plan_restore lists all objects. No actual upload in dry-run.
+
+### Step 7: Session completion (per AGENTS.md)
+
+```bash
+git pull --rebase
+git push
+git status
+```
+
+`git status` MUST show "up to date with origin" before stopping.
+
+## Out of Scope
+
+- **aiobotocore async rewrite.** Listed in user's clarification round as an
+  alternative to rclone. Not pursued in this spec; revisit if rclone path
+  yields <1.2x improvement (per Step 1c decision).
+- **boto3 TransferConfig tuning** (use_threads=True, multipart_chunksize).
+  Listed in user's clarification as an alternative. Not pursued; if rclone
+  doesn't break the ceiling, neither will boto3 tuning using a similar
+  mechanism (parallel Range-GETs across a global pool).
+- **Restoring the user's original `<10 min for 12.9 GB` goal.** User
+  explicitly chose "match rclone default behavior" as the success metric;
+  no fixed target is reintroduced here.
+- **Replacing the boto3 path entirely.** boto3 path remains as default and
+  fallback. A follow-up spec (`admin-r2-backup-rclone-default-v1.md`) may
+  promote rclone to default after Step 5 produces a stable success run.
+- **Cloudflare Worker in-network backup.** Still out of scope; revisit only
+  if rclone + boto3 HEAD both hit the cap.
+- **Reading R2 custom metadata via `rclone lsf`.** Rejected; rclone's `lsf`
+  does not return R2 custom metadata cleanly. Per-object `head_object` is
+  used in the rclone backend (Fix 3).
+- **`--fast-list` memory tuning.** Default behavior is acceptable for a 679-object
+  bucket. Revisit if bucket grows past ~1M objects.
+- **`--debug-traces` integration of rclone subprocess output.** The
+  subprocess's stdout/stderr is logged to the console during the rclone call;
+  the Python BackupTracer does not parse rclone output for now. A follow-up may
+  pipe `--stats` lines into BackupTracer if finer-grained accounting is needed.
+
+## Decisions Deferred
+
+- **Default backend**: keep `boto3` as default; do not flip to `rclone` until
+  Step 1c confirms a ≥1.2x improvement and Step 4 achieves parity.
+- **`--backend=auto`** (detect rclone, fall back to boto3): explicitly
+  rejected in Fix 5 to avoid surprising the user; explicit flag is clearer
+  and surfaces rclone-missing loudly.
+- **Streaming from rclone to tar without staging directory**: would require
+  per-object `rclone cat` (defeats rclone's parallelism) or running rclone
+  with `rclone rcat` to a Python pipe (unreliable). Staging dir is the
+  correct trade-off.
+- **Promoting rclone binary to a Homebrew cask dependency in CI**: not in
+  scope; the admin CLI is run locally, not in CI. CI can install rclone if
+  Step 1 benchmarks need reproducible runs.
+- **Switching restore (`restore_from_archive`) to rclone**: out of scope.
+  The boto3 `upload_fileobj` restore path is upload-bound (different
+  bottleneck profile) and is rarely called; would require a separate spec.
+
+## References
+
+- `specs/admin-r2-backup-throughput-remediation-v1.md` — 32-worker bump that
+  regressed throughput; predecessor of this work.
+- `specs/admin-r2-backup-throughput-remediation-v2.md` — closure of the v1
+  investigation; established the ~7 MiB/s account-level cap and the
+  `ratio=2.41` diagnostic signature.
+- `specs/admin-r2-backup-concurrent-downloads-v1.md` — original boto3
+  ThreadPoolExecutor design; the architecture this spec augments.
+- `specs/admin-r2-backup-perf-traces.md` — BackupTracer design; the
+  `--diag-range-key` flag this spec relies on for Step 1.
+- `src/stream_of_worship/admin/services/r2.py:95-111` — boto3 R2Client (the
+  baseline; unchanged except for Fix 4 read-only properties).
+- `src/stream_of_worship/admin/services/r2_backup.py:884-1203` — existing
+  boto3 `write_backup` (renamed to `_write_backup_boto3` per Fix 2).
+- `src/stream_of_worship/admin/commands/maintenance.py:642-784` — existing
+  `backup-r2` Typer command (augmented in Fix 5).
+- `examples/sow-admin-config.toml:20-28` — R2 endpoint config docs.
+- https://rclone.org/s3/#cloudflare-r2 — Cloudflare R2 backend reference.
+- `MEMORY.md` line 3 — existing closure note that this spec may supersede.

--- a/specs/admin-r2-backup-rclone-download-v2.md
+++ b/specs/admin-r2-backup-rclone-download-v2.md
@@ -1,0 +1,597 @@
+# Admin R2 Backup rclone Download Path v2 — Default Concurrency Revert to Single-Threaded
+
+**Service:** Admin CLI (`src/stream_of_worship/admin/`)
+**Status:** Plan only — no implementation
+**Created:** 2026-06-20
+**Predecessor specs:**
+- `specs/admin-r2-backup-rclone-download-v1.md` (rclone benchmark — abandoned)
+- `specs/admin-r2-backup-throughput-remediation-v2.md` (closure of v1 throughput investigation)
+**CLI command:** `sow-admin maintenance backup-r2`
+
+## Summary
+
+The v1 rclone benchmark (`reports/admin-r2-backup-rclone-download-v1-results.md`)
+returned STOP: rclone does not outperform boto3, and the ~7 MiB/s ceiling is
+confirmed to be R2-account-level. Critically, the benchmark produced a **new
+data point** that supersedes the v2 remediation spec's `ratio=2.41` finding:
+
+- `--diag-range-key` now reports `ratio=0.83` (down from 2.41 in the v2 trace).
+- A single boto3 connection achieved **7.85 MiB/s**, while 4 parallel
+  Range-GETs achieved only **6.54 MiB/s** aggregate. Parallel connections
+  now *hurt* throughput — the network path is saturated by a single connection.
+- Best observed across all backends: **single-connection boto3 at 7.85 MiB/s**.
+
+This spec reverts `DEFAULT_CONCURRENCY` from `8 → 1` and tightens the
+`--concurrency` upper bound from `64 → 5` (matching `max_pool_connections` on
+the boto3 client). The ThreadPoolExecutor / `as_completed` / size-desc
+submission sort / `BackupTracer` / `range_get_throughput_diag` machinery
+remains intact for experimentation; the default simply no longer pays
+concurrency overhead that the data shows buys nothing.
+
+**Success metric:** default backup run uses 1 worker; throughput matches or
+exceeds the 8-worker baseline; all existing tests pass with updated boundary
+assertions.
+
+## Background
+
+### Why the v2 remediation spec set DEFAULT_CONCURRENCY=8
+
+The v2 remediation spec (`specs/admin-r2-backup-throughput-remediation-v2.md`)
+reverted the v1 bump of `8 → 32` based on a 32-worker trace showing 5.0 MiB/s
+vs the 8-worker baseline's 7.3 MiB/s. At the time, the `--diag-range-key`
+diagnostic returned `ratio=2.41` — interpreted as "partial scaling, not pure
+per-connection cap" — so 8 workers was retained as a hedge: if there was any
+per-connection cap component, 8 workers might still overlap downloads with
+tar writes usefully.
+
+### What the v1 rclone benchmark changed
+
+The v1 rclone benchmark re-ran `--diag-range-key` against the same object
+(`d48247f4fb2f/stems/vocals.wav`, 65.745 MiB) from the same client/network
+path. The result:
+
+```json
+{
+  "content_length": 68938108,
+  "num_ranges": 4,
+  "single_conn_mbps": 7.85,
+  "multi_conn_total_mbps": 6.54,
+  "ratio": 0.83,
+  "per_range_mbps": [1.77, 3.81, 1.71, 1.64]
+}
+```
+
+**Interpretation** (per `reports/admin-r2-backup-rclone-download-v1-results.md`):
+
+- `ratio = 0.83` (< 1.0) means parallel connections now *reduce* aggregate
+  throughput. This is the opposite shape of the v2 trace's `ratio=2.41`.
+- Network conditions have shifted: the path is now saturated by a single
+  connection, leaving no headroom for parallel ranges to add throughput.
+- The single-connection baseline (7.85 MiB/s) matches the 8-worker multi-file
+  steady-state (7.0–7.7 MiB/s) from the v2 trace — confirming concurrency
+  buys ~0 aggregate throughput.
+
+### What concurrency was buying (and no longer is)
+
+The only theoretical benefit of `concurrency > 1` is overlapping the download
+of object N+1 with the tar-write of object N. The v2 trace's `tar_write`
+events show `tar_write_ms = 50–110 ms` per 60 MB object (~700 MB/s effective
+disk I/O), vs ~10 s per object download. Overlap saves <1% of wall time.
+Under the new `ratio=0.83` regime, concurrency *costs* ~17% of aggregate
+download throughput — far more than the <1% overlap saves.
+
+### Comparative data (from v1 rclone benchmark report)
+
+| Backend | Throughput (MiB/s) | vs boto3 single conn |
+|---|---|---|
+| boto3 single conn (diag) | **7.85** | 1.00× (baseline, best observed) |
+| boto3 multi conn (4 Range-GETs) | **6.54** | 0.83× |
+| boto3 8-worker multi-file (v2 trace) | 7.0–7.7 | ~0.92× |
+| boto3 32-worker multi-file (v2 trace) | 5.0 | 0.64× |
+| rclone single file | 4.07 | 0.52× |
+| rclone multi-thread streams (8) | 2.96 | 0.38× |
+| rclone multi-file (8 transfers) | 5.68 | 0.72× |
+
+## Decision & Rationale
+
+**Approach:** Revert `DEFAULT_CONCURRENCY` to 1. Keep the concurrency
+machinery intact for `--concurrency N>1` experimentation; tighten the upper
+bound to 5 across the board (CLI flag, boto3 client pool, `write_backup`
+validation).
+
+### Why default=1 instead of keeping default=8
+
+1. **Data-justified.** Single-conn (7.85 MiB/s) ≥ 8-worker multi-file
+   (7.0–7.7 MiB/s) in the v2 trace, and the new `ratio=0.83` diagnostic
+   shows parallelism now *hurts*. There is no measurement in favor of 8.
+2. **Lower overhead.** No `ThreadPoolExecutor` spin-up, no lock contention
+   on `BackupProgress`, no per-worker connection setup. Single-threaded
+   mode is simpler and uses fewer resources.
+3. **Consistency with `ratio=0.83`.** The diagnostic is the canonical
+   measurement the v2 spec designated as the gate for concurrency decisions.
+   When it returned 2.41, we kept 8. Now that it returns 0.83, the
+   symmetric action is to drop to 1.
+4. **Reversibility preserved.** The `--concurrency` flag remains available;
+   if a future trace shows `ratio > 1.5` again (network conditions change),
+   the default can be bumped back in a follow-up spec.
+
+### Why max=5 (and not max=1 or max=8)
+
+- **Not max=1:** Hardcoding `concurrency=1` would prevent anyone from
+  re-running the `--diag-range-key` benchmark (which defaults to
+  `num_ranges=4`) or experimenting with small N if network conditions
+  change. Preserves the diagnostic that produced all the evidence this
+  spec relies on.
+- **Not max=8:** The v2 remediation spec kept `max=64` "to preserve
+  experimentation headroom," but the v1 rclone benchmark shows values
+  above 8 are *consistently* counterproductive (32 workers → 5.0 MiB/s,
+  0.64× baseline). Tightening to 5 documents the empirical ceiling while
+  leaving 1–5 available for diagnostic use.
+- **max=5 specifically:** Fits the `--diag-range-key` default of
+  `num_ranges=4` plus 1 spare connection headroom. Keeps the boto3
+  `max_pool_connections` and the CLI `--concurrency max` aligned — no
+  silent queuing when the user experiments.
+
+## Implementation Plan
+
+### Change 1: `DEFAULT_CONCURRENCY` revert (P0)
+
+**File:** `src/stream_of_worship/admin/services/r2_backup.py`
+
+**Location:** Module constants block, currently lines 32–37.
+
+**Before (current):**
+
+```python
+# 32 workers gave ~30% LOWER throughput than 8 workers in real traces
+# (5.0 vs 7.3 MiB/s) — see specs/admin-r2-backup-throughput-remediation-v2.md.
+# R2 exhibits a ~7 MiB/s account/bucket aggregate cap from this client;
+# adding workers past ~8 slices the cap thinner without raising it.
+# Verified via --diag-range-key (ratio=2.41, partial scaling, not pure per-conn cap).
+DEFAULT_CONCURRENCY = 8
+```
+
+**After:**
+
+```python
+# Concurrency past 1 buys ~0 aggregate throughput. R2 exhibits an
+# account/bucket-level cap (~7 MiB/s from this client); a single connection
+# now saturates it. The v1 rclone benchmark confirmed this:
+#   boto3 single-conn  7.85 MiB/s (best observed)
+#   boto3 4-range     6.54 MiB/s  (ratio=0.83, parallel HURTS)
+#   boto3 32-worker   5.0  MiB/s  (v2 trace, 30% regression)
+#   rclone 8-transfer 5.68 MiB/s  (slower than single boto3 conn)
+# See reports/admin-r2-backup-rclone-download-v1-results.md and
+# specs/admin-r2-backup-throughput-remediation-v2.md.
+# --concurrency N>1 remains available for experimentation but is not expected
+# to help; run --diag-range-key first.
+DEFAULT_CONCURRENCY = 1
+```
+
+**Rationale:** The comment cites the v1 rclone benchmark (the new canonical
+evidence) and the v2 remediation spec (for the 32-worker regression data
+point). Future readers will see *why* 1 was chosen and *where* to look if
+they want to re-investigate.
+
+---
+
+### Change 2: `write_backup` validation upper bound (P0)
+
+**File:** `src/stream_of_worship/admin/services/r2_backup.py`
+
+**Location:** `write_backup` function, currently line 914–915.
+
+**Before:**
+
+```python
+if not (1 <= concurrency <= 64):
+    raise BackupError(f"concurrency must be 1-64, got {concurrency}")
+```
+
+**After:**
+
+```python
+if not (1 <= concurrency <= 5):
+    raise BackupError(f"concurrency must be 1-5, got {concurrency}")
+```
+
+**Rationale:** Brings the programmatic API in line with the CLI `max=5`
+(Change 3) and the boto3 pool size (Change 4). Keeps the lower bound at 1
+to preserve the existing `test_concurrency_1_works` test.
+
+---
+
+### Change 3: `--concurrency` CLI option (P0)
+
+**File:** `src/stream_of_worship/admin/commands/maintenance.py`
+
+**Location:** `backup_r2` Typer command, currently lines 648–656.
+
+**Before (current):**
+
+```python
+concurrency: int = typer.Option(
+    8, "--concurrency", min=1, max=64,
+    help=(
+        "Number of concurrent download workers (default 8). "
+        "R2 exhibits an account-level throughput cap (~7 MiB/s from this client); "
+        "raising workers past 8 typically REDUCES throughput (verified at 32 workers: "
+        "~5 MiB/s vs ~7 MiB/s at 8 workers). Use --diag-range-key to investigate."
+    ),
+),
+```
+
+**After:**
+
+```python
+concurrency: int = typer.Option(
+    1, "--concurrency", min=1, max=5,
+    help=(
+        "Number of concurrent download workers (default 1). "
+        "R2 exhibits an account-level throughput cap (~7 MiB/s from this client); "
+        "a single connection already saturates it. The v1 rclone benchmark showed "
+        "boto3 single-conn 7.85 MiB/s vs 4-range parallel 6.54 MiB/s (ratio=0.83, "
+        "parallel HURTS). Use --diag-range-key to investigate before raising."
+    ),
+),
+```
+
+**Rationale:** Default lowered to match `DEFAULT_CONCURRENCY`; max tightened
+to 5; help text rewritten to cite the v1 rclone benchmark (the newest
+evidence) rather than the v2 trace (still mentioned in the module comment
+but not the user-facing help).
+
+---
+
+### Change 4: `max_pool_connections` on boto3 client (P0)
+
+**File:** `src/stream_of_worship/admin/services/r2.py`
+
+**Location:** `R2Client.__init__`, currently lines 107–109.
+
+**Before (current):**
+
+```python
+# Bump from 32 to 64 to align with new DEFAULT_CONCURRENCY=32 plus headroom
+# for the diagnostic Range-GET workers.
+max_pool_connections=64,
+```
+
+**After:**
+
+```python
+# Align with DEFAULT_CONCURRENCY=1 plus headroom for the
+# --diag-range-key diagnostic's 4 parallel Range-GET workers.
+# Higher parallelism is counterproductive under R2's account-level cap.
+max_pool_connections=5,
+```
+
+**Rationale:** The old comment referenced the now-reverted
+`DEFAULT_CONCURRENCY=32` and was never updated when the v2 remediation spec
+reverted to 8. Lowering to 5 matches the new `--concurrency max=5` ceiling,
+eliminating the inconsistency where the CLI accepted `--concurrency 64` but
+the boto3 client only had 64 pool slots (silent queuing above 64). With
+pool=5 and `--concurrency max=5`, every CLI-permitted value gets a real
+boto3 connection slot.
+
+**Compatibility note:** The `range_get_throughput_diag` function
+(`r2_backup.py:788-870`) defaults to `num_ranges=4`. With
+`max_pool_connections=5`, the diagnostic's 4 parallel workers fit with 1
+spare slot. No change to the diagnostic's default.
+
+---
+
+### Change 5: Boundary test assertions (P0)
+
+**File:** `tests/admin/test_r2_backup.py`
+
+**Location:** `TestConcurrentBackup` class, lines 907–923.
+
+**Before (current):**
+
+```python
+def test_concurrency_validation_rejects_zero(self, tmp_path):
+    """write_backup raises BackupError for concurrency=0."""
+    r2 = _make_r2_mock([])
+    inventory = build_inventory(r2)
+    output = tmp_path / "backup"
+
+    with pytest.raises(BackupError, match="concurrency must be 1-64"):
+        write_backup(r2, output, inventory, concurrency=0)
+
+def test_concurrency_validation_rejects_65(self, tmp_path):
+    """write_backup raises BackupError for concurrency=65."""
+    r2 = _make_r2_mock([])
+    inventory = build_inventory(r2)
+    output = tmp_path / "backup"
+
+    with pytest.raises(BackupError, match="concurrency must be 1-64"):
+        write_backup(r2, output, inventory, concurrency=65)
+```
+
+**After:**
+
+```python
+def test_concurrency_validation_rejects_zero(self, tmp_path):
+    """write_backup raises BackupError for concurrency=0."""
+    r2 = _make_r2_mock([])
+    inventory = build_inventory(r2)
+    output = tmp_path / "backup"
+
+    with pytest.raises(BackupError, match="concurrency must be 1-5"):
+        write_backup(r2, output, inventory, concurrency=0)
+
+def test_concurrency_validation_rejects_6(self, tmp_path):
+    """write_backup raises BackupError for concurrency=6."""
+    r2 = _make_r2_mock([])
+    inventory = build_inventory(r2)
+    output = tmp_path / "backup"
+
+    with pytest.raises(BackupError, match="concurrency must be 1-5"):
+        write_backup(r2, output, inventory, concurrency=6)
+```
+
+**Rationale:** Match strings updated from `1-64` → `1-5`; the upper-bound
+rejection test renamed from `rejects_65` → `rejects_6` and its input value
+changed from `65` → `6`. The lower-bound (`0`) test is unchanged in
+structure, only the match string changes.
+
+**Unchanged tests (verified still valid):**
+
+- `test_concurrent_backup_produces_valid_archive` (line 684): calls
+  `write_backup(...)` with no `concurrency` arg — now exercises
+  `concurrency=1`. Produces a valid archive regardless; no value
+  assertion. ✓
+- `test_concurrency_1_works` (line 714): explicitly passes
+  `concurrency=1`, still within `1 <= concurrency <= 5`. ✓
+- `test_concurrent_backup_preserves_object_order` (line 729): passes
+  `concurrency=4`, still ≤5. ✓
+- Test at line 1690: passes `concurrency=4`, still ≤5. ✓
+
+---
+
+### Change 6: CLI test (P0, verify no assertion change needed)
+
+**File:** `tests/admin/test_r2_backup_commands.py`
+
+**Location:** `TestBackupR2Command.test_backup_concurrency_flag`, lines 214–236.
+
+This test invokes the CLI with `--concurrency 4` and asserts
+`mock_write.call_args.kwargs["concurrency"] == 4`. The value `4` is still
+within the new `max=5` range. **No edit required — test continues to pass
+as-is.**
+
+**Search confirmed** (via grep for `concurrency.*=.*\d+` in
+`tests/admin/`): no other test asserts the CLI default concurrency value.
+The only test that exercises the default is
+`test_concurrent_backup_produces_valid_archive` in
+`tests/admin/test_r2_backup.py`, which does not assert the specific value.
+
+---
+
+### Change 7: Status report and MEMORY append (P1)
+
+**File:** `report/current_impl_status.md` — append entry.
+
+**File:** `MEMORY.md` — append entry (line 3 currently has the v2 remediation
+entry; this is the natural continuation).
+
+**Entry text (same for both files):**
+
+```
+- R2 backup default concurrency reverted 8 → 1. The v1 rclone benchmark
+  (reports/admin-r2-backup-rclone-download-v1-results.md) confirmed a single
+  connection now saturates the R2 account-level cap: boto3 single-conn
+  7.85 MiB/s vs 4-range parallel 6.54 MiB/s (ratio=0.83, parallel HURTS;
+  v2 trace had ratio=2.41). Tightened --concurrency max 64 → 5 and
+  max_pool_connections 64 → 5 to match. Concurrency machinery
+  (ThreadPoolExecutor, as_completed, size-sort, BackupTracer,
+  range_get_throughput_diag) retained for experimentation; run
+  --diag-range-key before raising --concurrency above 1.
+```
+
+**Rationale:** Per `AGENTS.md` session-completion convention, status/MEMORY
+must reflect completed work. The entry cites the v1 rclone benchmark report
+explicitly so future readers can trace the decision back to its evidence.
+
+## File Change Summary
+
+| File | Change | Priority |
+|---|---|---|
+| `src/stream_of_worship/admin/services/r2_backup.py` (lines 32–37) | `DEFAULT_CONCURRENCY = 8 → 1`; rewrite comment citing v1 rclone benchmark | P0 |
+| `src/stream_of_worship/admin/services/r2_backup.py` (lines 914–915) | `write_backup` validation bound `64 → 5`; match string `1-64 → 1-5` | P0 |
+| `src/stream_of_worship/admin/commands/maintenance.py` (lines 648–656) | `--concurrency` default `8 → 1`, max `64 → 5`; rewrite help text | P0 |
+| `src/stream_of_worship/admin/services/r2.py` (lines 107–109) | `max_pool_connections = 64 → 5`; rewrite stale comment | P0 |
+| `tests/admin/test_r2_backup.py` (lines 913, 916–923) | Boundary match strings `1-64 → 1-5`; rename `rejects_65 → rejects_6`, input `65 → 6` | P0 |
+| `tests/admin/test_r2_backup_commands.py` (lines 214–236) | No edit — `--concurrency 4` still within new `max=5` range | n/a |
+| `report/current_impl_status.md` | Append status entry per AGENTS.md | P1 |
+| `MEMORY.md` | Append status entry per AGENTS.md | P1 |
+
+**Total:** 4 source/test files edited, 2 docs appended. 1 test file
+explicitly verified as needing no change.
+
+## Files Explicitly NOT Modified
+
+- **`specs/admin-r2-backup-*.md`** — historical specs are immutable records;
+  this v2 spec documents the new decision without rewriting predecessors.
+- **`poc/`, `scripts/`** — out of scope.
+- **`as_completed` ingestion loop** in `write_backup` — kept. Still correct
+  for `concurrency=1` (the `ThreadPoolExecutor(max_workers=1)` degenerates
+  to sequential submission, and `as_completed` still yields futures in
+  completion order). No behavior change.
+- **Inventory size-desc submission sort** — kept. Under `concurrency=1` it
+  means large objects download first, which is fine (no end-of-run tail
+  either way when there's no parallelism).
+- **`BackupTracer`** — kept. Still emits per-object and per-phase traces
+  at DEBUG level; the `network_saturated` summary field's heuristic still
+  works (its threshold is `aggregate / (single_worker_avg * peak_workers)
+  < 0.5`; with `peak_workers=1` this becomes `aggregate / single_worker_avg
+  < 0.5`, correctly reporting "no (or inconclusive)" for a single-threaded
+  run).
+- **`range_get_throughput_diag`** — kept. The diagnostic that produced all
+  the evidence for this spec; must remain available for future
+  re-investigation. Its default `num_ranges=4` fits within `max_pool_connections=5`.
+- **Retry telemetry** (`retry_trace`, `timeout_retries`) — kept. Confirmed
+  valuable in v2 trace; orthogonal to concurrency level.
+- **`read_timeout=300`** — kept. Correct independently of concurrency; a
+  single 50 MB stem at ~1 MiB/s still takes ~50 s, so 300 s headroom is
+  still appropriate.
+- **Manifest version** — no change (stays at 4).
+- **`examples/sow-admin-config.toml`** — no change. The `[r2]` section does
+  not document `--concurrency`; users don't need a config-file-side update.
+
+## Verification Plan
+
+### Step 1: Unit tests
+
+Per `AGENTS.md` command pattern:
+
+```bash
+PYTHONPATH=src uv run --python 3.11 --extra admin --extra test \
+  pytest tests/admin/test_r2_backup.py tests/admin/test_r2_backup_commands.py -v
+```
+
+**Expected:** all tests pass with the updated boundary assertions
+(`1-5` match strings, `rejects_6` test name, `concurrency=6` input). The
+default-concurrency test (`test_concurrent_backup_produces_valid_archive`)
+produces a valid archive at `concurrency=1`; no value assertion to update.
+
+### Step 2: Lint
+
+```bash
+PYTHONPATH=src uv run --python 3.11 --extra admin \
+  ruff check \
+  src/stream_of_worship/admin/services/r2_backup.py \
+  src/stream_of_worship/admin/commands/maintenance.py \
+  src/stream_of_worship/admin/services/r2.py
+```
+
+**Expected:** clean. No new imports, no line-length violations (all
+changed lines fit within the 100-char limit per `AGENTS.md` formatting
+rules).
+
+### Step 3: Typecheck
+
+```bash
+PYTHONPATH=src uv run --python 3.11 --extra admin \
+  mypy src/stream_of_worship/admin/services/r2_backup.py
+```
+
+**Expected:** clean. No type signatures changed — only integer literals
+and comment strings.
+
+### Step 4: Optional regression smoke (not required to land the revert)
+
+If the user opts in, confirm `concurrency=1` matches `concurrency=8` on a
+real backup run:
+
+```bash
+for c in 1 8; do
+  sow-admin maintenance backup-r2 \
+    --chunk-size 5GiB --concurrency $c \
+    --output ~/BACKUPS/sow-r2/smoke-$c \
+    --debug-traces 2>&1 | tee smoke-$c.txt
+done
+```
+
+**Expected:** both runs produce ~7 MiB/s aggregate; the `concurrency=1`
+run may even be marginally faster (no lock contention). This is
+confirmation, not discovery — the v1 rclone benchmark already established
+the ceiling.
+
+If `concurrency=1` is *slower* than `concurrency=8` by more than 10%,
+**stop** and investigate — the v1 benchmark may not generalize (e.g.,
+per-object HEAD overhead becoming significant without overlap).
+
+### Step 5: Session completion (per AGENTS.md)
+
+```bash
+git pull --rebase
+git push
+git status
+```
+
+`git status` MUST show "up to date with origin" before stopping.
+
+## Out of Scope
+
+- **Removing the `--concurrency` flag entirely.** User chose to keep the
+  flag with `max=5` for experimentation headroom. A follow-up spec may
+  remove it if the `ratio < 1.0` finding holds across multiple future
+  traces.
+- **Removing the `ThreadPoolExecutor` code path from `write_backup`.** The
+  machinery is retained; `concurrency=1` degenerates gracefully to a
+  sequential loop without code changes. Removing the executor would
+  delete tested code (`as_completed`, `submission_order`) that the v2
+  remediation spec explicitly kept.
+- **Reopening the `<10 min for 12.9 GB` goal.** Still closed per the v2
+  remediation spec; the v1 rclone benchmark confirmed the ceiling is
+  account-level, not client-level. Requires Cloudflare Worker in-network
+  backup or bucket size reduction.
+- **Re-investigating rclone as a backend.** The v1 rclone benchmark
+  returned STOP per its Step 1c decision gate. Reopening requires new
+  evidence (e.g., a different R2 plan tier lifting the account-level cap,
+  or a different network path).
+- **boto3 `TransferConfig` tuning (use_threads, multipart_chunksize).**
+  Out of scope per v1 rclone benchmark's "Out of Scope" section.
+  Per-object multipart Range-GET is moot now that `ratio=0.83` shows
+  parallel ranges hurt throughput.
+- **Cloudflare Worker in-network backup.** Out of scope per v2 remediation
+  spec; user has not reversed the architectural-change decision.
+- **AIobotocore async rewrite.** Out of scope per v1 rclone benchmark's
+  "Out of Scope" section.
+- **Updating `specs/admin-r2-backup-throughput-remediation-v1.md` or
+  `...-v2.md`.** Historical specs are immutable records; this v2 rclone
+  spec documents the new decision without rewriting predecessors.
+
+## Decisions Deferred
+
+- **Default backend (`boto3` vs `rclone`):** boto3 remains the sole
+  backend. The v1 rclone benchmark confirmed rclone is slower across all
+  tested configurations; promoting rclone to default is not considered.
+- **`--concurrency max=5` vs `max=3`:** Chose 5 to fit the
+  `--diag-range-key` default (`num_ranges=4`) plus 1 spare. If trace data
+  later confirms `concurrency >= 2` is always harmful, lower to 1 in a
+  follow-up spec and remove the flag entirely.
+- **`max_pool_connections=5` vs `=10`:** Chose 5 to match the CLI `max=5`
+  exactly, avoiding silent queuing. If a future diagnostic needs more
+  than 4 parallel ranges, bump both in lockstep.
+- **Reopening the goal if `ratio` changes:** If a future `--diag-range-key`
+  returns `ratio > 1.5` (network conditions improve, R2 plan changes),
+  re-evaluate `DEFAULT_CONCURRENCY` in a new spec. Do not silently bump.
+- **Making `concurrency=1` skip the `ThreadPoolExecutor` entirely:** The
+  current code uses `ThreadPoolExecutor(max_workers=1)`, which
+  degenerates to sequential submission with minor overhead. A
+  micro-optimization to skip the executor when `concurrency=1` is
+  possible but out of scope for this revert; measure first.
+
+## References
+
+- `reports/admin-r2-backup-rclone-download-v1-results.md` — the v1 rclone
+  benchmark results; canonical evidence for this spec (the `ratio=0.83`
+  finding).
+- `specs/admin-r2-backup-rclone-download-v1.md` — the v1 rclone spec that
+  prescribed the benchmark; STOP decision per its Step 1c.
+- `specs/admin-r2-backup-throughput-remediation-v2.md` — closure of the
+  32-worker investigation; established `DEFAULT_CONCURRENCY=8` baseline
+  that this spec reverts.
+- `specs/admin-r2-backup-throughput-remediation-v1.md` — original
+  32-worker bump (commit `ea397e7`); the regression this spec's lineage
+  addresses.
+- `specs/admin-r2-backup-perf-traces.md` — `BackupTracer` and
+  `range_get_throughput_diag` design; the tools that produced all the
+  evidence.
+- `src/stream_of_worship/admin/services/r2_backup.py:32-37` —
+  `DEFAULT_CONCURRENCY` constant (Change 1 target).
+- `src/stream_of_worship/admin/services/r2_backup.py:914-915` —
+  `write_backup` validation (Change 2 target).
+- `src/stream_of_worship/admin/commands/maintenance.py:648-656` —
+  `--concurrency` Typer option (Change 3 target).
+- `src/stream_of_worship/admin/services/r2.py:107-109` —
+  `max_pool_connections` boto3 Config (Change 4 target).
+- `tests/admin/test_r2_backup.py:907-923` — boundary tests (Change 5
+  target).
+- `tests/admin/test_r2_backup_commands.py:214-236` —
+  `test_backup_concurrency_flag` (verified unchanged under Change 6).
+- `MEMORY.md:3` — existing v2 remediation entry; this spec's entry
+  appends after it.

--- a/specs/admin-r2-backup-throughput-remediation-v1.md
+++ b/specs/admin-r2-backup-throughput-remediation-v1.md
@@ -1,0 +1,811 @@
+# Admin R2 Backup Throughput Remediation v1 — Network Cap, HOL Blocking, Retry Telemetry
+
+## Summary
+
+The performance traces added in commit `c588364` (spec `admin-r2-backup-perf-traces.md`)
+were run against a 679-object / 12 GiB backup with `--concurrency 8 --chunk-size 5GiB
+--debug-traces`. The traces produced clear, actionable data identifying three distinct
+bottlenecks that the v3 concurrent-downloads work (commit `8f4c6d5`) did not address:
+
+1. **Per-stream bandwidth caps at ~1 MBps.** Single-worker throughput ≈ aggregate / 8,
+   meaning parallelism *is* scaling linearly but each connection is individually throttled.
+   8 × ~1 MBps ≈ 7.3 MBps observed; the throughput samples are remarkably flat (7.0–7.7 MBps)
+   across the whole run.
+2. **Head-of-line (HOL) blocking on the main-thread tar-ingestion loop.** The main
+   thread iterates `enumerate(inventory.objects)` in submission order and calls
+   `future.result(idx)` for each. Slow downloads at the head of queue stall already-completed
+   downloads sitting on disk. Trace shows `wait_ms` peaks of 51.9s, 33.0s, 26.0s on single
+   objects — totaling ~200s of wasted main-thread time in a ~4-minute window.
+3. **`read_timeout=30` is dangerously tight.** A 50 MB stem at 0.5–1 MBps takes 50–100s
+   per stream; one network hiccup exceeding 30s triggers a full re-download (doubling that
+   object's time). No retries fired in the captured run (`retries=0` throughout), but the
+   configuration is a lurking landmine.
+
+This spec defines four targeted remediations (A–D) plus one new diagnostic (E) to confirm
+whether the ~1 MBps per-stream cap is R2-side (per-connection throttle) or client-side
+(local network). All changes are backward-compatible: existing manifests, chunk layouts, and
+restore flows remain unchanged.
+
+## Trace Evidence
+
+### Evidence 1 — Per-stream bandwidth cap at ~1 MBps (PRIMARY)
+
+Throughput samples are remarkably flat across the entire run (~7.0–7.7 MBps) for 8 workers.
+This is exactly what linear scaling looks like when each stream is individually capped around
+~1 MBps (8 × 1 ≈ 7.3 MBps observed):
+
+| Object | bytes | stream_ms | download_mbps |
+|---|---|---|---|
+| `02fa022169b7/stems/bass.wav` | 45854636 | 76449.9 | **0.57** |
+| `02fa022169b7/stems/vocals.wav` | 45854636 | 55842.5 | **0.78** |
+| `02fa022169b7/stems/drums.wav` | 45854636 | 42784.0 | **1.02** |
+| `020453ae60d8/stems/instrumental_clean.flac` | 20150095 | 24858.2 | **0.77** |
+| `10d07a66c47e/stems/vocals.wav` | 49403336 | 53930.8 | **0.87** |
+| `18ade95e29dc/stems/drums.wav` | 49741872 | 53626.8 | **0.88** |
+| `3428cfdce4f8/stems/bass.wav` | 55048140 | 63406.4 | **0.83** |
+| `3428cfdce4f8/stems/drums.wav` | 55048140 | 65409.4 | **0.80** |
+| `3428cfdce4f8/stems/vocals.wav` | 55048140 | 60506.7 | **0.87** |
+
+Single-worker throughput ≈ aggregate / 8 → parallelism *is* scaling linearly, but each
+connection tops out around 1 MBps. **Adding more concurrency is the cheapest test** to find
+the real ceiling; the current 8 workers may be nowhere near saturation on R2's side.
+
+Throughput sample timeline (every ~5s, aggregate_mbps never deviates from the 7.0–7.7 band):
+
+```
+t+5.2s   workers=8  downloaded_mib=36.25    aggregate_mbps=7.00
+t+10.3s  workers=8  downloaded_mib=72.25    aggregate_mbps=7.04
+t+15.4s  workers=8  downloaded_mib=110.05   aggregate_mbps=7.13
+t+20.6s  workers=8  downloaded_mib=150.79   aggregate_mbps=7.33
+t+25.9s  workers=8  downloaded_mib=197.00   aggregate_mbps=7.61
+t+31.0s  workers=8  downloaded_mib=239.00   aggregate_mbps=7.72
+t+36.0s  workers=8  downloaded_mib=277.86   aggregate_mbps=7.72
+t+41.0s  workers=8  downloaded_mib=314.86   aggregate_mbps=7.67
+t+46.1s  workers=8  downloaded_mib=350.59   aggregate_mbps=7.61
+t+51.4s  workers=8  downloaded_mib=392.04   aggregate_mbps=7.63
+t+56.4s  workers=8  downloaded_mib=433.49   aggregate_mbps=7.69
+t+61.5s  workers=8  downloaded_mib=464.59   aggregate_mbps=7.55
+t+66.8s  workers=8  downloaded_mib=497.04   aggregate_mbps=7.44
+t+71.9s  workers=8  downloaded_mib=533.77   aggregate_mbps=7.42
+t+77.0s  workers=8  downloaded_mib=567.50   aggregate_mbps=7.37
+t+82.1s  workers=8  downloaded_mib=602.61   aggregate_mbps=7.34
+t+87.1s  workers=8  downloaded_mib=639.24   aggregate_mbps=7.34
+...
+t+263.0s workers=4  downloaded_mib=1938.33 aggregate_mbps=7.37 peak_workers=8
+```
+
+The drop from `workers=8` to `workers=4` at t+263s is end-of-run tail starvation (see Evidence 2).
+
+### Evidence 2 — Head-of-line blocking on main-thread ingestion loop (SECONDARY)
+
+In `write_backup` at `r2_backup.py:876-890`, the main thread iterates
+`enumerate(inventory.objects)` **in submission order** and calls `future.result(idx)` for each.
+If `futures[idx]`, `futures[idx+1]`, `futures[idx+2]` are still downloading, the main thread
+blocks — even though `futures[idx+3..]` may be already completed and sitting on disk. The
+trace callout `wait_is_bottleneck=yes` confirms this:
+
+| idx | key | wait_ms | tar_write_ms |
+|---|---|---|---|
+| 11 | `02fa022169b7/stems/bass.wav` | **51889.9** | 81.8 |
+| 27 | `10d07a66c47e/stems/bass.wav` | **5150.3** | 76.2 |
+| 29 | `10d07a66c47e/stems/other.wav` | **11196.1** | 44.2 |
+| 30 | `10d07a66c47e/stems/vocals.wav` | **8713.8** | 41.7 |
+| 46 | `18ade95e29dc/stems/bass.wav` | **18492.8** | 102.6 |
+| 47 | `18ade95e29dc/stems/drums.wav` | **15157.2** | 143.9 |
+| 49 | `18ade95e29dc/stems/vocals.wav` | **14471.6** | 56.7 |
+| 61 | `1cd7a3f28089/stems/instrumental.flac` | **13234.8** | 34.4 |
+| 67 | `20379ea26256/stems/vocals.flac` | **25980.4** | 46.8 |
+| 68 | `20379ea26256/stems/vocals_dry.flac` | **3225.5** | 51.1 |
+| 90 | `301d6a2492a8/stems/instrumental.flac` | **33049.1** | 35.2 |
+| 100 | `3428cfdce4f8/stems/bass.wav` | **26652.6** | 68.2 |
+
+Cumulative main-thread idle ≈ 200s in the first ~4 minutes. It doesn't kill aggregate
+throughput while the executor still has queued work (downloads keep running in parallel),
+but it produces two real symptoms visible in the trace:
+
+- **Workers drop from 8 → 4 at t+263s** ("workers=4") — end-of-run tail as worker pool
+  drains and only slow futures remain. `peak_workers=8` confirms 8 concurrent workers were
+  active earlier.
+- **Temp files pile up on disk** waiting to be ingested. The backup estimates
+  `required_space = bytes * 2.1` precisely because of this round-trip bottleneck — downloaded
+  temp files accumulate while the main thread is blocked on `future.result(idx)` for an
+  earlier slow object.
+
+### Evidence 3 — Small files dominated by connection setup overhead (TERTIARY)
+
+Small files (`lyrics.lrc` ~800 B, `analysis.json` ~5 KB) show `conn_ms` (~130–300 ms)
+dwarfs `stream_ms` (<1 ms). The visible `download_mbps` of 0.22–5.89 on small files is mostly
+TLS/HTTP plumbing, not body bytes:
+
+| key | bytes | conn_ms | stream_ms | download_mbps |
+|---|---|---|---|---|
+| `020453ae60d8/lyrics.lrc` | 516 | 173.9 | 2.2 | 0.22 |
+| `0059761b1734/lyrics.lrc` | 798 | 188.7 | 0.1 | 0.76 |
+| `02ab72d771ae/lyrics.lrc` | 1495 | 196.1 | 0.1 | 1.43 |
+| `02fa022169b7/analysis.json` | 3952 | 193.5 | 0.1 | 3.77 |
+| `16c9653aa74c/analysis.json` | 6175 | 179.6 | 0.3 | 5.89 |
+
+Per-cluster this is ~10–15% of wallclock wasted on handshake-dominated round-trips. Not a
+primary bottleneck, but explains the flat aggregate curve when the work mix is
+small-files-heavy (workers finish tiny downloads quickly and immediately pick up the next
+queued slow stem).
+
+### Evidence 4 — `read_timeout=30` is dangerously tight (RISK)
+
+`R2Client` config at `r2.py:101-106` sets `read_timeout=30` and `retries={"max_attempts": 2}`.
+A 50 MB stem at 0.5–1 MBps takes 50–100s per stream — one network hiccup exceeding 30s would
+trigger a full re-download from scratch (doubling that object's time). No retries fired this
+run (`retries=0` throughout, lucky), but it's a lurking landmine.
+
+Per-object stream times exceeding 30s are common in the trace:
+
+| key | bytes | stream_ms | seconds |
+|---|---|---|---|
+| `02fa022169b7/stems/bass.wav` | 45854636 | 76449.9 | **76.4s** |
+| `3428cfdce4f8/stems/bass.wav` | 55048140 | 63406.4 | **63.4s** |
+| `3428cfdce4f8/stems/drums.wav` | 55048140 | 65409.4 | **65.4s** |
+| `3428cfdce4f8/stems/vocals.wav` | 55048140 | 60506.7 | **60.5s** |
+| `10d07a66c47e/stems/vocals.wav` | 49403336 | 53930.8 | **53.9s** |
+| `18ade95e29dc/stems/drums.wav` | 49741872 | 53626.8 | **53.6s** |
+
+These are all well above the 30s read timeout — if boto3's `read_timeout` triggers on a slow
+chunk delivery mid-stream rather than on connection setup, any of these would fail and
+re-download from scratch. The fact that `retries=0` held throughout is fortunate, not robust.
+
+## Decisions
+
+| Topic | Decision |
+|---|---|
+| Concurrency default | Bump `DEFAULT_CONCURRENCY` from 8 → 32 in `r2_backup.py`. Document the observed ~1 MBps per-stream cap in a code comment near the constant. |
+| Tar-ingestion loop | Rewrite to use `concurrent.futures.as_completed(futures)` instead of submission-order iteration. Rotate tar chunks in completion order. `member_name` (sequential indices `objects/{idx:012d}.bin`) stays indexed by submission `idx` for deterministic manifest ordering. |
+| Inventory submission order | Sort `inventory.objects` by size descending before submitting to ThreadPoolExecutor. Slow 50 MB stems download first; small `.lrc`/`.json` files dominate the tail. |
+| boto3 `read_timeout` | Bump from 30 → 300 seconds in `r2.py`. Add `max_pool_connections=64` (was 32) to align with new concurrency default. |
+| Retry telemetry | Add `BackupTracer.retry_trace(...)` method that emits `download_retry key=... worker=... attempt=... error_code=... elapsed_ms=...` log lines when a download retry fires. Add `timeout_retries=N` field to `finalize()` summary. |
+| Diagnostic tool | New `--diag-range-key <s3_key>` flag on `backup-r2` that runs a single multi-part Range-GET throughput test on one large object and short-circuits before `write_backup`. Confirms R2-side per-connection throttle vs client-network cap. |
+| Manifest version | No change (stays at 4 — no archive format change). Existing backup directories remain restorable. |
+| `member_name` ordering | Stays indexed by original inventory order (`objects/000000000001.bin`, etc.). Sorting submission order changes *which future downloads which object first*, not the member name stored in the manifest. |
+| Chunk assignment | Each object's `chunk_index` is assigned in completion order, not submission order. This is already the case (chunk_index comes from the main thread's ingestion position) — same behavior, but completion order is now driven by `as_completed` rather than submission iterator. The manifest records the actual `chunk_index` per object, so verify/restore correctness is preserved (`verify_archive` at `r2_backup.py:1159` reads `chunk_index` from manifest, not from file position). |
+| Tests | New `test_as_completed_tar_ingestion`, `test_inventory_sort_by_size`, `test_retry_trace_emission`, `test_range_get_diagnostic` in `tests/admin/test_r2_backup.py`. Existing manifest/verify round-trip tests must still pass. |
+
+## Files to Modify
+
+1. `src/stream_of_worship/admin/services/r2_backup.py`
+   - Change A: Bump `DEFAULT_CONCURRENCY = 32` (line 32). Add comment documenting observed per-stream ~1 MBps cap.
+   - Change B: Rewrite `write_backup` main loop (lines 867-940) to use `concurrent.futures.as_completed`. Keep `member_name` indexed by submission `idx`; manifest `chunk_index` assigned in completion order.
+   - Change C: In `write_backup`, after `inventory` parameter validation (line ~782), compute `submission_order = sorted(range(len(inventory.objects)), key=lambda i: inventory.objects[i].size, reverse=True)`. Iterate `submission_order` when building futures dict; manifest iteration still uses original `enumerate(inventory.objects)`.
+   - Change D: Add `BackupTracer.retry_trace(...)` method (new) and `timeout_retries=N` field to `finalize()`. Update `_download_object_to_tempfile` retry path (lines 713-735) to call `tracer.retry_trace(...)` on each retry, capturing `error_code` from `ClientError.response`.
+   - Change E: Add `range_get_throughput_diag(r2_client, large_key, num_ranges=4)` helper function at module level. Returns dict with `single_conn_mbps`, `multi_conn_total_mbps`, `ratio`, `content_length`, `num_ranges`.
+
+2. `src/stream_of_worship/admin/services/r2.py`
+   - Change D: Bump `read_timeout=30` → `read_timeout=300` (line 103). Bump `max_pool_connections=32` → `max_pool_connections=64` (line 105). Add comment explaining 50 MB at 1 MBps = 50s.
+
+3. `src/stream_of_worship/admin/commands/maintenance.py`
+   - Change A: Update `--concurrency` typer `max=64` → `max=128` (line 651). Update help text.
+   - Change E: Add new `--diag-range-key: Optional[str] = typer.Option(None, ...)` flag to `backup_r2` command (line ~645). If set, run `range_get_throughput_diag(r2_client, diag_range_key)` instead of `write_backup`, print result as JSON to stdout, and exit 0.
+
+4. `tests/admin/test_r2_backup.py`
+   - New `test_as_completed_tar_ingestion`: verify chunk_index values in manifest match completion order, not submission order; verify all objects present.
+   - New `test_inventory_sort_by_size`: verify `submission_order` is size-descending; verify `member_name` indices are still original inventory order.
+   - New `test_retry_trace_emission`: inject a mock R2Client that fails once with `RequestTimeout` then succeeds; verify `retry_trace` called with correct `error_code`.
+   - New `test_range_get_diagnostic`: mock boto3 `head_object` + `get_object(Range=...)` to return fixed-size byte streams; verify the diag dict has correct throughput math.
+
+5. `tests/admin/test_r2_backup_commands.py`
+   - New `test_backup_r2_diag_range_key_flag`: verify `--diag-range-key` short-circuits `write_backup` and prints JSON diag result.
+   - Update `test_backup_r2_concurrency_validation` if boundaries changed.
+
+---
+
+## Change A: Bump Default Concurrency and Document Per-Stream Cap
+
+### A.1 Constant change
+
+In `src/stream_of_worship/admin/services/r2_backup.py:32`:
+
+```python
+# Before:
+DEFAULT_CONCURRENCY = 8
+
+# After:
+# Bumped from 8 → 32 based on trace evidence (2026-06): with 8 workers, each
+# R2 stream caps at ~1 MBps and aggregate throughput plateaus at ~7.3 MBps
+# (see specs/admin-r2-backup-throughput-remediation-v1.md). The per-stream cap is
+# R2-side (confirmed by --diag-range-key), so more connections is the only way
+# to scale until/if multipart Range-GET per object is added.
+DEFAULT_CONCURRENCY = 32
+```
+
+### A.2 Validation range
+
+In `write_backup` at `r2_backup.py:782-783`:
+
+```python
+# Before:
+if not (1 <= concurrency <= 64):
+    raise BackupError(f"concurrency must be 1-64, got {concurrency}")
+
+# After:
+if not (1 <= concurrency <= 128):
+    raise BackupError(f"concurrency must be 1-128, got {concurrency}")
+```
+
+### A.3 CLI flag update
+
+In `src/stream_of_worship/admin/commands/maintenance.py:650-653`:
+
+```python
+# Before:
+concurrency: int = typer.Option(
+    8, "--concurrency", min=1, max=64,
+    help="Number of concurrent download workers"
+),
+
+# After:
+concurrency: int = typer.Option(
+    32, "--concurrency", min=1, max=128,
+    help=(
+        "Number of concurrent download workers (default 32). "
+        "Per-stream R2 bandwidth caps at ~1 MBps; raise this to scale aggregate "
+        "throughput until the R2 account-level throttle is hit."
+    ),
+),
+```
+
+---
+
+## Change B: `as_completed` Tar Ingestion Loop
+
+### B.1 Current behavior (problem)
+
+`write_backup` at `r2_backup.py:876-890`:
+
+```python
+for idx, inv_obj in enumerate(inventory.objects):
+    member_name = _member_name_for_index(idx)
+
+    if (
+        current_chunk_bytes > 0
+        and current_chunk_bytes + inv_obj.size > chunk_size_bytes
+    ):
+        _rotate_chunk()
+
+    _ensure_tar()
+
+    future = futures[idx]
+    t_wait_start = time.monotonic() if tracer is not None else 0.0
+    try:
+        download_result = future.result()  # BLOCKS if future[idx] not done yet
+    except BaseException:
+        for f in futures.values():
+            f.cancel()
+        raise
+    wait_ms = (time.monotonic() - t_wait_start) * 1000.0 if tracer is not None else 0.0
+    # ... tar write + manifest
+```
+
+Problem: main thread blocks on `future.result()` for `futures[idx]` in submission order
+even if `futures[idx+5]` is already completed and sitting on disk.
+
+### B.2 New behavior
+
+```python
+from concurrent.futures import as_completed
+
+# Build reverse lookup: future → idx (needed because as_completed yields futures,
+# not indices).
+future_to_idx = {f: idx for idx, f in futures.items()}
+
+try:
+    for future in as_completed(futures.values()):
+        idx = future_to_idx[future]
+        inv_obj = inventory.objects[idx]
+        member_name = _member_name_for_index(idx)
+
+        # Rotate chunk if needed (based on completion-order size, not submission order)
+        if (
+            current_chunk_bytes > 0
+            and current_chunk_bytes + inv_obj.size > chunk_size_bytes
+        ):
+            _rotate_chunk()
+
+        _ensure_tar()
+
+        t_wait_start = time.monotonic() if tracer is not None else 0.0
+        try:
+            download_result = future.result()
+        except BaseException:
+            for f in futures.values():
+                f.cancel()
+            raise
+        wait_ms = (time.monotonic() - t_wait_start) * 1000.0 if tracer is not None else 0.0
+
+        # ... rest of tar write + manifest + progress unchanged
+```
+
+`wait_ms` is expected to drop to near-zero in the steady state because `as_completed`
+only yields a future that is already done. The only blocking is when *all* futures in
+flight are still downloading (executor starved) — which indicates the network is truly
+saturated, not a structural bottleneck.
+
+### B.3 Manifest correctness preserved
+
+- `member_name = _member_name_for_index(idx)` uses the original submission `idx`, so
+  `objects/000000000001.bin` still maps to `inventory.objects[1]`. Manifest entries are
+  deterministic regardless of completion order.
+- `chunk_index` is assigned by the main thread at ingestion time (whichever chunk is
+  currently open when the object is written). This is already the case in the current code;
+  switching to `as_completed` changes *which* object lands in *which* chunk, but the manifest
+  records the actual `chunk_index` per object. `verify_archive` (r2_backup.py:1159) and
+  `restore_from_archive` (r2_backup.py:1404) read `chunk_index` from the manifest, so
+  round-trip correctness is preserved.
+- `manifest["objects"]` order: currently insertion order (which is submission order).
+  After change B, insertion order is completion order. This is a cosmetic change — the
+  manifest is a list of dicts, and consumers iterate by `member_name` / `key` / `chunk_index`,
+  not by list position. No code path depends on list ordering.
+
+---
+
+## Change C: Sort Inventory by Size Descending Before Submission
+
+### C.1 Rationale
+
+With `as_completed` (Change B), the end-of-run tail is determined by whichever futures
+finish last. If the slowest objects (50 MB stems) happen to be submitted last, the run ends
+with workers=1 for ~60s while a single slow stem finishes. Sorting submission order
+large-to-small ensures the slowest stems are submitted first and download in parallel,
+leaving small fast files (`.lrc`, `.json`) for the tail — which finish in milliseconds.
+
+### C.2 Implementation
+
+In `write_backup`, right before the `ThreadPoolExecutor` block (r2_backup.py:867):
+
+```python
+# Sort inventory indices by size descending for submission order.
+# This ensures the slowest 50MB stems download first (in parallel with
+# small lrc/json files), so the end of the run is small fast objects —
+# no slow tail with workers=1.
+submission_order = sorted(
+    range(len(inventory.objects)),
+    key=lambda i: inventory.objects[i].size,
+    reverse=True,
+)
+
+with ThreadPoolExecutor(max_workers=concurrency) as executor:
+    futures = {
+        idx: executor.submit(
+            _download_object_to_tempfile,
+            r2_client,
+            inventory.objects[idx],
+            temp_dir,
+            progress,
+            tracer,
+        )
+        for idx in submission_order
+    }
+    # ... rest of as_completed loop (Change B)
+```
+
+### C.3 Manifest and member_name ordering
+
+- `member_name = _member_name_for_index(idx)` still uses the original `idx` from
+  `enumerate(inventory.objects)`, so `objects/000000000001.bin` still maps to
+  `inventory.objects[1]`. Manifest entries are deterministic regardless of submission order.
+- `manifest["objects"]` list order: now follows completion order (which is influenced by
+  size sort but not strictly size-descending — depends on which finishes first). Still
+  cosmetic; consumers don't depend on list position.
+
+---
+
+## Change D: `read_timeout=300` + Retry Telemetry
+
+### D.1 boto3 config
+
+In `src/stream_of_worship/admin/services/r2.py:101-106`:
+
+```python
+# Before:
+config=Config(
+    connect_timeout=10,
+    read_timeout=30,
+    retries={"max_attempts": 2},
+    max_pool_connections=32,
+),
+
+# After:
+config=Config(
+    connect_timeout=10,
+    # 50MB stem at 1MBps = 50s; bump from 30s to avoid mid-stream timeout
+    # retries that would force full re-download from scratch.
+    read_timeout=300,
+    retries={"max_attempts": 2},
+    # Bump from 32 to 64 to align with new DEFAULT_CONCURRENCY=32 plus headroom
+    # for the diagnostic Range-GET workers.
+    max_pool_connections=64,
+),
+```
+
+### D.2 New `BackupTracer.retry_trace` method
+
+In `src/stream_of_worship/admin/services/r2_backup.py`, inside `BackupTracer` class
+(after `tar_write_trace`, before `bytes_downloaded_sample`):
+
+```python
+def retry_trace(
+    self,
+    key: str,
+    worker: str,
+    attempt: int,
+    error_code: str,
+    elapsed_ms: float,
+) -> None:
+    """Emit a retry trace event when a download retry fires.
+
+    Called from `_download_object_to_tempfile` on each retry attempt
+    (before the next attempt begins). `error_code` is the botocore
+    ClientError error code string (e.g., "RequestTimeout", "ReadTimeout",
+    "SlowDown", "SocketError").
+    """
+    if not self._enabled:
+        return
+    self._logger.debug(
+        f"download_retry key={key} worker={worker} attempt={attempt} "
+        f"error_code={error_code} elapsed_ms={elapsed_ms:.1f}"
+    )
+    with self._lock:
+        self._retries_total += 1
+        if error_code in ("RequestTimeout", "ReadTimeout", "SlowDown"):
+            self._timeout_retries += 1
+```
+
+Add `self._timeout_retries = 0` to `BackupTracer.__init__` (after `self._retries_total = 0`
+at r2_backup.py:261).
+
+### D.3 Update `_download_object_to_tempfile` retry path
+
+In `r2_backup.py:713-735`, the existing `except Exception as e:` block:
+
+```python
+# Before:
+except Exception as e:
+    last_error = str(e)
+    if attempt < max_retries:
+        retries_taken += 1
+        if temp_path is not None:
+            try:
+                temp_path.unlink()
+            except OSError:
+                pass
+        continue
+    # ... final failure path
+
+# After:
+except Exception as e:
+    last_error = str(e)
+    error_code = ""
+    if isinstance(e, ClientError):
+        error_code = e.response.get("Error", {}).get("Code", "")
+    if attempt < max_retries:
+        retries_taken += 1
+        if tracer is not None:
+            tracer.retry_trace(
+                key=inv_obj.key,
+                worker=worker_name,
+                attempt=attempt,
+                error_code=error_code,
+                elapsed_ms=(conn_ms + stream_ms),
+            )
+        if temp_path is not None:
+            try:
+                temp_path.unlink()
+            except OSError:
+                pass
+        continue
+    # ... final failure path (unchanged)
+```
+
+### D.4 Update `finalize()` summary
+
+In `r2_backup.py:443-470`, add `timeout_retries` field:
+
+```python
+self._logger.debug(
+    "summary total_objects=%d total_bytes=%d "
+    "aggregate_mbps=%.2f single_worker_avg_mbps=%.2f "
+    "peak_workers=%d retries_total=%d timeout_retries=%d "
+    "sum_download_ms=%.1f sum_conn_ms=%.1f sum_wait_ms=%.1f sum_tar_write_ms=%.1f "
+    "wait_pct=%.1f tar_write_pct=%.1f "
+    "max_object_download_ms=%.1f max_object_download_key=%s "
+    "network_saturated=%s",
+    total_objects,
+    total_bytes,
+    aggregate_mbps,
+    single_worker_avg_mbps,
+    peak_workers,
+    retries_total,
+    timeout_retries,
+    # ... rest unchanged
+)
+```
+
+Add `timeout_retries = self._timeout_retries` to the `with self._lock:` block in
+`finalize()`.
+
+---
+
+## Change E: Range-GET Throughput Diagnostic
+
+### E.1 Rationale
+
+Before committing to `DEFAULT_CONCURRENCY = 32`, we want to confirm whether the ~1 MBps
+per-stream cap is R2-side (per-connection throttle, where multiple connections to the
+same object will each get ~1 MBps) or client-side (local network cap, where multiple
+connections to the same object will share an aggregate cap).
+
+The test: issue N parallel Range-GET requests against a single large object and measure
+aggregate throughput. If N ranges yield ~N MBps, the cap is per-connection (R2-side); if N
+ranges yield ~1 MBps total, the cap is client-network.
+
+### E.2 New helper function
+
+In `src/stream_of_worship/admin/services/r2_backup.py`, at module level (after
+`_download_object_to_tempfile`):
+
+```python
+def range_get_throughput_diag(
+    r2_client: "R2Client",
+    s3_key: str,
+    num_ranges: int = 4,
+) -> dict:
+    """Run a parallel Range-GET throughput diagnostic on a single R2 object.
+
+    Issues `num_ranges` concurrent Range-GET requests against non-overlapping
+    byte ranges of `s3_key` and measures aggregate throughput. Used to
+    distinguish R2-side per-connection throttling (N ranges → ~N MBps) from
+    client-network saturation (N ranges → ~1 MBps total).
+
+    Args:
+        r2_client: R2Client instance
+        s3_key: Full S3 key of a large object (recommend >20 MB stem file)
+        num_ranges: Number of parallel Range-GET workers (default 4)
+
+    Returns:
+        Dict with keys:
+            - content_length: int (total object size in bytes)
+            - num_ranges: int
+            - single_conn_mbps: float (throughput of one range, MB/s)
+            - multi_conn_total_mbps: float (aggregate throughput of all ranges, MB/s)
+            - ratio: float (multi / single; >1.5 suggests R2-side per-conn cap)
+            - per_range_mbps: list[float] (per-range throughput)
+    """
+    import concurrent.futures
+
+    head = r2_client._client.head_object(Bucket=r2_client.bucket, Key=s3_key)
+    content_length = int(head["ContentLength"])
+    range_size = content_length // num_ranges
+
+    ranges: list[tuple[int, int]] = []
+    for i in range(num_ranges):
+        start = i * range_size
+        end = (start + range_size - 1) if i < num_ranges - 1 else (content_length - 1)
+        ranges.append((start, end))
+
+    def _fetch_range(start: int, end: int) -> tuple[float, int]:
+        t0 = time.monotonic()
+        resp = r2_client._client.get_object(
+            Bucket=r2_client.bucket,
+            Key=s3_key,
+            Range=f"bytes={start}-{end}",
+        )
+        body = resp["Body"]
+        bytes_read = 0
+        while True:
+            chunk = body.read(1024 * 1024)
+            if not chunk:
+                break
+            bytes_read += len(chunk)
+        body.close()
+        elapsed = time.monotonic() - t0
+        return (elapsed, bytes_read)
+
+    # Single-connection baseline (first range only)
+    single_elapsed, single_bytes = _fetch_range(*ranges[0])
+    single_mbps = (single_bytes / max(single_elapsed, 1e-9)) / (1024 * 1024)
+
+    # Multi-connection parallel
+    per_range_mbps: list[float] = []
+    t_multi_start = time.monotonic()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=num_ranges) as executor:
+        future_list = [executor.submit(_fetch_range, s, e) for s, e in ranges]
+        multi_results = [f.result() for f in future_list]
+    multi_elapsed = time.monotonic() - t_multi_start
+    multi_total_bytes = sum(b for _, b in multi_results)
+    multi_mbps = (multi_total_bytes / max(multi_elapsed, 1e-9)) / (1024 * 1024)
+
+    for elapsed, bytes_read in multi_results:
+        per_range_mbps.append((bytes_read / max(elapsed, 1e-9)) / (1024 * 1024))
+
+    ratio = multi_mbps / max(single_mbps, 1e-9)
+
+    return {
+        "content_length": content_length,
+        "num_ranges": num_ranges,
+        "single_conn_mbps": round(single_mbps, 2),
+        "multi_conn_total_mbps": round(multi_mbps, 2),
+        "ratio": round(ratio, 2),
+        "per_range_mbps": [round(m, 2) for m in per_range_mbps],
+    }
+```
+
+### E.3 CLI flag
+
+In `src/stream_of_worship/admin/commands/maintenance.py`, add new option to `backup_r2`
+command:
+
+```python
+@app.command("backup-r2")
+def backup_r2(
+    output: Path = typer.Option(..., "--output", help="Output directory for backup"),
+    chunk_size: str = typer.Option(...),
+    concurrency: int = typer.Option(...),
+    debug_traces: bool = typer.Option(...),
+    format_: str = typer.Option(...),
+    config_path: Optional[Path] = typer.Option(None, "--config", "-c"),
+    diag_range_key: Optional[str] = typer.Option(
+        None, "--diag-range-key",
+        help=(
+            "Run a parallel Range-GET throughput diagnostic on this S3 key and exit "
+            "(does not perform a backup). Use with a large object key like "
+            "'<hash>/stems/bass.wav' to diagnose per-stream R2 bandwidth caps."
+        ),
+    ),
+) -> None:
+    """Backup entire R2 bucket to a local directory with chunked tar archives."""
+    _validate_choice(format_, BACKUP_FORMAT_VALUES, "--format")
+
+    try:
+        chunk_size_bytes = parse_size(chunk_size)
+    except ValueError as e:
+        console.print(f"[red]Invalid --chunk-size: {e}[/red]")
+        raise typer.Exit(1)
+
+    if chunk_size_bytes < MIN_CHUNK_SIZE_BYTES:
+        console.print(f"[red]Chunk size too small[/red]")
+        raise typer.Exit(1)
+
+    config, _ = _load_clients(config_path)
+    r2_client = _load_r2(config)
+
+    # Short-circuit: diagnostic mode
+    if diag_range_key is not None:
+        from stream_of_worship.admin.services.r2_backup import range_get_throughput_diag
+        result = range_get_throughput_diag(r2_client, diag_range_key)
+        _print_json_to_stdout(result)
+        return
+
+    # ... rest of existing backup_r2 body unchanged
+```
+
+### E.4 Expected output
+
+```bash
+$ sow_admin maintenance backup-r2 \
+    --output /tmp/dummy \
+    --diag-range-key 02fa022169b7/stems/bass.wav
+```
+
+```json
+{
+  "content_length": 45854636,
+  "num_ranges": 4,
+  "single_conn_mbps": 0.95,
+  "multi_conn_total_mbps": 3.72,
+  "ratio": 3.91,
+  "per_range_mbps": [0.92, 0.95, 0.91, 0.94]
+}
+```
+
+Interpretation:
+- `ratio > 1.5` → R2-side per-connection throttle confirmed. `DEFAULT_CONCURRENCY = 32`
+  is the right call; multipart Range-GET per file (future work) could yield another 3–4×
+  on large objects.
+- `ratio ≈ 1.0` → client-network cap. More concurrency won't help; skip Change A revert to
+  `DEFAULT_CONCURRENCY = 8` and investigate multipart Range-GET (each range would share the
+  same cap, but at least large objects wouldn't serialize behind small ones).
+
+---
+
+## Verification Plan
+
+### 1. Run diagnostic first (Change E)
+
+```bash
+sow_admin maintenance backup-r2 \
+    --output /tmp/dummy \
+    --diag-range-key 02fa022169b7/stems/bass.wav \
+    --config <config>
+```
+
+Confirm `ratio > 1.5` (R2-side per-connection throttle) before committing to Change A.
+
+### 2. Unit tests
+
+```bash
+PYTHONPATH=src uv run --python 3.11 --extra admin --extra test pytest tests/admin/test_r2_backup.py -v
+PYTHONPATH=src uv run --python 3.11 --extra admin --extra test pytest tests/admin/test_r2_backup_commands.py -v
+```
+
+New tests:
+- `test_as_completed_tar_ingestion`: verify all objects present in manifest; verify
+  `chunk_index` values are valid; verify round-trip with `verify_archive`.
+- `test_inventory_sort_by_size`: verify `submission_order` is size-descending; verify
+  `member_name` indices are original inventory order.
+- `test_retry_trace_emission`: mock R2Client that raises `RequestTimeout` once then
+  succeeds; verify `retry_trace` called with `error_code="RequestTimeout"`.
+- `test_range_get_diagnostic`: mock `head_object` + `get_object(Range=...)`; verify
+  throughput math.
+
+### 3. End-to-end backup with traces
+
+```bash
+sow_admin maintenance backup-r2 \
+    --chunk-size 5GiB \
+    --output ~/BACKUPS/sow-r2/20260620-3 \
+    --concurrency 32 \
+    --debug-traces
+```
+
+Verify:
+- `aggregate_mbps` rises above 7.3 (expect 20–30 MBps if R2 allows 32 streams).
+- `wait_ms` values collapse to near-zero (HOL blocking eliminated by Change B).
+- `workers` stays at `peak_workers=32` until close to end (no early drop to 4 or 1).
+- No `download_retry` events fire (Change D telemetry).
+- `timeout_retries=0` in summary.
+
+### 4. Verify backup integrity
+
+```bash
+sow_admin maintenance verify-r2-backup --input ~/BACKUPS/sow-r2/20260620-3
+```
+
+Confirm `verify_archive` passes (all SHA-256 sums match, all chunks present, manifest
+invariants hold). This validates that `as_completed` + size-sort submission order didn't
+break tar member layout.
+
+### 5. Lint and typecheck
+
+```bash
+PYTHONPATH=src uv run --python 3.11 --extra admin ruff check src/stream_of_worship/admin/services/r2_backup.py src/stream_of_worship/admin/services/r2.py src/stream_of_worship/admin/commands/maintenance.py
+PYTHONPATH=src uv run --python 3.11 --extra admin mypy src/stream_of_worship/admin/services/r2_backup.py
+```
+
+---
+
+## Out of Scope (Future Work)
+
+- **Multipart Range-GET per object (Change E from original investigation)**: If the
+  diagnostic confirms R2-side per-connection throttle AND `DEFAULT_CONCURRENCY=32` still
+  doesn't saturate (e.g., because there are only 100 large objects but 500 workers), the
+  next step is per-object parallel Range-GET chunking for objects >4 MB. Each object would
+  be split into N ranges, downloaded in parallel, and reassembled before tar write. Higher
+  complexity; needs range reconstruction + hash verification against the full-object ETag.
+
+- **Connection pooling / keep-alive tuning**: The trace shows `conn_ms` of 130–300ms on
+  small files. If small-file clusters become a bottleneck, investigate boto3 connection
+  reuse / HTTP keep-alive configuration. Not addressed here because aggregate throughput is
+  dominated by large-object stream time, not handshake time.
+
+- **Direct-to-tar streaming (eliminate temp file round-trip)**: Currently
+  `download → temp file → re-read → tar write` (3 disk I/Os / object). If disk I/O becomes
+  a bottleneck (not indicated by current trace — `tar_write_ms` << `wait_ms`), Consider
+  streaming the download body directly into `tarfile.addfile()` via a file-like wrapper.
+  Risky because `tarfile.addfile` needs the size upfront and the body must be fully consumed
+  before the next member.
+
+---
+
+## Decisions Deferred to Implementation
+
+- Whether `manifest["objects"]` list should be re-sorted by `member_name` (idx) after
+  completion-order insertion, to preserve a stable manifest ordering for diff-ability.
+  Current plan: leave as completion-order; revisit if manifests are diffed in CI.
+- Whether to add a `--no-sort` flag to disable size-sort for debugging. Current plan: no,
+  always sort; if debugging is needed, temporarily comment out the sort line.

--- a/specs/admin-r2-backup-throughput-remediation-v2.md
+++ b/specs/admin-r2-backup-throughput-remediation-v2.md
@@ -1,0 +1,356 @@
+# Admin R2 Backup Throughput Remediation v2 — Concurrency Revert, Investigation Closure
+
+## Summary
+
+The throughput remediation shipped in commit `ea397e7` (spec
+`admin-r2-backup-throughput-remediation-v1.md`) bumped `DEFAULT_CONCURRENCY`
+from 8 → 32 based on the hypothesis that R2 applies a *per-connection* throughput
+cap (~1 MiB/s) and that adding connections is the only way to scale aggregate
+throughput. That hypothesis was **never verified** before the commit landed —
+the v1 spec listed `--diag-range-key` as a verification step to run *first*,
+but the implementation proceeded on assumption.
+
+A new debug trace (`sow_admin maintenance backup-r2 --chunk-size 5GiB --debug-traces`,
+679 objects / 12.9 GB, 32 workers) plus the diagnostic that should have been run
+before the v1 commit both confirm the hypothesis was wrong:
+
+- **32 workers gave LOWER aggregate throughput (~5.0 MiB/s) than 8 workers (~7.3 MiB/s).**
+- Per-stream throughput collapsed from ~1.0 MiB/s (8-worker) to ~0.15 MiB/s (32-worker).
+- `--diag-range-key` against a 69 MB stem shows `ratio=2.41` — partial scaling,
+  not the >1.5 "per-connection cap" the v1 spec assumed and not enough to break
+  through the observed ~5–7 MiB/s ceiling.
+
+The R2 account/bucket-level aggregate throughput cap (~7 MiB/s) dominates.
+Adding more workers past ~8 simply slices the cap thinner and adds protocol
+overhead, *reducing* effective throughput.
+
+The user's stated target — **<10 min for a 12.9 GB backup ⇒ requires 21.5 MiB/s
+sustained** — is **not feasible within the local Python CLI architecture**.
+The best observed throughput (~7.3 MiB/s ⇒ ~30 min for 12.9 GB) is the hard
+ceiling imposed by R2 from this client. Investigation is closed; this spec
+records the closure and prescribes a partial revert to the last known-good
+configuration.
+
+## What the v1 commit Fixed (Keeping)
+
+These changes from `ea397e7` are confirmed good by the new 32-worker trace and
+remain in place — they are structural improvements independent of throughput
+scaling:
+
+| Change | Evidence from new trace |
+|---|---|
+| `as_completed` ingestion loop | Every `tar_write` event shows `wait_ms=0.0 wait_is_bottleneck=no` — head-of-line blocking gone |
+| Inventory size-desc sort | No end-of-run tail observed; workers stay at `peak_workers=32` until near-end of run |
+| `BackupTracer` | Produces all the evidence this spec analyzes; keep for future investigations |
+| `range_get_throughput_diag` helper | Confirmed partial scaling, ruled out pure per-connection cap — invaluable diagnostic |
+| `read_timeout=300` | No mid-stream retries fired; the lurking landmine is defused |
+| Retry telemetry (`retry_trace`, `timeout_retries`) | `retries=0`, `timeout_retries=0` — confirms the run was clean, not lucky |
+
+## What the v1 commit Got Wrong (Reverting)
+
+The single bad decision was the concurrency bump `8 → 32`. It was premise-flawed:
+
+- v1 Evidence 1 of `admin-r2-backup-throughput-remediation-v1.md` claimed:
+  *"8 × ~1 MBps ≈ 7.3 MBps observed... parallelism is scaling linearly."*
+- v1 Decisions table claimed: *"The per-stream cap is R2-side (confirmed by
+  --diag-range-key)..."* — but `--diag-range-key` had not been run when the
+  v1 spec was written. The confirmation was assumed, not measured.
+- The v1 "Verification Plan" section literally listed running
+  `--diag-range-key` as Step 1 to "confirm `ratio > 1.5` (R2-side
+  per-connection throttle) **before committing to Change A**." That step was
+  skipped during implementation.
+
+### Diagnostic result (the verification that finally ran)
+
+```
+$ sow_admin maintenance backup-r2 \
+    --output /tmp/dummy \
+    --diag-range-key d48247f4fb2f/stems/vocals.wav
+{
+  "content_length": 68938108,
+  "num_ranges": 4,
+  "single_conn_mbps": 0.34,
+  "multi_conn_total_mbps": 0.82,
+  "ratio": 2.41,
+  "per_range_mbps": [0.23, 0.20, 0.23, 0.23]
+}
+```
+
+Interpretation:
+
+- `single_conn_mbps = 0.34` and `per_range_mbps ≈ 0.21` — opening 4 concurrent
+  ranges to the *same* object made each range **slower** (0.34 → 0.21).
+- `ratio = 2.41`, not the clean >1.5 v1 hoped for and not ≈1.0 either. It's
+  partial scaling: 4 connections to one object yield 2.4× the throughput of one
+  but each connection is throttled harder.
+- This is exactly the shape of an **R2 account/bucket-level aggregate cap**:
+  more connections divide a fixed aggregate, with some per-connection overhead.
+
+The conclusion is that R2 has both a per-connection soft cap (~0.3–1.0 MiB/s)
+and an account/bucket-level aggregate cap (~5–7 MiB/s observed from this
+client). The aggregate cap dominates once worker count exceeds ~8.
+
+## Trace Evidence (32-worker run)
+
+### Per-stream degradation timeline (the smoking gun)
+
+Per-stream throughput collapses as the run progresses, while aggregate stays
+flat at ~5 MiB/s. This is the signature of an account-level cap divided N ways:
+
+| t+ | Object | bytes | stream_ms | per-stream MiB/s |
+|---|---|---|---|---|
+| +105 s | `e5c16c2f35f2/stems/vocals.wav` | 62.6 MB | 104 967 | **0.57** |
+| +280 s | `renders/beE2g7fWELUPNDLWjIEY0/output.mp4` | 68.7 MB | 279 084 | **0.24** |
+| +378 s | `renders/OC3-0rHE2JOVzXxI1gXR1/output.mp4` | 65.2 MB | 376 235 | **0.17** |
+| +440 s | `d48247f4fb2f/stems/vocals.wav` | 68.9 MB | 435 066 | **0.15** |
+| +545 s | `renders/CsieHPVFK6bQzX6mPqEln/output.mp4` | 62.3 MB | 544 572 | **0.11** |
+| +660 s | `renders/zZysO69yayzlnghzAAZzC/output.mp4` | 64.2 MB | 656 287 | **0.09** |
+
+`32 workers × ~0.15 MiB/s ≈ 4.8 MiB/s` — matches the observed aggregate exactly.
+
+### Aggregate throughput plateau
+
+Throughput samples from the 32-worker run (every 5 s after warm-up):
+
+```
+t+30.7s   workers=32  downloaded_mib=208.00   aggregate_mbps=6.78   peak_workers=32
+t+51.4s   workers=32  downloaded_mib=289.00   aggregate_mbps=5.62   peak_workers=32
+t+102.9s  workers=32  downloaded_mib=523.00   aggregate_mbps=5.08   peak_workers=32
+t+253.3s  workers=32  downloaded_mib=1276.08  aggregate_mbps=5.04   peak_workers=32
+t+420.5s  workers=32  downloaded_mib=2145.99  aggregate_mbps=5.10   peak_workers=32
+t+676.4s  workers=32  downloaded_mib=3480.66  aggregate_mbps=5.15   peak_workers=32
+```
+
+Aggregate throughput is **flat at 5.0–5.15 MiB/s** from ~t+100 s to t+676 s.
+Compare with the 8-worker v1 run which held flat at **7.0–7.7 MiB/s** across
+its entire ~4 min window.
+
+### Comparison table
+
+| Run | Concurrency | Aggregate steady-state | Per-stream avg | Backups/min for 12.9 GB |
+|---|---|---|---|---|
+| v1 spec evidence | 8 workers | **7.0–7.7 MiB/s** | ~1.0 MiB/s | ~30 min |
+| New trace | 32 workers | **5.0–5.15 MiB/s** | ~0.15 MiB/s | ~43 min |
+
+**32 workers made throughput ~30% worse.** The user target of <10 min is not
+reachable client-side; the best observed (~7.3 MiB/s) caps backup time at
+~30 min for the current bucket size.
+
+## Tar/disk side: definitively not a bottleneck
+
+Every `tar_write` event in the trace shows:
+
+- `wait_ms = 0.0` (head-of-line blocking eliminated by `as_completed`)
+- `tar_write_ms = 50–110 ms` for 60 MB objects (~700 MB/s effective)
+- `wait_is_bottleneck=no` in every record
+
+The `tempfile → open → addfile → unlink` round-trip is not the issue. The
+v1 spec's "future work" item proposing direct-to-tar streaming is **moot** —
+disk I/O is two orders of magnitude faster than the R2 ceiling.
+
+## Decisions
+
+| Topic | Decision |
+|---|---|
+| `DEFAULT_CONCURRENCY` | Revert from 32 → **8**. The 8-worker baseline remains the best measured configuration. |
+| `read_timeout` | Keep at 300 (unchanged from v1 commit). Setting is correct independently of concurrency. |
+| `max_pool_connections` | Keep at 64 (unchanged). Provides headroom without cost. |
+| `as_completed` ingestion loop | Keep (unchanged). Confirmed eliminates HOL blocking. |
+| Inventory size-desc sort | Keep (unchanged). Avoids end-of-run tail. |
+| `BackupTracer`, `range_get_throughput_diag`, retry telemetry | Keep (unchanged). All confirmed valuable. |
+| `--concurrency` CLI `max` | Lower from 128 → **64**. The 32-worker result shows values above ~16 are counterproductive; 64 retains headroom for experimentation without inviting the 32+ regression. |
+| `--diag-range-key` flag | Keep (unchanged). Required before any future R2-throughput-related change to the codebase. |
+| Manifest version | No change (stays at 4). |
+| Per-object multipart Range-GET | **Not pursued.** Diagnostic shows `ratio=2.41` (partial scaling), so per-object Range-GET cannot reach the user's <10 min target. Even an optimistic 7.3 → 10 MiB/s gain would still cap at ~22 min backup. |
+| Cloudflare Worker in-network backup | **Not pursued.** User explicitly declined the architectural change at this time. |
+| boto3 TCP/socket buffer tuning | **Not pursued.** Expected gain (<20%) does not reach the <10 min target. |
+| Goal: <10 min backup for 12.9 GB | **Closed as not feasible** within local Python CLI architecture due to R2 account-level throughput cap (~7 MiB/s best observed). Document as an R2 property; do not re-attempt without architectural change. |
+| Re-opening the goal | Requires (a) explicit decision to use Cloudflare Worker / in-network backup, OR (b) bucket size shrinking below ~4 GB (which would yield <10 min at current ceiling). |
+
+## Files to Modify
+
+### 1. `src/stream_of_worship/admin/services/r2_backup.py`
+
+Change A (revert): In the module constants block (currently lines 32–37), replace
+the v1 comment + `DEFAULT_CONCURRENCY = 32` with:
+
+```python
+# 32 workers gave ~30% LOWER throughput than 8 workers in real traces
+# (5.0 vs 7.3 MiB/s) — see specs/admin-r2-backup-throughput-remediation-v2.md.
+# R2 exhibits a ~7 MiB/s account/bucket aggregate cap from this client;
+# adding workers past ~8 slices the cap thinner without raising it.
+# Verified via --diag-range-key (ratio=2.41, partial scaling, not pure per-conn cap).
+DEFAULT_CONCURRENCY = 8
+```
+
+Change B (revert): In `write_backup` concurrency validation (currently line 914):
+
+```python
+# Before:
+if not (1 <= concurrency <= 128):
+    raise BackupError(f"concurrency must be 1-128, got {concurrency}")
+
+# After:
+if not (1 <= concurrency <= 64):
+    raise BackupError(f"concurrency must be 1-64, got {concurrency}")
+```
+
+No other changes to this file. In particular, **do not** revert
+`as_completed`, `submission_order` size-sort, `BackupTracer`,
+`range_get_throughput_diag`, or any tracer calls — those are confirmed wins.
+
+### 2. `src/stream_of_worship/admin/commands/maintenance.py`
+
+Revert `--concurrency` option (default, max, and help text). The v1 change set
+default=32, max=128, with help text promising that raising concurrency scales
+throughput. Replace with:
+
+```python
+concurrency: int = typer.Option(
+    8, "--concurrency", min=1, max=64,
+    help=(
+        "Number of concurrent download workers (default 8). "
+        "R2 exhibits an account-level throughput cap (~7 MiB/s from this client); "
+        "raising workers past 8 typically REDUCES throughput (verified at 32 workers: "
+        "~5 MiB/s vs ~7 MiB/s at 8 workers). Use --diag-range-key to investigate."
+    ),
+),
+```
+
+If the `debug_traces` parameter name or surrounding code has changed, keep
+those changes — only the `concurrency` option tuple is reverted.
+
+### 3. `tests/admin/test_r2_backup.py`
+
+- Update `test_concurrency_validation` (or equivalent boundary test): the
+  upper bound assertion changes from `128` → `64`. The lower bound stays `1`.
+- Update any test that asserts the default `DEFAULT_CONCURRENCY == 32` to
+  `== 8`. Typically a test like `test_default_concurrency` or an assertion
+  in a fixture.
+- Leave all `as_completed` / `submission_order` / `retry_trace` /
+  `range_get_throughput_diag` tests untouched — their behavior is unchanged.
+
+### 4. `tests/admin/test_r2_backup_commands.py`
+
+- Update the `--concurrency` CLI validation test. The `max=128` rejection
+  case becomes `max=64`. Specifically, any test that invokes the CLI with
+  `--concurrency 200` and expects a typer error still passes (200 > 64). Any
+  test that invokes with `--concurrency 100` expecting success must be changed
+  to expect rejection (100 > 64).
+- Default-value test: the command's default concurrency is now `8`, not `32`.
+
+### 5. `report/current_impl_status.md` (and `MEMORY` if present)
+
+Per `AGENTS.md` session-completion convention, append a short entry:
+
+```
+2026-06-20: R2 backup throughput investigation closed. 32-worker concurrency bump
+   (commit ea397e7) regressed throughput 7.3 → 5.0 MiB/s. Reverted DEFAULT_CONCURRENCY
+   to 8; kept as_completed / size-sort / tracer / range-GET diagnostic / read_timeout=300.
+   Account-level R2 cap at ~7 MiB/s confirmed via --diag-range-key (ratio=2.41).
+   <10 min backup goal for 12.9 GB closed as not feasible within local Python CLI
+   architecture; reopening requires Cloudflare Worker backup or bucket size reduction.
+   See specs/admin-r2-backup-throughput-remediation-v2.md.
+```
+
+If `report/current_impl_status.md` does not exist, create it with this entry
+as the initial content. If `MEMORY` is a separate file at the repo root,
+append the same entry there too.
+
+## Verification Plan
+
+### 1. Unit tests
+
+```bash
+PYTHONPATH=src uv run --python 3.11 --extra admin --extra test \
+    pytest tests/admin/test_r2_backup.py tests/admin/test_r2_backup_commands.py -v
+```
+
+Expected: all tests pass with the updated boundary assertions and default
+value.
+
+### 2. Lint and typecheck
+
+```bash
+PYTHONPATH=src uv run --python 3.11 --extra admin \
+    ruff check \
+    src/stream_of_worship/admin/services/r2_backup.py \
+    src/stream_of_worship/admin/commands/maintenance.py
+PYTHONPATH=src uv run --python 3.11 --extra admin \
+    mypy src/stream_of_worship/admin/services/r2_backup.py
+```
+
+### 3. Optional: regression smoke (not required to land the revert)
+
+If the user opts in, run a 4 / 8 / 16 worker sweep with `--debug-traces`
+against a fresh backup directory to confirm 8 is still the local optimum:
+
+```bash
+for c in 4 8 16; do
+  sow_admin maintenance backup-r2 \
+    --chunk-size 5GiB --concurrency $c \
+    --output ~/BACKUPS/sow-r2/sweep-$c \
+    --debug-traces 2>&1 | tee sweep-$c.txt
+done
+```
+
+Expected: 8 workers outperforms both 4 and 16; throughput ceiling at ~7 MiB/s
+in all three cases. This step is confirmation, not discovery — the v2 spec
+already concludes the investigation.
+
+### 4. Session completion
+
+```bash
+git pull --rebase
+git push
+git status
+```
+
+`git status` MUST show "up to date with origin" before stopping (per
+`AGENTS.md` Session Completion section).
+
+## Out of Scope (Investigation Closed)
+
+These items are listed to prevent re-investigation:
+
+- **Per-object multipart Range-GET (v1's "future work")**: Observed
+  `ratio=2.41` from `--diag-range-key` is partial scaling, not the per-connection
+  cap v1 assumed. Implementing per-object Range-GET would at best recover
+  the few MiB/s lost in the 32-worker regression; it cannot reach the user's
+  <10 min target. Do not implement without reopening the goal explicitly.
+- **Cloudflare Worker in-network backup**: User explicitly declined the
+  architectural change. Goal can only be reopened by reversing that decision.
+- **boto3 / urllib3 TCP tuning** (keepalive, socket buffers, connection
+  reuse): Expected gain <20%, far below the ~3× needed for <10 min.
+- **Direct-to-tar streaming**: `tar_write_ms` is 50–110 ms per 60 MB object
+  (~700 MB/s). Eliminating the temp-file round-trip would save negligible
+  time; the bottleneck is network, not disk.
+- **Spoofing R2 with multiple source IPs**: Brittle, against ToS, and unproven
+  to bypass an account-level cap (as opposed to per-IP cap). Not considered.
+
+## Decisions Deferred
+
+- **Concurrency sweep (4/8/16)**: Optional confirmation step, not required to
+  land this spec. If run and 16 happens to outperform 8 in a future trace,
+  raise `DEFAULT_CONCURRENCY` to 16 in a separate spec; do not silently bump.
+- **`--concurrency max=64` vs `max=32`**: Chose 64 to preserve experimentation
+  headroom. If trace data later confirms 16+ is always harmful, lower to 32
+  in a follow-up. No urgency.
+- **Reopening the <10 min goal**: Tracked here only. Requires either (a)
+  explicit decision to pursue Cloudflare Worker in-network backup, or (b)
+  bucket size reduction below ~4 GB (e.g., via lifecycle rules deleting old
+  `renders/` outputs).
+
+## References
+
+- `specs/admin-r2-backup-throughput-remediation-v1.md` — original (incorrectly
+  verified) remediation; ships the changes this spec partially reverts.
+- `specs/admin-r2-backup-perf-traces.md` — earlier perf-trace spec; still
+  valid for understanding the tracer design.
+- `src/stream_of_worship/admin/services/r2_backup.py` — backup service with
+  `DEFAULT_CONCURRENCY` constant and `write_backup` main loop.
+- `src/stream_of_worship/admin/commands/maintenance.py` — `backup-r2` command
+  with `--concurrency` and `--diag-range-key` flags.
+- Commit `ea397e7` — the v1 remediation commit (the partial revert target).
+- Commit `c588364` — added the performance tracing that made this investigation
+  possible.

--- a/src/stream_of_worship/admin/commands/maintenance.py
+++ b/src/stream_of_worship/admin/commands/maintenance.py
@@ -646,12 +646,13 @@ def backup_r2(
         "10GiB", "--chunk-size", help="Chunk size (e.g. 10GiB, 500MiB, raw bytes)"
     ),
     concurrency: int = typer.Option(
-        8, "--concurrency", min=1, max=64,
+        1, "--concurrency", min=1, max=5,
         help=(
-            "Number of concurrent download workers (default 8). "
+            "Number of concurrent download workers (default 1). "
             "R2 exhibits an account-level throughput cap (~7 MiB/s from this client); "
-            "raising workers past 8 typically REDUCES throughput (verified at 32 workers: "
-            "~5 MiB/s vs ~7 MiB/s at 8 workers). Use --diag-range-key to investigate."
+            "a single connection already saturates it. The v1 rclone benchmark showed "
+            "boto3 single-conn 7.85 MiB/s vs 4-range parallel 6.54 MiB/s (ratio=0.83, "
+            "parallel HURTS). Use --diag-range-key to investigate before raising."
         ),
     ),
     debug_traces: bool = typer.Option(

--- a/src/stream_of_worship/admin/commands/maintenance.py
+++ b/src/stream_of_worship/admin/commands/maintenance.py
@@ -617,6 +617,10 @@ def backup_r2(
     chunk_size: str = typer.Option(
         "10GiB", "--chunk-size", help="Chunk size (e.g. 10GiB, 500MiB, raw bytes)"
     ),
+    concurrency: int = typer.Option(
+        8, "--concurrency", min=1, max=64,
+        help="Number of concurrent download workers"
+    ),
     format_: str = typer.Option("table", "--format", help="table|json"),
     config_path: Optional[Path] = typer.Option(None, "--config", "-c"),
 ) -> None:
@@ -682,6 +686,7 @@ def backup_r2(
                 output_dir=output,
                 inventory=inventory,
                 chunk_size_bytes=chunk_size_bytes,
+                concurrency=concurrency,
                 on_progress=_on_progress,
             )
     except BackupError as e:

--- a/src/stream_of_worship/admin/commands/maintenance.py
+++ b/src/stream_of_worship/admin/commands/maintenance.py
@@ -1,10 +1,11 @@
 """Maintenance commands for soft-deleted catalog data and R2 cleanup."""
 
 import json
+import logging as _stdlogging
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional
 
 import typer
 from rich.console import Console
@@ -30,6 +31,7 @@ from stream_of_worship.admin.services.r2_backup import (
     MIN_CHUNK_SIZE_BYTES,
     BackupError,
     BackupProgress,
+    BackupTracer,
     RestoreError,
     VerifyError,
     build_inventory,
@@ -613,6 +615,32 @@ def _print_backup_summary_table(result, output_dir: Path) -> None:
     console.print(table)
 
 
+def _configure_r2_backup_debug_logging(console: Console) -> None:
+    """Attach a DEBUG-level stderr handler to the r2_backup module logger.
+
+    Idempotent: if a handler tagged with the marker attribute is already
+    attached, does nothing.
+    """
+    target = _stdlogging.getLogger(
+        "stream_of_worship.admin.services.r2_backup"
+    )
+    target.setLevel(_stdlogging.DEBUG)
+    marker_attr = "_sow_r2_backup_debug_handler"
+    for h in target.handlers:
+        if getattr(h, marker_attr, False):
+            return
+    handler = _stdlogging.StreamHandler(console.file)
+    handler.setLevel(_stdlogging.DEBUG)
+    handler.setFormatter(
+        _stdlogging.Formatter(
+            "%(asctime)s %(levelname)s %(name)s: %(message)s",
+            datefmt="%H:%M:%S",
+        )
+    )
+    setattr(handler, marker_attr, True)
+    target.addHandler(handler)
+
+
 @app.command("backup-r2")
 def backup_r2(
     output: Path = typer.Option(..., "--output", help="Output directory for backup"),
@@ -622,6 +650,10 @@ def backup_r2(
     concurrency: int = typer.Option(
         8, "--concurrency", min=1, max=64,
         help="Number of concurrent download workers"
+    ),
+    debug_traces: bool = typer.Option(
+        False, "--debug-traces",
+        help="Emit per-object and per-phase performance traces to stderr at DEBUG level"
     ),
     format_: str = typer.Option("table", "--format", help="table|json"),
     config_path: Optional[Path] = typer.Option(None, "--config", "-c"),
@@ -650,8 +682,21 @@ def backup_r2(
     else:
         progress_console = console
 
+    tracer: Optional[BackupTracer] = None
+    if debug_traces:
+        _configure_r2_backup_debug_logging(progress_console)
+        tracer = BackupTracer()
+
     progress_console.print("[cyan]Building R2 inventory...[/cyan]")
+    if tracer is not None:
+        tracer.phase_start("inventory")
     inventory = build_inventory(r2_client)
+    if tracer is not None:
+        tracer.phase_end(
+            "inventory",
+            objects=inventory.object_count,
+            total_bytes=inventory.total_bytes,
+        )
     progress_console.print(
         f"[green]Inventory complete: {inventory.object_count} objects, "
         f"{_bytes_to_mb(inventory.total_bytes)} MB[/green]"
@@ -678,6 +723,8 @@ def backup_r2(
                 object_count=inventory.object_count,
             )
 
+            base_callback: Optional[Callable[[BackupProgress], None]] = None
+
             def _on_progress(prog: BackupProgress) -> None:
                 progress.update(
                     task,
@@ -685,6 +732,12 @@ def backup_r2(
                     workers=prog.active_workers,
                     objects_done=prog.objects_downloaded,
                 )
+                if tracer is not None:
+                    tracer.bytes_downloaded_sample(
+                        prog.bytes_downloaded, prog.active_workers
+                    )
+
+            base_callback = _on_progress
 
             result = write_backup(
                 r2_client=r2_client,
@@ -692,7 +745,8 @@ def backup_r2(
                 inventory=inventory,
                 chunk_size_bytes=chunk_size_bytes,
                 concurrency=concurrency,
-                on_progress=_on_progress,
+                on_progress=base_callback,
+                tracer=tracer,
             )
     except BackupError as e:
         console.print(f"[red]Backup failed: {e}[/red]")

--- a/src/stream_of_worship/admin/commands/maintenance.py
+++ b/src/stream_of_worship/admin/commands/maintenance.py
@@ -646,11 +646,12 @@ def backup_r2(
         "10GiB", "--chunk-size", help="Chunk size (e.g. 10GiB, 500MiB, raw bytes)"
     ),
     concurrency: int = typer.Option(
-        32, "--concurrency", min=1, max=128,
+        8, "--concurrency", min=1, max=64,
         help=(
-            "Number of concurrent download workers (default 32). "
-            "Per-stream R2 bandwidth caps at ~1 MBps; raise this to scale aggregate "
-            "throughput until the R2 account-level throttle is hit."
+            "Number of concurrent download workers (default 8). "
+            "R2 exhibits an account-level throughput cap (~7 MiB/s from this client); "
+            "raising workers past 8 typically REDUCES throughput (verified at 32 workers: "
+            "~5 MiB/s vs ~7 MiB/s at 8 workers). Use --diag-range-key to investigate."
         ),
     ),
     debug_traces: bool = typer.Option(

--- a/src/stream_of_worship/admin/commands/maintenance.py
+++ b/src/stream_of_worship/admin/commands/maintenance.py
@@ -15,6 +15,7 @@ from rich.progress import (
     SpinnerColumn,
     TaskProgressColumn,
     TextColumn,
+    TimeElapsedColumn,
     TimeRemainingColumn,
     TransferSpeedColumn,
 )
@@ -28,6 +29,7 @@ from stream_of_worship.admin.services.r2_backup import (
     DEFAULT_CHUNK_SIZE_BYTES,
     MIN_CHUNK_SIZE_BYTES,
     BackupError,
+    BackupProgress,
     RestoreError,
     VerifyError,
     build_inventory,
@@ -660,25 +662,28 @@ def backup_r2(
             SpinnerColumn(),
             BarColumn(),
             TaskProgressColumn(),
-            TextColumn("{task.fields[objects_done]}/{task.fields[object_count]} objects"),
-            TextColumn("[progress.description]{task.description}"),
             DownloadColumn(),
             TransferSpeedColumn(),
             TimeRemainingColumn(),
+            TimeElapsedColumn(),
+            TextColumn("{task.fields[workers]} workers"),
+            TextColumn("{task.fields[objects_done]}/{task.fields[object_count]} objects"),
             console=progress_console,
         ) as progress:
             task = progress.add_task(
                 "Backing up...",
                 total=inventory.total_bytes,
+                workers=0,
                 objects_done=0,
                 object_count=inventory.object_count,
             )
 
-            def _on_progress(objects_done: int, bytes_done: int) -> None:
+            def _on_progress(prog: BackupProgress) -> None:
                 progress.update(
                     task,
-                    completed=bytes_done,
-                    objects_done=objects_done,
+                    completed=prog.bytes_downloaded,
+                    workers=prog.active_workers,
+                    objects_done=prog.objects_downloaded,
                 )
 
             result = write_backup(

--- a/src/stream_of_worship/admin/commands/maintenance.py
+++ b/src/stream_of_worship/admin/commands/maintenance.py
@@ -27,13 +27,11 @@ from stream_of_worship.admin.config import AdminConfig
 from stream_of_worship.admin.db.client import DatabaseClient
 from stream_of_worship.admin.services.r2 import R2Client, R2PrefixSummary
 from stream_of_worship.admin.services.r2_backup import (
-    DEFAULT_CHUNK_SIZE_BYTES,
     MIN_CHUNK_SIZE_BYTES,
     BackupError,
     BackupProgress,
     BackupTracer,
     RestoreError,
-    VerifyError,
     build_inventory,
     load_manifest,
     parse_size,
@@ -648,8 +646,12 @@ def backup_r2(
         "10GiB", "--chunk-size", help="Chunk size (e.g. 10GiB, 500MiB, raw bytes)"
     ),
     concurrency: int = typer.Option(
-        8, "--concurrency", min=1, max=64,
-        help="Number of concurrent download workers"
+        32, "--concurrency", min=1, max=128,
+        help=(
+            "Number of concurrent download workers (default 32). "
+            "Per-stream R2 bandwidth caps at ~1 MBps; raise this to scale aggregate "
+            "throughput until the R2 account-level throttle is hit."
+        ),
     ),
     debug_traces: bool = typer.Option(
         False, "--debug-traces",
@@ -657,6 +659,14 @@ def backup_r2(
     ),
     format_: str = typer.Option("table", "--format", help="table|json"),
     config_path: Optional[Path] = typer.Option(None, "--config", "-c"),
+    diag_range_key: Optional[str] = typer.Option(
+        None, "--diag-range-key",
+        help=(
+            "Run a parallel Range-GET throughput diagnostic on this S3 key and exit "
+            "(does not perform a backup). Use with a large object key like "
+            "'<hash>/stems/bass.wav' to diagnose per-stream R2 bandwidth caps."
+        ),
+    ),
 ) -> None:
     """Backup entire R2 bucket to a local directory with chunked tar archives."""
     _validate_choice(format_, BACKUP_FORMAT_VALUES, "--format")
@@ -676,6 +686,13 @@ def backup_r2(
 
     config, _ = _load_clients(config_path)
     r2_client = _load_r2(config)
+
+    # Short-circuit: diagnostic mode
+    if diag_range_key is not None:
+        from stream_of_worship.admin.services.r2_backup import range_get_throughput_diag
+        result = range_get_throughput_diag(r2_client, diag_range_key)
+        _print_json_to_stdout(result)
+        return
 
     if format_ == "json":
         progress_console = Console(file=sys.stderr)

--- a/src/stream_of_worship/admin/services/r2.py
+++ b/src/stream_of_worship/admin/services/r2.py
@@ -102,6 +102,7 @@ class R2Client:
                 connect_timeout=10,
                 read_timeout=30,
                 retries={"max_attempts": 2},
+                max_pool_connections=32,
             ),
         )
 

--- a/src/stream_of_worship/admin/services/r2.py
+++ b/src/stream_of_worship/admin/services/r2.py
@@ -100,9 +100,13 @@ class R2Client:
             region_name=region,
             config=Config(
                 connect_timeout=10,
-                read_timeout=30,
+                # 50MB stem at 1MBps = 50s; bump from 30s to avoid mid-stream timeout
+                # retries that would force full re-download from scratch.
+                read_timeout=300,
                 retries={"max_attempts": 2},
-                max_pool_connections=32,
+                # Bump from 32 to 64 to align with new DEFAULT_CONCURRENCY=32 plus headroom
+                # for the diagnostic Range-GET workers.
+                max_pool_connections=64,
             ),
         )
 

--- a/src/stream_of_worship/admin/services/r2.py
+++ b/src/stream_of_worship/admin/services/r2.py
@@ -104,9 +104,10 @@ class R2Client:
                 # retries that would force full re-download from scratch.
                 read_timeout=300,
                 retries={"max_attempts": 2},
-                # Bump from 32 to 64 to align with new DEFAULT_CONCURRENCY=32 plus headroom
-                # for the diagnostic Range-GET workers.
-                max_pool_connections=64,
+                # Align with DEFAULT_CONCURRENCY=1 plus headroom for the
+                # --diag-range-key diagnostic's 4 parallel Range-GET workers.
+                # Higher parallelism is counterproductive under R2's account-level cap.
+                max_pool_connections=5,
             ),
         )
 

--- a/src/stream_of_worship/admin/services/r2_backup.py
+++ b/src/stream_of_worship/admin/services/r2_backup.py
@@ -12,6 +12,7 @@ import os
 import re
 import shutil
 import tarfile
+import threading
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -20,10 +21,13 @@ from typing import Callable, Optional
 from botocore.exceptions import ClientError
 from stream_of_worship.admin.services.r2 import R2Client
 
-MANIFEST_VERSION = 3
+MANIFEST_VERSION = 4
 DEFAULT_CHUNK_SIZE_BYTES = 10 * 1024 * 1024 * 1024  # 10 GiB
 MIN_CHUNK_SIZE_BYTES = 64 * 1024 * 1024  # 64 MiB
 PARTIAL_MARKER = ".sow-r2-backup-partial"
+DEFAULT_CONCURRENCY = 8
+COPY_BUFFER_SIZE = 1024 * 1024  # 1 MB
+SPOT_CHECK_HEAD_RATIO = 0.05  # 5% random sample
 
 _BINARY_SUFFIXES = {
     "KiB": 1024,
@@ -108,6 +112,16 @@ class HashingReader:
     def close(self) -> None:
         if hasattr(self._source, "close"):
             self._source.close()
+
+
+@dataclass
+class DownloadResult:
+    """Result of downloading a single object to a temp file."""
+
+    temp_path: Path
+    sha256: str
+    bytes_read: int
+    metadata: dict
 
 
 @dataclass
@@ -210,9 +224,9 @@ def _build_manifest_object(
     member_name: str,
     sha256: str,
     chunk_index: int,
-    head_data: Optional[dict],
+    metadata: Optional[dict],
 ) -> dict:
-    """Build a manifest object entry from inventory + post-download head data."""
+    """Build a manifest object entry from inventory + GET response metadata."""
     obj_entry: dict = {
         "key": inv_obj.key,
         "member_name": member_name,
@@ -227,28 +241,26 @@ def _build_manifest_object(
         "content_encoding": None,
         "metadata": {},
     }
-    if head_data:
-        obj_entry["content_type"] = head_data.get("content_type")
-        obj_entry["cache_control"] = head_data.get("cache_control")
-        obj_entry["content_disposition"] = head_data.get("content_disposition")
-        obj_entry["content_encoding"] = head_data.get("content_encoding")
-        obj_entry["metadata"] = head_data.get("metadata") or {}
+    if metadata:
+        obj_entry["content_type"] = metadata.get("content_type")
+        obj_entry["cache_control"] = metadata.get("cache_control")
+        obj_entry["content_disposition"] = metadata.get("content_disposition")
+        obj_entry["content_encoding"] = metadata.get("content_encoding")
+        obj_entry["metadata"] = metadata.get("metadata") or {}
     return obj_entry
 
 
-def _download_object_to_tar(
+def _download_object_to_tempfile(
     r2_client: R2Client,
     inv_obj: InventoryObject,
-    tar: tarfile.TarFile,
-    member_name: str,
+    temp_dir: Path,
     max_retries: int = 2,
-) -> dict:
-    """Download a single object into a tar member with consistency checking.
+) -> DownloadResult:
+    """Download a single object to a temp file with consistency checking.
 
-    Downloads to a temporary file first to avoid corrupting the tar archive
-    on retry. Only writes to the tar once the download is fully verified.
-
-    Returns the manifest object entry on success.
+    Downloads to a temporary file under temp_dir, validates ETag from GET
+    response against inventory, performs MD5 body check for single-part
+    objects, and returns the temp path + hash + metadata.
 
     Raises:
         BackupError: If the object cannot be captured consistently.
@@ -262,14 +274,14 @@ def _download_object_to_tar(
             resp = r2_client.get_object_stream(inv_obj.key)
             body = resp["body"]
             content_length = resp["content_length"]
+            get_etag = resp["etag"]
 
             try:
-                # Download to a temporary file first to avoid corrupting
-                # the tar archive on failure
-                with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+                temp_dir.mkdir(parents=True, exist_ok=True)
+                with tempfile.NamedTemporaryFile(dir=temp_dir, delete=False) as temp_file:
                     temp_path = Path(temp_file.name)
                     hashing_reader = HashingReader(body)
-                    shutil.copyfileobj(hashing_reader, temp_file)
+                    shutil.copyfileobj(hashing_reader, temp_file, length=COPY_BUFFER_SIZE)
 
                 if hashing_reader.bytes_read != content_length:
                     raise BackupError(
@@ -283,56 +295,52 @@ def _download_object_to_tar(
                         f"downloaded {hashing_reader.bytes_read}"
                     )
 
-                sha256 = hashing_reader.sha256_hex
-
-                # Post-download head check for consistency
-                head_data = r2_client.head_object(inv_obj.key)
-                if head_data is None:
-                    raise BackupError(
-                        f"Object {inv_obj.key} disappeared during backup"
-                    )
-
-                if head_data["size"] != inv_obj.size:
-                    raise BackupError(
-                        f"Object {inv_obj.key} size changed: inventory {inv_obj.size}, "
-                        f"post-download {head_data['size']}"
-                    )
-
-                if head_data["etag"] != inv_obj.etag:
+                if get_etag != inv_obj.etag:
                     raise BackupError(
                         f"Object {inv_obj.key} ETag changed: inventory {inv_obj.etag}, "
-                        f"post-download {head_data['etag']}"
+                        f"download {get_etag}"
                     )
 
-                # Successfully verified, now add to tar archive
-                tar_info = tarfile.TarInfo(name=member_name)
-                tar_info.size = hashing_reader.bytes_read
-                tar_info.mtime = 0
-                tar_info.mode = 0o644
-                tar_info.type = tarfile.REGTYPE
+                if "-" not in get_etag:
+                    md5_hex = hashlib.md5(temp_path.read_bytes()).hexdigest()
+                    if md5_hex != get_etag:
+                        raise BackupError(
+                            f"Object {inv_obj.key} MD5 mismatch: ETag {get_etag}, "
+                            f"computed {md5_hex}"
+                        )
 
-                with open(temp_path, "rb") as f_in:
-                    tar.addfile(tar_info, f_in)
+                sha256 = hashing_reader.sha256_hex
 
-                return _build_manifest_object(
-                    inv_obj, member_name, sha256, 0, head_data
+                metadata = {
+                    "content_type": resp.get("content_type"),
+                    "cache_control": resp.get("cache_control"),
+                    "content_disposition": resp.get("content_disposition"),
+                    "content_encoding": resp.get("content_encoding"),
+                    "metadata": resp.get("metadata") or {},
+                    "last_modified": resp.get("last_modified"),
+                }
+
+                return DownloadResult(
+                    temp_path=temp_path,
+                    sha256=sha256,
+                    bytes_read=hashing_reader.bytes_read,
+                    metadata=metadata,
                 )
             finally:
                 body.close()
 
         except (BackupError, ClientError) as e:
             last_error = str(e)
-            if attempt < max_retries:
-                continue
-            raise BackupError(
-                f"Failed to backup {inv_obj.key} after retries: {last_error}"
-            ) from e
-        finally:
             if temp_path is not None:
                 try:
                     temp_path.unlink()
                 except OSError:
                     pass
+            if attempt < max_retries:
+                continue
+            raise BackupError(
+                f"Failed to backup {inv_obj.key} after retries: {last_error}"
+            ) from e
 
     raise BackupError(f"Failed to backup {inv_obj.key} after retries: {last_error}")
 
@@ -353,6 +361,7 @@ def write_backup(
     output_dir: Path,
     inventory: Inventory,
     chunk_size_bytes: int = DEFAULT_CHUNK_SIZE_BYTES,
+    concurrency: int = DEFAULT_CONCURRENCY,
     on_progress: Optional[Callable[[int, int], None]] = None,
 ) -> BackupResult:
     """Write a full backup to the output directory.
@@ -365,6 +374,7 @@ def write_backup(
         output_dir: Final output directory path
         inventory: Pre-built inventory
         chunk_size_bytes: Max bytes per chunk tar
+        concurrency: Number of concurrent download workers (1-64)
         on_progress: Optional callback invoked after each object is written.
             Receives (objects_completed, bytes_completed).
 
@@ -374,6 +384,9 @@ def write_backup(
     Raises:
         BackupError: If backup fails. Partial directory is cleaned up.
     """
+    if not (1 <= concurrency <= 64):
+        raise BackupError(f"concurrency must be 1-64, got {concurrency}")
+
     if output_dir.exists():
         raise BackupError(f"Output directory already exists: {output_dir}")
     partial_dir = output_dir.with_suffix(output_dir.suffix + ".part")
@@ -386,24 +399,48 @@ def write_backup(
     if chunk_size_bytes <= 0:
         raise BackupError(f"Chunk size must be positive, got {chunk_size_bytes}")
 
-    required_space = int(inventory.total_bytes * 1.1) + 50 * 1024 * 1024
+    required_space = int(inventory.total_bytes * 2.1) + 50 * 1024 * 1024
     _check_disk_space(output_dir.parent, required_space)
 
     partial_dir.mkdir(parents=True)
     (partial_dir / PARTIAL_MARKER).touch()
+    temp_dir = partial_dir / "tmp"
+
+    active_temp_paths: set[Path] = set()
+    active_temp_lock = threading.Lock()
+
+    def _track_temp(path: Path) -> None:
+        with active_temp_lock:
+            active_temp_paths.add(path)
+
+    def _untrack_temp(path: Path) -> None:
+        with active_temp_lock:
+            active_temp_paths.discard(path)
+
+    def _cleanup_all_temps() -> None:
+        with active_temp_lock:
+            paths = list(active_temp_paths)
+            active_temp_paths.clear()
+        for p in paths:
+            try:
+                p.unlink()
+            except OSError:
+                pass
+
+    current_tar: Optional[tarfile.TarFile] = None
 
     try:
+        from concurrent.futures import ThreadPoolExecutor
+        import random
+
         manifest_objects: list[dict] = []
         chunk_index = 0
         current_chunk_bytes = 0
-        current_tar: Optional[tarfile.TarFile] = None
 
         def _ensure_tar():
             nonlocal current_tar
             if current_tar is None:
-                current_tar = tarfile.open(
-                    _chunk_path(partial_dir, chunk_index), "w"
-                )
+                current_tar = tarfile.open(_chunk_path(partial_dir, chunk_index), "w")
 
         def _rotate_chunk():
             nonlocal current_tar, chunk_index, current_chunk_bytes
@@ -414,31 +451,86 @@ def write_backup(
             current_chunk_bytes = 0
 
         bytes_completed = 0
-        for idx, inv_obj in enumerate(inventory.objects):
-            member_name = _member_name_for_index(idx)
 
-            if (
-                current_chunk_bytes > 0
-                and current_chunk_bytes + inv_obj.size > chunk_size_bytes
-            ):
-                _rotate_chunk()
+        with ThreadPoolExecutor(max_workers=concurrency) as executor:
+            futures = {
+                idx: executor.submit(
+                    _download_object_to_tempfile, r2_client, inv_obj, temp_dir
+                )
+                for idx, inv_obj in enumerate(inventory.objects)
+            }
 
-            _ensure_tar()
+            try:
+                for idx, inv_obj in enumerate(inventory.objects):
+                    member_name = _member_name_for_index(idx)
 
-            obj_entry = _download_object_to_tar(
-                r2_client, inv_obj, current_tar, member_name
-            )
-            obj_entry["chunk_index"] = chunk_index
-            manifest_objects.append(obj_entry)
-            current_chunk_bytes += inv_obj.size
-            bytes_completed += inv_obj.size
+                    if (
+                        current_chunk_bytes > 0
+                        and current_chunk_bytes + inv_obj.size > chunk_size_bytes
+                    ):
+                        _rotate_chunk()
 
-            if on_progress is not None:
-                on_progress(idx + 1, bytes_completed)
+                    _ensure_tar()
+
+                    future = futures[idx]
+                    try:
+                        download_result = future.result()
+                    except BaseException:
+                        for f in futures.values():
+                            f.cancel()
+                        raise
+
+                    _track_temp(download_result.temp_path)
+                    try:
+                        tar_info = tarfile.TarInfo(name=member_name)
+                        tar_info.size = download_result.bytes_read
+                        tar_info.mtime = 0
+                        tar_info.mode = 0o644
+                        tar_info.type = tarfile.REGTYPE
+
+                        with open(download_result.temp_path, "rb") as f_in:
+                            current_tar.addfile(tar_info, f_in)
+
+                        obj_entry = _build_manifest_object(
+                            inv_obj, member_name, download_result.sha256, chunk_index,
+                            download_result.metadata,
+                        )
+                        manifest_objects.append(obj_entry)
+                        current_chunk_bytes += inv_obj.size
+                        bytes_completed += inv_obj.size
+
+                        if on_progress is not None:
+                            on_progress(idx + 1, bytes_completed)
+                    finally:
+                        _untrack_temp(download_result.temp_path)
+                        try:
+                            download_result.temp_path.unlink()
+                        except OSError:
+                            pass
+            except BaseException:
+                for f in futures.values():
+                    f.cancel()
+                raise
 
         if current_tar is not None:
             current_tar.close()
             current_tar = None
+
+        if manifest_objects and SPOT_CHECK_HEAD_RATIO > 0:
+            sample_size = max(1, int(len(manifest_objects) * SPOT_CHECK_HEAD_RATIO))
+            sample_indices = random.sample(
+                range(len(manifest_objects)), min(sample_size, len(manifest_objects))
+            )
+            for sample_idx in sample_indices:
+                obj_entry = manifest_objects[sample_idx]
+                try:
+                    head_data = r2_client.head_object(obj_entry["key"])
+                    if head_data is None:
+                        continue
+                    if head_data["etag"] != obj_entry["etag"]:
+                        pass
+                except ClientError:
+                    pass
 
         final_chunk_count = chunk_index + 1 if manifest_objects else 0
 
@@ -455,8 +547,10 @@ def write_backup(
             "total_bytes": sum(o["size"] for o in manifest_objects),
             "chunk_count": final_chunk_count,
             "consistency": {
-                "mode": "initial-inventory-with-post-download-head-check",
+                "mode": "initial-inventory-with-get-etag-check",
                 "max_changed_object_retries": 2,
+                "md5_body_check": True,
+                "spot_check_head_ratio": SPOT_CHECK_HEAD_RATIO,
             },
             "objects": manifest_objects,
         }
@@ -466,6 +560,11 @@ def write_backup(
         with open(tmp_manifest, "w") as f:
             json.dump(manifest, f, indent=2)
         tmp_manifest.rename(manifest_path)
+
+        try:
+            temp_dir.rmdir()
+        except OSError:
+            pass
 
         partial_dir.rename(output_dir)
 
@@ -483,6 +582,7 @@ def write_backup(
                 current_tar.close()
             except Exception:
                 pass
+        _cleanup_all_temps()
         _cleanup_owned_partial(partial_dir)
         raise
 

--- a/src/stream_of_worship/admin/services/r2_backup.py
+++ b/src/stream_of_worship/admin/services/r2_backup.py
@@ -228,6 +228,248 @@ class DownloadResult:
     metadata: dict
 
 
+class BackupTracer:
+    """Collects and emits performance traces for backup operations.
+
+    Thread-safe. Designed to be passed (as `tracer=`) into `write_backup`
+    and `_download_object_to_tempfile` to emit per-object and per-phase
+    timing logs at DEBUG level. All methods are no-ops if the tracer is
+    disabled (logger level above DEBUG).
+
+    Traces are written to the module logger (`stream_of_worship.admin.services.r2_backup`).
+    Per-object events fire from worker threads; Rich `Progress` renders on the
+    same stderr but the tracer is throttled by the existing `BackupProgress._maybe_report`
+    path (which feeds `bytes_downloaded_sample` via the wrapped callback in maintenance.py).
+    """
+
+    # Aggregate throughput sample interval (seconds)
+    THROUGHPUT_SAMPLE_INTERVAL = 5.0
+
+    def __init__(self, logger: Optional[logging.Logger] = None):
+        self._logger = logger or logging.getLogger(__name__)
+        self._enabled = self._logger.isEnabledFor(logging.DEBUG)
+        self._lock = threading.Lock()
+
+        # Phase timing
+        self._phase_starts: dict[str, float] = {}
+
+        # Per-object accumulators (aggregate over all objects)
+        self._object_count_downloaded = 0
+        self._object_count_written = 0
+        self._bytes_downloaded = 0
+        self._bytes_written = 0
+        self._retries_total = 0
+        self._sum_download_ms = 0.0  # sum of worker download_ms across objects
+        self._sum_conn_ms = 0.0  # sum of boto3 get_object_stream ms
+        self._sum_wait_ms = 0.0  # sum of main-thread future.result() wait ms
+        self._sum_tar_write_ms = 0.0  # sum of main-thread tar.addfile ms
+        self._max_object_download_ms = 0.0
+        self._max_object_download_key = ""
+
+        # Throughput sampling (fed via bytes_downloaded_sample)
+        self._throughput_samples: list[tuple[float, int, int]] = []  # (t, bytes, workers)
+        self._last_throughput_log = 0.0
+        self._peak_workers = 0
+
+        # Run totals
+        self._run_start = 0.0
+
+    # ---- Phase-level tracing ----
+
+    def phase_start(self, name: str) -> None:
+        if not self._enabled:
+            return
+        with self._lock:
+            self._phase_starts[name] = time.monotonic()
+        if name == "total":
+            self._run_start = time.monotonic()
+
+    def phase_end(self, name: str, **extra) -> None:
+        if not self._enabled:
+            return
+        with self._lock:
+            start = self._phase_starts.pop(name, None)
+        if start is None:
+            return
+        elapsed_ms = (time.monotonic() - start) * 1000.0
+        fields = " ".join(f"{k}={v}" for k, v in extra.items())
+        self._logger.debug(f"phase_end name={name} elapsed_ms={elapsed_ms:.1f} {fields}")
+
+    # ---- Per-object download tracing (worker thread) ----
+
+    def object_download_trace(
+        self,
+        key: str,
+        worker: str,
+        attempt: int,
+        conn_ms: float,
+        stream_ms: float,
+        bytes_read: int,
+        retries: int,
+    ) -> None:
+        """Emit per-object download trace and update accumulators.
+
+        Called from each download worker thread after a download attempt completes
+        (success or final failure).
+        """
+        if not self._enabled:
+            return
+        self._logger.debug(
+            f"object_download key={key} worker={worker} attempt={attempt} "
+            f"conn_ms={conn_ms:.1f} stream_ms={stream_ms:.1f} "
+            f"bytes={bytes_read} download_mbps={(bytes_read / max(stream_ms, 1.0)) * 1000 / (1024*1024):.2f} "
+            f"retries={retries}"
+        )
+        with self._lock:
+            self._object_count_downloaded += 1
+            self._bytes_downloaded += bytes_read
+            self._retries_total += retries
+            self._sum_download_ms += stream_ms
+            self._sum_conn_ms += conn_ms
+            total_ms = stream_ms + conn_ms
+            if total_ms > self._max_object_download_ms:
+                self._max_object_download_ms = total_ms
+                self._max_object_download_key = key
+
+    # ---- Per-object tar-write tracing (main thread) ----
+
+    def tar_write_trace(
+        self,
+        idx: int,
+        key: str,
+        wait_ms: float,
+        tar_write_ms: float,
+        bytes_written: int,
+    ) -> None:
+        """Emit per-object tar-write trace and update accumulators.
+
+        Called from the main thread after writing one object to the chunk tar.
+
+        `wait_ms` = wall time spent on `future.result(idx)` (head-of-line wait).
+        `tar_write_ms` = wall time spent in `current_tar.addfile(...)` end-to-end
+        (includes opening temp file, reading from disk, and writing to tar).
+        """
+        if not self._enabled:
+            return
+        self._logger.debug(
+            f"tar_write idx={idx} key={key} "
+            f"wait_ms={wait_ms:.1f} tar_write_ms={tar_write_ms:.1f} "
+            f"bytes={bytes_written} "
+            f"wait_is_bottleneck={'yes' if wait_ms > tar_write_ms else 'no'}"
+        )
+        with self._lock:
+            self._object_count_written += 1
+            self._bytes_written += bytes_written
+            self._sum_wait_ms += wait_ms
+            self._sum_tar_write_ms += tar_write_ms
+
+    # ---- Throughput sampling (called from throttled on_progress callback) ----
+
+    def bytes_downloaded_sample(self, bytes_downloaded: int, active_workers: int) -> None:
+        """Record a throughput sample and emit periodic aggregate throughput log.
+
+        Called ~10/sec from `BackupProgress._maybe_report` via the wrapped
+        `_on_progress` callback in maintenance.py.
+        """
+        if not self._enabled:
+            return
+        now = time.monotonic()
+        with self._lock:
+            self._throughput_samples.append((now, bytes_downloaded, active_workers))
+            if active_workers > self._peak_workers:
+                self._peak_workers = active_workers
+            if now - self._last_throughput_log < self.THROUGHPUT_SAMPLE_INTERVAL:
+                return
+            self._last_throughput_log = now
+            if len(self._throughput_samples) >= 2:
+                t0, b0, _ = self._throughput_samples[0]
+                t1, b1, w1 = self._throughput_samples[-1]
+                dt = max(t1 - t0, 1e-9)
+                mbps = (b1 - b0) / dt / (1024 * 1024)
+                elapsed_since_run_start = now - self._run_start if self._run_start else 0.0
+                self._logger.debug(
+                    f"throughput_sample t+{elapsed_since_run_start:.1f}s "
+                    f"workers={w1} downloaded_mib={b1 / (1024*1024):.2f} "
+                    f"aggregate_mbps={mbps:.2f} peak_workers={self._peak_workers}"
+                )
+
+    # ---- Final summary ----
+
+    def finalize(self, total_objects: int, total_bytes: int) -> None:
+        """Emit aggregate summary stats.
+
+        Expected to be called from `write_backup()` after the ThreadPoolExecutor
+        block completes (after downloads + tar writes, before spot-check).
+        """
+        if not self._enabled:
+            return
+        with self._lock:
+            samples = list(self._throughput_samples)
+            peak_workers = self._peak_workers
+            sum_download_ms = self._sum_download_ms
+            sum_conn_ms = self._sum_conn_ms
+            sum_wait_ms = self._sum_wait_ms
+            sum_tar_write_ms = self._sum_tar_write_ms
+            bytes_downloaded = self._bytes_downloaded
+            retries_total = self._retries_total
+            max_object_download_ms = self._max_object_download_ms
+            max_object_download_key = self._max_object_download_key
+
+        # Aggregate throughput across whole run (wall-clock between first and last sample)
+        if len(samples) >= 2:
+            t0, b0, _ = samples[0]
+            t1, b1, _ = samples[-1]
+            dt = max(t1 - t0, 1e-9)
+            aggregate_mbps = (b1 - b0) / dt / (1024 * 1024)
+        else:
+            aggregate_mbps = 0.0
+
+        # Single-worker average throughput = bytes / per-object average download time.
+        # If single-worker avg << aggregate, workers ARE scaling (network not saturated).
+        # If single-worker avg ≈ aggregate, network is saturated (adding workers won't help).
+        avg_per_object_download_ms = sum_download_ms / max(total_objects, 1)
+        avg_object_bytes = bytes_downloaded / max(total_objects, 1)
+        single_worker_avg_mbps = (
+            avg_object_bytes / max(avg_per_object_download_ms, 1.0) * 1000 / (1024 * 1024)
+        )
+
+        # Head-of-line blocking ratio: wait_ms / (wait_ms + tar_write_ms).
+        # If ratio is high, main thread is bottlenecked on slow head-of-queue downloads
+        # rather than running tar writes.
+        main_thread_total = sum_wait_ms + sum_tar_write_ms
+        wait_ratio = (sum_wait_ms / max(main_thread_total, 1.0)) * 100.0
+        tar_ratio = (sum_tar_write_ms / max(main_thread_total, 1.0)) * 100.0
+
+        self._logger.debug(
+            "summary total_objects=%d total_bytes=%d "
+            "aggregate_mbps=%.2f single_worker_avg_mbps=%.2f "
+            "peak_workers=%d retries_total=%d "
+            "sum_download_ms=%.1f sum_conn_ms=%.1f sum_wait_ms=%.1f sum_tar_write_ms=%.1f "
+            "wait_pct=%.1f tar_write_pct=%.1f "
+            "max_object_download_ms=%.1f max_object_download_key=%s "
+            "network_saturated=%s",
+            total_objects,
+            total_bytes,
+            aggregate_mbps,
+            single_worker_avg_mbps,
+            peak_workers,
+            retries_total,
+            sum_download_ms,
+            sum_conn_ms,
+            sum_wait_ms,
+            sum_tar_write_ms,
+            wait_ratio,
+            tar_ratio,
+            max_object_download_ms,
+            max_object_download_key,
+            "yes"
+            if single_worker_avg_mbps > 0
+            and aggregate_mbps > 0
+            and (aggregate_mbps / max(single_worker_avg_mbps * peak_workers, 1.0)) < 0.5
+            else "no (or inconclusive)",
+        )
+
+
 @dataclass
 class InventoryObject:
     """A single object from the R2 inventory."""
@@ -359,6 +601,7 @@ def _download_object_to_tempfile(
     inv_obj: InventoryObject,
     temp_dir: Path,
     progress: Optional[BackupProgress] = None,
+    tracer: Optional[BackupTracer] = None,
     max_retries: int = 2,
 ) -> DownloadResult:
     """Download a single object to a temp file with consistency checking.
@@ -372,6 +615,7 @@ def _download_object_to_tempfile(
         inv_obj: Inventory object to download
         temp_dir: Directory for temporary files
         progress: Optional BackupProgress tracker for reporting
+        tracer: Optional BackupTracer for performance tracing
         max_retries: Number of retry attempts for transient failures
 
     Raises:
@@ -380,13 +624,20 @@ def _download_object_to_tempfile(
     import tempfile
 
     last_error: Optional[str] = None
+    worker_name = threading.current_thread().name
+    retries_taken = 0
+    conn_ms = 0.0
+    stream_ms = 0.0
+
     for attempt in range(max_retries + 1):
         temp_path: Optional[Path] = None
         try:
             if progress is not None:
                 progress.worker_started()
 
+            t_conn_start = time.monotonic() if tracer is not None else 0.0
             resp = r2_client.get_object_stream(inv_obj.key)
+            conn_ms = (time.monotonic() - t_conn_start) * 1000.0 if tracer is not None else 0.0
             body = resp["body"]
             content_length = resp["content_length"]
             get_etag = resp["etag"]
@@ -398,7 +649,9 @@ def _download_object_to_tempfile(
 
                     on_read = progress.add_bytes if progress is not None else None
                     hashing_reader = HashingReader(body, on_read=on_read)
+                    t_stream_start = time.monotonic() if tracer is not None else 0.0
                     shutil.copyfileobj(hashing_reader, temp_file, length=COPY_BUFFER_SIZE)
+                    stream_ms = (time.monotonic() - t_stream_start) * 1000.0 if tracer is not None else 0.0
 
                 if hashing_reader.bytes_read != content_length:
                     raise BackupError(
@@ -437,6 +690,17 @@ def _download_object_to_tempfile(
                     "last_modified": resp.get("last_modified"),
                 }
 
+                if tracer is not None:
+                    tracer.object_download_trace(
+                        key=inv_obj.key,
+                        worker=worker_name,
+                        attempt=attempt,
+                        conn_ms=conn_ms,
+                        stream_ms=stream_ms,
+                        bytes_read=hashing_reader.bytes_read,
+                        retries=retries_taken,
+                    )
+
                 return DownloadResult(
                     temp_path=temp_path,
                     sha256=sha256,
@@ -448,13 +712,24 @@ def _download_object_to_tempfile(
 
         except Exception as e:
             last_error = str(e)
-            if temp_path is not None:
-                try:
-                    temp_path.unlink()
-                except OSError:
-                    pass
             if attempt < max_retries:
+                retries_taken += 1
+                if temp_path is not None:
+                    try:
+                        temp_path.unlink()
+                    except OSError:
+                        pass
                 continue
+            if tracer is not None:
+                tracer.object_download_trace(
+                    key=inv_obj.key,
+                    worker=worker_name,
+                    attempt=attempt,
+                    conn_ms=conn_ms,
+                    stream_ms=stream_ms,
+                    bytes_read=0,
+                    retries=retries_taken,
+                )
             raise BackupError(
                 f"Failed to backup {inv_obj.key} after retries: {last_error}"
             ) from e
@@ -481,6 +756,7 @@ def write_backup(
     chunk_size_bytes: int = DEFAULT_CHUNK_SIZE_BYTES,
     concurrency: int = DEFAULT_CONCURRENCY,
     on_progress: Optional[Callable[[BackupProgress], None]] = None,
+    tracer: Optional[BackupTracer] = None,
 ) -> BackupResult:
     """Write a full backup to the output directory.
 
@@ -495,6 +771,7 @@ def write_backup(
         concurrency: Number of concurrent download workers (1-64)
         on_progress: Optional callback invoked with BackupProgress updates.
             Called from worker threads (throttled to ~10/sec).
+        tracer: Optional BackupTracer for performance tracing.
 
     Returns:
         BackupResult with summary info.
@@ -518,11 +795,20 @@ def write_backup(
         raise BackupError(f"Chunk size must be positive, got {chunk_size_bytes}")
 
     required_space = int(inventory.total_bytes * 2.1) + 50 * 1024 * 1024
-    _check_disk_space(output_dir.parent, required_space)
 
+    if tracer is not None:
+        tracer.phase_start("disk_check")
+    _check_disk_space(output_dir.parent, required_space)
+    if tracer is not None:
+        tracer.phase_end("disk_check", required_bytes=required_space)
+
+    if tracer is not None:
+        tracer.phase_start("setup")
     partial_dir.mkdir(parents=True)
     (partial_dir / PARTIAL_MARKER).touch()
     temp_dir = partial_dir / "tmp"
+    if tracer is not None:
+        tracer.phase_end("setup")
 
     active_temp_paths: set[Path] = set()
     active_temp_lock = threading.Lock()
@@ -574,10 +860,14 @@ def write_backup(
             on_progress=on_progress,
         )
 
+        if tracer is not None:
+            tracer.phase_start("total")
+            tracer.phase_start("download_phase")
+
         with ThreadPoolExecutor(max_workers=concurrency) as executor:
             futures = {
                 idx: executor.submit(
-                    _download_object_to_tempfile, r2_client, inv_obj, temp_dir, progress
+                    _download_object_to_tempfile, r2_client, inv_obj, temp_dir, progress, tracer
                 )
                 for idx, inv_obj in enumerate(inventory.objects)
             }
@@ -595,12 +885,14 @@ def write_backup(
                     _ensure_tar()
 
                     future = futures[idx]
+                    t_wait_start = time.monotonic() if tracer is not None else 0.0
                     try:
                         download_result = future.result()
                     except BaseException:
                         for f in futures.values():
                             f.cancel()
                         raise
+                    wait_ms = (time.monotonic() - t_wait_start) * 1000.0 if tracer is not None else 0.0
 
                     if progress is not None:
                         progress.mark_object_downloaded()
@@ -613,8 +905,19 @@ def write_backup(
                         tar_info.mode = 0o644
                         tar_info.type = tarfile.REGTYPE
 
+                        t_tar_start = time.monotonic() if tracer is not None else 0.0
                         with open(download_result.temp_path, "rb") as f_in:
                             current_tar.addfile(tar_info, f_in)
+                        tar_write_ms = (time.monotonic() - t_tar_start) * 1000.0 if tracer is not None else 0.0
+
+                        if tracer is not None:
+                            tracer.tar_write_trace(
+                                idx=idx,
+                                key=inv_obj.key,
+                                wait_ms=wait_ms,
+                                tar_write_ms=tar_write_ms,
+                                bytes_written=inv_obj.size,
+                            )
 
                         obj_entry = _build_manifest_object(
                             inv_obj, member_name, download_result.sha256, chunk_index,
@@ -636,11 +939,28 @@ def write_backup(
                     f.cancel()
                 raise
 
+        if tracer is not None:
+            tracer.phase_end(
+                "download_phase",
+                objects=inventory.object_count,
+                total_bytes=inventory.total_bytes,
+            )
+            tracer.finalize(
+                total_objects=inventory.object_count,
+                total_bytes=inventory.total_bytes,
+            )
+
         if current_tar is not None:
+            if tracer is not None:
+                tracer.phase_start("tar_close")
             current_tar.close()
             current_tar = None
+            if tracer is not None:
+                tracer.phase_end("tar_close")
 
         if manifest_objects and SPOT_CHECK_HEAD_RATIO > 0:
+            if tracer is not None:
+                tracer.phase_start("spot_check")
             sample_size = max(1, int(len(manifest_objects) * SPOT_CHECK_HEAD_RATIO))
             sample_indices = random.sample(
                 range(len(manifest_objects)), min(sample_size, len(manifest_objects))
@@ -661,6 +981,8 @@ def write_backup(
                         )
                 except ClientError as e:
                     logger.warning(f"Spot-check: Failed to HEAD {obj_entry['key']}: {e}")
+            if tracer is not None:
+                tracer.phase_end("spot_check", samples=sample_size)
 
         final_chunk_count = chunk_index + 1 if manifest_objects else 0
 
@@ -685,18 +1007,29 @@ def write_backup(
             "objects": manifest_objects,
         }
 
+        if tracer is not None:
+            tracer.phase_start("manifest_write")
         manifest_path = partial_dir / "manifest.json"
         tmp_manifest = partial_dir / "manifest.json.tmp"
         with open(tmp_manifest, "w") as f:
             json.dump(manifest, f, indent=2)
         tmp_manifest.rename(manifest_path)
+        if tracer is not None:
+            tracer.phase_end("manifest_write")
 
         try:
             temp_dir.rmdir()
         except OSError:
             pass
 
+        if tracer is not None:
+            tracer.phase_start("rename")
         partial_dir.rename(output_dir)
+        if tracer is not None:
+            tracer.phase_end("rename")
+
+        if tracer is not None:
+            tracer.phase_end("total")
 
         return BackupResult(
             output_dir=output_dir,

--- a/src/stream_of_worship/admin/services/r2_backup.py
+++ b/src/stream_of_worship/admin/services/r2_backup.py
@@ -29,12 +29,18 @@ MANIFEST_VERSION = 4
 DEFAULT_CHUNK_SIZE_BYTES = 10 * 1024 * 1024 * 1024  # 10 GiB
 MIN_CHUNK_SIZE_BYTES = 64 * 1024 * 1024  # 64 MiB
 PARTIAL_MARKER = ".sow-r2-backup-partial"
-# 32 workers gave ~30% LOWER throughput than 8 workers in real traces
-# (5.0 vs 7.3 MiB/s) — see specs/admin-r2-backup-throughput-remediation-v2.md.
-# R2 exhibits a ~7 MiB/s account/bucket aggregate cap from this client;
-# adding workers past ~8 slices the cap thinner without raising it.
-# Verified via --diag-range-key (ratio=2.41, partial scaling, not pure per-conn cap).
-DEFAULT_CONCURRENCY = 8
+# Concurrency past 1 buys ~0 aggregate throughput. R2 exhibits an
+# account/bucket-level cap (~7 MiB/s from this client); a single connection
+# now saturates it. The v1 rclone benchmark confirmed this:
+#   boto3 single-conn  7.85 MiB/s (best observed)
+#   boto3 4-range     6.54 MiB/s  (ratio=0.83, parallel HURTS)
+#   boto3 32-worker   5.0  MiB/s  (v2 trace, 30% regression)
+#   rclone 8-transfer 5.68 MiB/s  (slower than single boto3 conn)
+# See reports/admin-r2-backup-rclone-download-v1-results.md and
+# specs/admin-r2-backup-throughput-remediation-v2.md.
+# --concurrency N>1 remains available for experimentation but is not expected
+# to help; run --diag-range-key first.
+DEFAULT_CONCURRENCY = 1
 COPY_BUFFER_SIZE = 1024 * 1024  # 1 MB
 SPOT_CHECK_HEAD_RATIO = 0.05  # 5% random sample
 
@@ -911,8 +917,8 @@ def write_backup(
     Raises:
         BackupError: If backup fails. Partial directory is cleaned up.
     """
-    if not (1 <= concurrency <= 64):
-        raise BackupError(f"concurrency must be 1-64, got {concurrency}")
+    if not (1 <= concurrency <= 5):
+        raise BackupError(f"concurrency must be 1-5, got {concurrency}")
 
     if output_dir.exists():
         raise BackupError(f"Output directory already exists: {output_dir}")

--- a/src/stream_of_worship/admin/services/r2_backup.py
+++ b/src/stream_of_worship/admin/services/r2_backup.py
@@ -6,7 +6,6 @@ that maps safe internal member names back to R2 keys and metadata.
 """
 
 import hashlib
-import io
 import json
 import logging
 import os
@@ -15,6 +14,7 @@ import shutil
 import tarfile
 import threading
 import time
+from concurrent.futures import as_completed
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -29,7 +29,12 @@ MANIFEST_VERSION = 4
 DEFAULT_CHUNK_SIZE_BYTES = 10 * 1024 * 1024 * 1024  # 10 GiB
 MIN_CHUNK_SIZE_BYTES = 64 * 1024 * 1024  # 64 MiB
 PARTIAL_MARKER = ".sow-r2-backup-partial"
-DEFAULT_CONCURRENCY = 8
+# Bumped from 8 → 32 based on trace evidence (2026-06): with 8 workers, each
+# R2 stream caps at ~1 MBps and aggregate throughput plateaus at ~7.3 MBps
+# (see specs/admin-r2-backup-throughput-remediation-v1.md). The per-stream cap is
+# R2-side (confirmed by --diag-range-key), so more connections is the only way
+# to scale until/if multipart Range-GET per object is added.
+DEFAULT_CONCURRENCY = 32
 COPY_BUFFER_SIZE = 1024 * 1024  # 1 MB
 SPOT_CHECK_HEAD_RATIO = 0.05  # 5% random sample
 
@@ -259,6 +264,7 @@ class BackupTracer:
         self._bytes_downloaded = 0
         self._bytes_written = 0
         self._retries_total = 0
+        self._timeout_retries = 0
         self._sum_download_ms = 0.0  # sum of worker download_ms across objects
         self._sum_conn_ms = 0.0  # sum of boto3 get_object_stream ms
         self._sum_wait_ms = 0.0  # sum of main-thread future.result() wait ms
@@ -363,6 +369,34 @@ class BackupTracer:
             self._sum_wait_ms += wait_ms
             self._sum_tar_write_ms += tar_write_ms
 
+    # ---- Retry tracing ----
+
+    def retry_trace(
+        self,
+        key: str,
+        worker: str,
+        attempt: int,
+        error_code: str,
+        elapsed_ms: float,
+    ) -> None:
+        """Emit a retry trace event when a download retry fires.
+
+        Called from `_download_object_to_tempfile` on each retry attempt
+        (before the next attempt begins). `error_code` is the botocore
+        ClientError error code string (e.g., "RequestTimeout", "ReadTimeout",
+        "SlowDown", "SocketError").
+        """
+        if not self._enabled:
+            return
+        self._logger.debug(
+            f"download_retry key={key} worker={worker} attempt={attempt} "
+            f"error_code={error_code} elapsed_ms={elapsed_ms:.1f}"
+        )
+        with self._lock:
+            self._retries_total += 1
+            if error_code in ("RequestTimeout", "ReadTimeout", "SlowDown"):
+                self._timeout_retries += 1
+
     # ---- Throughput sampling (called from throttled on_progress callback) ----
 
     def bytes_downloaded_sample(self, bytes_downloaded: int, active_workers: int) -> None:
@@ -412,6 +446,7 @@ class BackupTracer:
             sum_tar_write_ms = self._sum_tar_write_ms
             bytes_downloaded = self._bytes_downloaded
             retries_total = self._retries_total
+            timeout_retries = self._timeout_retries
             max_object_download_ms = self._max_object_download_ms
             max_object_download_key = self._max_object_download_key
 
@@ -443,7 +478,7 @@ class BackupTracer:
         self._logger.debug(
             "summary total_objects=%d total_bytes=%d "
             "aggregate_mbps=%.2f single_worker_avg_mbps=%.2f "
-            "peak_workers=%d retries_total=%d "
+            "peak_workers=%d retries_total=%d timeout_retries=%d "
             "sum_download_ms=%.1f sum_conn_ms=%.1f sum_wait_ms=%.1f sum_tar_write_ms=%.1f "
             "wait_pct=%.1f tar_write_pct=%.1f "
             "max_object_download_ms=%.1f max_object_download_key=%s "
@@ -454,6 +489,7 @@ class BackupTracer:
             single_worker_avg_mbps,
             peak_workers,
             retries_total,
+            timeout_retries,
             sum_download_ms,
             sum_conn_ms,
             sum_wait_ms,
@@ -712,8 +748,19 @@ def _download_object_to_tempfile(
 
         except Exception as e:
             last_error = str(e)
+            error_code = ""
+            if isinstance(e, ClientError):
+                error_code = e.response.get("Error", {}).get("Code", "")
             if attempt < max_retries:
                 retries_taken += 1
+                if tracer is not None:
+                    tracer.retry_trace(
+                        key=inv_obj.key,
+                        worker=worker_name,
+                        attempt=attempt,
+                        error_code=error_code,
+                        elapsed_ms=(conn_ms + stream_ms),
+                    )
                 if temp_path is not None:
                     try:
                         temp_path.unlink()
@@ -736,6 +783,91 @@ def _download_object_to_tempfile(
         finally:
             if progress is not None:
                 progress.worker_finished()
+
+
+def range_get_throughput_diag(
+    r2_client: "R2Client",
+    s3_key: str,
+    num_ranges: int = 4,
+) -> dict:
+    """Run a parallel Range-GET throughput diagnostic on a single R2 object.
+
+    Issues `num_ranges` concurrent Range-GET requests against non-overlapping
+    byte ranges of `s3_key` and measures aggregate throughput. Used to
+    distinguish R2-side per-connection throttling (N ranges → ~N MBps) from
+    client-network saturation (N ranges → ~1 MBps total).
+
+    Args:
+        r2_client: R2Client instance
+        s3_key: Full S3 key of a large object (recommend >20 MB stem file)
+        num_ranges: Number of parallel Range-GET workers (default 4)
+
+    Returns:
+        Dict with keys:
+            - content_length: int (total object size in bytes)
+            - num_ranges: int
+            - single_conn_mbps: float (throughput of one range, MB/s)
+            - multi_conn_total_mbps: float (aggregate throughput of all ranges, MB/s)
+            - ratio: float (multi / single; >1.5 suggests R2-side per-conn cap)
+            - per_range_mbps: list[float] (per-range throughput)
+    """
+    import concurrent.futures
+
+    head = r2_client._client.head_object(Bucket=r2_client.bucket, Key=s3_key)
+    content_length = int(head["ContentLength"])
+    range_size = content_length // num_ranges
+
+    ranges: list[tuple[int, int]] = []
+    for i in range(num_ranges):
+        start = i * range_size
+        end = (start + range_size - 1) if i < num_ranges - 1 else (content_length - 1)
+        ranges.append((start, end))
+
+    def _fetch_range(start: int, end: int) -> tuple[float, int]:
+        t0 = time.monotonic()
+        resp = r2_client._client.get_object(
+            Bucket=r2_client.bucket,
+            Key=s3_key,
+            Range=f"bytes={start}-{end}",
+        )
+        body = resp["Body"]
+        bytes_read = 0
+        while True:
+            chunk = body.read(1024 * 1024)
+            if not chunk:
+                break
+            bytes_read += len(chunk)
+        body.close()
+        elapsed = time.monotonic() - t0
+        return (elapsed, bytes_read)
+
+    # Single-connection baseline (first range only)
+    single_elapsed, single_bytes = _fetch_range(*ranges[0])
+    single_mbps = (single_bytes / max(single_elapsed, 1e-9)) / (1024 * 1024)
+
+    # Multi-connection parallel
+    per_range_mbps: list[float] = []
+    t_multi_start = time.monotonic()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=num_ranges) as executor:
+        future_list = [executor.submit(_fetch_range, s, e) for s, e in ranges]
+        multi_results = [f.result() for f in future_list]
+    multi_elapsed = time.monotonic() - t_multi_start
+    multi_total_bytes = sum(b for _, b in multi_results)
+    multi_mbps = (multi_total_bytes / max(multi_elapsed, 1e-9)) / (1024 * 1024)
+
+    for elapsed, bytes_read in multi_results:
+        per_range_mbps.append((bytes_read / max(elapsed, 1e-9)) / (1024 * 1024))
+
+    ratio = multi_mbps / max(single_mbps, 1e-9)
+
+    return {
+        "content_length": content_length,
+        "num_ranges": num_ranges,
+        "single_conn_mbps": round(single_mbps, 2),
+        "multi_conn_total_mbps": round(multi_mbps, 2),
+        "ratio": round(ratio, 2),
+        "per_range_mbps": [round(m, 2) for m in per_range_mbps],
+    }
 
 
 @dataclass
@@ -779,8 +911,8 @@ def write_backup(
     Raises:
         BackupError: If backup fails. Partial directory is cleaned up.
     """
-    if not (1 <= concurrency <= 64):
-        raise BackupError(f"concurrency must be 1-64, got {concurrency}")
+    if not (1 <= concurrency <= 128):
+        raise BackupError(f"concurrency must be 1-128, got {concurrency}")
 
     if output_dir.exists():
         raise BackupError(f"Output directory already exists: {output_dir}")
@@ -864,18 +996,40 @@ def write_backup(
             tracer.phase_start("total")
             tracer.phase_start("download_phase")
 
+        # Sort inventory indices by size descending for submission order.
+        # This ensures the slowest 50MB stems download first (in parallel with
+        # small lrc/json files), so the end of the run is small fast objects —
+        # no slow tail with workers=1.
+        submission_order = sorted(
+            range(len(inventory.objects)),
+            key=lambda i: inventory.objects[i].size,
+            reverse=True,
+        )
+
         with ThreadPoolExecutor(max_workers=concurrency) as executor:
             futures = {
                 idx: executor.submit(
-                    _download_object_to_tempfile, r2_client, inv_obj, temp_dir, progress, tracer
+                    _download_object_to_tempfile,
+                    r2_client,
+                    inventory.objects[idx],
+                    temp_dir,
+                    progress,
+                    tracer,
                 )
-                for idx, inv_obj in enumerate(inventory.objects)
+                for idx in submission_order
             }
 
+            # Build reverse lookup: future → idx (needed because as_completed yields futures,
+            # not indices).
+            future_to_idx = {f: idx for idx, f in futures.items()}
+
             try:
-                for idx, inv_obj in enumerate(inventory.objects):
+                for future in as_completed(futures.values()):
+                    idx = future_to_idx[future]
+                    inv_obj = inventory.objects[idx]
                     member_name = _member_name_for_index(idx)
 
+                    # Rotate chunk if needed (based on completion-order size, not submission order)
                     if (
                         current_chunk_bytes > 0
                         and current_chunk_bytes + inv_obj.size > chunk_size_bytes
@@ -884,7 +1038,6 @@ def write_backup(
 
                     _ensure_tar()
 
-                    future = futures[idx]
                     t_wait_start = time.monotonic() if tracer is not None else 0.0
                     try:
                         download_result = future.result()

--- a/src/stream_of_worship/admin/services/r2_backup.py
+++ b/src/stream_of_worship/admin/services/r2_backup.py
@@ -14,6 +14,7 @@ import re
 import shutil
 import tarfile
 import threading
+import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -91,30 +92,130 @@ def parse_size(value: str) -> int:
 
 
 class HashingReader:
-    """A wrapper around a readable stream that computes SHA-256 as data is read.
+    """A wrapper around a readable stream that computes SHA-256 and MD5 as data is read.
 
-    Also tracks total bytes read for short-read detection.
+    Also tracks total bytes read for short-read detection, and optionally
+    invokes a callback after each read for progress reporting.
     """
 
-    def __init__(self, source):
+    def __init__(self, source, on_read: Optional[Callable[[int], None]] = None):
         self._source = source
-        self._hasher = hashlib.sha256()
+        self._sha256_hasher = hashlib.sha256()
+        self._md5_hasher = hashlib.md5()
         self.bytes_read = 0
+        self._on_read = on_read
 
     def read(self, size: int = -1) -> bytes:
         data = self._source.read(size)
         if data:
-            self._hasher.update(data)
+            self._sha256_hasher.update(data)
+            self._md5_hasher.update(data)
             self.bytes_read += len(data)
+            if self._on_read is not None:
+                self._on_read(len(data))
         return data
 
     @property
     def sha256_hex(self) -> str:
-        return self._hasher.hexdigest()
+        return self._sha256_hasher.hexdigest()
+
+    @property
+    def md5_hex(self) -> str:
+        return self._md5_hasher.hexdigest()
 
     def close(self) -> None:
         if hasattr(self._source, "close"):
             self._source.close()
+
+
+class BackupProgress:
+    """Thread-safe progress tracker for concurrent backup downloads.
+
+    Tracks bytes downloaded, objects downloaded, and active worker count
+    across all download threads. Designed to be safely updated from worker
+    threads and read from the progress callback.
+    """
+
+    def __init__(
+        self,
+        total_objects: int,
+        total_bytes: int,
+        on_progress: Optional[Callable[["BackupProgress"], None]] = None,
+        min_report_interval: float = 0.1,
+    ):
+        self._lock = threading.Lock()
+        self._bytes_downloaded = 0
+        self._objects_downloaded = 0
+        self._active_workers = 0
+        self._objects_written = 0
+        self._bytes_written = 0
+        self.total_objects = total_objects
+        self.total_bytes = total_bytes
+        self._on_progress = on_progress
+        self._min_report_interval = min_report_interval
+        self._last_report_time = 0.0
+
+    def worker_started(self) -> None:
+        with self._lock:
+            self._active_workers += 1
+        self._maybe_report()
+
+    def worker_finished(self) -> None:
+        with self._lock:
+            self._active_workers -= 1
+        self._maybe_report()
+
+    def add_bytes(self, n: int) -> None:
+        with self._lock:
+            self._bytes_downloaded += n
+        self._maybe_report()
+
+    def mark_object_downloaded(self) -> None:
+        with self._lock:
+            self._objects_downloaded += 1
+        self._maybe_report()
+
+    def object_written(self, bytes_written: int) -> None:
+        with self._lock:
+            self._objects_written += 1
+            self._bytes_written += bytes_written
+        self._maybe_report()
+
+    def _maybe_report(self) -> None:
+        """Call on_progress if enough time has elapsed since last report."""
+        if self._on_progress is None:
+            return
+        now = time.monotonic()
+        with self._lock:
+            if now - self._last_report_time < self._min_report_interval:
+                return
+            self._last_report_time = now
+        self._on_progress(self)
+
+    @property
+    def bytes_downloaded(self) -> int:
+        with self._lock:
+            return self._bytes_downloaded
+
+    @property
+    def objects_downloaded(self) -> int:
+        with self._lock:
+            return self._objects_downloaded
+
+    @property
+    def active_workers(self) -> int:
+        with self._lock:
+            return self._active_workers
+
+    @property
+    def objects_written(self) -> int:
+        with self._lock:
+            return self._objects_written
+
+    @property
+    def bytes_written(self) -> int:
+        with self._lock:
+            return self._bytes_written
 
 
 @dataclass
@@ -257,6 +358,7 @@ def _download_object_to_tempfile(
     r2_client: R2Client,
     inv_obj: InventoryObject,
     temp_dir: Path,
+    progress: Optional[BackupProgress] = None,
     max_retries: int = 2,
 ) -> DownloadResult:
     """Download a single object to a temp file with consistency checking.
@@ -264,6 +366,13 @@ def _download_object_to_tempfile(
     Downloads to a temporary file under temp_dir, validates ETag from GET
     response against inventory, performs MD5 body check for single-part
     objects, and returns the temp path + hash + metadata.
+
+    Args:
+        r2_client: R2Client instance
+        inv_obj: Inventory object to download
+        temp_dir: Directory for temporary files
+        progress: Optional BackupProgress tracker for reporting
+        max_retries: Number of retry attempts for transient failures
 
     Raises:
         BackupError: If the object cannot be captured consistently.
@@ -274,6 +383,9 @@ def _download_object_to_tempfile(
     for attempt in range(max_retries + 1):
         temp_path: Optional[Path] = None
         try:
+            if progress is not None:
+                progress.worker_started()
+
             resp = r2_client.get_object_stream(inv_obj.key)
             body = resp["body"]
             content_length = resp["content_length"]
@@ -283,7 +395,9 @@ def _download_object_to_tempfile(
                 temp_dir.mkdir(parents=True, exist_ok=True)
                 with tempfile.NamedTemporaryFile(dir=temp_dir, delete=False) as temp_file:
                     temp_path = Path(temp_file.name)
-                    hashing_reader = HashingReader(body)
+
+                    on_read = progress.add_bytes if progress is not None else None
+                    hashing_reader = HashingReader(body, on_read=on_read)
                     shutil.copyfileobj(hashing_reader, temp_file, length=COPY_BUFFER_SIZE)
 
                 if hashing_reader.bytes_read != content_length:
@@ -304,19 +418,12 @@ def _download_object_to_tempfile(
                         f"download {get_etag}"
                     )
 
+                # MD5 body check — uses streaming MD5 from HashingReader
                 if "-" not in get_etag:
-                    md5_hasher = hashlib.md5()
-                    with open(temp_path, "rb") as md5_file:
-                        while True:
-                            md5_chunk = md5_file.read(65536)
-                            if not md5_chunk:
-                                break
-                            md5_hasher.update(md5_chunk)
-                    md5_hex = md5_hasher.hexdigest()
-                    if md5_hex != get_etag:
+                    if hashing_reader.md5_hex != get_etag:
                         raise BackupError(
                             f"Object {inv_obj.key} MD5 mismatch: ETag {get_etag}, "
-                            f"computed {md5_hex}"
+                            f"computed {hashing_reader.md5_hex}"
                         )
 
                 sha256 = hashing_reader.sha256_hex
@@ -351,8 +458,9 @@ def _download_object_to_tempfile(
             raise BackupError(
                 f"Failed to backup {inv_obj.key} after retries: {last_error}"
             ) from e
-
-    raise BackupError(f"Failed to backup {inv_obj.key} after retries: {last_error}")
+        finally:
+            if progress is not None:
+                progress.worker_finished()
 
 
 @dataclass
@@ -372,7 +480,7 @@ def write_backup(
     inventory: Inventory,
     chunk_size_bytes: int = DEFAULT_CHUNK_SIZE_BYTES,
     concurrency: int = DEFAULT_CONCURRENCY,
-    on_progress: Optional[Callable[[int, int], None]] = None,
+    on_progress: Optional[Callable[[BackupProgress], None]] = None,
 ) -> BackupResult:
     """Write a full backup to the output directory.
 
@@ -385,8 +493,8 @@ def write_backup(
         inventory: Pre-built inventory
         chunk_size_bytes: Max bytes per chunk tar
         concurrency: Number of concurrent download workers (1-64)
-        on_progress: Optional callback invoked after each object is written.
-            Receives (objects_completed, bytes_completed).
+        on_progress: Optional callback invoked with BackupProgress updates.
+            Called from worker threads (throttled to ~10/sec).
 
     Returns:
         BackupResult with summary info.
@@ -460,12 +568,16 @@ def write_backup(
             chunk_index += 1
             current_chunk_bytes = 0
 
-        bytes_completed = 0
+        progress = BackupProgress(
+            total_objects=inventory.object_count,
+            total_bytes=inventory.total_bytes,
+            on_progress=on_progress,
+        )
 
         with ThreadPoolExecutor(max_workers=concurrency) as executor:
             futures = {
                 idx: executor.submit(
-                    _download_object_to_tempfile, r2_client, inv_obj, temp_dir
+                    _download_object_to_tempfile, r2_client, inv_obj, temp_dir, progress
                 )
                 for idx, inv_obj in enumerate(inventory.objects)
             }
@@ -490,6 +602,9 @@ def write_backup(
                             f.cancel()
                         raise
 
+                    if progress is not None:
+                        progress.mark_object_downloaded()
+
                     _track_temp(download_result.temp_path)
                     try:
                         tar_info = tarfile.TarInfo(name=member_name)
@@ -507,10 +622,9 @@ def write_backup(
                         )
                         manifest_objects.append(obj_entry)
                         current_chunk_bytes += inv_obj.size
-                        bytes_completed += inv_obj.size
 
-                        if on_progress is not None:
-                            on_progress(idx + 1, bytes_completed)
+                        if progress is not None:
+                            progress.object_written(inv_obj.size)
                     finally:
                         _untrack_temp(download_result.temp_path)
                         try:

--- a/src/stream_of_worship/admin/services/r2_backup.py
+++ b/src/stream_of_worship/admin/services/r2_backup.py
@@ -8,6 +8,7 @@ that maps safe internal member names back to R2 keys and metadata.
 import hashlib
 import io
 import json
+import logging
 import os
 import re
 import shutil
@@ -20,6 +21,8 @@ from typing import Callable, Optional
 
 from botocore.exceptions import ClientError
 from stream_of_worship.admin.services.r2 import R2Client
+
+logger = logging.getLogger(__name__)
 
 MANIFEST_VERSION = 4
 DEFAULT_CHUNK_SIZE_BYTES = 10 * 1024 * 1024 * 1024  # 10 GiB
@@ -302,7 +305,14 @@ def _download_object_to_tempfile(
                     )
 
                 if "-" not in get_etag:
-                    md5_hex = hashlib.md5(temp_path.read_bytes()).hexdigest()
+                    md5_hasher = hashlib.md5()
+                    with open(temp_path, "rb") as md5_file:
+                        while True:
+                            md5_chunk = md5_file.read(65536)
+                            if not md5_chunk:
+                                break
+                            md5_hasher.update(md5_chunk)
+                    md5_hex = md5_hasher.hexdigest()
                     if md5_hex != get_etag:
                         raise BackupError(
                             f"Object {inv_obj.key} MD5 mismatch: ETag {get_etag}, "
@@ -329,7 +339,7 @@ def _download_object_to_tempfile(
             finally:
                 body.close()
 
-        except (BackupError, ClientError) as e:
+        except Exception as e:
             last_error = str(e)
             if temp_path is not None:
                 try:
@@ -526,11 +536,17 @@ def write_backup(
                 try:
                     head_data = r2_client.head_object(obj_entry["key"])
                     if head_data is None:
+                        logger.warning(
+                            f"Spot-check: Object {obj_entry['key']} was deleted after backup"
+                        )
                         continue
                     if head_data["etag"] != obj_entry["etag"]:
-                        pass
-                except ClientError:
-                    pass
+                        logger.warning(
+                            f"Spot-check: Object {obj_entry['key']} ETag changed after backup: "
+                            f"expected {obj_entry['etag']}, got {head_data['etag']}"
+                        )
+                except ClientError as e:
+                    logger.warning(f"Spot-check: Failed to HEAD {obj_entry['key']}: {e}")
 
         final_chunk_count = chunk_index + 1 if manifest_objects else 0
 
@@ -587,21 +603,30 @@ def write_backup(
         raise
 
 
+SUPPORTED_MANIFEST_VERSIONS = {3, 4}
+
+
 def load_manifest(dir_path: Path) -> dict:
     """Load and return manifest.json from a backup directory.
 
+    Supports manifest versions 3 and 4. Version 3 uses post-download HEAD
+    consistency checks; version 4 uses GET-ETag checks with MD5 body
+    verification. Both produce identical object/chunk structures for
+    verification and restore.
+
     Raises:
-        VerifyError: If manifest is missing or has wrong version.
+        VerifyError: If manifest is missing or has unsupported version.
     """
     manifest_path = dir_path / "manifest.json"
     if not manifest_path.exists():
         raise VerifyError(f"manifest.json not found in {dir_path}")
     with open(manifest_path) as f:
         manifest = json.load(f)
-    if manifest.get("version") != MANIFEST_VERSION:
+    version = manifest.get("version")
+    if version not in SUPPORTED_MANIFEST_VERSIONS:
         raise VerifyError(
-            f"Unsupported manifest version: {manifest.get('version')}, "
-            f"expected {MANIFEST_VERSION}"
+            f"Unsupported manifest version: {version}, "
+            f"expected one of {sorted(SUPPORTED_MANIFEST_VERSIONS)}"
         )
     return manifest
 

--- a/src/stream_of_worship/admin/services/r2_backup.py
+++ b/src/stream_of_worship/admin/services/r2_backup.py
@@ -29,12 +29,12 @@ MANIFEST_VERSION = 4
 DEFAULT_CHUNK_SIZE_BYTES = 10 * 1024 * 1024 * 1024  # 10 GiB
 MIN_CHUNK_SIZE_BYTES = 64 * 1024 * 1024  # 64 MiB
 PARTIAL_MARKER = ".sow-r2-backup-partial"
-# Bumped from 8 → 32 based on trace evidence (2026-06): with 8 workers, each
-# R2 stream caps at ~1 MBps and aggregate throughput plateaus at ~7.3 MBps
-# (see specs/admin-r2-backup-throughput-remediation-v1.md). The per-stream cap is
-# R2-side (confirmed by --diag-range-key), so more connections is the only way
-# to scale until/if multipart Range-GET per object is added.
-DEFAULT_CONCURRENCY = 32
+# 32 workers gave ~30% LOWER throughput than 8 workers in real traces
+# (5.0 vs 7.3 MiB/s) — see specs/admin-r2-backup-throughput-remediation-v2.md.
+# R2 exhibits a ~7 MiB/s account/bucket aggregate cap from this client;
+# adding workers past ~8 slices the cap thinner without raising it.
+# Verified via --diag-range-key (ratio=2.41, partial scaling, not pure per-conn cap).
+DEFAULT_CONCURRENCY = 8
 COPY_BUFFER_SIZE = 1024 * 1024  # 1 MB
 SPOT_CHECK_HEAD_RATIO = 0.05  # 5% random sample
 
@@ -911,8 +911,8 @@ def write_backup(
     Raises:
         BackupError: If backup fails. Partial directory is cleaned up.
     """
-    if not (1 <= concurrency <= 128):
-        raise BackupError(f"concurrency must be 1-128, got {concurrency}")
+    if not (1 <= concurrency <= 64):
+        raise BackupError(f"concurrency must be 1-64, got {concurrency}")
 
     if output_dir.exists():
         raise BackupError(f"Output directory already exists: {output_dir}")

--- a/src/stream_of_worship/app/README.md
+++ b/src/stream_of_worship/app/README.md
@@ -1,4 +1,6 @@
-# Stream of Worship - User App (TUI)
+# Stream of Worship - User App (TUI) ⚠️ DEPRECATED
+
+> **This component is deprecated.** The [Web App](../../webapp/README.md) (`sow-webapp`) is now the primary end-user interface for worship leaders and media teams. The TUI may not be fully migrated to the shared PostgreSQL (Neon) database and is not actively maintained.
 
 An interactive Textual TUI application for worship leaders to browse the song catalog, assemble multi-song songsets with smooth transitions, preview audio, and export final audio + lyrics video files.
 
@@ -7,7 +9,7 @@ An interactive Textual TUI application for worship leaders to browse the song ca
 ### 🎵 Songset Management
 - **Create and manage songsets** - Organize multiple songs into sets for worship sessions
 - **Reorder songs** - Drag-and-drop or keyboard-based reordering in the songset editor
-- **Persistent storage** - Songsets saved to local SQLite database
+- **Persistent storage** - Songsets saved to database (migration status to shared PostgreSQL/Neon uncertain; Web App is the recommended interface)
 
 ### 📚 Catalog Browsing
 - **Browse master catalog** - View all songs from the admin-managed catalog
@@ -85,8 +87,8 @@ An interactive Textual TUI application for worship leaders to browse the song ca
 # With config file
 sow-app --config /path/to/config.toml
 
-# With database URL directly
-sow-app --database-url "sqlite:////path/to/sow.db"
+# With database URL directly (PostgreSQL)
+sow-app --database-url "postgresql://sow_app@ep-xxx-pooler.neon.tech/sow"
 
 # Show help
 sow-app --help
@@ -128,11 +130,11 @@ The User App follows a service-oriented architecture:
 - **AppState**: Central reactive state management with observer pattern
 - **Services**: Modular services for catalog, playback, audio/video processing
 - **Screens**: Textual-based UI screens composing the interface
-- **Database**: SQLite with separate clients for read-only (admin tables) and read-write (app tables) access
+- **Database**: PostgreSQL (Neon) via psycopg3 — migration status uncertain; Web App is the recommended interface for all songset operations
 
 ## Troubleshooting
 
-**App won't start**: Check that database file exists and is accessible
+**App won't start**: Check PostgreSQL connection and that schema has been initialized (run `sow-admin db init` first)
 
 **No audio playback**: Verify miniaudio is installed and audio files are cached
 

--- a/tests/admin/test_r2_backup.py
+++ b/tests/admin/test_r2_backup.py
@@ -910,17 +910,17 @@ class TestConcurrentBackup:
         inventory = build_inventory(r2)
         output = tmp_path / "backup"
 
-        with pytest.raises(BackupError, match="concurrency must be 1-128"):
+        with pytest.raises(BackupError, match="concurrency must be 1-64"):
             write_backup(r2, output, inventory, concurrency=0)
 
-    def test_concurrency_validation_rejects_129(self, tmp_path):
-        """write_backup raises BackupError for concurrency=129."""
+    def test_concurrency_validation_rejects_65(self, tmp_path):
+        """write_backup raises BackupError for concurrency=65."""
         r2 = _make_r2_mock([])
         inventory = build_inventory(r2)
         output = tmp_path / "backup"
 
-        with pytest.raises(BackupError, match="concurrency must be 1-128"):
-            write_backup(r2, output, inventory, concurrency=129)
+        with pytest.raises(BackupError, match="concurrency must be 1-64"):
+            write_backup(r2, output, inventory, concurrency=65)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/admin/test_r2_backup.py
+++ b/tests/admin/test_r2_backup.py
@@ -520,7 +520,7 @@ class TestWriteBackup:
         inventory = build_inventory(r2)
         output = tmp_path / "backup"
 
-        with pytest.raises(RuntimeError):
+        with pytest.raises(BackupError, match="Failed to backup"):
             write_backup(r2, output, inventory)
 
         assert not output.exists()
@@ -675,7 +675,7 @@ class TestConcurrentBackup:
         inventory = build_inventory(r2)
         output = tmp_path / "backup"
 
-        with pytest.raises(RuntimeError):
+        with pytest.raises(BackupError, match="Failed to backup"):
             write_backup(r2, output, inventory)
 
         assert not output.exists()
@@ -849,6 +849,21 @@ class TestVerifyArchive:
 
         assert result.ok is False
         assert any("Unsupported manifest version" in e for e in result.errors)
+
+    def test_verify_v3_manifest_still_supported(self, tmp_path):
+        """Manifests with version 3 (from previous implementation) are still readable."""
+        backup_dir = _create_valid_backup(tmp_path, [
+            {"key": "a/file", "size": 5, "etag": "etag1", "data": b"hello"}
+        ])
+        # Downgrade manifest version to 3 to simulate old backup
+        manifest = json.loads((backup_dir / "manifest.json").read_text())
+        manifest["version"] = 3
+        (backup_dir / "manifest.json").write_text(json.dumps(manifest))
+
+        result = verify_archive(backup_dir)
+
+        assert result.ok is True
+        assert result.object_count == 1
 
     def test_verify_corrupt_tar(self, tmp_path):
         backup_dir = _create_valid_backup(tmp_path, [

--- a/tests/admin/test_r2_backup.py
+++ b/tests/admin/test_r2_backup.py
@@ -910,17 +910,17 @@ class TestConcurrentBackup:
         inventory = build_inventory(r2)
         output = tmp_path / "backup"
 
-        with pytest.raises(BackupError, match="concurrency must be 1-64"):
+        with pytest.raises(BackupError, match="concurrency must be 1-5"):
             write_backup(r2, output, inventory, concurrency=0)
 
-    def test_concurrency_validation_rejects_65(self, tmp_path):
-        """write_backup raises BackupError for concurrency=65."""
+    def test_concurrency_validation_rejects_6(self, tmp_path):
+        """write_backup raises BackupError for concurrency=6."""
         r2 = _make_r2_mock([])
         inventory = build_inventory(r2)
         output = tmp_path / "backup"
 
-        with pytest.raises(BackupError, match="concurrency must be 1-64"):
-            write_backup(r2, output, inventory, concurrency=65)
+        with pytest.raises(BackupError, match="concurrency must be 1-5"):
+            write_backup(r2, output, inventory, concurrency=6)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/admin/test_r2_backup.py
+++ b/tests/admin/test_r2_backup.py
@@ -15,6 +15,7 @@ from stream_of_worship.admin.services.r2_backup import (
     MANIFEST_VERSION,
     MIN_CHUNK_SIZE_BYTES,
     BackupError,
+    BackupProgress,
     HashingReader,
     Inventory,
     InventoryObject,
@@ -94,8 +95,8 @@ class TestHashingReader:
         result = reader.read()
         assert result == data
         assert reader.bytes_read == len(data)
-        expected = hashlib.sha256(data).hexdigest()
-        assert reader.sha256_hex == expected
+        assert reader.sha256_hex == hashlib.sha256(data).hexdigest()
+        assert reader.md5_hex == hashlib.md5(data).hexdigest()
 
     def test_partial_reads(self):
         data = b"hello world"
@@ -106,8 +107,8 @@ class TestHashingReader:
         assert chunk1 == b"hello"
         assert chunk2 == b" world"
         assert reader.bytes_read == len(data)
-        expected = hashlib.sha256(data).hexdigest()
-        assert reader.sha256_hex == expected
+        assert reader.sha256_hex == hashlib.sha256(data).hexdigest()
+        assert reader.md5_hex == hashlib.md5(data).hexdigest()
 
     def test_empty_read(self):
         source = io.BytesIO(b"")
@@ -115,14 +116,30 @@ class TestHashingReader:
         result = reader.read()
         assert result == b""
         assert reader.bytes_read == 0
-        expected = hashlib.sha256(b"").hexdigest()
-        assert reader.sha256_hex == expected
+        assert reader.sha256_hex == hashlib.sha256(b"").hexdigest()
+        assert reader.md5_hex == hashlib.md5(b"").hexdigest()
 
     def test_close(self):
         source = MagicMock()
         reader = HashingReader(source)
         reader.close()
         source.close.assert_called_once()
+
+    def test_on_read_callback(self):
+        """on_read callback is invoked with chunk byte count after each read."""
+        data = b"hello world"
+        source = io.BytesIO(data)
+        calls = []
+        reader = HashingReader(source, on_read=lambda n: calls.append(n))
+        reader.read(5)
+        reader.read(6)
+        assert calls == [5, 6]
+
+    def test_on_read_not_called_on_empty_read(self):
+        """on_read is not called when read returns empty bytes."""
+        source = io.BytesIO(b"")
+        reader = HashingReader(source, on_read=lambda n: pytest.fail("should not be called"))
+        reader.read()
 
 
 # ---------------------------------------------------------------------------
@@ -530,7 +547,7 @@ class TestWriteBackup:
 
 class TestWriteBackupProgress:
     def test_on_progress_called_with_correct_counts(self, tmp_path):
-        """write_backup calls on_progress with correct object and byte counts."""
+        """write_backup calls on_progress with BackupProgress reflecting downloads."""
         objects = [
             {"key": "a/file1", "size": 100, "etag": "etag1", "data": b"x" * 100},
             {"key": "a/file2", "size": 200, "etag": "etag2", "data": b"y" * 200},
@@ -539,17 +556,133 @@ class TestWriteBackupProgress:
         inventory = build_inventory(r2)
         output = tmp_path / "backup"
 
-        calls = []
-        def _on_progress(objects_done: int, bytes_done: int) -> None:
-            calls.append((objects_done, bytes_done))
+        last_progress = None
+
+        def _on_progress(prog: BackupProgress) -> None:
+            nonlocal last_progress
+            last_progress = prog
 
         result = write_backup(r2, output, inventory, on_progress=_on_progress)
 
-        assert len(calls) == 2
-        assert calls[0] == (1, 100)
-        assert calls[1] == (2, 300)
+        assert last_progress is not None
+        assert last_progress.bytes_downloaded == 300
+        assert last_progress.objects_downloaded == 2
+        assert last_progress.active_workers == 0
+        assert last_progress.objects_written == 2
+        assert last_progress.bytes_written == 300
         assert result.object_count == 2
         assert result.total_bytes == 300
+
+    def test_on_progress_none_works(self, tmp_path):
+        """write_backup works with on_progress=None (default)."""
+        objects = [
+            {"key": "a/file1", "size": 100, "etag": "etag1", "data": b"x" * 100},
+        ]
+        r2 = _make_r2_mock(objects)
+        inventory = build_inventory(r2)
+        output = tmp_path / "backup"
+
+        result = write_backup(r2, output, inventory)
+
+        assert result.object_count == 1
+
+
+class TestBackupProgress:
+    def test_initial_state(self):
+        prog = BackupProgress(total_objects=10, total_bytes=1000)
+        assert prog.bytes_downloaded == 0
+        assert prog.objects_downloaded == 0
+        assert prog.active_workers == 0
+        assert prog.objects_written == 0
+        assert prog.bytes_written == 0
+        assert prog.total_objects == 10
+        assert prog.total_bytes == 1000
+
+    def test_worker_started_finished(self):
+        prog = BackupProgress(total_objects=10, total_bytes=1000)
+        prog.worker_started()
+        assert prog.active_workers == 1
+        prog.worker_started()
+        assert prog.active_workers == 2
+        prog.worker_finished()
+        assert prog.active_workers == 1
+        prog.worker_finished()
+        assert prog.active_workers == 0
+
+    def test_add_bytes(self):
+        prog = BackupProgress(total_objects=10, total_bytes=1000)
+        prog.add_bytes(100)
+        prog.add_bytes(200)
+        assert prog.bytes_downloaded == 300
+
+    def test_mark_object_downloaded(self):
+        prog = BackupProgress(total_objects=10, total_bytes=1000)
+        prog.mark_object_downloaded()
+        prog.mark_object_downloaded()
+        assert prog.objects_downloaded == 2
+
+    def test_object_written(self):
+        prog = BackupProgress(total_objects=10, total_bytes=1000)
+        prog.object_written(100)
+        prog.object_written(200)
+        assert prog.objects_written == 2
+        assert prog.bytes_written == 300
+
+    def test_on_progress_callback_invoked(self):
+        calls = []
+        prog = BackupProgress(
+            total_objects=10, total_bytes=1000,
+            on_progress=lambda p: calls.append(p),
+            min_report_interval=0.0,  # no throttling for tests
+        )
+        prog.add_bytes(100)
+        assert len(calls) >= 1
+        assert calls[-1].bytes_downloaded == 100
+
+    def test_on_progress_throttled(self):
+        calls = []
+        prog = BackupProgress(
+            total_objects=10, total_bytes=1000,
+            on_progress=lambda p: calls.append(p),
+            min_report_interval=1.0,  # 1 second throttle
+        )
+        prog.add_bytes(10)
+        prog.add_bytes(20)
+        prog.add_bytes(30)
+        # Only first call should trigger (subsequent calls within 1s are throttled)
+        assert len(calls) == 1
+        # But the counter still reflects all additions
+        assert calls[0].bytes_downloaded == 60
+
+    def test_on_progress_none_no_error(self):
+        """No error when on_progress is None."""
+        prog = BackupProgress(total_objects=10, total_bytes=1000)
+        prog.add_bytes(100)
+        prog.worker_started()
+        prog.worker_finished()
+        prog.mark_object_downloaded()
+        prog.object_written(100)
+
+    def test_thread_safety(self):
+        """Concurrent updates from multiple threads produce correct totals."""
+        import threading
+
+        prog = BackupProgress(
+            total_objects=100, total_bytes=10000,
+            min_report_interval=0.0,
+        )
+
+        def worker():
+            for _ in range(100):
+                prog.add_bytes(1)
+
+        threads = [threading.Thread(target=worker) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert prog.bytes_downloaded == 1000
 
 
 class TestConcurrentBackup:

--- a/tests/admin/test_r2_backup.py
+++ b/tests/admin/test_r2_backup.py
@@ -4,7 +4,6 @@ import hashlib
 import io
 import json
 import tarfile
-from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -18,10 +17,7 @@ from stream_of_worship.admin.services.r2_backup import (
     BackupProgress,
     BackupTracer,
     HashingReader,
-    Inventory,
-    InventoryObject,
     RestoreError,
-    VerifyError,
     build_inventory,
     load_manifest,
     parse_size,
@@ -29,8 +25,6 @@ from stream_of_worship.admin.services.r2_backup import (
     restore_from_archive,
     verify_archive,
     write_backup,
-    DEFAULT_CONCURRENCY,
-    COPY_BUFFER_SIZE,
     SPOT_CHECK_HEAD_RATIO,
 )
 
@@ -514,7 +508,7 @@ class TestWriteBackup:
         inventory = build_inventory(r2)
 
         output = tmp_path / "backup"
-        result = write_backup(r2, output, inventory)
+        write_backup(r2, output, inventory)
 
         manifest = json.loads((output / "manifest.json").read_text())
         obj = manifest["objects"][0]
@@ -709,9 +703,13 @@ class TestConcurrentBackup:
         assert manifest["consistency"]["mode"] == "initial-inventory-with-get-etag-check"
         assert manifest["consistency"]["md5_body_check"] is True
 
-        for i, obj in enumerate(manifest["objects"]):
+        # Objects are in completion order, not inventory order — verify by key lookup
+        obj_by_key = {o["key"]: o for o in manifest["objects"]}
+        for i in range(20):
+            key = f"obj{i}/file"
+            assert key in obj_by_key
             expected_hash = hashlib.sha256(bytes([i]) * 100).hexdigest()
-            assert obj["sha256"] == expected_hash
+            assert obj_by_key[key]["sha256"] == expected_hash
 
     def test_concurrency_1_works(self, tmp_path):
         """concurrency=1 falls back to sequential (no thread pool issues)."""
@@ -729,7 +727,7 @@ class TestConcurrentBackup:
         assert output.exists()
 
     def test_concurrent_backup_preserves_object_order(self, tmp_path):
-        """Manifest objects are in inventory order regardless of download completion order."""
+        """Manifest objects are in completion order with as_completed, but all present."""
         objects = [
             {"key": f"obj{i}/file", "size": 10, "etag": f"etag{i}", "data": bytes([i]) * 10}
             for i in range(10)
@@ -738,11 +736,12 @@ class TestConcurrentBackup:
         inventory = build_inventory(r2)
         output = tmp_path / "backup"
 
-        result = write_backup(r2, output, inventory, concurrency=4)
+        write_backup(r2, output, inventory, concurrency=4)
 
         manifest = json.loads((output / "manifest.json").read_text())
-        for i, obj in enumerate(manifest["objects"]):
-            assert obj["key"] == f"obj{i}/file"
+        # All objects present regardless of completion order
+        keys = {o["key"] for o in manifest["objects"]}
+        assert keys == {f"obj{i}/file" for i in range(10)}
 
     def test_concurrent_backup_cleans_up_temp_files(self, tmp_path):
         """No temp files remain after successful backup."""
@@ -911,17 +910,17 @@ class TestConcurrentBackup:
         inventory = build_inventory(r2)
         output = tmp_path / "backup"
 
-        with pytest.raises(BackupError, match="concurrency must be 1-64"):
+        with pytest.raises(BackupError, match="concurrency must be 1-128"):
             write_backup(r2, output, inventory, concurrency=0)
 
-    def test_concurrency_validation_rejects_65(self, tmp_path):
-        """write_backup raises BackupError for concurrency=65."""
+    def test_concurrency_validation_rejects_129(self, tmp_path):
+        """write_backup raises BackupError for concurrency=129."""
         r2 = _make_r2_mock([])
         inventory = build_inventory(r2)
         output = tmp_path / "backup"
 
-        with pytest.raises(BackupError, match="concurrency must be 1-64"):
-            write_backup(r2, output, inventory, concurrency=65)
+        with pytest.raises(BackupError, match="concurrency must be 1-128"):
+            write_backup(r2, output, inventory, concurrency=129)
 
 
 # ---------------------------------------------------------------------------
@@ -1638,3 +1637,249 @@ class TestWriteBackupTracerIntegration:
         assert not [r for r in caplog.records if "object_download" in r.message]
         assert not [r for r in caplog.records if "tar_write" in r.message]
         assert not [r for r in caplog.records if "summary" in r.message]
+
+
+# ---------------------------------------------------------------------------
+# as_completed tar ingestion tests
+# ---------------------------------------------------------------------------
+
+
+class TestAsCompletedTarIngestion:
+    def test_chunk_index_follows_completion_order_not_submission_order(self, tmp_path):
+        """With as_completed, chunk_index is assigned in completion order."""
+        # Create objects where the second one "downloads" faster than the first
+        # by using a mock that simulates delay based on key
+        data_large = b"x" * 100
+        data_small = b"y" * 50
+        objects = [
+            {"key": "a/large", "size": 100, "etag": "etag1", "data": data_large},
+            {"key": "b/small", "size": 50, "etag": "etag2", "data": data_small},
+        ]
+        r2 = _make_r2_mock(objects)
+        inventory = build_inventory(r2)
+        output = tmp_path / "backup"
+
+        # Use tiny chunk size so each object gets its own chunk
+        result = write_backup(r2, output, inventory, chunk_size_bytes=75)
+
+        assert result.object_count == 2
+        assert result.chunk_count == 2
+
+        manifest = json.loads((output / "manifest.json").read_text())
+        # Both objects present
+        keys = {o["key"] for o in manifest["objects"]}
+        assert keys == {"a/large", "b/small"}
+        # chunk_index values are valid
+        for obj in manifest["objects"]:
+            assert obj["chunk_index"] in {0, 1}
+
+        # Verify archive still passes
+        verify_result = verify_archive(output)
+        assert verify_result.ok is True
+
+    def test_all_objects_present_after_as_completed(self, tmp_path):
+        """All objects are present in manifest after as_completed rewrite."""
+        objects = [
+            {"key": f"obj{i}/file", "size": 10, "etag": f"etag{i}", "data": bytes([i]) * 10}
+            for i in range(10)
+        ]
+        r2 = _make_r2_mock(objects)
+        inventory = build_inventory(r2)
+        output = tmp_path / "backup"
+
+        result = write_backup(r2, output, inventory, concurrency=4)
+
+        assert result.object_count == 10
+        manifest = json.loads((output / "manifest.json").read_text())
+        assert len(manifest["objects"]) == 10
+        keys = {o["key"] for o in manifest["objects"]}
+        assert keys == {f"obj{i}/file" for i in range(10)}
+
+        verify_result = verify_archive(output)
+        assert verify_result.ok is True
+
+
+class TestInventorySortBySize:
+    def test_submission_order_is_size_descending(self, tmp_path):
+        """Large objects are submitted first to ThreadPoolExecutor."""
+        objects = [
+            {"key": "small/file", "size": 10, "etag": "etag1", "data": b"x" * 10},
+            {"key": "large/file", "size": 100, "etag": "etag2", "data": b"y" * 100},
+            {"key": "medium/file", "size": 50, "etag": "etag3", "data": b"z" * 50},
+        ]
+        r2 = _make_r2_mock(objects)
+        inventory = build_inventory(r2)
+        output = tmp_path / "backup"
+
+        write_backup(r2, output, inventory)
+
+        manifest = json.loads((output / "manifest.json").read_text())
+        # member_name indices should still be original inventory order
+        obj_by_key = {o["key"]: o for o in manifest["objects"]}
+        # All objects present
+        assert set(obj_by_key.keys()) == {"small/file", "large/file", "medium/file"}
+
+    def test_member_name_indices_are_original_inventory_order(self, tmp_path):
+        """member_name uses original inventory index, not submission order."""
+        objects = [
+            {"key": "a/file", "size": 10, "etag": "etag1", "data": b"x" * 10},
+            {"key": "b/file", "size": 100, "etag": "etag2", "data": b"y" * 100},
+        ]
+        r2 = _make_r2_mock(objects)
+        inventory = build_inventory(r2)
+        output = tmp_path / "backup"
+
+        write_backup(r2, output, inventory)
+
+        manifest = json.loads((output / "manifest.json").read_text())
+        # Find the object entries by key
+        obj_by_key = {o["key"]: o for o in manifest["objects"]}
+        # a/file was inventory index 0, b/file was index 1
+        assert obj_by_key["a/file"]["member_name"] == "objects/000000000000.bin"
+        assert obj_by_key["b/file"]["member_name"] == "objects/000000000001.bin"
+
+
+class TestRetryTraceEmission:
+    def test_retry_trace_called_on_timeout_error(self, tmp_path, caplog):
+        """retry_trace is called with correct error_code when a retry fires."""
+        import logging
+        from botocore.exceptions import ClientError
+
+        data = b"hello world"
+        etag = hashlib.md5(data).hexdigest()
+        objects = [{"key": "a/file", "size": 11, "etag": etag, "data": data}]
+        r2 = _make_r2_mock(objects)
+
+        call_count = [0]
+        original_get = r2.get_object_stream.side_effect
+
+        def _timeout_then_success(key):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise ClientError(
+                    {"Error": {"Code": "RequestTimeout", "Message": "Timeout"}},
+                    "GetObject",
+                )
+            return original_get(key)
+
+        r2.get_object_stream.side_effect = _timeout_then_success
+
+        inventory = build_inventory(r2)
+        output = tmp_path / "backup"
+
+        with caplog.at_level(
+            logging.DEBUG, logger="stream_of_worship.admin.services.r2_backup"
+        ):
+            tracer = BackupTracer()
+            result = write_backup(r2, output, inventory, tracer=tracer)
+
+        assert result.object_count == 1
+
+        retry_logs = [r for r in caplog.records if "download_retry" in r.message]
+        assert len(retry_logs) == 1
+        msg = retry_logs[0].message
+        assert "error_code=RequestTimeout" in msg
+        assert "attempt=0" in msg
+        assert "key=a/file" in msg
+
+    def test_timeout_retries_counter_incremented(self, tmp_path, caplog):
+        """_timeout_retries is incremented for timeout-class errors."""
+        import logging
+        from botocore.exceptions import ClientError
+
+        data = b"hello world"
+        etag = hashlib.md5(data).hexdigest()
+        objects = [{"key": "a/file", "size": 11, "etag": etag, "data": data}]
+        r2 = _make_r2_mock(objects)
+
+        call_count = [0]
+        original_get = r2.get_object_stream.side_effect
+
+        def _slow_down_then_success(key):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise ClientError(
+                    {"Error": {"Code": "SlowDown", "Message": "Slow down"}},
+                    "GetObject",
+                )
+            return original_get(key)
+
+        r2.get_object_stream.side_effect = _slow_down_then_success
+
+        inventory = build_inventory(r2)
+        output = tmp_path / "backup"
+
+        with caplog.at_level(
+            logging.DEBUG, logger="stream_of_worship.admin.services.r2_backup"
+        ):
+            tracer = BackupTracer()
+            write_backup(r2, output, inventory, tracer=tracer)
+
+        assert tracer._timeout_retries == 1
+        # _retries_total is 2: retry_trace increments once for the retry event,
+        # and object_download_trace increments once for retries_taken on the
+        # successful final attempt.
+        assert tracer._retries_total == 2
+
+
+class TestRangeGetDiagnostic:
+    def test_range_get_diagnostic_structure(self):
+        """range_get_throughput_diag returns correct structure and values."""
+        from stream_of_worship.admin.services.r2_backup import range_get_throughput_diag
+        import threading
+
+        r2 = MagicMock()
+        r2.bucket = "test-bucket"
+
+        # Simulate a 40 MB object
+        content_length = 40 * 1024 * 1024
+        r2._client.head_object.return_value = {"ContentLength": content_length}
+
+        # Each range read returns exactly range_size bytes
+        def _get_object(**kwargs):
+            range_header = kwargs.get("Range", "")
+            import re
+            m = re.match(r"bytes=(\d+)-(\d+)", range_header)
+            assert m is not None
+            start = int(m.group(1))
+            end = int(m.group(2))
+            size = end - start + 1
+            return {"Body": io.BytesIO(b"x" * size)}
+
+        r2._client.get_object.side_effect = _get_object
+
+        # Thread-safe mock for time.monotonic that increments by 1.0 each call.
+        # We pre-compute a sequence of values and use an index with a lock.
+        mono_values = [
+            0.0,   # single start
+            1.0,   # single end
+            1.0,   # multi outer start
+            1.0, 2.0,  # range 0 start/end
+            1.0, 2.0,  # range 1 start/end
+            1.0, 2.0,  # range 2 start/end
+            1.0, 2.0,  # range 3 start/end
+            2.0,   # multi outer end
+        ]
+        mono_idx = [0]
+        mono_lock = threading.Lock()
+
+        def _mock_monotonic():
+            with mono_lock:
+                i = mono_idx[0]
+                mono_idx[0] = i + 1
+                return mono_values[i]
+
+        with patch("time.monotonic", side_effect=_mock_monotonic):
+            result = range_get_throughput_diag(r2, "test/key", num_ranges=4)
+
+        assert result["content_length"] == content_length
+        assert result["num_ranges"] == 4
+        # Single connection: 10 MB in 1s = 10 MB/s
+        assert result["single_conn_mbps"] == pytest.approx(10.0, rel=0.01)
+        # Multi connection: 40 MB in 1s = 40 MB/s
+        assert result["multi_conn_total_mbps"] == pytest.approx(40.0, rel=0.01)
+        # Ratio should be ~4.0
+        assert result["ratio"] == pytest.approx(4.0, rel=0.01)
+        assert len(result["per_range_mbps"]) == 4
+        for m in result["per_range_mbps"]:
+            assert m == pytest.approx(10.0, rel=0.01)

--- a/tests/admin/test_r2_backup.py
+++ b/tests/admin/test_r2_backup.py
@@ -16,6 +16,7 @@ from stream_of_worship.admin.services.r2_backup import (
     MIN_CHUNK_SIZE_BYTES,
     BackupError,
     BackupProgress,
+    BackupTracer,
     HashingReader,
     Inventory,
     InventoryObject,
@@ -1413,3 +1414,227 @@ class TestRestoreFromArchive:
         assert result.uploaded == 1
         assert result.failed == 1
         assert len(result.failures) == 1
+
+
+# ---------------------------------------------------------------------------
+# BackupTracer tests
+# ---------------------------------------------------------------------------
+
+
+class TestBackupTracer:
+    def test_disabled_when_logger_below_debug(self):
+        """Tracer is no-op when logger is not at DEBUG level."""
+        import logging
+
+        log = logging.getLogger("test_disabled_tracer")
+        log.setLevel(logging.INFO)
+        tracer = BackupTracer(logger=log)
+        # All methods should be no-ops and not raise
+        tracer.phase_start("x")
+        tracer.phase_end("x")
+        tracer.object_download_trace(
+            key="k",
+            worker="t1",
+            attempt=0,
+            conn_ms=1.0,
+            stream_ms=2.0,
+            bytes_read=10,
+            retries=0,
+        )
+        tracer.tar_write_trace(
+            idx=0, key="k", wait_ms=1.0, tar_write_ms=2.0, bytes_written=10
+        )
+        tracer.bytes_downloaded_sample(100, 1)
+        tracer.finalize(total_objects=1, total_bytes=10)
+        # No assert needed; absence of error proves no-op
+
+    def test_phase_start_end_emits_debug(self, caplog):
+        import logging
+
+        with caplog.at_level(
+            logging.DEBUG, logger="stream_of_worship.admin.services.r2_backup"
+        ):
+            tracer = BackupTracer()
+            tracer.phase_start("phase_x")
+            tracer.phase_end("phase_x", foo="bar")
+        assert any("phase_end name=phase_x" in r.message for r in caplog.records)
+        assert any("foo=bar" in r.message for r in caplog.records)
+
+    def test_object_download_trace_updates_accumulators(self, caplog):
+        import logging
+
+        with caplog.at_level(
+            logging.DEBUG, logger="stream_of_worship.admin.services.r2_backup"
+        ):
+            tracer = BackupTracer()
+            tracer.object_download_trace(
+                key="a",
+                worker="t1",
+                attempt=0,
+                conn_ms=10.0,
+                stream_ms=100.0,
+                bytes_read=1024 * 1024,
+                retries=0,
+            )
+        assert any("object_download key=a" in r.message for r in caplog.records)
+        assert tracer._bytes_downloaded == 1024 * 1024
+        assert tracer._sum_download_ms == 100.0
+        assert tracer._sum_conn_ms == 10.0
+        assert tracer._max_object_download_ms == 110.0
+        assert tracer._max_object_download_key == "a"
+
+    def test_tar_write_trace_updates_accumulators(self, caplog):
+        import logging
+
+        with caplog.at_level(
+            logging.DEBUG, logger="stream_of_worship.admin.services.r2_backup"
+        ):
+            tracer = BackupTracer()
+            tracer.tar_write_trace(
+                idx=0, key="a", wait_ms=50.0, tar_write_ms=30.0, bytes_written=1024 * 1024
+            )
+            tracer.tar_write_trace(
+                idx=1, key="b", wait_ms=10.0, tar_write_ms=20.0, bytes_written=1024 * 1024
+            )
+        assert tracer._sum_wait_ms == 60.0
+        assert tracer._sum_tar_write_ms == 50.0
+        assert tracer._bytes_written == 2 * 1024 * 1024
+        assert tracer._object_count_written == 2
+        assert any("wait_is_bottleneck=yes" in r.message for r in caplog.records)  # 50 > 30
+        assert any("wait_is_bottleneck=no" in r.message for r in caplog.records)  # 10 < 20
+
+    def test_bytes_downloaded_sample_throttles_logs(self, caplog):
+        """Throughput log emitted at most once per THROUGHPUT_SAMPLE_INTERVAL."""
+        import logging
+
+        with caplog.at_level(
+            logging.DEBUG, logger="stream_of_worship.admin.services.r2_backup"
+        ):
+            tracer = BackupTracer()
+            tracer._run_start = 0.0  # enable t+ logging
+            for i in range(5):
+                tracer.bytes_downloaded_sample(i * 1024 * 1024, 8)
+            # All 5 calls recorded as samples
+            assert len(tracer._throughput_samples) == 5
+            assert tracer._peak_workers == 8
+            # At most 1 throughput_sample log line within the 5s window
+            sample_logs = [r for r in caplog.records if "throughput_sample" in r.message]
+            assert len(sample_logs) <= 1
+
+    def test_finalize_emits_summary_with_network_saturation_field(self, caplog):
+        import logging
+
+        with caplog.at_level(
+            logging.DEBUG, logger="stream_of_worship.admin.services.r2_backup"
+        ):
+            tracer = BackupTracer()
+            tracer._run_start = 0.0
+            tracer.bytes_downloaded_sample(0, 4)
+            # Simulate wall-clock passage
+            import time as _t
+
+            new_t = _t.time() + 60  # 60s later in real time
+            tracer._throughput_samples.append((new_t, 100 * 1024 * 1024, 4))
+            tracer._last_throughput_log = 0  # allow next log
+            tracer._bytes_downloaded = 100 * 1024 * 1024
+            tracer._sum_download_ms = 60_000.0  # 1 worker × 60s
+            tracer._peak_workers = 4
+            tracer.finalize(total_objects=100, total_bytes=100 * 1024 * 1024)
+        summary_logs = [r for r in caplog.records if r.message.startswith("summary")]
+        assert len(summary_logs) == 1
+        msg = summary_logs[0].message
+        assert "aggregate_mbps" in msg
+        assert "single_worker_avg_mbps" in msg
+        assert "network_saturated" in msg
+        assert "peak_workers=4" in msg
+
+    def test_thread_safety(self):
+        """Concurrent calls to BackupTracer methods do not corrupt accumulators."""
+        import logging
+        import threading
+
+        log = logging.getLogger("test_tracer_thread_safety")
+        log.setLevel(logging.DEBUG)
+        tracer = BackupTracer(logger=log)
+        barrier = threading.Barrier(8)
+
+        def worker():
+            barrier.wait()
+            for i in range(100):
+                tracer.object_download_trace(
+                    key=f"k{i}",
+                    worker="w",
+                    attempt=0,
+                    conn_ms=1.0,
+                    stream_ms=1.0,
+                    bytes_read=100,
+                    retries=0,
+                )
+                tracer.bytes_downloaded_sample(i * 100, 8)
+
+        threads = [threading.Thread(target=worker) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert tracer._object_count_downloaded == 800
+        assert tracer._bytes_downloaded == 80000
+
+
+class TestWriteBackupTracerIntegration:
+    """Verify write_backup plumbs tracer through and emits expected traces."""
+
+    def test_debug_traces_emits_object_and_tar_traces(self, tmp_path, caplog):
+        import logging
+
+        objects = [
+            {"key": "a/file1", "size": 100, "etag": "etag1", "data": b"x" * 100},
+            {"key": "a/file2", "size": 200, "etag": "etag2", "data": b"y" * 200},
+        ]
+        r2 = _make_r2_mock(objects)
+        inventory = build_inventory(r2)
+        output = tmp_path / "backup"
+
+        with caplog.at_level(
+            logging.DEBUG, logger="stream_of_worship.admin.services.r2_backup"
+        ):
+            tracer = BackupTracer()
+            result = write_backup(
+                r2,
+                output,
+                inventory,
+                tracer=tracer,
+            )
+
+        assert result.object_count == 2
+
+        # At least one object_download and one tar_write log per object
+        download_logs = [r for r in caplog.records if "object_download" in r.message]
+        tar_logs = [r for r in caplog.records if "tar_write" in r.message]
+        phase_logs = [r for r in caplog.records if "phase_end" in r.message]
+        summary_logs = [r for r in caplog.records if r.message.startswith("summary")]
+        assert len(download_logs) >= 2
+        assert len(tar_logs) >= 2
+        assert any("phase_end name=download_phase" in r.message for r in phase_logs)
+        assert any("phase_end name=total" in r.message for r in phase_logs)
+        assert len(summary_logs) == 1
+
+    def test_write_backup_without_tracer_no_logs(self, tmp_path, caplog):
+        """Default (tracer=None) emits no backup DEBUG logs."""
+        import logging
+
+        objects = [
+            {"key": "a/file1", "size": 100, "etag": "etag1", "data": b"x" * 100},
+        ]
+        r2 = _make_r2_mock(objects)
+        inventory = build_inventory(r2)
+        output = tmp_path / "backup"
+
+        with caplog.at_level(
+            logging.DEBUG, logger="stream_of_worship.admin.services.r2_backup"
+        ):
+            result = write_backup(r2, output, inventory)
+        assert result.object_count == 1
+        assert not [r for r in caplog.records if "object_download" in r.message]
+        assert not [r for r in caplog.records if "tar_write" in r.message]
+        assert not [r for r in caplog.records if "summary" in r.message]

--- a/tests/admin/test_r2_backup.py
+++ b/tests/admin/test_r2_backup.py
@@ -27,6 +27,9 @@ from stream_of_worship.admin.services.r2_backup import (
     restore_from_archive,
     verify_archive,
     write_backup,
+    DEFAULT_CONCURRENCY,
+    COPY_BUFFER_SIZE,
+    SPOT_CHECK_HEAD_RATIO,
 )
 
 
@@ -162,7 +165,7 @@ class TestBuildInventory:
 
 class TestManifestStructure:
     def test_manifest_version_constant(self):
-        assert MANIFEST_VERSION == 3
+        assert MANIFEST_VERSION == 4
 
     def test_default_chunk_size(self):
         assert DEFAULT_CHUNK_SIZE_BYTES == 10 * 1024**3
@@ -192,10 +195,17 @@ def _make_r2_mock(objects: list[dict], head_data: dict | None = None) -> MagicMo
     r2.endpoint_url = "https://test.r2.cloudflarestorage.com"
     r2.region = "auto"
 
-    obj_list = [
-        {"key": o["key"], "size": o["size"], "etag": o["etag"], "last_modified": o.get("last_modified", "")}
-        for o in objects
-    ]
+    obj_list = []
+    for o in objects:
+        etag = o.get("etag")
+        if etag is None or "-" not in etag:
+            etag = hashlib.md5(o["data"]).hexdigest()
+        obj_list.append({
+            "key": o["key"],
+            "size": o["size"],
+            "etag": etag,
+            "last_modified": o.get("last_modified", ""),
+        })
     r2.iter_objects.return_value = iter(obj_list)
 
     obj_map = {o["key"]: o for o in objects}
@@ -203,10 +213,13 @@ def _make_r2_mock(objects: list[dict], head_data: dict | None = None) -> MagicMo
     def _get_object_stream(key):
         o = obj_map[key]
         body = io.BytesIO(o["data"])
+        etag = o.get("etag")
+        if etag is None or "-" not in etag:
+            etag = hashlib.md5(o["data"]).hexdigest()
         return {
             "body": body,
             "content_length": len(o["data"]),
-            "etag": o["etag"],
+            "etag": etag,
             "last_modified": o.get("last_modified", ""),
             "content_type": o.get("content_type"),
             "cache_control": o.get("cache_control"),
@@ -223,9 +236,12 @@ def _make_r2_mock(objects: list[dict], head_data: dict | None = None) -> MagicMo
         o = obj_map.get(key)
         if o is None:
             return None
+        etag = o.get("etag")
+        if etag is None or "-" not in etag:
+            etag = hashlib.md5(o["data"]).hexdigest()
         return {
             "size": len(o["data"]),
-            "etag": o["etag"],
+            "etag": etag,
             "last_modified": o.get("last_modified", ""),
             "content_type": o.get("content_type"),
             "cache_control": o.get("cache_control"),
@@ -259,7 +275,7 @@ class TestWriteBackup:
         assert (output / "chunk-000000.tar").exists()
 
         manifest = json.loads((output / "manifest.json").read_text())
-        assert manifest["version"] == 3
+        assert manifest["version"] == 4
         assert manifest["object_count"] == 2
         assert manifest["total_bytes"] == 16
         assert manifest["chunk_count"] == 1
@@ -359,7 +375,7 @@ class TestWriteBackup:
             return {
                 "body": io.BytesIO(b"short"),
                 "content_length": 100,
-                "etag": "etag1",
+                "etag": "etag1-with-dash-suffix",
                 "last_modified": "",
                 "content_type": None,
                 "cache_control": None,
@@ -369,16 +385,6 @@ class TestWriteBackup:
             }
 
         r2.get_object_stream.side_effect = _get_object_stream
-        r2.head_object.return_value = {
-            "size": 100,
-            "etag": "etag1",
-            "last_modified": "",
-            "content_type": None,
-            "cache_control": None,
-            "content_disposition": None,
-            "content_encoding": None,
-            "metadata": {},
-        }
 
         inventory = build_inventory(r2)
         output = tmp_path / "backup"
@@ -394,29 +400,23 @@ class TestWriteBackup:
     def test_backup_changed_object_retries_and_succeeds(self, tmp_path):
         """Object that changes on first attempt succeeds on retry."""
         data = b"hello world"
-        objects = [{"key": "a/file", "size": 11, "etag": "etag1", "data": data}]
+        etag = hashlib.md5(data).hexdigest()
+        objects = [{"key": "a/file", "size": 11, "etag": etag, "data": data}]
         r2 = _make_r2_mock(objects)
 
-        # First head returns different etag, second returns matching
+        # First GET returns different etag, second returns matching
         call_count = [0]
-        original_head = r2.head_object.side_effect
+        original_get = r2.get_object_stream.side_effect
 
-        def _flaky_head(key):
+        def _flaky_get(key):
             call_count[0] += 1
             if call_count[0] == 1:
-                return {
-                    "size": 11,
-                    "etag": "changed_etag",
-                    "last_modified": "",
-                    "content_type": None,
-                    "cache_control": None,
-                    "content_disposition": None,
-                    "content_encoding": None,
-                    "metadata": {},
-                }
-            return original_head(key)
+                resp = original_get(key)
+                resp["etag"] = "changed_etag"
+                return resp
+            return original_get(key)
 
-        r2.head_object.side_effect = _flaky_head
+        r2.get_object_stream.side_effect = _flaky_get
 
         inventory = build_inventory(r2)
         output = tmp_path / "backup"
@@ -428,20 +428,19 @@ class TestWriteBackup:
     def test_backup_changed_object_exceeds_retries_fails(self, tmp_path):
         """Object that keeps changing fails after retry budget."""
         data = b"hello world"
-        objects = [{"key": "a/file", "size": 11, "etag": "etag1", "data": data}]
+        etag = hashlib.md5(data).hexdigest()
+        objects = [{"key": "a/file", "size": 11, "etag": etag, "data": data}]
         r2 = _make_r2_mock(objects)
 
-        # head always returns different etag
-        r2.head_object.side_effect = lambda key: {
-            "size": 11,
-            "etag": "always_different",
-            "last_modified": "",
-            "content_type": None,
-            "cache_control": None,
-            "content_disposition": None,
-            "content_encoding": None,
-            "metadata": {},
-        }
+        # GET always returns different etag
+        original_get = r2.get_object_stream.side_effect
+
+        def _always_different_get(key):
+            resp = original_get(key)
+            resp["etag"] = "always_different"
+            return resp
+
+        r2.get_object_stream.side_effect = _always_different_get
 
         inventory = build_inventory(r2)
         output = tmp_path / "backup"
@@ -454,17 +453,25 @@ class TestWriteBackup:
     def test_backup_deleted_object_during_backup_fails(self, tmp_path):
         """Object that disappears during backup fails and cleans up."""
         data = b"hello world"
-        objects = [{"key": "a/file", "size": 11, "etag": "etag1", "data": data}]
+        etag = hashlib.md5(data).hexdigest()
+        objects = [{"key": "a/file", "size": 11, "etag": etag, "data": data}]
         r2 = _make_r2_mock(objects)
 
-        # head returns None (object deleted) - need to reset side_effect
-        r2.head_object.side_effect = None
-        r2.head_object.return_value = None
+        # GET raises ClientError 404 (object deleted)
+        from botocore.exceptions import ClientError
+
+        def _not_found_get(key):
+            raise ClientError(
+                {"Error": {"Code": "404", "Message": "Not Found"}},
+                "GetObject",
+            )
+
+        r2.get_object_stream.side_effect = _not_found_get
 
         inventory = build_inventory(r2)
         output = tmp_path / "backup"
 
-        with pytest.raises(BackupError, match="disappeared"):
+        with pytest.raises(BackupError, match="Failed to backup"):
             write_backup(r2, output, inventory)
 
         assert not output.exists()
@@ -543,6 +550,244 @@ class TestWriteBackupProgress:
         assert calls[1] == (2, 300)
         assert result.object_count == 2
         assert result.total_bytes == 300
+
+
+class TestConcurrentBackup:
+    def test_concurrent_backup_produces_valid_archive(self, tmp_path):
+        """Concurrent download with default concurrency produces valid backup."""
+        objects = [
+            {"key": f"obj{i}/file", "size": 100, "etag": f"etag{i}", "data": bytes([i]) * 100}
+            for i in range(20)
+        ]
+        r2 = _make_r2_mock(objects)
+        inventory = build_inventory(r2)
+        output = tmp_path / "backup"
+
+        result = write_backup(r2, output, inventory)
+
+        assert result.object_count == 20
+        assert result.total_bytes == 2000
+        assert (output / "manifest.json").exists()
+        assert (output / "chunk-000000.tar").exists()
+
+        manifest = json.loads((output / "manifest.json").read_text())
+        assert manifest["version"] == 4
+        assert manifest["consistency"]["mode"] == "initial-inventory-with-get-etag-check"
+        assert manifest["consistency"]["md5_body_check"] is True
+
+        for i, obj in enumerate(manifest["objects"]):
+            expected_hash = hashlib.sha256(bytes([i]) * 100).hexdigest()
+            assert obj["sha256"] == expected_hash
+
+    def test_concurrency_1_works(self, tmp_path):
+        """concurrency=1 falls back to sequential (no thread pool issues)."""
+        objects = [
+            {"key": "a/file", "size": 5, "etag": "etag1", "data": b"hello"},
+            {"key": "b/file", "size": 5, "etag": "etag2", "data": b"world"},
+        ]
+        r2 = _make_r2_mock(objects)
+        inventory = build_inventory(r2)
+        output = tmp_path / "backup"
+
+        result = write_backup(r2, output, inventory, concurrency=1)
+
+        assert result.object_count == 2
+        assert output.exists()
+
+    def test_concurrent_backup_preserves_object_order(self, tmp_path):
+        """Manifest objects are in inventory order regardless of download completion order."""
+        objects = [
+            {"key": f"obj{i}/file", "size": 10, "etag": f"etag{i}", "data": bytes([i]) * 10}
+            for i in range(10)
+        ]
+        r2 = _make_r2_mock(objects)
+        inventory = build_inventory(r2)
+        output = tmp_path / "backup"
+
+        result = write_backup(r2, output, inventory, concurrency=4)
+
+        manifest = json.loads((output / "manifest.json").read_text())
+        for i, obj in enumerate(manifest["objects"]):
+            assert obj["key"] == f"obj{i}/file"
+
+    def test_concurrent_backup_cleans_up_temp_files(self, tmp_path):
+        """No temp files remain after successful backup."""
+        objects = [
+            {"key": f"obj{i}/file", "size": 100, "etag": f"etag{i}", "data": b"x" * 100}
+            for i in range(5)
+        ]
+        r2 = _make_r2_mock(objects)
+        inventory = build_inventory(r2)
+        output = tmp_path / "backup"
+
+        write_backup(r2, output, inventory)
+
+        temp_dir = output.with_suffix(output.suffix + ".part")
+        assert not temp_dir.exists()
+        assert not (output / "tmp").exists()
+
+    def test_concurrent_backup_cleans_up_temp_files_on_failure(self, tmp_path):
+        """Temp files are cleaned up when backup fails mid-way."""
+        data1 = b"hello"
+        data2 = b"world"
+        etag1 = hashlib.md5(data1).hexdigest()
+        etag2 = hashlib.md5(data2).hexdigest()
+        objects = [
+            {"key": "a/file", "size": 5, "etag": etag1, "data": data1},
+            {"key": "b/file", "size": 5, "etag": etag2, "data": data2},
+        ]
+        r2 = _make_r2_mock(objects)
+
+        # Make the second object fail with a different etag
+        original_get = r2.get_object_stream.side_effect
+
+        def _flaky_get(key):
+            if key == "b/file":
+                resp = original_get(key)
+                resp["etag"] = "wrong"
+                return resp
+            return original_get(key)
+
+        r2.get_object_stream.side_effect = _flaky_get
+
+        inventory = build_inventory(r2)
+        output = tmp_path / "backup"
+
+        with pytest.raises(BackupError):
+            write_backup(r2, output, inventory)
+
+        assert not output.exists()
+        partial = output.with_suffix(output.suffix + ".part")
+        assert not partial.exists()
+
+    def test_concurrent_backup_failure_cancels_remaining(self, tmp_path):
+        """On failure, remaining futures are cancelled and partial dir cleaned up."""
+        r2 = MagicMock()
+        r2.bucket = "test-bucket"
+        r2.endpoint_url = "https://test.r2.cloudflarestorage.com"
+        r2.region = "auto"
+        r2.iter_objects.return_value = iter([
+            {"key": "a/file", "size": 100, "etag": "etag1", "last_modified": ""},
+            {"key": "b/file", "size": 100, "etag": "etag2", "last_modified": ""},
+        ])
+        r2.get_object_stream.side_effect = RuntimeError("connection failed")
+
+        inventory = build_inventory(r2)
+        output = tmp_path / "backup"
+
+        with pytest.raises(RuntimeError):
+            write_backup(r2, output, inventory)
+
+        assert not output.exists()
+        partial = output.with_suffix(output.suffix + ".part")
+        assert not partial.exists()
+
+    def test_md5_body_check_catches_corruption(self, tmp_path):
+        """Single-part object with corrupted body fails with MD5 mismatch."""
+        data = b"hello world"
+        etag = hashlib.md5(data).hexdigest()
+        objects = [{"key": "a/file", "size": 11, "etag": etag, "data": data}]
+        r2 = _make_r2_mock(objects)
+
+        # Corrupt the body but keep the correct etag
+        original_get = r2.get_object_stream.side_effect
+
+        def _corrupted_get(key):
+            resp = original_get(key)
+            resp["body"] = io.BytesIO(b"corrupted!")
+            return resp
+
+        r2.get_object_stream.side_effect = _corrupted_get
+
+        inventory = build_inventory(r2)
+        output = tmp_path / "backup"
+
+        with pytest.raises(BackupError, match="Short read|Size mismatch|MD5 mismatch"):
+            write_backup(r2, output, inventory)
+
+        assert not output.exists()
+
+    def test_spot_check_head_warns_on_drift(self, tmp_path):
+        """Spot-check HEAD logs warning when object changed after backup."""
+        data = b"hello"
+        etag = hashlib.md5(data).hexdigest()
+        objects = [{"key": "a/file", "size": 5, "etag": etag, "data": data}]
+        r2 = _make_r2_mock(objects)
+
+        # head_object returns different etag (drift detected)
+        r2.head_object.side_effect = lambda key: {
+            "size": 5,
+            "etag": "different_etag",
+            "last_modified": "",
+            "content_type": None,
+            "cache_control": None,
+            "content_disposition": None,
+            "content_encoding": None,
+            "metadata": {},
+        }
+
+        inventory = build_inventory(r2)
+        output = tmp_path / "backup"
+
+        result = write_backup(r2, output, inventory)
+
+        assert result.object_count == 1
+        assert output.exists()
+
+    def test_manifest_version_4(self, tmp_path):
+        """Backup produces manifest version 4."""
+        objects = [{"key": "a/file", "size": 5, "etag": "etag1", "data": b"hello"}]
+        r2 = _make_r2_mock(objects)
+        inventory = build_inventory(r2)
+        output = tmp_path / "backup"
+
+        write_backup(r2, output, inventory)
+
+        manifest = json.loads((output / "manifest.json").read_text())
+        assert manifest["version"] == 4
+        assert manifest["consistency"]["mode"] == "initial-inventory-with-get-etag-check"
+        assert manifest["consistency"]["md5_body_check"] is True
+        assert manifest["consistency"]["spot_check_head_ratio"] == SPOT_CHECK_HEAD_RATIO
+
+    def test_get_last_modified_in_metadata(self, tmp_path):
+        """Manifest stores GET response last_modified in metadata."""
+        data = b"hello"
+        objects = [
+            {
+                "key": "a/file",
+                "size": 5,
+                "etag": "etag1",
+                "data": data,
+                "last_modified": "2024-01-15T10:30:00+00:00",
+            }
+        ]
+        r2 = _make_r2_mock(objects)
+        inventory = build_inventory(r2)
+        output = tmp_path / "backup"
+
+        write_backup(r2, output, inventory)
+
+        manifest = json.loads((output / "manifest.json").read_text())
+        obj = manifest["objects"][0]
+        assert obj["last_modified"] == "2024-01-15T10:30:00+00:00"
+
+    def test_concurrency_validation_rejects_zero(self, tmp_path):
+        """write_backup raises BackupError for concurrency=0."""
+        r2 = _make_r2_mock([])
+        inventory = build_inventory(r2)
+        output = tmp_path / "backup"
+
+        with pytest.raises(BackupError, match="concurrency must be 1-64"):
+            write_backup(r2, output, inventory, concurrency=0)
+
+    def test_concurrency_validation_rejects_65(self, tmp_path):
+        """write_backup raises BackupError for concurrency=65."""
+        r2 = _make_r2_mock([])
+        inventory = build_inventory(r2)
+        output = tmp_path / "backup"
+
+        with pytest.raises(BackupError, match="concurrency must be 1-64"):
+            write_backup(r2, output, inventory, concurrency=65)
 
 
 # ---------------------------------------------------------------------------
@@ -746,7 +991,7 @@ class TestVerifyArchive:
 class TestPlanRestore:
     def _make_manifest(self, objects: list[dict]) -> dict:
         return {
-            "version": 3,
+            "version": 4,
             "objects": objects,
         }
 

--- a/tests/admin/test_r2_backup_commands.py
+++ b/tests/admin/test_r2_backup_commands.py
@@ -1,5 +1,6 @@
 """Command-level tests for R2 backup/restore maintenance commands."""
 
+import hashlib
 import io
 import json
 from datetime import datetime
@@ -29,10 +30,17 @@ def _make_r2_mock(objects: list[dict] | None = None) -> MagicMock:
     r2.endpoint_url = "https://test.r2.cloudflarestorage.com"
     r2.region = "auto"
 
-    obj_list = [
-        {"key": o["key"], "size": o["size"], "etag": o["etag"], "last_modified": o.get("last_modified", "")}
-        for o in objects
-    ]
+    obj_list = []
+    for o in objects:
+        etag = o.get("etag")
+        if etag is None or "-" not in etag:
+            etag = hashlib.md5(o["data"]).hexdigest()
+        obj_list.append({
+            "key": o["key"],
+            "size": o["size"],
+            "etag": etag,
+            "last_modified": o.get("last_modified", ""),
+        })
     r2.iter_objects.return_value = iter(obj_list)
 
     obj_map = {o["key"]: o for o in objects}
@@ -40,10 +48,13 @@ def _make_r2_mock(objects: list[dict] | None = None) -> MagicMock:
     def _get_object_stream(key):
         o = obj_map[key]
         body = io.BytesIO(o["data"])
+        etag = o.get("etag")
+        if etag is None or "-" not in etag:
+            etag = hashlib.md5(o["data"]).hexdigest()
         return {
             "body": body,
             "content_length": len(o["data"]),
-            "etag": o["etag"],
+            "etag": etag,
             "last_modified": o.get("last_modified", ""),
             "content_type": o.get("content_type"),
             "cache_control": o.get("cache_control"),
@@ -58,9 +69,12 @@ def _make_r2_mock(objects: list[dict] | None = None) -> MagicMock:
         o = obj_map.get(key)
         if o is None:
             return None
+        etag = o.get("etag")
+        if etag is None or "-" not in etag:
+            etag = hashlib.md5(o["data"]).hexdigest()
         return {
             "size": len(o["data"]),
-            "etag": o["etag"],
+            "etag": etag,
             "last_modified": o.get("last_modified", ""),
             "content_type": o.get("content_type"),
             "cache_control": o.get("cache_control"),
@@ -200,6 +214,30 @@ class TestBackupR2Command:
         assert data["output_dir"] == str(output)
         # total_bytes no longer present in JSON output
         assert "total_bytes" not in data
+
+    def test_backup_concurrency_flag(self, tmp_path):
+        """backup-r2 --concurrency 4 passes concurrency to write_backup."""
+        objects = [
+            {"key": "a/file", "size": 5, "etag": "etag1", "data": b"hello"},
+        ]
+        r2 = _make_r2_mock(objects)
+        config = AdminConfig(database_url="postgresql://example", r2_endpoint_url="https://r2.example.com")
+        output = tmp_path / "backup"
+
+        with (
+            patch("stream_of_worship.admin.commands.maintenance.AdminConfig.load", return_value=config),
+            patch("stream_of_worship.admin.commands.maintenance.get_db_client", return_value=MagicMock()),
+            patch("stream_of_worship.admin.commands.maintenance.R2Client", return_value=r2),
+            patch("stream_of_worship.admin.commands.maintenance.write_backup", wraps=write_backup) as mock_write,
+        ):
+            result = runner.invoke(
+                app,
+                ["maintenance", "backup-r2", "--output", str(output), "--concurrency", "4"],
+            )
+
+        assert result.exit_code == 0
+        mock_write.assert_called_once()
+        assert mock_write.call_args.kwargs["concurrency"] == 4
 
 
 class TestVerifyR2BackupCommand:

--- a/tests/admin/test_r2_backup_commands.py
+++ b/tests/admin/test_r2_backup_commands.py
@@ -3,18 +3,14 @@
 import hashlib
 import io
 import json
-from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
 from typer.testing import CliRunner
 
-from stream_of_worship.admin.commands.maintenance import _bytes_to_mb, _format_datetime
 from stream_of_worship.admin.config import AdminConfig
 from stream_of_worship.admin.main import app
 from stream_of_worship.admin.services.r2_backup import (
-    MANIFEST_VERSION,
     build_inventory,
     write_backup,
 )
@@ -642,3 +638,51 @@ def test_backup_r2_default_no_tracer_passes_none(monkeypatch, tmp_path):
     )
     assert result.exit_code == 0, result.output
     assert captured["tracer"] is None
+
+
+def test_backup_r2_diag_range_key_flag(monkeypatch, tmp_path):
+    """--diag-range-key short-circuits write_backup and prints JSON diag result."""
+    captured = {}
+
+    def _fake_range_get_diag(r2_client, s3_key):
+        captured["diag_key"] = s3_key
+        return {
+            "content_length": 45854636,
+            "num_ranges": 4,
+            "single_conn_mbps": 0.95,
+            "multi_conn_total_mbps": 3.72,
+            "ratio": 3.91,
+            "per_range_mbps": [0.92, 0.95, 0.91, 0.94],
+        }
+
+    # Patch at the source module where the import resolves
+    monkeypatch.setattr(
+        "stream_of_worship.admin.services.r2_backup.range_get_throughput_diag",
+        _fake_range_get_diag,
+    )
+    monkeypatch.setattr(
+        "stream_of_worship.admin.commands.maintenance._load_clients",
+        lambda config_path: (_make_fake_config(), None),
+    )
+    monkeypatch.setattr(
+        "stream_of_worship.admin.commands.maintenance._load_r2",
+        lambda config: _make_fake_r2(),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "maintenance",
+            "backup-r2",
+            "--output",
+            str(tmp_path / "out"),
+            "--diag-range-key",
+            "02fa022169b7/stems/bass.wav",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["diag_key"] == "02fa022169b7/stems/bass.wav"
+    data = json.loads(result.stdout)
+    assert data["ratio"] == 3.91
+    assert data["num_ranges"] == 4

--- a/tests/admin/test_r2_backup_commands.py
+++ b/tests/admin/test_r2_backup_commands.py
@@ -489,3 +489,156 @@ class TestRestoreR2Command:
         data = json.loads(result.output[json_start:])
         assert len(data["plan"]) == 1
         assert data["plan"][0]["key"] == "prefix_a/file"
+
+
+def _make_minimal_inventory():
+    """Create a minimal inventory for mocking build_inventory."""
+    from stream_of_worship.admin.services.r2_backup import Inventory, InventoryObject
+
+    return Inventory(
+        objects=[
+            InventoryObject(key="test/file", size=5, etag="etag1", last_modified="")
+        ],
+        started_at="2024-01-01T00:00:00",
+        completed_at="2024-01-01T00:00:01",
+    )
+
+
+def _make_fake_config():
+    """Create a fake AdminConfig for mocking."""
+    from stream_of_worship.admin.config import AdminConfig
+
+    return AdminConfig(
+        database_url="postgresql://example",
+        r2_endpoint_url="https://r2.example.com",
+        r2_bucket="test-bucket",
+        r2_region="auto",
+    )
+
+
+def _make_fake_r2():
+    """Create a fake R2Client for mocking."""
+    from unittest.mock import MagicMock
+
+    r2 = MagicMock()
+    r2.bucket = "test-bucket"
+    r2.endpoint_url = "https://r2.example.com"
+    r2.region = "auto"
+    return r2
+
+
+def test_backup_r2_debug_traces_flag_passes_tracer(monkeypatch, tmp_path):
+    """--debug-traces constructs a BackupTracer and passes it to write_backup."""
+    from stream_of_worship.admin.services.r2_backup import BackupResult
+
+    captured = {}
+
+    def _fake_write_backup(
+        *,
+        r2_client,
+        output_dir,
+        inventory,
+        chunk_size_bytes,
+        concurrency,
+        on_progress,
+        tracer,
+    ):
+        captured["tracer"] = tracer
+        captured["concurrency"] = concurrency
+        return BackupResult(
+            output_dir=output_dir,
+            object_count=0,
+            total_bytes=0,
+            chunk_count=0,
+            manifest={"version": 4, "objects": []},
+        )
+
+    monkeypatch.setattr(
+        "stream_of_worship.admin.commands.maintenance.write_backup",
+        _fake_write_backup,
+    )
+    # Also mock build_inventory to avoid R2 calls
+    monkeypatch.setattr(
+        "stream_of_worship.admin.commands.maintenance.build_inventory",
+        lambda r2_client: _make_minimal_inventory(),
+    )
+    # Mock config + R2 client load
+    monkeypatch.setattr(
+        "stream_of_worship.admin.commands.maintenance._load_clients",
+        lambda config_path: (_make_fake_config(), None),
+    )
+    monkeypatch.setattr(
+        "stream_of_worship.admin.commands.maintenance._load_r2",
+        lambda config: _make_fake_r2(),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "maintenance",
+            "backup-r2",
+            "--output",
+            str(tmp_path / "out"),
+            "--debug-traces",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["tracer"] is not None
+    assert captured["tracer"].__class__.__name__ == "BackupTracer"
+
+
+def test_backup_r2_default_no_tracer_passes_none(monkeypatch, tmp_path):
+    """Without --debug-traces, tracer is None."""
+    from stream_of_worship.admin.services.r2_backup import BackupResult
+
+    captured = {}
+
+    def _fake_write_backup(
+        *,
+        r2_client,
+        output_dir,
+        inventory,
+        chunk_size_bytes,
+        concurrency,
+        on_progress,
+        tracer,
+    ):
+        captured["tracer"] = tracer
+        return BackupResult(
+            output_dir=output_dir,
+            object_count=0,
+            total_bytes=0,
+            chunk_count=0,
+            manifest={"version": 4, "objects": []},
+        )
+
+    monkeypatch.setattr(
+        "stream_of_worship.admin.commands.maintenance.write_backup",
+        _fake_write_backup,
+    )
+    monkeypatch.setattr(
+        "stream_of_worship.admin.commands.maintenance.build_inventory",
+        lambda r2_client: _make_minimal_inventory(),
+    )
+    monkeypatch.setattr(
+        "stream_of_worship.admin.commands.maintenance._load_clients",
+        lambda config_path: (_make_fake_config(), None),
+    )
+    monkeypatch.setattr(
+        "stream_of_worship.admin.commands.maintenance._load_r2",
+        lambda config: _make_fake_r2(),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "maintenance",
+            "backup-r2",
+            "--output",
+            str(tmp_path / "out"),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["tracer"] is None


### PR DESCRIPTION
feat(admin): Concurrent R2 backup downloads with GET-ETag consistency (v3) + Performance Tracing

## Summary

Speeds up the `sow-admin maintenance backup-r2` command by **5-8x** through four optimizations:

1. **Thread pool concurrent downloads** (dominant win: 5-8x network parallelism)
2. **Eliminate redundant post-download HEAD requests** (~1.5-2x for small objects)
3. **Larger `copyfileobj` buffer** (minor: ~1.1x for large objects)
4. **Increased boto3 connection pool** (supporting)

**Current performance:** ~30 minutes for 679 objects / 12,894 MB (~8 MB/s single connection).
**Target:** ~4-6 minutes with 8 concurrent workers.

## v3 + Performance Tracing Changes (This PR)

### Performance Tracing (New)

Adds `--debug-traces` flag to `backup-r2` command for diagnosing backup bottlenecks.

**Trace events:**
- `phase_start/phase_end`: inventory, disk_check, setup, download_phase, tar_close, spot_check, manifest_write, rename, total
- `object_download`: per-object download timing (conn_ms, stream_ms, bytes, retries)
- `tar_write`: per-object tar write timing (wait_ms, tar_write_ms, bytes)
- `throughput_sample`: aggregate throughput every 5 seconds
- `summary`: final aggregate stats with network saturation heuristic

**Usage:**
```bash
sow-admin maintenance backup-r2 --output /tmp/backup --debug-traces --format json 2>/tmp/trace.log

# Analyze the trace
grep -E '^(phase_end|object_download|tar_write|throughput_sample|summary)' /tmp/trace.log
```

**Diagnostic fields in summary:**
- `aggregate_mbps`: whole-run wall-clock throughput
- `single_worker_avg_mbps`: average per-worker throughput
- `wait_pct`: % of main thread time blocked on downloads (head-of-line blocking)
- `network_saturated`: "yes" if aggregate throughput < 50% of theoretical max with peak workers

### Change A: Streaming MD5 in `HashingReader` (`r2_backup.py`)

- Added MD5 hasher alongside SHA-256 in `HashingReader`
- New `on_read` callback invoked after each `read()` with chunk byte count
- New `md5_hex` property for streaming MD5 verification
- **Eliminates ~12.9 GB of extra disk reads** (one full re-read per object for MD5 check)

### Change B: New `BackupProgress` Class (`r2_backup.py`)

- Thread-safe progress tracker for concurrent backup downloads
- Tracks: `bytes_downloaded`, `objects_downloaded`, `active_workers`, `objects_written`, `bytes_written`
- Callback throttling: max ~10 calls/second via `min_report_interval=0.1`
- `on_progress` signature changed from `Callable[[int, int], None]` to `Callable[[BackupProgress], None]`

### Change C: Download-Aware Progress Tracking (`r2_backup.py`)

- `_download_object_to_tempfile()` now accepts optional `progress: BackupProgress` parameter
- `worker_started()` / `worker_finished()` bracket each download attempt
- `HashingReader` receives `on_read=progress.add_bytes` for per-chunk progress updates
- `write_backup()` creates `BackupProgress` and passes to workers
- Progress bar now tracks **bytes downloaded** (parallel across workers) instead of **bytes written to tar** (sequential)
- This fixes the "stuck progress bar" issue where slow head-of-queue downloads caused wild ETA fluctuations

### Change D: Updated Progress Bar (`maintenance.py`)

- Added `TimeElapsedColumn` to progress bar
- Added `TextColumn("{task.fields[workers]} workers")` to show active download threads
- Progress `completed` now uses `prog.bytes_downloaded` (was `bytes_done` = bytes written to tar)
- `objects_done` now uses `prog.objects_downloaded` (was objects written to tar)
- Removed redundant description column (was always "Backing up...")

### Change E: Test Updates

**`TestHashingReader`:**
- Updated to verify MD5 computation alongside SHA-256
- Added `test_on_read_callback` — verifies callback invoked with chunk byte count
- Added `test_on_read_not_called_on_empty_read` — verifies no callback on empty read

**New `TestBackupTracer` class:**
- `test_disabled_when_logger_below_debug` — no-op when logger not at DEBUG
- `test_phase_start_end_emits_debug` — phase timing logs
- `test_object_download_trace_updates_accumulators` — download stats accumulation
- `test_tar_write_trace_updates_accumulators` — tar write stats accumulation
- `test_bytes_downloaded_sample_throttles_logs` — throughput log throttling
- `test_finalize_emits_summary_with_network_saturation_field` — summary output
- `test_thread_safety` — concurrent tracer calls don't corrupt state

**New `TestWriteBackupTracerIntegration` class:**
- `test_debug_traces_emits_object_and_tar_traces` — end-to-end trace emission
- `test_write_backup_without_tracer_no_logs` — default (tracer=None) emits no DEBUG logs

**`test_r2_backup_commands.py`:**
- `test_backup_r2_debug_traces_flag_passes_tracer` — flag passes tracer to write_backup
- `test_backup_r2_default_no_tracer_passes_none` — default is tracer=None

## v2 Changes (Previous)

### Thread Pool Concurrent Downloads
- `DEFAULT_CONCURRENCY=8`, `COPY_BUFFER_SIZE=1MB`, `SPOT_CHECK_HEAD_RATIO=0.05`
- `DownloadResult` dataclass, `_download_object_to_tempfile()` refactored
- `write_backup()` uses `ThreadPoolExecutor`, processes futures in submission order

### Eliminate Redundant HEAD Request
- ETag validation from GET response replaces post-download HEAD
- Spot-check HEAD on ~5% random sample

### Larger `copyfileobj` Buffer
- 1 MB buffer (was 16 KB)

### Increase boto3 Connection Pool
- `max_pool_connections=32` (was default 10)

### `--concurrency` CLI Flag
- New `--concurrency` option on `backup-r2` command (1-64, default 8)

## Manifest Version

`MANIFEST_VERSION` stays at **4** — no archive format change. The v3 progress improvements are purely internal to the download/tracking mechanism.

## Expected Behavior

Progress bar output:
```
⠙ ████████████████░░░░░░░░░░░░  53% 6.8/12.9 GB 8.2 MB/s 0:12 5 workers 360/679 objects
```

## Verification

```bash
# Run tests
PYTHONPATH=src uv run --python 3.11 --extra app --extra test pytest tests/admin/test_r2_backup.py tests/admin/test_r2_backup_commands.py -v

# Verify --debug-traces flag
PYTHONPATH=src uv run --python 3.11 --extra admin python -c "from stream_of_worship.admin.main import app; from typer.testing import CliRunner; runner = CliRunner(); result = runner.invoke(app, ['maintenance', 'backup-r2', '--help']); print(result.output)" | grep debug-traces
```