### PR TITLE
fix(webapp/cast): move StreamType to chrome.cast.media namespace

### DIFF
--- a/delivery/webapp/src/hooks/useCast.ts
+++ b/delivery/webapp/src/hooks/useCast.ts
@@ -725,7 +725,7 @@ export function useCastTransport({ media, onError }: UseCastTransportOptions): C
         title: m.title,
         metadataType: chrome.cast.media.MetadataType.GENERIC,
       };
-      mediaInfo.streamType = chrome.cast.StreamType.BUFFERED;
+      mediaInfo.streamType = chrome.cast.media.StreamType.BUFFERED;
       const loadRequest = new chrome.cast.media.LoadRequest(mediaInfo);
       loadRequest.currentTime = m.startSeconds ?? 0;
       await new Promise<void>((resolve, reject) => {

--- a/delivery/webapp/src/test/hooks/useCastTransport.test.ts
+++ b/delivery/webapp/src/test/hooks/useCastTransport.test.ts
@@ -136,7 +136,6 @@ function setupCastSdkMock(opts?: {
   (window as unknown as { chrome: unknown }).chrome = {
     cast: {
       AutoJoinPolicy: { TAB_AND_ORIGIN_SCOPED: "tab_and_origin_scoped" },
-      StreamType: { BUFFERED: "buffered" },
       media: {
         DEFAULT_MEDIA_RECEIVER_APP_ID: "DEFAULT",
         MediaInfo: function MediaInfo(this: unknown, contentId: string, contentType: string) {
@@ -152,6 +151,7 @@ function setupCastSdkMock(opts?: {
           this.currentTime = 0;
         },
         MetadataType: { GENERIC: 0 },
+        StreamType: { BUFFERED: "buffered" },
         GenericMediaMetadata: function GenericMediaMetadata() {},
       },
     },
@@ -355,6 +355,11 @@ describe("useCastTransport", () => {
       expect(result.current.deviceName).toBe(player.displayName);
       expect(result.current.isConnecting).toBe(false);
       expect(session.loadMedia).toHaveBeenCalledTimes(1);
+      // Guards against the StreamType namespace regression: the real SDK exposes
+      // StreamType under chrome.cast.media, not chrome.cast. If this assertion
+      // breaks, the call site in useCast.ts has reverted to the wrong namespace.
+      const loadRequest = session.loadMedia.mock.calls[0][0];
+      expect(loadRequest.media.streamType).toBe("buffered");
     });
 
     it("requestSession cancel → isConnecting=false, no session leak, no telemetry POST", async () => {

--- a/delivery/webapp/src/types/cast-sdk.d.ts
+++ b/delivery/webapp/src/types/cast-sdk.d.ts
@@ -38,12 +38,6 @@ declare namespace chrome.cast {
     AUDIO_IN = "audio_in",
   }
 
-  export enum StreamType {
-    BUFFERED = "buffered",
-    LIVE = "live",
-    OTHER = "other",
-  }
-
   /** Structured error passed to Cast SDK failure callbacks. */
   export interface Error {
     code: string;
@@ -73,13 +67,20 @@ declare namespace chrome.cast {
       AUDIOBOOK_CHAPTER = 5,
     }
 
+    /** Stream type hint used by MediaInfo.streamType. */
+    export enum StreamType {
+      BUFFERED = "buffered",
+      LIVE = "live",
+      OTHER = "other",
+    }
+
     /** Description of the media the receiver should load. */
     export class MediaInfo {
       constructor(contentId: string, contentType: string);
       contentId: string;
       contentType: string;
       metadata?: GenericMediaMetadata & { metadataType?: MetadataType };
-      streamType?: StreamType | string;
+      streamType?: media.StreamType | string;
       duration?: number | null;
       customData?: Record<string, unknown> | null;
       textTrackStyle?: unknown;

--- a/specs/chromecast-androidtv-discovery-fix-plan-2026-06-30.md
+++ b/specs/chromecast-androidtv-discovery-fix-plan-2026-06-30.md
@@ -1,0 +1,244 @@
+# Chromecast → AndroidTV `session_request_failed` — Fix Plan (2026-06-30)
+
+Status: **Plan only. Not implemented.**
+
+Scope: `delivery/webapp` (Cast sender path), local HTTPS dev server at `https://localhost:8080`,
+diagnosing against an AndroidTV receiver. This plan is the execution companion to the
+investigation note `specs/chromecast-androidtv-discovery-investigation-2026-06-30.md` and does
+not modify it.
+
+## Request
+
+Chromecast to AndroidTV is not working. Investigate with Chrome DevTools and write a detailed
+plan only. Do not implement.
+
+Known starting context (from the user):
+
+- Chrome is pointed at local webapp `https://localhost:8080`.
+- `NEXT_PUBLIC_CAST_RECEIVER_APP_ID` is not defined for the webapp.
+- Chromecast discovery was working yesterday, but was blocked by the login screen.
+- Today cast discovery is broken, possibly due to changes from PR #119.
+- User tested in **both** a regular Chrome and the chrome-devtools-mcp-launched Chrome.
+- Symptom on screen: `error: cast session request failed`.
+- Preferred investigation approach: diagnose in a normal Chrome (the MCP automation Chrome
+  cannot run Cast).
+
+## Summary of findings (read-only investigation)
+
+### The dev server and code are NOT the regression
+
+- The `:8080` dev server (node PID 66177) started today at **13:13**, *after* both Cast
+  fixes, so the running bundle includes them:
+  - `f1305d8` "Fix Cast framework initialization" (12:55) — added `?loadCastFramework=1` to
+    the sender URL (`delivery/webapp/src/lib/cast/loader.ts:18`) so `window.cast.framework`
+    actually loads; without it `isCastSdkSupported()` returns false → `availability:"unavailable"`
+    → no real Cast path.
+  - `1fd9c0f` "Improve Cast session failure diagnostics" (13:09) — added
+    `resolveCastReceiverAppId()` (with `.trim()`), `formatCastRequestError()`, and logs
+    `castErrorCode` / `castState` / `sessionState` to `POST /api/log-client-error`.
+- `NEXT_PUBLIC_CAST_RECEIVER_APP_ID` being unset is **by design** (`.env.example`,
+  `delivery/webapp/README.md`): the v3 default path falls back to
+  `chrome.cast.media.DEFAULT_MEDIA_RECEIVER_APP_ID` (`"CC1AD845"`) after SDK load
+  (`delivery/webapp/src/hooks/useCast.ts:582`). There is no `.env.local` / `.env.development`
+  setting it.
+
+### PR #119 fixed yesterday's symptom, it did not cause today's
+
+PR #119 (merged Jun 29 15:08 UTC) "Fix TV projection, playback controls, and lyric editor
+polish" made projection routes public in `delivery/webapp/src/proxy.ts` and changed
+unauthenticated API requests to return JSON `401` instead of an HTML `/login` redirect —
+exactly the fix for the "blocked by login screen" / `invalid token '<'` receiver failure seen
+yesterday. It also omitted `androidReceiverCompatible` from `setOptions` so AndroidTV stays on
+the Default Media Receiver path instead of the unsupported Cast Connect path
+(`delivery/webapp/src/hooks/useCast.ts:596-605`).
+
+### The decisive clue: the symptom string identifies the failure point
+
+`error: cast session request failed` is the exact fallback string emitted by
+`formatCastRequestError()` (`delivery/webapp/src/hooks/useCast.ts:175`, added in `1fd9c0f`).
+That means:
+
+- The Cast framework **loaded** (`?loadCastFramework=1` worked).
+- `setOptions` **ran** with a resolved `receiverApplicationId`.
+- `cast.framework.CastContext.requestSession()` was **called and rejected**.
+
+This is NOT "no devices found" (`RECEIVER_UNAVAILABLE`). The failure is downstream of
+discovery, at session request time. `1fd9c0f` only changed error *formatting/logging*; it
+cannot cause the failure, only make it visible. So PR #119 is not the regression — it surfaced a
+pre-existing AndroidTV receiver failure that was previously masked by the framework never
+loading (pre-`f1305d8`) and the app silently falling back to the Presentation API (which is what
+hit the login wall yesterday).
+
+### Why the MCP automation Chrome cannot be used for this investigation
+
+The chrome-devtools-mcp browser (PID 66834) was launched with:
+
+```
+--disable-features=Translate,AcceptCHFrame,MediaRouter,OptimizationHints,WebUIReloadButton,...
+--enable-automation --user-data-dir=<ephemeral>
+```
+
+`MediaRouter` is the Chrome feature that powers Chromecast device discovery and the Cast
+extension surface. With it disabled (plus `--enable-automation` and an ephemeral profile),
+Cast cannot run in that browser regardless of webapp code. Cast must be diagnosed in a normal
+Chrome (per the user's choice).
+
+### Secondary blocker: DevTools MCP connectivity is currently wedged
+
+`list_pages` fails with `Failed to fetch browser webSocket URL from http://127.0.0.1:9222`
+because the MCP Chrome uses `--remote-debugging-pipe` (not port 9222), and there are two
+competing `chrome-devtools-mcp` processes (PIDs `62014`/`62347` @12:51 and `66485` @1:15). The
+investigation tooling itself must be restored before any DevTools-driven capture.
+
+## Root-cause hypothesis (to confirm empirically)
+
+`cast.framework.requestSession()` rejects against the AndroidTV when using the Default Media
+Receiver app id from `https://localhost:8080`. Candidate causes, in priority order:
+
+1. **Origin / secure-context eligibility.** Cast on `localhost` HTTPS is supported, but a
+   self-signed cert that is only "proceeded past" (not trusted) can weaken Cast eligibility for
+   the AndroidTV receiver. Confirm the dev cert is trusted (e.g. via `mkcert`), and confirm
+   `pnpm dev:https` wiring in `delivery/webapp/package.json`.
+2. **AndroidTV Cast service state.** TV's Cast receiver service stale, TV not on the same LAN
+   as the laptop, or SSDP/mDNS blocked by VPN/firewall. (Yesterday devices were seen, so this
+   is more likely a transient TV-side state than a network topology change.)
+3. **Default Media Receiver not resolving on this AndroidTV.** `CC1AD845` should launch the
+   TV's built-in media receiver; verify by casting a non-SOW URL (e.g. a public MP4) to the TV
+   from the same Chrome.
+4. **`setOptions` shape / `autoJoinPolicy` interaction with AndroidTV.** Confirm
+   `androidReceiverCompatible` is absent and `autoJoinPolicy` is `TAB_AND_ORIGIN_SCOPED`
+   (`delivery/webapp/src/hooks/useCast.ts:595`).
+5. **SDK timing.** If `castAppIdMode` ever reports `"unset"`, the SDK did not expose
+   `chrome.cast.media.DEFAULT_MEDIA_RECEIVER_APP_ID` at init time and the fallback did not
+   resolve — would require deferring `setOptions` until `chrome.cast.isAvailable` is true.
+
+## Execution plan
+
+### Phase 0 — Restore DevTools MCP connectivity
+
+1. Quit the duplicate/stale MCP processes and the pipe Chrome:
+   - Kill `chrome-devtools-mcp` PIDs `62014`, `62347`, `66485` and watchdog `62348`.
+   - Kill the MCP-managed Chrome PID `66834` (the one with `MediaRouter` disabled).
+2. Restart a single `chrome-devtools-mcp` cleanly so the DevTools tools can attach to a browser
+   again. (This browser will still be automation-only and Cast-incapable — it is used only for
+   the non-Cast DevTools steps; Phase 1 launches the Cast-capable browser.)
+
+### Phase 1 — Launch a Cast-capable Chrome (normal Chrome, per user choice)
+
+The automation Chrome has `MediaRouter` disabled and `--enable-automation` set, so Cast cannot
+run there. Launch a normal Chrome instead:
+
+```
+/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
+  --remote-debugging-port=9222 \
+  --user-data-dir=/tmp/sow-cast-debug-profile \
+  --no-first-run --no-default-browser-check
+```
+
+- Do **not** pass `--disable-features=MediaRouter` or `--enable-automation` (keeps Cast
+  discovery and the Cast surface alive).
+- Do **not** reuse the user's live profile (Chrome disallows two instances per profile). A
+  fresh dir is fine; modern Chrome has Cast built in via MediaRouter, so a new profile can
+  still discover devices.
+- Navigate to `https://localhost:8080` and **accept/trust the self-signed cert** — Cast requires
+  a secure context; `localhost` over HTTPS qualifies only if the cert is trusted.
+
+### Phase 2 — Confirm the framework/boot path is healthy (console evaluate)
+
+Before reproducing, verify SDK state in the DevTools console:
+
+- `window.chrome?.cast && window.cast?.framework` → both truthy (i.e. `isCastSdkSupported()`
+  true).
+- `chrome.cast.media.DEFAULT_MEDIA_RECEIVER_APP_ID` → `"CC1AD845"`; `chrome.cast.isAvailable`
+  → `true`.
+- `cast.framework.CastContext.getInstance().getCastState()` → expect `"NO_DEVICES_AVAILABLE"`
+  or `"NOT_CONNECTED"`.
+- `cast.framework.CastContext.getInstance().getOptions()?.receiverApplicationId` → `"CC1AD845"`;
+  confirm `androidReceiverCompatible` is **absent**.
+- Network panel: `cast_sender.js?loadCastFramework=1` returned 200 and was not blocked by CSP
+  or an ad blocker.
+
+### Phase 3 — Reproduce and capture the real SDK rejection
+
+1. Open DevTools **Network** panel with "Preserve log" on. Trigger Cast from the controller UI
+   (`/songsets/[id]/play/controller` or `/share/[token]/play/controller`).
+2. Capture the `POST /api/log-client-error` request body. It now contains `castErrorCode`,
+   `castState`, `sessionState`, `castAppIdMode`, `browser`, `platform`. **This payload is the
+   primary diagnostic artifact.**
+3. In the console, wrap `requestSession` to log the raw rejection shape:
+   ```js
+   const ctx = cast.framework.CastContext.getInstance();
+   const _r = ctx.requestSession.bind(ctx);
+   ctx.requestSession = () =>
+     _r().then(v => (console.log("requestSession OK", v), v),
+               e => (console.log("requestSession REJECT", JSON.stringify(e)), Promise.reject(e)));
+   ```
+4. Capture the full reject object: `code`, `description`, `details`, `errorCode`, and all
+   enumerable keys. Map `chrome.cast.ErrorCode.*`:
+   - `RECEIVER_UNAVAILABLE` → no devices / MediaRouter off / TV offline.
+   - `SESSION_ERROR` / `INVALID_PARAMETER` → receiver app id problem or origin not eligible.
+   - `CANCEL` / `TIMEOUT` → user dismissed the picker / picker hung.
+   - No code (generic "Cast session request failed") → SDK returned an unrecognized shape; dump
+     the full object.
+
+### Phase 4 — Resolve the AndroidTV-specific failure
+
+Based on the captured code:
+
+- **`RECEIVER_UNAVAILABLE` / no devices:** confirm AndroidTV + laptop on the same LAN; reboot
+  the AndroidTV; in `chrome://flags` ensure `#load-media-router-component-extension` is enabled;
+  verify SSDP/mDNS is not blocked by VPN/firewall.
+- **Session error on the Default Media Receiver:** test casting a non-SOW URL to the TV from the
+  same Chrome to confirm the TV casts at all from this machine. If only SOW fails, the receiver
+  id path is the issue.
+- **Origin / HTTPS:** confirm the dev cert is trusted (not just "proceed"). If trust is the
+  issue, generate a trusted cert with `mkcert` and wire it into `pnpm dev:https` via
+  `NEXT_DEV_HTTPS_KEY` / `NEXT_DEV_HTTPS_CERT` (verify the script in
+  `delivery/webapp/package.json`).
+- **If `castAppIdMode === "unset"` ever appears:** the SDK did not expose
+  `chrome.cast.media.DEFAULT_MEDIA_RECEIVER_APP_ID` at init time and the fallback did not
+  resolve. Mitigation: defer `setOptions` until `chrome.cast.isAvailable === true` (or until the
+  `cast.framework` `CAST_STATE_CHANGED` first fires), rather than resolving the id immediately
+  in the `loadCastSdk().then()` callback.
+
+### Phase 5 — Verify the PR #119 receiver-auth fix (once a session establishes)
+
+- Confirm `/songsets/.../play/projection` and `/share/.../play/projection` are not redirected to
+  `/login` (public-route list in `delivery/webapp/src/proxy.ts`).
+- Confirm an unauthenticated API call returns JSON `401`, not an HTML `/login` redirect (the old
+  `invalid token '<'` failure).
+- Cast the MP4; the Default Media Receiver on AndroidTV should play the R2 signed URL (4-hour
+  TTL, `cast=true`). Inspect the `loadMedia` `MediaInfo` content URL to confirm it is the
+  presigned R2 URL, not an `/api/...` path.
+
+### Phase 6 — Hardening / options (only after the root cause is known)
+
+- If origin trust is the issue: extend the Cast HTTPS workflow section in
+  `delivery/webapp/README.md` (PR #119 already added a section) to document `mkcert` +
+  `pnpm dev:https`.
+- Consider a clearer user-facing message in `formatCastRequestError`
+  (`delivery/webapp/src/hooks/useCast.ts:175`) that maps `RECEIVER_UNAVAILABLE` vs
+  `SESSION_ERROR` distinctly, instead of the generic "Cast session request failed".
+- Optionally surface `castState` / `sessionState` in the existing diagnostic sheet for live
+  triage.
+
+## Files that may be touched during implementation (NOT in this plan)
+
+- `delivery/webapp/src/hooks/useCast.ts` — error mapping; possibly deferred `setOptions`.
+- `delivery/webapp/src/lib/cast/loader.ts` — only if SDK timing is implicated.
+- `delivery/webapp/README.md` + `delivery/webapp/package.json` (`dev:https`) — cert workflow.
+- `delivery/webapp/src/proxy.ts` — verify projection routes are public (read-only check).
+
+## Verification
+
+- `pnpm --filter sow-webapp lint && pnpm --filter sow-webapp test` after any code change.
+- Re-run the Phase 3 capture: `castErrorCode` should move from the failing code to a successful
+  `castState === "CONNECTED"`, and `loadMedia` should play the MP4 on the AndroidTV.
+
+## Open questions to resolve during execution
+
+- What is the exact `castErrorCode` in the `POST /api/log-client-error` body? (Determines which
+  Phase 4 branch applies.)
+- Is the `https://localhost:8080` dev cert trusted by the system keychain, or only "proceeded
+  past" in Chrome?
+- Can the same Chrome cast a non-SOW URL to the AndroidTV? (Isolates SOW vs TV/network.)

--- a/specs/chromecast-androidtv-discovery-investigation-2026-06-30.md
+++ b/specs/chromecast-androidtv-discovery-investigation-2026-06-30.md
@@ -1,0 +1,431 @@
+# Chromecast AndroidTV Discovery Investigation — 2026-06-30
+
+Status: **Investigation complete; implementation not started.**
+
+Scope: `delivery/webapp`, local HTTPS dev server at `https://localhost:8080`.
+
+## Request
+
+Chromecast to AndroidTV is not working. Investigate with Chrome DevTools and write
+a detailed plan only. Do not implement.
+
+Known starting context:
+
+- Chrome is pointed at local webapp `https://localhost:8080`.
+- `NEXT_PUBLIC_CAST_RECEIVER_APP_ID` is not defined for the webapp.
+- Chromecast discovery worked yesterday, but was blocked by the login screen.
+- Today Cast discovery is broken, possibly due to changes from PR #119.
+
+## Chrome DevTools Findings
+
+DevTools initially exposed only `about:blank`, so the local app was opened in the
+DevTools-controlled tab at `https://localhost:8080`.
+
+The app loaded and redirected to `/songsets` with an authenticated session.
+Clicking Play on a rendered songset opened:
+
+```text
+https://localhost:8080/songsets/Jxyu78jKqWfw6Ot-5NSG6/play/controller
+```
+
+Runtime Cast probe from the controller page:
+
+```json
+{
+  "href": "https://localhost:8080/songsets/Jxyu78jKqWfw6Ot-5NSG6/play/controller",
+  "isSecureContext": true,
+  "hasChromeCast": true,
+  "hasCastFramework": true,
+  "hasGCastCallback": "function",
+  "defaultReceiverAppId": "CC1AD845",
+  "castState": "NO_DEVICES_AVAILABLE",
+  "sessionState": "NO_SESSION",
+  "castScripts": [
+    "https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1",
+    "https://www.gstatic.com/eureka/clank/149/cast_sender.js"
+  ],
+  "presentationRequest": "function",
+  "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36"
+}
+```
+
+Network evidence:
+
+- `cast_sender.js?loadCastFramework=1` loaded with HTTP 200.
+- `cast_framework.js` loaded with HTTP 304.
+- `gstatic.com/eureka/clank/149/cast_sender.js` loaded with HTTP 200.
+- `/api/signed-url?renderJobId=...&fileType=video&cast=true` returned HTTP 200.
+- The generated R2 MP4 URL returned HTTP 206 range responses in the local video
+  element.
+- `POST /api/log-client-error` returned HTTP 400 twice.
+
+Visible page state after pressing the focused Cast button:
+
+```text
+Toast: "Cast session request failed"
+Cast button remains visible as "Send to TV"
+```
+
+Telemetry POST body:
+
+```json
+{
+  "message": "Cast session request failed",
+  "kind": "cast_load",
+  "meta": {
+    "platform": "macos",
+    "browser": "chrome",
+    "castAppIdMode": "default",
+    "castState": "NO_DEVICES_AVAILABLE",
+    "sessionState": "NO_SESSION",
+    "transportKind": "cast",
+    "mediaSourceKind": "songset"
+  }
+}
+```
+
+Telemetry response:
+
+```json
+{
+  "error": "Invalid request body",
+  "details": [
+    {
+      "code": "unrecognized_keys",
+      "keys": ["castState", "sessionState"],
+      "path": ["meta"],
+      "message": "Unrecognized keys: \"castState\", \"sessionState\""
+    }
+  ]
+}
+```
+
+## Interpretation
+
+The current failure is **not** that the Cast Web Sender SDK cannot initialize.
+On local HTTPS it initializes correctly:
+
+- secure context is true,
+- `window.chrome.cast` exists,
+- `window.cast.framework` exists,
+- Default Media Receiver app ID resolves to `CC1AD845`,
+- CastContext is available.
+
+The current failure is that CastContext reports:
+
+```text
+NO_DEVICES_AVAILABLE
+```
+
+That means the sender framework has no currently discoverable Cast devices for
+the selected receiver app ID. Since `NEXT_PUBLIC_CAST_RECEIVER_APP_ID` is unset,
+the app is using Google's Default Media Receiver, which should not need a custom
+receiver registration.
+
+The app now also has a diagnostics regression: the hook posts newly-added
+`castState` and `sessionState` fields, but `/api/log-client-error` rejects those
+fields because its Zod schema is strict and does not include them. This does not
+cause discovery to fail, but it discards the exact diagnostics needed to
+differentiate `NO_DEVICES_AVAILABLE`, `NOT_CONNECTED`, framework init failure,
+and session request errors.
+
+## PR #119 Assessment
+
+The local git history shows:
+
+```text
+1abcbc8 fix(webapp): address PR #119 review feedback
+3b768f6 fix(webapp): update share landing test
+f1305d8 Fix Cast framework initialization
+1fd9c0f Improve Cast session failure diagnostics
+```
+
+Commit `1abcbc8` touched only:
+
+- `delivery/webapp/src/app/songsets/[id]/play/controller/page.tsx`
+- `delivery/webapp/src/components/play/LyricJumpList.tsx`
+- `delivery/webapp/src/components/play/ProjectionPlayer.tsx`
+
+It did **not** touch:
+
+- `delivery/webapp/src/hooks/useCast.ts`
+- `delivery/webapp/src/lib/cast/loader.ts`
+- `delivery/webapp/src/app/api/log-client-error/route.ts`
+
+Based on the inspected files and runtime evidence, PR #119 review feedback is
+unlikely to be the direct cause of the current `NO_DEVICES_AVAILABLE` discovery
+state.
+
+The Cast-specific changes after that range are more relevant:
+
+1. `f1305d8 Fix Cast framework initialization`
+   - changed the sender script URL to include `?loadCastFramework=1`.
+   - changed default receiver lookup toward `chrome.cast.media.DEFAULT_MEDIA_RECEIVER_APP_ID`.
+   - This appears necessary and is working in the live DevTools probe.
+
+2. `1fd9c0f Improve Cast session failure diagnostics`
+   - added `castState`, `sessionState`, and `castErrorCode` to client telemetry.
+   - did not update the strict server telemetry schema to accept those fields.
+   - This explains the observed HTTP 400 diagnostics failure.
+
+## Working Hypotheses
+
+### H1: Browser/device discovery is broken outside the app
+
+Most likely based on DevTools: the SDK is initialized, but Chrome reports
+`NO_DEVICES_AVAILABLE`. This can happen when:
+
+- AndroidTV is powered off, asleep, or on a different Wi-Fi/VLAN.
+- AP/client isolation, guest Wi-Fi, VPN, firewall, or mDNS/SSDP restrictions
+  block discovery.
+- Chrome's built-in Cast menu cannot see the TV either.
+- The currently controlled Chrome profile/session has Cast discovery disabled or
+  blocked.
+
+This is an environment/device condition, not a webapp code path.
+
+### H2: The app is using a different receiver app ID mode than yesterday
+
+Current runtime mode is `default` with receiver app ID `CC1AD845` because
+`NEXT_PUBLIC_CAST_RECEIVER_APP_ID` is unset. This should launch the Default Media
+Receiver, not a SOW custom receiver.
+
+If yesterday used a custom app ID, discovery may have appeared differently, but
+the prompt states the env var is unset today. The plan should verify there is no
+stale custom app ID in:
+
+- `.env.local`
+- shell env used to start `pnpm dev:https`
+- browser bundle output
+- Vercel preview/prod envs, if comparing with deployed behavior
+
+### H3: Diagnostics are currently masking the actionable failure detail
+
+Confirmed. The client sends `castState` and `sessionState`, but the API rejects
+them. This should be fixed before relying on telemetry to debug more Cast cases.
+
+### H4: The old login-screen blocker is a separate issue
+
+Yesterday's symptom was "discovery worked, but TV hit the login screen." That
+matches the earlier local-dev projection fallback/login issue, where non-media
+Cast/Presentation paths could load SOW webapp URLs on the receiver without a
+session.
+
+Today's observed path is different: the real Cast SDK is loaded and uses Default
+Media Receiver mode, but no device is discoverable. The receiver never gets far
+enough to load a SOW page or an MP4.
+
+## Clarification Needed
+
+The key external check is:
+
+```text
+Can Chrome's built-in toolbar Cast menu see the AndroidTV from this same browser
+session right now?
+```
+
+Interpretation:
+
+- If **No**, the current failure is almost certainly LAN/device/Chrome discovery
+  state outside the webapp.
+- If **Yes**, the app's CastContext setup/requestSession path needs deeper
+  inspection, because Chrome itself can see receivers while this app cannot.
+
+I attempted to use the structured Question tool for this, but the current Codex
+session is not in the mode where that tool is available.
+
+## Remediation Plan
+
+### Phase 1 — Establish External Discovery Baseline
+
+No code changes.
+
+1. From the same Chrome profile used by DevTools, open Chrome's built-in Cast
+   menu.
+2. Record whether the AndroidTV appears.
+3. If it does not appear:
+   - confirm AndroidTV is awake and on the same Wi-Fi/VLAN as the Mac,
+   - disable VPNs or network filters temporarily,
+   - confirm no guest-network/client-isolation mode is active,
+   - reboot AndroidTV/Chromecast service if necessary,
+   - retry Chrome built-in Cast menu before testing the app.
+4. If it appears in Chrome's menu, return to the controller page and run the
+   page-context probe again:
+
+   ```js
+   ({
+     castState: cast.framework.CastContext.getInstance().getCastState(),
+     sessionState: cast.framework.CastContext.getInstance().getSessionState(),
+     defaultReceiverAppId: chrome.cast.media.DEFAULT_MEDIA_RECEIVER_APP_ID,
+   })
+   ```
+
+Expected app result when the TV is discoverable:
+
+```text
+castState: NOT_CONNECTED
+sessionState: NO_SESSION
+```
+
+`NO_DEVICES_AVAILABLE` after Chrome's own Cast menu sees the AndroidTV would be
+an app-level or receiver-app-ID-level discrepancy.
+
+### Phase 2 — Fix Telemetry Contract
+
+Implement after approval.
+
+Files:
+
+- `delivery/webapp/src/app/api/log-client-error/route.ts`
+- `delivery/webapp/src/test/api/log-client-error.test.ts`
+- optionally `delivery/webapp/src/db/schema.ts` comments/docs if field meaning is
+  documented there
+
+Changes:
+
+1. Extend `metaSchema` to accept:
+   - `castErrorCode?: string`
+   - `castState?: string`
+   - `sessionState?: string`
+2. Persist those fields in `redactedMeta`.
+3. Keep the schema strict after adding the known keys.
+4. Add API tests proving:
+   - Cast diagnostics with `castState/sessionState/castErrorCode` return 202.
+   - Unknown meta keys are still rejected.
+   - Existing PII redaction contract remains unchanged.
+
+This does not fix discovery, but it makes the new diagnostics actually usable.
+
+### Phase 3 — Improve Sender-Side Discovery Diagnostics
+
+Implement after approval.
+
+Files:
+
+- `delivery/webapp/src/hooks/useCast.ts`
+- `delivery/webapp/src/components/play/ControllerPlayer.tsx`
+- `delivery/webapp/src/test/hooks/useCastTransport.test.ts`
+- relevant controller/player tests
+
+Changes:
+
+1. Subscribe to `cast.framework.CastContextEventType.CAST_STATE_CHANGED`.
+2. Store the latest Cast state separately from generic `availability`.
+3. Treat states distinctly:
+   - `NO_DEVICES_AVAILABLE`: SDK initialized, but no receivers discovered.
+   - `NOT_CONNECTED`: receiver available, no active session.
+   - `CONNECTING`: session request in progress.
+   - `CONNECTED`: active session.
+4. Update user-facing diagnostic copy:
+   - for `NO_DEVICES_AVAILABLE`: same Wi-Fi/VLAN, TV awake, Chrome toolbar Cast
+     menu comparison, VPN/firewall/client isolation.
+   - for SDK unavailable: HTTPS, browser support, gstatic script loading.
+   - for session request failure: include sanitized Cast error code.
+5. Keep `availability` for coarse button rendering, but do not collapse all
+   initialized/no-device states into an opaque "available" or generic failure.
+
+Expected UX:
+
+- If no devices exist, the Cast button should be tappable and open a diagnostic
+  sheet that explicitly says no Cast devices were discovered.
+- If devices exist, tapping should open the receiver picker/session flow.
+
+### Phase 4 — Verify Default Media Receiver Path
+
+No custom receiver app ID should be required for the current v3 flow.
+
+Verification steps:
+
+1. Ensure `NEXT_PUBLIC_CAST_RECEIVER_APP_ID` is unset or blank.
+2. Confirm runtime resolves:
+
+   ```text
+   chrome.cast.media.DEFAULT_MEDIA_RECEIVER_APP_ID = CC1AD845
+   castAppIdMode = default
+   ```
+
+3. Start Cast from a rendered songset controller page.
+4. Confirm `requestSession()` succeeds after selecting AndroidTV.
+5. Confirm `session.loadMedia()` receives:
+   - content ID: signed R2 MP4 URL,
+   - content type: `video/mp4`,
+   - stream type: `BUFFERED`,
+   - title metadata.
+6. Confirm the TV plays the MP4 directly from R2 and does not navigate to:
+   - `/login`,
+   - `/songsets/.../play/projection`,
+   - `/share/.../play/projection`.
+
+### Phase 5 — Regression Tests
+
+Implement after approval.
+
+Add or update tests for:
+
+1. SDK loader uses `?loadCastFramework=1`.
+2. blank `NEXT_PUBLIC_CAST_RECEIVER_APP_ID` uses
+   `chrome.cast.media.DEFAULT_MEDIA_RECEIVER_APP_ID`.
+3. `requestSession` errors include safe Cast state/session diagnostics.
+4. `/api/log-client-error` accepts the full Cast diagnostics payload.
+5. `NO_DEVICES_AVAILABLE` state produces actionable diagnostic UI.
+6. PR #119 touched controller/lyric/projection code does not regress Cast
+   initialization or button visibility.
+
+Recommended commands:
+
+```bash
+pnpm --filter sow-webapp test -- src/test/hooks/useCastTransport.test.ts
+pnpm --filter sow-webapp test -- src/test/api/log-client-error.test.ts
+pnpm --filter sow-webapp test
+```
+
+### Phase 6 — Manual End-to-End Checklist
+
+Run from `delivery/webapp` or project root:
+
+```bash
+pnpm --filter sow-webapp dev:https
+```
+
+Checklist:
+
+1. Open `https://localhost:8080` and accept the self-signed certificate.
+2. Log in.
+3. Open a rendered songset controller page.
+4. Confirm page probe:
+
+   ```text
+   isSecureContext = true
+   hasChromeCast = true
+   hasCastFramework = true
+   defaultReceiverAppId = CC1AD845
+   ```
+
+5. Confirm Chrome's built-in Cast menu sees AndroidTV.
+6. Confirm app Cast button either:
+   - opens a device picker when devices are available, or
+   - opens a clear diagnostic sheet when no devices are discoverable.
+7. Select AndroidTV.
+8. Confirm TV plays the rendered MP4.
+9. Confirm no `/login` page appears on TV.
+10. Confirm local telemetry accepts the Cast diagnostics payload with HTTP 202.
+
+## Proposed Implementation Order
+
+1. Fix `/api/log-client-error` schema/persistence for new Cast diagnostic fields.
+2. Add CastContext state listener and explicit `NO_DEVICES_AVAILABLE` UI path.
+3. Add focused tests for both.
+4. Re-run manual DevTools probe with AndroidTV visible from Chrome toolbar.
+5. Only if Chrome toolbar sees the TV but the app still reports
+   `NO_DEVICES_AVAILABLE`, investigate CastContext options or receiver app ID
+   setup further.
+
+## Non-Goals
+
+- Do not reintroduce `androidReceiverCompatible`; the app does not have a native
+  Android TV Cast Connect receiver.
+- Do not require a custom `NEXT_PUBLIC_CAST_RECEIVER_APP_ID` for the v3 default
+  MP4 playback path.
+- Do not route Chromecast playback through authenticated SOW projection pages.
+- Do not persist raw signed R2 URLs, Cast session IDs, or user IDs in telemetry.
+

--- a/specs/chromecast-streamtype-namespace-fix-2026-06-30.md
+++ b/specs/chromecast-streamtype-namespace-fix-2026-06-30.md
@@ -1,0 +1,215 @@
+# Chromecast `loadMedia` throws `Cannot read properties of undefined (reading 'BUFFERED')` — Fix Plan (2026-06-30)
+
+Status: **Plan only. Not implemented.**
+
+Scope: `delivery/webapp` (Cast sender `loadMedia` path). This is the execution companion
+to the prior investigation `specs/chromecast-androidtv-discovery-fix-plan-2026-06-30.md`
+and supersedes its Phase 3/4 hypothesis: the failure is no longer at
+`cast.framework.requestSession()` — discovery and session establishment now succeed. The
+new symptom is a JavaScript `TypeError` thrown *after* the session is established, in the
+`loadMedia` step.
+
+## Request
+
+Chrome can now find the AndroidTV and `requestSession()` succeeds (the prior
+`session_request_failed` is resolved). On Cast, `loadMedia` throws:
+`Cannot read properties of undefined (reading 'BUFFERED')`. Investigate and write a
+detailed plan only. Do not implement.
+
+## Summary of findings (read-only investigation)
+
+### The symptom moved downstream of discovery and session request
+
+The prior plan's hypothesis was that `cast.framework.requestSession()` rejects against
+AndroidTV. The new error string — `Cannot read properties of undefined (reading 'BUFFERED')`
+— is a runtime `TypeError`, not an SDK rejection. It is thrown by the app's own code at
+`delivery/webapp/src/hooks/useCast.ts:728`, inside the `loadMedia` block that runs only
+*after* `ctx.requestSession()` resolves and `getCurrentSession()` returns a live session:
+
+```ts
+// delivery/webapp/src/hooks/useCast.ts (excerpt)
+const mediaInfo = new chrome.cast.media.MediaInfo(m.videoUrl, "video/mp4");
+mediaInfo.metadata = {
+  title: m.title,
+  metadataType: chrome.cast.media.MetadataType.GENERIC,
+};
+mediaInfo.streamType = chrome.cast.StreamType.BUFFERED;   // <- THROWS
+```
+
+That `requestSession()` no longer rejects confirms:
+- `loadCastFramework=1` is loading the framework (Phase 2 of the prior plan is satisfied).
+- `setOptions` ran with a resolved `receiverApplicationId` (the Default Media Receiver
+  `CC1AD845` fallback resolved).
+- The device picker dialog was shown and the user selected the AndroidTV.
+- A `chrome.cast.Session` object was returned.
+
+The failure is therefore *not* a discovery, eligibility, origin, cert-trust,
+`autoJoinPolicy`, `androidReceiverCompatible`, or `castAppIdMode === "unset"` problem.
+Those branches of the prior plan's Phase 4 do not apply.
+
+### Root cause: `StreamType` is declared and accessed at the wrong namespace
+
+The Google Cast Web Sender SDK exposes `StreamType` at
+**`chrome.cast.media.StreamType`**, *not* `chrome.cast.StreamType`
+([reference](https://developers.google.com/cast/docs/reference/web_sender/chrome.cast.media.StreamType)).
+The app's ambient type declaration declares it at the wrong spot, and the implementation
+follows that wrong path:
+
+- **Declaration bug** — `delivery/webapp/src/types/cast-sdk.d.ts:41` declares
+  `export enum StreamType { ... }` directly inside `namespace chrome.cast` (top-level of
+  the chrome.cast namespace). The SDK actually exposes it inside `chrome.cast.media`.
+- **Call-site bug** — `delivery/webapp/src/hooks/useCast.ts:728` reads
+  `chrome.cast.StreamType.BUFFERED`. At runtime `chrome.cast.StreamType` is `undefined`
+  (only `chrome.cast.media.StreamType` exists on the SDK global), so accessing `.BUFFERED`
+  throws `TypeError: Cannot read properties of undefined (reading 'BUFFERED')`.
+
+Notably, the neighboring `MetadataType` is declared and used *correctly* under
+`chrome.cast.media` (cast-sdk.d.ts:67, useCast.ts:726). `StreamType` is an inconsistent
+outlier.
+
+### Why tests did not catch it
+
+`delivery/webapp/src/test/hooks/useCastTransport.test.ts:139` mocks `chrome.cast` with
+`StreamType: { BUFFERED: "buffered" }` placed at the `chrome.cast` level (mirroring the
+buggy code), not under `chrome.cast.media`. The test therefore passes against the buggy
+shape because the mock matches the wrong namespace the code reads from. The test should
+mirror the real SDK shape (`StreamType` nested under `chrome.cast.media`) so it guards
+against the regression rather than encoding it.
+
+The SDK is loaded at runtime via `delivery/webapp/src/lib/cast/loader.ts` as an external
+script (`cast_sender.js?loadCastFramework=1`); its globals are not statically checked
+against the ambient `.d.ts` in any test that actually constructs a `MediaInfo` and reaches
+line 728 end-to-end.
+
+### Why PR #119 / framework-loading commits are not implicated
+
+Neither PR #119 ("Fix TV projection, playback controls...") nor the `f1305d8` / `1fd9c0f`
+Cast commits touched the `MediaInfo` / `streamType` assignment or the `StreamType` enum
+declaration. The assignment has been referencing the wrong namespace since the
+`streamType` line was introduced; discovery failing earlier (per the prior plan) simply
+masked it, because `requestSession()` rejecting short-circuited the function before line
+728 was ever reached. The session now succeeding has *uncovered* a latent bug rather than
+introducing one.
+
+## Root cause (confirmed by static analysis)
+
+`chrome.cast.StreamType` does not exist on the Cast SDK global; only
+`chrome.cast.media.StreamType` does. `delivery/webapp/src/hooks/useCast.ts:728` reads the
+non-existent path, throwing the exact `TypeError` the user reported.
+
+## Execution plan
+
+### Phase 1 — Move the `StreamType` declaration into the `chrome.cast.media` namespace
+
+File: `delivery/webapp/src/types/cast-sdk.d.ts`
+
+1. Remove the `export enum StreamType { ... }` block (lines 41–45) from the top of
+   `namespace chrome.cast` (just below `VERSION` / `isAvailable` / `AutoJoinPolicy` /
+   `Capability`).
+2. Add the same `export enum StreamType { BUFFERED = "buffered", LIVE = "live", OTHER = "other" }`
+   block inside `namespace chrome.cast.media`, adjacent to the existing
+   `export enum MetadataType { ... }` block (cast-sdk.d.ts:67). Place it either immediately
+   before or immediately after `MetadataType` for locality with the `MediaInfo` class that
+   consumes it.
+3. On line 82 (the `MediaInfo.streamType` field), the type reference
+   `streamType?: StreamType | string;` must become `streamType?: media.StreamType | string;`
+   — `StreamType` is no longer in scope from the outer `chrome.cast` namespace, so use the
+   qualified path matching the rest of the namespace's type aliases.
+
+### Phase 2 — Fix the call site in `useCast.ts`
+
+File: `delivery/webapp/src/hooks/useCast.ts`
+
+1. Line 728 — change `chrome.cast.StreamType.BUFFERED` → `chrome.cast.media.StreamType.BUFFERED`.
+
+Note: `streamType` is optional on `MediaInfo`; an alternative would be to drop the
+assignment entirely (the receiver defaults to buffered). But explicit assignment is the
+documented best practice for VOD MP4 content, so keep it with the corrected namespace
+rather than removing it.
+
+### Phase 3 — Fix the test mock to mirror the real SDK shape
+
+File: `delivery/webapp/src/test/hooks/useCastTransport.test.ts`
+
+1. Move `StreamType: { BUFFERED: "buffered" }` from the `chrome.cast` mock object
+   (currently around line 139, sibling of `AutoJoinPolicy`) into the `chrome.cast.media`
+   mock object (around line 140, sibling of `MetadataType` / `DEFAULT_MEDIA_RECEIVER_APP_ID`).
+2. Confirm no other test mocks `chrome.cast` with a top-level `StreamType` (rg surfaced
+   only this one occurrence outside of `cast-sdk.d.ts` and `useCast.ts`).
+3. Optionally add a post-`loadMedia` assertion that verifies `mediaInfo.streamType === "buffered"`
+   on the mocked `MediaInfo` instance, so the guarantee becomes explicit.
+
+### Phase 4 — Verify the Phase 5 receiver-auth/URL fix from the prior plan
+
+Once the `TypeError` is resolved, `loadMedia` will actually fire against the AndroidTV
+receiver. The prior plan's Phase 5 items then become runnable for the first time:
+
+- Confirm `/songsets/.../play/projection` and `/share/.../play/projection` routes are public
+  (`delivery/webapp/src/proxy.ts` public-route list) — no `/login` redirect for the
+  receiver's projection fetch.
+- Confirm an unauthenticated API call returns JSON `401`, not an HTML `/login` redirect
+  (the old `invalid token '<'` failure surface).
+- Inspect the `loadMedia` `MediaInfo.contentId` to confirm it is the presigned R2 URL
+  with `cast=true` (4-hour TTL), *not* an `/api/...` path.
+- Confirm playback starts on the AndroidTV (not merely `loadMedia` resolving). If
+  `loadMedia` resolves but the receiver errors out (e.g. URL redirects to HTML login),
+  that is a *new* bug distinct from this one and should be captured in a separate plan
+  rather than scattering Phase 4 of this plan.
+
+### Phase 5 — Verification gates
+
+```bash
+pnpm --filter sow-webapp lint
+pnpm --filter sow-webapp test
+```
+
+Both must pass. The transport test (`useCastTransport.test.ts`) must still pass with the
+corrected mock shape — if it breaks, the mock was over-coupled to the bug rather than to
+the SDK, which is itself a finding worth a comment in the test file.
+
+After lint+test pass, re-run the live Phase 3 capture from the prior plan: a fresh
+`POST /api/log-client-error` body (if any error is still posted) should no longer mention
+`BUFFERED`, and `castState` should reach `CONNECTED` with `loadMedia` playing the MP4 on
+the AndroidTV.
+
+## Files that will be touched during implementation
+
+- `delivery/webapp/src/types/cast-sdk.d.ts` — move `StreamType` enum into
+  `chrome.cast.media`; update `MediaInfo.streamType` type reference on line 82.
+- `delivery/webapp/src/hooks/useCast.ts` — single-character-namespace fix on line 728.
+- `delivery/webapp/src/test/hooks/useCastTransport.test.ts` — move `StreamType` mock into
+  the `chrome.cast.media` block; optional post-`loadMedia` assertion.
+
+## Files that will NOT be touched (explicit non-goals)
+
+- `delivery/webapp/src/lib/cast/loader.ts` — SDK timing is not implicated; discovery and
+  session establishment succeed, so `?loadCastFramework=1` and the `loadCastSdk().then()`
+  flow are healthy.
+- `delivery/webapp/src/proxy.ts`, cert/mkcert workflow, `package.json` `dev:https` —
+  origin/secure-context is not implicated; discovery proves the secure context is
+  eligible.
+- `formatCastRequestError` (`useCast.ts:175`) — error formatting is not implicated; the
+  thrown `TypeError` was surfacing as a catch-all, and once fixed, `formatCastRequestError`
+  need not change unless Phase 4 surfaces a *new* SDK error code that warrants a clearer
+  message (defer to a separate hardening plan).
+- `androidReceiverCompatible` / `autoJoinPolicy` / `castAppIdMode` paths — previously
+  covered, not implicated here.
+
+## Risks / out-of-scope follow-ups
+
+- If `loadMedia` resolves but the receiver hits the old `invalid token '<'` failure (i.e.
+  the projection URL still returns HTML redirect), that is a *new* bug to capture in a
+  separate plan — do not expand this fix's scope into PR #119's projection-route territory.
+- If a *second* wrong-namespace enum lurks in `cast-sdk.d.ts` (we confirmed only
+  `StreamType` was mis-declared; `MetadataType` is correct), a future audit pass could
+  cross-check every `chrome.cast.*`/`chrome.cast.media.*` access site. Out of scope here.
+- The Phase 6 hardening items from the prior plan (clearer `formatCastRequestError`
+  messages mapping `RECEIVER_UNAVAILABLE` vs `SESSION_ERROR`; surfacing `castState` in
+  the diagnostic sheet) remain unaddressed and are intentionally deferred.
+
+## Verification (summary)
+
+- `pnpm --filter sow-webapp lint && pnpm --filter sow-webapp test` passes with the
+  corrected mock shape.
+- Live re-cast against the AndroidTV: no `BUFFERED` error; `castState === "CONNECTED"`;
+  the MP4 plays on the TV.


### PR DESCRIPTION
## Summary

Fixes the `TypeError: Cannot read properties of undefined (reading 'BUFFERED')` thrown by `loadMedia` after a Cast session is established against an AndroidTV receiver.

## Root Cause

The Google Cast Web Sender SDK exposes `StreamType` at **`chrome.cast.media.StreamType`**, not `chrome.cast.StreamType`. The app's ambient type declaration, the `useCast.ts` call site, and the test mock all used the wrong namespace.

This bug was latent: the prior `requestSession()` failure (now resolved by the discovery fix) short-circuited the function before line 728 was ever reached. Once session establishment began succeeding, the latent wrong-namespace access surfaced as a runtime `TypeError`.

## Changes

### 1. `delivery/webapp/src/types/cast-sdk.d.ts` — Declaration fix
- Removed the `export enum StreamType { BUFFERED, LIVE, OTHER }` block from the top-level `namespace chrome.cast` (where it never existed on the real SDK global).
- Added the same enum inside `namespace chrome.cast.media`, adjacent to the existing (correctly-placed) `MetadataType` enum.
- Updated the `MediaInfo.streamType` field type reference from `StreamType | string` to `media.StreamType | string`, since `StreamType` is no longer in scope from the outer `chrome.cast` namespace.

### 2. `delivery/webapp/src/hooks/useCast.ts` — Call site fix (line 728)
- Changed `chrome.cast.StreamType.BUFFERED` → `chrome.cast.media.StreamType.BUFFERED`.
- Explicit `streamType` assignment is retained (documented best practice for VOD MP4 content; the receiver defaults to buffered, but explicit is safer).

### 3. `delivery/webapp/src/test/hooks/useCastTransport.test.ts` — Mock + assertion fix
- Moved `StreamType: { BUFFERED: "buffered" }` from the `chrome.cast` mock object into the `chrome.cast.media` mock object (sibling of `MetadataType` / `DEFAULT_MEDIA_RECEIVER_APP_ID`), mirroring the real SDK shape.
- Added a post-`loadMedia` assertion verifying `loadRequest.media.streamType === "buffered"` on the mocked `MediaInfo` instance, so the test guards against the regression rather than encoding it.

## Why Tests Did Not Catch It

The test mock placed `StreamType` at the `chrome.cast` level (mirroring the buggy code), so the test passed against the wrong shape. No test that constructs a `MediaInfo` and reaches the `streamType` assignment was checking the actual SDK namespace structure. The new assertion closes that gap.

## Non-Goals (explicitly out of scope)

- `src/lib/cast/loader.ts` — SDK timing is not implicated; discovery and session establishment succeed.
- `src/proxy.ts`, cert/mkcert workflow, `dev:https` — origin/secure-context is not implicated.
- `formatCastRequestError` — error formatting is not implicated.
- `androidReceiverCompatible` / `autoJoinPolicy` / `castAppIdMode` paths — previously covered, not implicated.
- Phase 4 receiver-auth/URL verification (projection route public access, R2 presigned URL with `cast=true`) — deferred to a separate plan if `loadMedia` resolves but the receiver errors out.

## Verification

- [x] `pnpm --filter sow-webapp lint` — passes clean
- [x] `pnpm --filter sow-webapp test` — all 1679 tests pass (including the updated `useCastTransport.test.ts`)
- [ ] Live re-cast against AndroidTV: no `BUFFERED` error; `castState === "CONNECTED"`; MP4 plays on the TV (to be verified post-merge on device)

## Spec

Detailed investigation and execution plan: `specs/chromecast-streamtype-namespace-fix-2026-06-30.md`