### PR TITLE
feat: agentic songset constructor POC + scale key/BPM analysis batch v4

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,3 +1,9 @@
+## 2026-07-01
+
+- Updated the lab songset constructor LLM defaults: timeout now defaults to
+  300 seconds, max retries to 2, and max attempts to 4 while preserving the
+  existing `SOW_LLM_*` environment overrides.
+
 ## 2026-06-29
 
 - Updated Worship Playback lyrics pullup title behavior: song title clicks now

--- a/lab/poc-scripts/construct_songset_agent.py
+++ b/lab/poc-scripts/construct_songset_agent.py
@@ -1,0 +1,7 @@
+"""Entrypoint wrapper for the agentic songset constructor POC."""
+
+from poc.songset_constructor.cli import app
+
+
+if __name__ == "__main__":
+    app()

--- a/lab/poc-scripts/poc/songset_constructor/__init__.py
+++ b/lab/poc-scripts/poc/songset_constructor/__init__.py
@@ -1,0 +1,5 @@
+"""Agentic songset constructor POC package."""
+
+from .models import ConstructorConfig, SongCandidate, SongsetProposal, TransitionCandidate
+
+__all__ = ["ConstructorConfig", "SongCandidate", "SongsetProposal", "TransitionCandidate"]

--- a/lab/poc-scripts/poc/songset_constructor/artifacts.py
+++ b/lab/poc-scripts/poc/songset_constructor/artifacts.py
@@ -1,0 +1,114 @@
+"""Artifact writers for songset constructor runs."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from typing import Any
+
+from .models import ConstructorState, SongCandidate, SongsetProposal
+
+
+def write_artifacts(state: ConstructorState, output_dir: Path) -> dict[str, Path]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    paths = {
+        "proposals": output_dir / "proposals.json",
+        "report": output_dir / "proposal_report.md",
+        "pool": output_dir / "candidate_pool.csv",
+        "trace": output_dir / "graph_trace.jsonl",
+    }
+    paths["proposals"].write_text(
+        json.dumps(
+            [_proposal_contract(p) for p in state.final_proposals],
+            ensure_ascii=False,
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    paths["report"].write_text(_render_report(state.final_proposals), encoding="utf-8")
+    _write_pool(paths["pool"], state.pool)
+    with paths["trace"].open("w", encoding="utf-8") as handle:
+        for event in state.trace:
+            handle.write(json.dumps(event, ensure_ascii=False, default=str) + "\n")
+    return paths
+
+
+def _proposal_contract(proposal: SongsetProposal) -> dict[str, Any]:
+    return {
+        "items": [
+            {
+                "song_id": item.song_id,
+                "recording_hash_prefix": item.recording_hash_prefix,
+                "position": item.position,
+                "key_shift_semitones": item.key_shift_semitones,
+                "tempo_ratio": item.tempo_ratio,
+                "gap_beats": item.gap_beats,
+                "crossfade_enabled": item.crossfade_enabled,
+                "crossfade_duration_seconds": item.crossfade_duration_seconds,
+            }
+            for item in proposal.items
+        ],
+        "score_breakdown": proposal.score_breakdown.model_dump(),
+        "llm_rationale": proposal.llm_rationale,
+        "warnings": proposal.validation_warnings,
+    }
+
+
+def _render_report(proposals: list[SongsetProposal]) -> str:
+    lines = ["# Agentic Songset Proposals", ""]
+    if not proposals:
+        return "# Agentic Songset Proposals\n\nNo valid proposals generated.\n"
+    for index, proposal in enumerate(proposals, start=1):
+        lines.extend(
+            [
+                f"## Proposal {index} - score {proposal.score_breakdown.total:.3f}",
+                "",
+                proposal.llm_rationale or "Deterministic candidate selected by validator.",
+                "",
+            ]
+        )
+        for item in proposal.items:
+            title = item.title or item.song_id
+            transition = ""
+            if item.position > 1:
+                transition = (
+                    f" shift={item.key_shift_semitones:+d}, tempo={item.tempo_ratio:.3f}, "
+                    f"gap={item.gap_beats:g}, crossfade={item.crossfade_enabled}"
+                )
+            lines.append(
+                f"{item.position}. {title} ({item.phase or 'Unknown'}) "
+                f"`{item.recording_hash_prefix}`{transition}"
+            )
+        if proposal.validation_warnings:
+            lines.extend(["", "Warnings: " + ", ".join(proposal.validation_warnings)])
+        lines.append("")
+    return "\n".join(lines)
+
+
+def _write_pool(path: Path, pool: list[SongCandidate]) -> None:
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=[
+                "song_id",
+                "title",
+                "recording_hash_prefix",
+                "bpm",
+                "musical_key",
+                "musical_mode",
+                "key_confidence",
+                "album_name",
+                "album_series",
+                "composer",
+                "inferred_themes",
+                "phase",
+                "source_warnings",
+            ],
+        )
+        writer.writeheader()
+        for song in pool:
+            row = song.model_dump()
+            row["inferred_themes"] = "|".join(song.inferred_themes)
+            row["source_warnings"] = "|".join(song.source_warnings)
+            writer.writerow({key: row.get(key) for key in writer.fieldnames})

--- a/lab/poc-scripts/poc/songset_constructor/catalog.py
+++ b/lab/poc-scripts/poc/songset_constructor/catalog.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 import psycopg.rows
@@ -10,6 +11,8 @@ from stream_of_worship.admin.config import AdminConfig
 from stream_of_worship.db.connection import ConnectionProvider
 
 from .models import ConstructorConfig, SongCandidate
+
+logger = logging.getLogger(__name__)
 
 
 CATALOG_QUERY = """
@@ -46,26 +49,38 @@ def load_connection_provider() -> ConnectionProvider:
 def fetch_catalog(provider: ConnectionProvider, config: ConstructorConfig) -> list[SongCandidate]:
     query = CATALOG_QUERY
     params: list[Any] = []
+    filters: list[str] = []
     if not config.include_cpw:
         query += " AND COALESCE(s.album_series, '') NOT ILIKE %s"
         params.append("%CPW%")
+        filters.append("exclude CPW")
     if not config.include_dev:
         query += " AND COALESCE(s.album_series, '') NOT ILIKE %s"
         params.append("%DEV%")
+        filters.append("exclude DEV")
     if config.album_series:
         query += " AND COALESCE(s.album_series, '') ILIKE %s"
         params.append(f"%{config.album_series}%")
+        filters.append(f"album_series~{config.album_series}")
     if config.season:
         query += " AND (s.title ILIKE %s OR s.album_name ILIKE %s OR s.lyrics_raw ILIKE %s)"
         season = f"%{config.season}%"
         params.extend([season, season, season])
+        filters.append(f"season~{config.season}")
     query += " ORDER BY r.imported_at DESC LIMIT %s"
     params.append(config.pool_limit)
+
+    logger.info(
+        "fetch_catalog: pool_limit=%d, filters=[%s]",
+        config.pool_limit,
+        ", ".join(filters) if filters else "none",
+    )
 
     conn = provider.get_connection()
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cursor:
         cursor.execute(query, params)
         rows = cursor.fetchall()
+    logger.info("fetch_catalog: query returned %d rows", len(rows))
     return [_row_to_candidate(row) for row in rows]
 
 

--- a/lab/poc-scripts/poc/songset_constructor/catalog.py
+++ b/lab/poc-scripts/poc/songset_constructor/catalog.py
@@ -34,8 +34,9 @@ FROM songs s
 JOIN recordings r ON r.song_id = s.id
 WHERE s.deleted_at IS NULL
   AND r.deleted_at IS NULL
-  AND r.analysis_status = 'completed'
-  AND r.visibility_status = 'published'
+  AND r.lrc_status = 'completed'
+  AND r.r2_lrc_url IS NOT NULL
+  AND r.visibility_status IN ('review', 'published')
   AND r.tempo_bpm IS NOT NULL
   AND COALESCE(r.musical_key, s.musical_key) IS NOT NULL
 """

--- a/lab/poc-scripts/poc/songset_constructor/catalog.py
+++ b/lab/poc-scripts/poc/songset_constructor/catalog.py
@@ -1,0 +1,91 @@
+"""Read-only catalog access for the songset constructor POC."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import psycopg.rows
+
+from stream_of_worship.admin.config import AdminConfig
+from stream_of_worship.db.connection import ConnectionProvider
+
+from .models import ConstructorConfig, SongCandidate
+
+
+CATALOG_QUERY = """
+SELECT
+    s.id AS song_id,
+    s.title,
+    s.album_name,
+    s.album_series,
+    s.composer,
+    s.lyricist,
+    s.musical_key AS song_key,
+    s.lyrics_raw,
+    r.hash_prefix AS recording_hash_prefix,
+    r.tempo_bpm,
+    COALESCE(r.musical_key, s.musical_key) AS musical_key,
+    r.musical_mode,
+    r.key_confidence
+FROM songs s
+JOIN recordings r ON r.song_id = s.id
+WHERE s.deleted_at IS NULL
+  AND r.deleted_at IS NULL
+  AND r.analysis_status = 'completed'
+  AND r.visibility_status = 'published'
+  AND r.tempo_bpm IS NOT NULL
+  AND COALESCE(r.musical_key, s.musical_key) IS NOT NULL
+"""
+
+
+def load_connection_provider() -> ConnectionProvider:
+    config = AdminConfig.load()
+    return ConnectionProvider(config.get_connection_url())
+
+
+def fetch_catalog(provider: ConnectionProvider, config: ConstructorConfig) -> list[SongCandidate]:
+    query = CATALOG_QUERY
+    params: list[Any] = []
+    if not config.include_cpw:
+        query += " AND COALESCE(s.album_series, '') NOT ILIKE %s"
+        params.append("%CPW%")
+    if not config.include_dev:
+        query += " AND COALESCE(s.album_series, '') NOT ILIKE %s"
+        params.append("%DEV%")
+    if config.album_series:
+        query += " AND COALESCE(s.album_series, '') ILIKE %s"
+        params.append(f"%{config.album_series}%")
+    if config.season:
+        query += " AND (s.title ILIKE %s OR s.album_name ILIKE %s OR s.lyrics_raw ILIKE %s)"
+        season = f"%{config.season}%"
+        params.extend([season, season, season])
+    query += " ORDER BY r.imported_at DESC LIMIT %s"
+    params.append(config.pool_limit)
+
+    conn = provider.get_connection()
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cursor:
+        cursor.execute(query, params)
+        rows = cursor.fetchall()
+    return [_row_to_candidate(row) for row in rows]
+
+
+def _row_to_candidate(row: dict[str, Any]) -> SongCandidate:
+    warnings: list[str] = []
+    if row.get("key_confidence") is not None and row["key_confidence"] < 0.6:
+        warnings.append("low_key_confidence")
+    mode = row.get("musical_mode") or "major"
+    return SongCandidate(
+        song_id=row["song_id"],
+        title=row["title"],
+        recording_hash_prefix=row["recording_hash_prefix"],
+        bpm=float(row["tempo_bpm"]),
+        musical_key=row["musical_key"],
+        musical_mode=mode,
+        key_confidence=row.get("key_confidence"),
+        album_name=row.get("album_name"),
+        album_series=row.get("album_series"),
+        composer=row.get("composer"),
+        lyricist=row.get("lyricist"),
+        lyrics_raw=row.get("lyrics_raw"),
+        source_warnings=warnings,
+    )

--- a/lab/poc-scripts/poc/songset_constructor/cli.py
+++ b/lab/poc-scripts/poc/songset_constructor/cli.py
@@ -1,0 +1,63 @@
+"""CLI for the agentic songset constructor POC."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+from rich.console import Console
+
+from .graph import run_constructor
+from .models import ConstructorConfig
+
+
+app = typer.Typer(help="Generate read-only songset proposal artifacts with a LangGraph agent.")
+console = Console()
+
+
+@app.command()
+def main(
+    songs: int = typer.Option(
+        5,
+        "--songs",
+        min=4,
+        max=5,
+        help="Song count; webapp-compatible values are 4 or 5.",
+    ),
+    top_k: int = typer.Option(3, "--top-k", min=1),
+    pool_limit: int = typer.Option(200, "--pool-limit", min=10),
+    output_dir: Path = typer.Option(
+        Path("lab/poc-scripts/output/songset_constructor"),
+        "--output-dir",
+    ),
+    album_series: str | None = typer.Option(None, "--album-series"),
+    include_dev: bool = typer.Option(True, "--include-dev/--no-include-dev"),
+    include_cpw: bool = typer.Option(False, "--include-cpw/--no-include-cpw"),
+    intimate: bool = typer.Option(False, "--intimate"),
+    hymnal_mode: bool = typer.Option(False, "--hymnal-mode"),
+    season: str | None = typer.Option(None, "--season"),
+    interactive_review: bool = typer.Option(False, "--interactive-review"),
+    resume_thread_id: str | None = typer.Option(None, "--resume-thread-id"),
+    llm_model: str | None = typer.Option(None, "--llm-model"),
+) -> None:
+    config = ConstructorConfig(
+        songs=songs,
+        top_k=top_k,
+        pool_limit=pool_limit,
+        output_dir=str(output_dir),
+        album_series=album_series,
+        include_dev=include_dev,
+        include_cpw=include_cpw,
+        intimate=intimate,
+        hymnal_mode=hymnal_mode,
+        season=season,
+        interactive_review=interactive_review,
+        resume_thread_id=resume_thread_id,
+        llm_model=llm_model,
+    )
+    state = run_constructor(config)
+    console.print(f"Wrote {len(state.final_proposals)} proposal(s) to {output_dir}")
+
+
+if __name__ == "__main__":
+    app()

--- a/lab/poc-scripts/poc/songset_constructor/cli.py
+++ b/lab/poc-scripts/poc/songset_constructor/cli.py
@@ -40,6 +40,11 @@ def main(
     interactive_review: bool = typer.Option(False, "--interactive-review"),
     resume_thread_id: str | None = typer.Option(None, "--resume-thread-id"),
     llm_model: str | None = typer.Option(None, "--llm-model"),
+    no_llm: bool = typer.Option(
+        False,
+        "--no-llm/--llm",
+        help="Use deterministic beam proposals without calling the LLM.",
+    ),
     verbose: bool = typer.Option(True, "--verbose/--quiet", help="Enable debug traces."),
 ) -> None:
     if verbose:
@@ -61,6 +66,7 @@ def main(
         interactive_review=interactive_review,
         resume_thread_id=resume_thread_id,
         llm_model=llm_model,
+        no_llm=no_llm,
     )
     state = run_constructor(config)
     console.print(f"Wrote {len(state.final_proposals)} proposal(s) to {output_dir}")

--- a/lab/poc-scripts/poc/songset_constructor/cli.py
+++ b/lab/poc-scripts/poc/songset_constructor/cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import typer
@@ -39,7 +40,13 @@ def main(
     interactive_review: bool = typer.Option(False, "--interactive-review"),
     resume_thread_id: str | None = typer.Option(None, "--resume-thread-id"),
     llm_model: str | None = typer.Option(None, "--llm-model"),
+    verbose: bool = typer.Option(True, "--verbose/--quiet", help="Enable debug traces."),
 ) -> None:
+    if verbose:
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        )
     config = ConstructorConfig(
         songs=songs,
         top_k=top_k,

--- a/lab/poc-scripts/poc/songset_constructor/graph.py
+++ b/lab/poc-scripts/poc/songset_constructor/graph.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+import logging
 import os
+import random
+import threading
+import time
+from collections import Counter
 from collections.abc import Iterator
 from collections.abc import Callable
 from contextlib import contextmanager
@@ -12,6 +17,13 @@ from typing import Any
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_openai import ChatOpenAI
 from langgraph.graph import END, StateGraph
+
+logger = logging.getLogger(__name__)
+
+POOL_SAMPLE_SIZE = 10
+LLM_POOL_SLICE = 15
+LLM_MAX_CONCURRENCY = int(os.environ.get("SOW_LLM_MAX_CONCURRENCY", "1"))
+_llm_concurrency_sem = threading.Semaphore(LLM_MAX_CONCURRENCY)
 
 try:
     from langgraph.checkpoint.memory import InMemorySaver
@@ -142,7 +154,14 @@ def build_llm_planner(config: ConstructorConfig) -> Planner:
     if missing:
         raise RuntimeError(f"Missing LLM configuration: {', '.join(missing)}")
 
-    llm = ChatOpenAI(api_key=api_key, base_url=base_url, model=model, temperature=0.2)
+    llm = ChatOpenAI(
+        api_key=api_key,
+        base_url=base_url,
+        model=model,
+        temperature=0.2,
+        timeout=120,
+        max_retries=0,
+    )
     structured = llm.with_structured_output(LlmDraft)
     prompt = ChatPromptTemplate.from_messages(
         [
@@ -157,8 +176,17 @@ def build_llm_planner(config: ConstructorConfig) -> Planner:
             ),
         ]
     )
+    chain = prompt | structured
 
     def planner(state: ConstructorState) -> list[LlmDraft]:
+        pool_slice = state.pool[:LLM_POOL_SLICE]
+        logger.info(
+            "llm_plan: pool has %d songs, sending first %d to LLM (slice=state.pool[:%d])",
+            len(state.pool),
+            len(pool_slice),
+            LLM_POOL_SLICE,
+        )
+        _log_pool_sample("llm_plan", pool_slice)
         pool_summary = [
             {
                 "hash": song.recording_hash_prefix,
@@ -169,16 +197,43 @@ def build_llm_planner(config: ConstructorConfig) -> Planner:
                 "themes": song.inferred_themes,
                 "phase": song.phase,
             }
-            for song in state.pool[:80]
+            for song in pool_slice
         ]
-        draft = (prompt | structured).invoke(
-            {
-                "songs": state.config.songs,
-                "pool": pool_summary,
-                "feedback": state.validation_feedback[-10:],
-            }
-        )
-        return [draft]
+        max_attempts = 20
+        last_exc: Exception | None = None
+        prompt_vars = {
+            "songs": state.config.songs,
+            "pool": pool_summary,
+            "feedback": state.validation_feedback[-10:],
+        }
+        for attempt_num in range(1, max_attempts + 1):
+            try:
+                logger.info(
+                    "llm_plan prompt sent to LLM:\n%s",
+                    _format_llm_prompt_trace(prompt.format_messages(**prompt_vars)),
+                )
+                with _llm_concurrency_sem:
+                    draft = chain.invoke(prompt_vars)
+                return [draft]
+            except Exception as exc:
+                last_exc = exc
+                is_timeout = "timed out" in str(exc).lower() or "timeout" in str(exc).lower()
+                if is_timeout:
+                    wait_s = 120.0
+                else:
+                    base_delay = _extract_retry_after(exc)
+                    wait_s = min(base_delay * (2 ** (attempt_num - 1)), 30.0)
+                logger.warning(
+                    "llm_plan attempt %d/%d failed (%s): %s — waiting %.1fs",
+                    attempt_num,
+                    max_attempts,
+                    "timeout" if is_timeout else "error",
+                    exc,
+                    wait_s,
+                )
+                if attempt_num < max_attempts:
+                    time.sleep(wait_s)
+        raise last_exc  # type: ignore[misc]
 
     return planner
 
@@ -189,15 +244,24 @@ def load_catalog(
 ) -> ConstructorState:
     pool = loader(state.config)
     state.pool = pool
+    _log_pool_sample("load_catalog", pool)
     return state
 
 
 def enrich_pool(state: ConstructorState) -> ConstructorState:
+    before = len(state.pool)
     state.pool = [
         enrich_candidate(song)
         for song in state.pool
         if song.bpm > 0 and song.musical_key
     ]
+    dropped = before - len(state.pool)
+    logger.info(
+        "enrich_pool: kept %d songs, dropped %d (bpm<=0 or missing key)",
+        len(state.pool),
+        dropped,
+    )
+    _log_pool_sample("enrich_pool", state.pool)
     return state
 
 
@@ -304,6 +368,74 @@ def write_artifacts(state: ConstructorState, output_dir: Path) -> ConstructorSta
 def _default_catalog_loader(config: ConstructorConfig) -> list[SongCandidate]:
     with load_connection_provider() as provider:
         return fetch_catalog(provider, config)
+
+
+def _extract_retry_after(exc: Exception) -> float:
+    """Extract retry_after (seconds) from an openai RateLimitError or similar."""
+    retry_after = getattr(exc, "retry_after", None)
+    if isinstance(retry_after, (int, float)):
+        return float(retry_after)
+    response = getattr(exc, "response", None)
+    if response is not None:
+        header = getattr(response, "headers", {})
+        if isinstance(header, dict):
+            ra = header.get("retry-after") or header.get("Retry-After")
+            if ra:
+                try:
+                    return float(ra)
+                except (TypeError, ValueError):
+                    pass
+    body = getattr(exc, "body", None) or {}
+    if isinstance(body, dict):
+        retry_after_val = body.get("retry_after")
+        if isinstance(retry_after_val, (int, float)):
+            return float(retry_after_val)
+        strategy = body.get("retry_strategy") or {}
+        if isinstance(strategy, dict):
+            suggested = strategy.get("suggested_initial_delay_s")
+            if isinstance(suggested, (int, float)):
+                return float(suggested)
+    return 2.0
+
+
+def _format_llm_prompt_trace(messages: list[Any]) -> str:
+    blocks = []
+    for message in messages:
+        role = str(getattr(message, "type", message.__class__.__name__)).upper()
+        content = getattr(message, "content", "")
+        if not isinstance(content, str):
+            content = repr(content)
+        blocks.append(f"[{role}]\n{content}")
+    return "\n\n".join(blocks)
+
+
+def _log_pool_sample(node: str, pool: list[SongCandidate]) -> None:
+    if not pool:
+        logger.info("%s: pool is empty", node)
+        return
+    sample = random.sample(pool, min(POOL_SAMPLE_SIZE, len(pool)))
+    logger.info("%s: pool size=%d, sampling %d random songs:", node, len(pool), len(sample))
+    for song in sample:
+        logger.info(
+            "  - hash=%s title=%r bpm=%.1f key=%s mode=%s phase=%s themes=%s "
+            "source: album=%r series=%r composer=%r",
+            song.recording_hash_prefix,
+            song.title,
+            song.bpm,
+            song.musical_key,
+            song.musical_mode,
+            song.phase,
+            song.inferred_themes,
+            song.album_name,
+            song.album_series,
+            song.composer,
+        )
+    series_counts: Counter[str] = Counter(song.album_series or "(none)" for song in pool)
+    logger.info(
+        "%s: pool source breakdown by album_series: %s",
+        node,
+        dict(series_counts),
+    )
 
 
 def _trace_node(name: str, fn: GraphNode) -> GraphNode:

--- a/lab/poc-scripts/poc/songset_constructor/graph.py
+++ b/lab/poc-scripts/poc/songset_constructor/graph.py
@@ -25,7 +25,7 @@ LLM_POOL_SLICE = 15
 LLM_MAX_CONCURRENCY = int(os.environ.get("SOW_LLM_MAX_CONCURRENCY", "1"))
 _llm_concurrency_sem = threading.Semaphore(LLM_MAX_CONCURRENCY)
 LLM_TIMEOUT = float(os.environ.get("SOW_LLM_TIMEOUT", "30"))
-LLM_MAX_ATTEMPTS = int(os.environ.get("SOW_LLM_MAX_ATTEMPTS", "5"))
+LLM_MAX_ATTEMPTS = int(os.environ.get("SOW_LLM_MAX_ATTEMPTS", "1"))
 LLM_MAX_BACKOFF_S = 30.0
 
 try:
@@ -69,7 +69,7 @@ def build_graph(
     checkpointer: Any | None = None,
 ) -> Any:
     loader = catalog_loader or _default_catalog_loader
-    llm_planner = planner or build_llm_planner(config)
+    llm_planner = None if config.no_llm else planner or build_llm_planner(config)
     run_output_dir = output_dir or Path(config.output_dir)
 
     graph = StateGraph(ConstructorState)
@@ -80,12 +80,7 @@ def build_graph(
         _trace_node("build_transition_matrix", build_transition_matrix),
     )
     graph.add_node("beam_seed_candidates", _trace_node("beam_seed_candidates", seed_candidates))
-    graph.add_node("llm_plan", _trace_node("llm_plan", lambda s: llm_plan(s, llm_planner)))
     graph.add_node("validate_score", _trace_node("validate_score", validate_score))
-    graph.add_node(
-        "llm_refine",
-        _trace_node("llm_refine", lambda s: llm_plan(s, llm_planner, refine=True)),
-    )
     graph.add_node("optional_review", _trace_node("optional_review", optional_review))
     graph.add_node(
         "write_artifacts",
@@ -95,14 +90,24 @@ def build_graph(
     graph.add_edge("load_catalog", "enrich_pool")
     graph.add_edge("enrich_pool", "build_transition_matrix")
     graph.add_edge("build_transition_matrix", "beam_seed_candidates")
-    graph.add_edge("beam_seed_candidates", "llm_plan")
-    graph.add_edge("llm_plan", "validate_score")
-    graph.add_conditional_edges(
-        "validate_score",
-        should_refine,
-        {"refine": "llm_refine", "review": "optional_review"},
-    )
-    graph.add_edge("llm_refine", "validate_score")
+    if config.no_llm:
+        graph.add_edge("beam_seed_candidates", "validate_score")
+        graph.add_edge("validate_score", "optional_review")
+    else:
+        assert llm_planner is not None
+        graph.add_node("llm_plan", _trace_node("llm_plan", lambda s: llm_plan(s, llm_planner)))
+        graph.add_node(
+            "llm_refine",
+            _trace_node("llm_refine", lambda s: llm_plan(s, llm_planner, refine=True)),
+        )
+        graph.add_edge("beam_seed_candidates", "llm_plan")
+        graph.add_edge("llm_plan", "validate_score")
+        graph.add_conditional_edges(
+            "validate_score",
+            should_refine,
+            {"refine": "llm_refine", "review": "optional_review"},
+        )
+        graph.add_edge("llm_refine", "validate_score")
     graph.add_edge("optional_review", "write_artifacts")
     graph.add_edge("write_artifacts", END)
     return graph.compile(checkpointer=checkpointer or InMemorySaver())
@@ -220,19 +225,20 @@ def build_llm_planner(config: ConstructorConfig) -> Planner:
                 return [draft]
             except Exception as exc:
                 last_exc = exc
-                is_timeout = "timed out" in str(exc).lower() or "timeout" in str(exc).lower()
+                if not _is_retryable_rate_limit(exc) or attempt_num >= max_attempts:
+                    raise
                 base_delay = _extract_retry_after(exc)
                 wait_s = min(base_delay * (2 ** (attempt_num - 1)), LLM_MAX_BACKOFF_S)
+                wait_s += random.uniform(0.0, min(1.0, wait_s * 0.1))
                 logger.warning(
-                    "llm_plan attempt %d/%d failed (%s): %s — waiting %.1fs",
+                    "llm_plan attempt %d/%d hit provider rate limit (%s): %s; waiting %.1fs",
                     attempt_num,
                     max_attempts,
-                    "timeout" if is_timeout else "error",
+                    _rate_limit_reason(exc),
                     exc,
                     wait_s,
                 )
-                if attempt_num < max_attempts:
-                    time.sleep(wait_s)
+                time.sleep(wait_s)
         raise last_exc  # type: ignore[misc]
 
     return planner
@@ -331,7 +337,7 @@ def validate_score(state: ConstructorState) -> ConstructorState:
         key=lambda p: p.score_breakdown.total,
         reverse=True,
     )[: state.config.top_k]
-    if state.llm_drafts and not valid_draft_seen and state.iteration < 3:
+    if state.llm_drafts and not valid and not valid_draft_seen and state.iteration < 3:
         state.final_proposals = []
     return state
 
@@ -396,6 +402,31 @@ def _extract_retry_after(exc: Exception) -> float:
             if isinstance(suggested, (int, float)):
                 return float(suggested)
     return 2.0
+
+
+def _is_retryable_rate_limit(exc: Exception) -> bool:
+    status_code = getattr(exc, "status_code", None)
+    response = getattr(exc, "response", None)
+    if status_code == 429 or getattr(response, "status_code", None) == 429:
+        return True
+    body = getattr(exc, "body", None)
+    if isinstance(body, dict):
+        code = str(body.get("code") or body.get("type") or "")
+        if "rate" in code.lower() or "concurrent_budget_exceeded" in code:
+            return True
+    message = str(exc).lower()
+    return "rate limit" in message or "429" in message or "concurrent_budget_exceeded" in message
+
+
+def _rate_limit_reason(exc: Exception) -> str:
+    body = getattr(exc, "body", None)
+    if isinstance(body, dict):
+        code = body.get("code") or body.get("type")
+        if code:
+            return str(code)
+    if "concurrent_budget_exceeded" in str(exc):
+        return "account-level concurrent_budget_exceeded"
+    return "429"
 
 
 def _format_llm_prompt_trace(messages: list[Any]) -> str:

--- a/lab/poc-scripts/poc/songset_constructor/graph.py
+++ b/lab/poc-scripts/poc/songset_constructor/graph.py
@@ -1,0 +1,326 @@
+"""LangGraph orchestration for the agentic songset constructor POC."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from collections.abc import Callable
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_openai import ChatOpenAI
+from langgraph.graph import END, StateGraph
+
+try:
+    from langgraph.checkpoint.memory import InMemorySaver
+except ImportError:  # pragma: no cover - older LangGraph compatibility
+    from langgraph.checkpoint.memory import MemorySaver as InMemorySaver
+
+try:
+    from langgraph.checkpoint.sqlite import SqliteSaver
+except ImportError:  # pragma: no cover - optional checkpoint package
+    SqliteSaver = None
+
+try:
+    from langgraph.types import interrupt
+except ImportError:  # pragma: no cover
+    interrupt = None
+
+from .artifacts import write_artifacts as write_artifact_files
+from .catalog import fetch_catalog, load_connection_provider
+from .models import ConstructorConfig, ConstructorState, LlmDraft, SongCandidate, SongsetProposal
+from .music_rules import (
+    beam_seed_candidates,
+    build_transition,
+    detect_dead_ends,
+    enrich_candidate,
+    make_proposal,
+    validate_and_score,
+)
+
+
+GraphNode = Callable[[ConstructorState], ConstructorState]
+Planner = Callable[[ConstructorState], list[LlmDraft]]
+
+
+def build_graph(
+    config: ConstructorConfig,
+    *,
+    catalog_loader: Callable[[ConstructorConfig], list[SongCandidate]] | None = None,
+    planner: Planner | None = None,
+    output_dir: Path | None = None,
+    checkpointer: Any | None = None,
+) -> Any:
+    loader = catalog_loader or _default_catalog_loader
+    llm_planner = planner or build_llm_planner(config)
+    run_output_dir = output_dir or Path(config.output_dir)
+
+    graph = StateGraph(ConstructorState)
+    graph.add_node("load_catalog", _trace_node("load_catalog", lambda s: load_catalog(s, loader)))
+    graph.add_node("enrich_pool", _trace_node("enrich_pool", enrich_pool))
+    graph.add_node(
+        "build_transition_matrix",
+        _trace_node("build_transition_matrix", build_transition_matrix),
+    )
+    graph.add_node("beam_seed_candidates", _trace_node("beam_seed_candidates", seed_candidates))
+    graph.add_node("llm_plan", _trace_node("llm_plan", lambda s: llm_plan(s, llm_planner)))
+    graph.add_node("validate_score", _trace_node("validate_score", validate_score))
+    graph.add_node(
+        "llm_refine",
+        _trace_node("llm_refine", lambda s: llm_plan(s, llm_planner, refine=True)),
+    )
+    graph.add_node("optional_review", _trace_node("optional_review", optional_review))
+    graph.add_node(
+        "write_artifacts",
+        _trace_node("write_artifacts", lambda s: write_artifacts(s, run_output_dir)),
+    )
+    graph.set_entry_point("load_catalog")
+    graph.add_edge("load_catalog", "enrich_pool")
+    graph.add_edge("enrich_pool", "build_transition_matrix")
+    graph.add_edge("build_transition_matrix", "beam_seed_candidates")
+    graph.add_edge("beam_seed_candidates", "llm_plan")
+    graph.add_edge("llm_plan", "validate_score")
+    graph.add_conditional_edges(
+        "validate_score",
+        should_refine,
+        {"refine": "llm_refine", "review": "optional_review"},
+    )
+    graph.add_edge("llm_refine", "validate_score")
+    graph.add_edge("optional_review", "write_artifacts")
+    graph.add_edge("write_artifacts", END)
+    return graph.compile(checkpointer=checkpointer or InMemorySaver())
+
+
+def run_constructor(
+    config: ConstructorConfig,
+    *,
+    catalog_loader: Callable[[ConstructorConfig], list[SongCandidate]] | None = None,
+    planner: Planner | None = None,
+) -> ConstructorState:
+    with _checkpointer_for_config(config) as checkpointer:
+        app = build_graph(
+            config,
+            catalog_loader=catalog_loader,
+            planner=planner,
+            checkpointer=checkpointer,
+        )
+        initial = ConstructorState(config=config)
+        thread_id = config.resume_thread_id or "songset-constructor-poc"
+        result = app.invoke(initial, config={"configurable": {"thread_id": thread_id}})
+    if isinstance(result, ConstructorState):
+        return result
+    return ConstructorState.model_validate(result)
+
+
+@contextmanager
+def _checkpointer_for_config(config: ConstructorConfig) -> Iterator[Any]:
+    if (config.interactive_review or config.resume_thread_id) and SqliteSaver is not None:
+        output_dir = Path(config.output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        checkpoint_path = output_dir / "langgraph_checkpoint.sqlite"
+        with SqliteSaver.from_conn_string(str(checkpoint_path)) as saver:
+            yield saver
+        return
+    yield InMemorySaver()
+
+
+def build_llm_planner(config: ConstructorConfig) -> Planner:
+    api_key = os.environ.get("SOW_LLM_API_KEY")
+    base_url = os.environ.get("SOW_LLM_BASE_URL")
+    model = config.llm_model or os.environ.get("SOW_LLM_MODEL")
+    missing = [
+        name
+        for name, value in {
+            "SOW_LLM_API_KEY": api_key,
+            "SOW_LLM_BASE_URL": base_url,
+            "SOW_LLM_MODEL": model,
+        }.items()
+        if not value
+    ]
+    if missing:
+        raise RuntimeError(f"Missing LLM configuration: {', '.join(missing)}")
+
+    llm = ChatOpenAI(api_key=api_key, base_url=base_url, model=model, temperature=0.2)
+    structured = llm.with_structured_output(LlmDraft)
+    prompt = ChatPromptTemplate.from_messages(
+        [
+            (
+                "system",
+                "You assemble Chinese worship songsets. Return only known recording_hashes. "
+                "Deterministic validation is authoritative.",
+            ),
+            (
+                "human",
+                "Need {songs} songs. Pool JSON: {pool}. Prior drafts/feedback: {feedback}.",
+            ),
+        ]
+    )
+
+    def planner(state: ConstructorState) -> list[LlmDraft]:
+        pool_summary = [
+            {
+                "hash": song.recording_hash_prefix,
+                "title": song.title,
+                "bpm": song.bpm,
+                "key": song.musical_key,
+                "mode": song.musical_mode,
+                "themes": song.inferred_themes,
+                "phase": song.phase,
+            }
+            for song in state.pool[:80]
+        ]
+        draft = (prompt | structured).invoke(
+            {
+                "songs": state.config.songs,
+                "pool": pool_summary,
+                "feedback": state.validation_feedback[-10:],
+            }
+        )
+        return [draft]
+
+    return planner
+
+
+def load_catalog(
+    state: ConstructorState,
+    loader: Callable[[ConstructorConfig], list[SongCandidate]],
+) -> ConstructorState:
+    pool = loader(state.config)
+    state.pool = pool
+    return state
+
+
+def enrich_pool(state: ConstructorState) -> ConstructorState:
+    state.pool = [
+        enrich_candidate(song)
+        for song in state.pool
+        if song.bpm > 0 and song.musical_key
+    ]
+    return state
+
+
+def build_transition_matrix(state: ConstructorState) -> ConstructorState:
+    matrix = {song.recording_hash_prefix: {} for song in state.pool}
+    for source in state.pool:
+        for target in state.pool:
+            if source.recording_hash_prefix == target.recording_hash_prefix:
+                continue
+            matrix[source.recording_hash_prefix][target.recording_hash_prefix] = build_transition(
+                source,
+                target,
+            )
+    state.transition_matrix = matrix
+    dead_ends = detect_dead_ends(state.pool, state.transition_matrix)
+    if dead_ends:
+        state.validation_feedback.extend(dead_ends[:20])
+    return state
+
+
+def seed_candidates(state: ConstructorState) -> ConstructorState:
+    state.candidate_beams = beam_seed_candidates(state.pool, state.transition_matrix, state.config)
+    return state
+
+
+def llm_plan(state: ConstructorState, planner: Planner, refine: bool = False) -> ConstructorState:
+    drafts = planner(state)
+    state.llm_drafts.extend(drafts)
+    state.iteration += 1 if refine else 0
+    return state
+
+
+def validate_score(state: ConstructorState) -> ConstructorState:
+    pool_by_hash = {song.recording_hash_prefix: song for song in state.pool}
+    proposals: list[SongsetProposal] = []
+    valid_draft_seen = False
+    for draft in state.llm_drafts[-3:]:
+        if len(set(draft.recording_hashes)) != len(draft.recording_hashes):
+            state.validation_feedback.append("H2 duplicate recordings")
+            continue
+        songs = [pool_by_hash[h] for h in draft.recording_hashes if h in pool_by_hash]
+        if len(songs) == len(draft.recording_hashes):
+            proposals.append(
+                make_proposal(songs, state.transition_matrix, state.config, draft.rationale)
+            )
+            valid_draft_seen = True
+        else:
+            missing = sorted(set(draft.recording_hashes) - set(pool_by_hash))
+            state.validation_feedback.append(f"Unknown recording hashes: {', '.join(missing)}")
+
+    proposals.extend(state.candidate_beams)
+    for proposal in proposals:
+        errors, warnings, score = validate_and_score(
+            proposal,
+            pool_by_hash,
+            state.transition_matrix,
+            state.config,
+        )
+        proposal.validation_errors = errors
+        proposal.validation_warnings = warnings
+        proposal.score_breakdown = score
+        if errors:
+            state.validation_feedback.extend(errors)
+    valid = [proposal for proposal in proposals if not proposal.validation_errors]
+    state.final_proposals = sorted(
+        valid,
+        key=lambda p: p.score_breakdown.total,
+        reverse=True,
+    )[: state.config.top_k]
+    if state.llm_drafts and not valid_draft_seen and state.iteration < 3:
+        state.final_proposals = []
+    return state
+
+
+def should_refine(state: ConstructorState) -> str:
+    if state.final_proposals:
+        return "review"
+    if state.iteration < 3:
+        return "refine"
+    state.final_proposals = state.candidate_beams[: state.config.top_k]
+    return "review"
+
+
+def optional_review(state: ConstructorState) -> ConstructorState:
+    if state.config.interactive_review and interrupt is not None:
+        summaries = [
+            {
+                "score": proposal.score_breakdown.total,
+                "items": [item.model_dump() for item in proposal.items],
+                "warnings": proposal.validation_warnings,
+            }
+            for proposal in state.final_proposals
+        ]
+        interrupt({"proposals": summaries})
+    return state
+
+
+def write_artifacts(state: ConstructorState, output_dir: Path) -> ConstructorState:
+    paths = write_artifact_files(state, output_dir)
+    state.trace.append({"node": "write_artifacts", "paths": {k: str(v) for k, v in paths.items()}})
+    return state
+
+
+def _default_catalog_loader(config: ConstructorConfig) -> list[SongCandidate]:
+    with load_connection_provider() as provider:
+        return fetch_catalog(provider, config)
+
+
+def _trace_node(name: str, fn: GraphNode) -> GraphNode:
+    def wrapped(state: ConstructorState) -> ConstructorState:
+        state = ConstructorState.model_validate(state)
+        before = len(state.final_proposals)
+        state = fn(state)
+        state.trace.append(
+            {
+                "node": name,
+                "pool_size": len(state.pool),
+                "candidate_beams": len(state.candidate_beams),
+                "final_proposals_before": before,
+                "final_proposals_after": len(state.final_proposals),
+                "iteration": state.iteration,
+            }
+        )
+        return state
+
+    return wrapped

--- a/lab/poc-scripts/poc/songset_constructor/graph.py
+++ b/lab/poc-scripts/poc/songset_constructor/graph.py
@@ -24,6 +24,9 @@ POOL_SAMPLE_SIZE = 10
 LLM_POOL_SLICE = 15
 LLM_MAX_CONCURRENCY = int(os.environ.get("SOW_LLM_MAX_CONCURRENCY", "1"))
 _llm_concurrency_sem = threading.Semaphore(LLM_MAX_CONCURRENCY)
+LLM_TIMEOUT = float(os.environ.get("SOW_LLM_TIMEOUT", "30"))
+LLM_MAX_ATTEMPTS = int(os.environ.get("SOW_LLM_MAX_ATTEMPTS", "5"))
+LLM_MAX_BACKOFF_S = 30.0
 
 try:
     from langgraph.checkpoint.memory import InMemorySaver
@@ -159,8 +162,8 @@ def build_llm_planner(config: ConstructorConfig) -> Planner:
         base_url=base_url,
         model=model,
         temperature=0.2,
-        timeout=120,
-        max_retries=0,
+        timeout=LLM_TIMEOUT,
+        max_retries=2,
     )
     structured = llm.with_structured_output(LlmDraft)
     prompt = ChatPromptTemplate.from_messages(
@@ -199,7 +202,7 @@ def build_llm_planner(config: ConstructorConfig) -> Planner:
             }
             for song in pool_slice
         ]
-        max_attempts = 20
+        max_attempts = LLM_MAX_ATTEMPTS
         last_exc: Exception | None = None
         prompt_vars = {
             "songs": state.config.songs,
@@ -218,11 +221,8 @@ def build_llm_planner(config: ConstructorConfig) -> Planner:
             except Exception as exc:
                 last_exc = exc
                 is_timeout = "timed out" in str(exc).lower() or "timeout" in str(exc).lower()
-                if is_timeout:
-                    wait_s = 120.0
-                else:
-                    base_delay = _extract_retry_after(exc)
-                    wait_s = min(base_delay * (2 ** (attempt_num - 1)), 30.0)
+                base_delay = _extract_retry_after(exc)
+                wait_s = min(base_delay * (2 ** (attempt_num - 1)), LLM_MAX_BACKOFF_S)
                 logger.warning(
                     "llm_plan attempt %d/%d failed (%s): %s — waiting %.1fs",
                     attempt_num,

--- a/lab/poc-scripts/poc/songset_constructor/graph.py
+++ b/lab/poc-scripts/poc/songset_constructor/graph.py
@@ -24,9 +24,9 @@ POOL_SAMPLE_SIZE = 10
 LLM_POOL_SLICE = 15
 LLM_MAX_CONCURRENCY = int(os.environ.get("SOW_LLM_MAX_CONCURRENCY", "1"))
 _llm_concurrency_sem = threading.Semaphore(LLM_MAX_CONCURRENCY)
-LLM_TIMEOUT = float(os.environ.get("SOW_LLM_TIMEOUT", "30"))
-LLM_MAX_RETRIES = int(os.environ.get("SOW_LLM_MAX_RETRIES", "0"))
-LLM_MAX_ATTEMPTS = int(os.environ.get("SOW_LLM_MAX_ATTEMPTS", "1"))
+LLM_TIMEOUT = float(os.environ.get("SOW_LLM_TIMEOUT", "300"))
+LLM_MAX_RETRIES = int(os.environ.get("SOW_LLM_MAX_RETRIES", "2"))
+LLM_MAX_ATTEMPTS = int(os.environ.get("SOW_LLM_MAX_ATTEMPTS", "4"))
 LLM_MAX_BACKOFF_S = 30.0
 
 try:

--- a/lab/poc-scripts/poc/songset_constructor/graph.py
+++ b/lab/poc-scripts/poc/songset_constructor/graph.py
@@ -25,6 +25,7 @@ LLM_POOL_SLICE = 15
 LLM_MAX_CONCURRENCY = int(os.environ.get("SOW_LLM_MAX_CONCURRENCY", "1"))
 _llm_concurrency_sem = threading.Semaphore(LLM_MAX_CONCURRENCY)
 LLM_TIMEOUT = float(os.environ.get("SOW_LLM_TIMEOUT", "30"))
+LLM_MAX_RETRIES = int(os.environ.get("SOW_LLM_MAX_RETRIES", "0"))
 LLM_MAX_ATTEMPTS = int(os.environ.get("SOW_LLM_MAX_ATTEMPTS", "1"))
 LLM_MAX_BACKOFF_S = 30.0
 
@@ -168,7 +169,7 @@ def build_llm_planner(config: ConstructorConfig) -> Planner:
         model=model,
         temperature=0.2,
         timeout=LLM_TIMEOUT,
-        max_retries=2,
+        max_retries=LLM_MAX_RETRIES,
     )
     structured = llm.with_structured_output(LlmDraft)
     prompt = ChatPromptTemplate.from_messages(

--- a/lab/poc-scripts/poc/songset_constructor/models.py
+++ b/lab/poc-scripts/poc/songset_constructor/models.py
@@ -1,0 +1,104 @@
+"""Data models for the agentic songset constructor POC."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+Phase = Literal["Praise", "Thanksgiving", "Worship", "Response", "Sending"]
+
+
+class ConstructorConfig(BaseModel):
+    songs: int = 5
+    top_k: int = 3
+    pool_limit: int = 200
+    output_dir: str = "lab/poc-scripts/output/songset_constructor"
+    album_series: str | None = None
+    include_dev: bool = True
+    include_cpw: bool = False
+    intimate: bool = False
+    hymnal_mode: bool = False
+    season: str | None = None
+    interactive_review: bool = False
+    resume_thread_id: str | None = None
+    llm_model: str | None = None
+
+
+class SongCandidate(BaseModel):
+    song_id: str
+    title: str
+    recording_hash_prefix: str
+    bpm: float
+    musical_key: str
+    musical_mode: str = "major"
+    key_confidence: float | None = None
+    album_name: str | None = None
+    album_series: str | None = None
+    composer: str | None = None
+    lyricist: str | None = None
+    lyrics_raw: str | None = None
+    inferred_themes: list[str] = Field(default_factory=list)
+    phase: Phase = "Worship"
+    source_warnings: list[str] = Field(default_factory=list)
+
+
+class TransitionCandidate(BaseModel):
+    from_hash: str
+    to_hash: str
+    bpm_delta: float
+    cfd: int
+    compatibility_score: float
+    key_shift_semitones: int = 0
+    tempo_ratio: float = 1.0
+    gap_beats: float = 2.0
+    crossfade_enabled: bool = False
+    crossfade_duration_seconds: float | None = None
+    warnings: list[str] = Field(default_factory=list)
+
+
+class ProposalItem(BaseModel):
+    song_id: str
+    recording_hash_prefix: str
+    position: int
+    title: str | None = None
+    phase: Phase | None = None
+    key_shift_semitones: int = 0
+    tempo_ratio: float = 1.0
+    gap_beats: float = 2.0
+    crossfade_enabled: bool = False
+    crossfade_duration_seconds: float | None = None
+
+
+class ScoreBreakdown(BaseModel):
+    theme: float = 0.0
+    tempo: float = 0.0
+    harmony: float = 0.0
+    diversity: float = 0.0
+    total: float = 0.0
+
+
+class SongsetProposal(BaseModel):
+    items: list[ProposalItem]
+    score_breakdown: ScoreBreakdown = Field(default_factory=ScoreBreakdown)
+    llm_rationale: str = ""
+    validation_warnings: list[str] = Field(default_factory=list)
+    validation_errors: list[str] = Field(default_factory=list)
+
+
+class LlmDraft(BaseModel):
+    recording_hashes: list[str]
+    rationale: str = ""
+
+
+class ConstructorState(BaseModel):
+    config: ConstructorConfig
+    pool: list[SongCandidate] = Field(default_factory=list)
+    transition_matrix: dict[str, dict[str, TransitionCandidate]] = Field(default_factory=dict)
+    candidate_beams: list[SongsetProposal] = Field(default_factory=list)
+    llm_drafts: list[LlmDraft] = Field(default_factory=list)
+    validation_feedback: list[str] = Field(default_factory=list)
+    final_proposals: list[SongsetProposal] = Field(default_factory=list)
+    trace: list[dict[str, Any]] = Field(default_factory=list)
+    iteration: int = 0

--- a/lab/poc-scripts/poc/songset_constructor/models.py
+++ b/lab/poc-scripts/poc/songset_constructor/models.py
@@ -24,6 +24,7 @@ class ConstructorConfig(BaseModel):
     interactive_review: bool = False
     resume_thread_id: str | None = None
     llm_model: str | None = None
+    no_llm: bool = False
 
 
 class SongCandidate(BaseModel):

--- a/lab/poc-scripts/poc/songset_constructor/music_rules.py
+++ b/lab/poc-scripts/poc/songset_constructor/music_rules.py
@@ -1,0 +1,394 @@
+"""Deterministic worship-set music rules used by the POC graph."""
+
+from __future__ import annotations
+
+from collections import Counter
+from itertools import combinations
+from math import inf
+
+from .models import (
+    ConstructorConfig,
+    Phase,
+    ProposalItem,
+    ScoreBreakdown,
+    SongCandidate,
+    SongsetProposal,
+    TransitionCandidate,
+)
+
+
+NOTE_TO_PC = {
+    "C": 0,
+    "B#": 0,
+    "C#": 1,
+    "Db": 1,
+    "D": 2,
+    "D#": 3,
+    "Eb": 3,
+    "E": 4,
+    "Fb": 4,
+    "E#": 5,
+    "F": 5,
+    "F#": 6,
+    "Gb": 6,
+    "G": 7,
+    "G#": 8,
+    "Ab": 8,
+    "A": 9,
+    "A#": 10,
+    "Bb": 10,
+    "B": 11,
+    "Cb": 11,
+}
+PC_TO_KEY = {
+    0: "C",
+    1: "Db",
+    2: "D",
+    3: "Eb",
+    4: "E",
+    5: "F",
+    6: "Gb",
+    7: "G",
+    8: "Ab",
+    9: "A",
+    10: "Bb",
+    11: "B",
+}
+COF_INDEX = {0: 0, 7: 1, 2: 2, 9: 3, 4: 4, 11: 5, 6: 6, 1: 7, 8: 8, 3: 9, 10: 10, 5: 11}
+
+PHASE_ORDER: list[Phase] = ["Praise", "Thanksgiving", "Worship", "Response", "Sending"]
+PHASE_TARGETS = {
+    "Praise": (110, 140),
+    "Thanksgiving": (95, 125),
+    "Worship": (75, 100),
+    "Response": (60, 85),
+    "Sending": (70, 95),
+}
+PHASE_THEMES = {
+    "Praise": {"赞美", "讚美"},
+    "Thanksgiving": {"感恩", "感谢", "謝謝", "谢谢"},
+    "Worship": {"敬拜", "祈祷", "禱告", "信心", "圣灵", "聖靈"},
+    "Response": {"奉献", "奉獻", "认罪", "認罪", "十字架", "降服"},
+    "Sending": {"差遣", "跟随", "跟隨", "复兴", "復興", "使命"},
+}
+THEME_KEYWORDS = {
+    "赞美": ["赞美", "讚美", "称颂", "稱頌", "哈利路亚", "歡呼", "欢呼"],
+    "感恩": ["感恩", "感谢", "感謝", "恩典", "谢谢", "謝謝"],
+    "敬拜": ["敬拜", "敬畏", "荣耀", "榮耀", "圣洁", "聖潔"],
+    "奉献": ["奉献", "奉獻", "献上", "獻上", "降服", "摆上", "擺上"],
+    "认罪": ["认罪", "認罪", "赦免", "悔改", "洁净", "潔淨"],
+    "差遣": ["差遣", "使命", "万国", "萬國", "传扬", "傳揚"],
+    "信心": ["信心", "相信", "倚靠", "盼望", "应许", "應許"],
+    "祈祷": ["祈祷", "禱告", "呼求", "求你", "医治", "醫治"],
+    "复兴": ["复兴", "復興", "更新", "燃烧", "燃燒"],
+    "圣灵": ["圣灵", "聖靈", "灵火", "靈火"],
+    "十字架": ["十字架", "宝血", "寶血", "救赎", "救贖"],
+    "跟随": ["跟随", "跟隨", "道路", "脚步", "腳步"],
+}
+
+
+def parse_key(key: str) -> int:
+    normalized = key.strip().replace("♯", "#").replace("♭", "b")
+    if normalized.endswith("maj") or normalized.endswith("min"):
+        normalized = normalized[:-3]
+    if normalized not in NOTE_TO_PC:
+        raise ValueError(f"Unsupported key: {key}")
+    return NOTE_TO_PC[normalized]
+
+
+def normalize_mode(mode: str | None) -> str:
+    value = (mode or "major").strip().lower()
+    if value in {"minor", "min", "m"}:
+        return "minor"
+    return "major"
+
+
+def relative_major_pc(pc: int, mode: str | None) -> int:
+    return (pc + 3) % 12 if normalize_mode(mode) == "minor" else pc
+
+
+def fifth_distance_on_circle(a: int, b: int) -> int:
+    ia, ib = COF_INDEX[a], COF_INDEX[b]
+    return min((ia - ib) % 12, (ib - ia) % 12)
+
+
+def cfd(key_a: str, mode_a: str | None, key_b: str, mode_b: str | None) -> int:
+    pa = relative_major_pc(parse_key(key_a), mode_a)
+    pb = relative_major_pc(parse_key(key_b), mode_b)
+    return fifth_distance_on_circle(pa, pb)
+
+
+def key_compatibility_score(distance: int) -> float:
+    return max(0.0, 1.0 - distance / 6.0)
+
+
+def suggest_key_shift(source: SongCandidate, target: SongCandidate) -> tuple[int, int]:
+    best_shift = 0
+    best_distance = cfd(
+        source.musical_key,
+        source.musical_mode,
+        target.musical_key,
+        target.musical_mode,
+    )
+    target_pc = parse_key(target.musical_key)
+    for shift in [0, 1, -1, 2, -2]:
+        shifted_key = PC_TO_KEY[(target_pc + shift) % 12]
+        distance = cfd(source.musical_key, source.musical_mode, shifted_key, target.musical_mode)
+        if distance < best_distance:
+            best_distance = distance
+            best_shift = shift
+    return best_shift, best_distance
+
+
+def classify_themes(title: str, lyrics: str | None, album_series: str | None = None) -> list[str]:
+    text = f"{title}\n{lyrics or ''}"
+    scores: Counter[str] = Counter()
+    for theme, keywords in THEME_KEYWORDS.items():
+        for keyword in keywords:
+            if keyword in text:
+                scores[theme] += 1
+    series = (album_series or "").upper()
+    if "DEV" in series:
+        scores["敬拜"] += 1
+    if "HYMN" in series:
+        scores["差遣"] += 1
+    if not scores:
+        return ["敬拜"]
+    return [theme for theme, _ in scores.most_common(3)]
+
+
+def infer_phase(
+    themes: list[str],
+    album_series: str | None = None,
+    bpm: float | None = None,
+) -> Phase:
+    series = (album_series or "").upper()
+    if "DEV" in series:
+        return "Response"
+    for phase in PHASE_ORDER:
+        if set(themes) & PHASE_THEMES[phase]:
+            return phase
+    if bpm is not None:
+        if bpm >= 110:
+            return "Praise"
+        if bpm >= 95:
+            return "Thanksgiving"
+        if bpm >= 80:
+            return "Worship"
+        return "Response"
+    return "Worship"
+
+
+def enrich_candidate(song: SongCandidate) -> SongCandidate:
+    themes = classify_themes(song.title, song.lyrics_raw, song.album_series)
+    phase = infer_phase(themes, song.album_series, song.bpm)
+    return song.model_copy(update={"inferred_themes": themes, "phase": phase})
+
+
+def build_transition(source: SongCandidate, target: SongCandidate) -> TransitionCandidate:
+    shift, distance = suggest_key_shift(source, target)
+    bpm_delta = target.bpm - source.bpm
+    warnings: list[str] = []
+    if abs(bpm_delta) > 15:
+        warnings.append("tempo_delta_gt_15")
+    if distance > 2:
+        warnings.append("distant_key_requires_vamp")
+    if target.key_confidence is not None and target.key_confidence < 0.6 and shift:
+        warnings.append("low_key_confidence_for_transposition")
+    crossfade = distance > 2 or abs(bpm_delta) > 15
+    return TransitionCandidate(
+        from_hash=source.recording_hash_prefix,
+        to_hash=target.recording_hash_prefix,
+        bpm_delta=bpm_delta,
+        cfd=distance,
+        compatibility_score=key_compatibility_score(distance),
+        key_shift_semitones=shift,
+        tempo_ratio=max(0.85, min(1.15, source.bpm / target.bpm)),
+        gap_beats=8.0 if abs(bpm_delta) > 15 else 2.0,
+        crossfade_enabled=crossfade,
+        crossfade_duration_seconds=6.0 if crossfade else None,
+        warnings=warnings,
+    )
+
+
+def phase_template(song_count: int) -> list[Phase]:
+    if song_count == 4:
+        return ["Praise", "Thanksgiving", "Worship", "Response"]
+    return PHASE_ORDER[:song_count]
+
+
+def candidate_to_item(song: SongCandidate, position: int) -> ProposalItem:
+    return ProposalItem(
+        song_id=song.song_id,
+        recording_hash_prefix=song.recording_hash_prefix,
+        position=position,
+        title=song.title,
+        phase=song.phase,
+    )
+
+
+def make_proposal(
+    songs: list[SongCandidate],
+    matrix: dict[str, dict[str, TransitionCandidate]],
+    config: ConstructorConfig,
+    rationale: str = "",
+) -> SongsetProposal:
+    items = [candidate_to_item(song, index + 1) for index, song in enumerate(songs)]
+    for index in range(1, len(items)):
+        transition = matrix[items[index - 1].recording_hash_prefix][
+            items[index].recording_hash_prefix
+        ]
+        items[index].key_shift_semitones = transition.key_shift_semitones
+        items[index].tempo_ratio = transition.tempo_ratio
+        items[index].gap_beats = transition.gap_beats
+        items[index].crossfade_enabled = transition.crossfade_enabled
+        items[index].crossfade_duration_seconds = transition.crossfade_duration_seconds
+    proposal = SongsetProposal(items=items, llm_rationale=rationale)
+    errors, warnings, score = validate_and_score(
+        proposal,
+        {s.recording_hash_prefix: s for s in songs},
+        matrix,
+        config,
+    )
+    proposal.validation_errors = errors
+    proposal.validation_warnings = warnings
+    proposal.score_breakdown = score
+    return proposal
+
+
+def validate_and_score(
+    proposal: SongsetProposal,
+    pool_by_hash: dict[str, SongCandidate],
+    matrix: dict[str, dict[str, TransitionCandidate]],
+    config: ConstructorConfig,
+) -> tuple[list[str], list[str], ScoreBreakdown]:
+    errors: list[str] = []
+    warnings: list[str] = []
+    if len(proposal.items) != config.songs:
+        errors.append(f"H1 expected {config.songs} songs")
+    hashes = [item.recording_hash_prefix for item in proposal.items]
+    if len(set(hashes)) != len(hashes):
+        errors.append("H2 duplicate recordings")
+    missing = [h for h in hashes if h not in pool_by_hash]
+    if missing:
+        errors.append(f"H3 unknown recordings: {', '.join(missing)}")
+        return errors, warnings, ScoreBreakdown()
+
+    songs = [pool_by_hash[h] for h in hashes]
+    if any(song.bpm <= 0 or not song.musical_key for song in songs):
+        errors.append("H3 unusable BPM/key metadata")
+    expected = phase_template(config.songs)
+    phase_matches = sum(1 for song, phase in zip(songs, expected) if song.phase == phase)
+    if phase_matches < max(2, config.songs - 2):
+        warnings.append("H4 weak phase arc")
+    if songs and songs[0].bpm < 105:
+        warnings.append("H5 opener below praise tempo")
+    closing_limit = 80 if config.intimate else 95
+    if songs and songs[-1].bpm > closing_limit:
+        warnings.append("H6 closer above target tempo")
+
+    tempo_scores: list[float] = []
+    harmony_scores: list[float] = []
+    upticks = 0
+    for left, right in zip(songs, songs[1:]):
+        transition = matrix[left.recording_hash_prefix][right.recording_hash_prefix]
+        if transition.bpm_delta > 0:
+            upticks += 1
+        if abs(transition.bpm_delta) > 20:
+            errors.append("H7 adjacent tempo delta above 20 BPM")
+        if transition.cfd > 2 and not transition.crossfade_enabled:
+            errors.append("H8 distant key without transition")
+        tempo_scores.append(max(0.0, 1.0 - abs(transition.bpm_delta) / 30.0))
+        harmony_scores.append(transition.compatibility_score)
+        warnings.extend(transition.warnings)
+    if upticks > 1:
+        warnings.append("more_than_one_tempo_uptick")
+
+    theme_score = phase_matches / max(1, len(expected))
+    tempo_score = sum(tempo_scores) / len(tempo_scores) if tempo_scores else 0.0
+    harmony_score = sum(harmony_scores) / len(harmony_scores) if harmony_scores else 0.0
+    composers = {song.composer for song in songs if song.composer}
+    albums = {song.album_name for song in songs if song.album_name}
+    diversity_score = min(1.0, (len(composers) + len(albums)) / max(1, len(songs)))
+    total = theme_score * 0.4 + tempo_score * 0.3 + harmony_score * 0.2 + diversity_score * 0.1
+    return errors, sorted(set(warnings)), ScoreBreakdown(
+        theme=round(theme_score, 4),
+        tempo=round(tempo_score, 4),
+        harmony=round(harmony_score, 4),
+        diversity=round(diversity_score, 4),
+        total=round(total, 4),
+    )
+
+
+def beam_seed_candidates(
+    pool: list[SongCandidate],
+    matrix: dict[str, dict[str, TransitionCandidate]],
+    config: ConstructorConfig,
+) -> list[SongsetProposal]:
+    template = phase_template(config.songs)
+    phase_ranked: list[list[SongCandidate]] = []
+    for phase in template:
+        low, high = PHASE_TARGETS[phase]
+        midpoint = (low + high) / 2
+        matches = [song for song in pool if song.phase == phase] or pool
+        phase_ranked.append(
+            sorted(matches, key=lambda song: (abs(song.bpm - midpoint), song.title))[:30]
+        )
+
+    beams: list[list[SongCandidate]] = [[]]
+    for ranked in phase_ranked:
+        next_beams: list[list[SongCandidate]] = []
+        for beam in beams:
+            used = {song.recording_hash_prefix for song in beam}
+            for song in ranked:
+                if song.recording_hash_prefix in used:
+                    continue
+                if beam:
+                    transition = matrix[beam[-1].recording_hash_prefix][song.recording_hash_prefix]
+                    if abs(transition.bpm_delta) > 25 or transition.cfd == 6:
+                        continue
+                next_beams.append([*beam, song])
+        beams = sorted(
+            next_beams,
+            key=lambda seq: _sequence_pre_score(seq, matrix, template),
+            reverse=True,
+        )[:80]
+
+    proposals = [make_proposal(seq, matrix, config, "deterministic beam seed") for seq in beams]
+    proposals = [proposal for proposal in proposals if not proposal.validation_errors] or proposals
+    return sorted(
+        proposals,
+        key=lambda proposal: proposal.score_breakdown.total,
+        reverse=True,
+    )[: config.top_k * 4]
+
+
+def _sequence_pre_score(
+    songs: list[SongCandidate],
+    matrix: dict[str, dict[str, TransitionCandidate]],
+    template: list[Phase],
+) -> float:
+    phase_score = sum(1 for song, phase in zip(songs, template) if song.phase == phase)
+    transition_score = 0.0
+    for left, right in zip(songs, songs[1:]):
+        transition = matrix[left.recording_hash_prefix][right.recording_hash_prefix]
+        transition_score += transition.compatibility_score - abs(transition.bpm_delta) / 30
+    return phase_score + transition_score
+
+
+def detect_dead_ends(
+    pool: list[SongCandidate],
+    matrix: dict[str, dict[str, TransitionCandidate]],
+) -> list[str]:
+    warnings: list[str] = []
+    for song in pool:
+        fanout = 0
+        for other in pool:
+            if other.recording_hash_prefix == song.recording_hash_prefix:
+                continue
+            transition = matrix[song.recording_hash_prefix][other.recording_hash_prefix]
+            if abs(transition.bpm_delta) <= 20 and transition.cfd <= 2:
+                fanout += 1
+        if fanout < 2:
+            warnings.append(f"dead_end:{song.recording_hash_prefix}")
+    return warnings

--- a/lab/poc-scripts/pyproject.toml
+++ b/lab/poc-scripts/pyproject.toml
@@ -91,7 +91,11 @@ songset_constructor = [
     "rich>=15.0.0",
     "typer>=0.26.8",
 ]
-test = ["pytest>=7.4.0", "pytest-mock>=3.12.0"]
+test = [
+    "pypinyin>=0.52.0",
+    "pytest>=7.4.0",
+    "pytest-mock>=3.12.0",
+]
 
 [tool.uv.sources]
 stream-of-worship = { path = "../../ops/admin-cli" }

--- a/lab/poc-scripts/pyproject.toml
+++ b/lab/poc-scripts/pyproject.toml
@@ -82,6 +82,15 @@ score_lrc_base = [
     "pypinyin>=0.52.0",
 ]
 fix_lrc = ["sow-lab-poc-scripts[poc_qwen3_mlx,poc_qwen3_align,score_lrc_base]"]
+songset_constructor = [
+    "langchain-core>=1.4.8",
+    "langchain-openai>=1.3.3",
+    "langgraph-checkpoint-sqlite>=3.1.0",
+    "langgraph>=1.2.7",
+    "pydantic>=2.13.4",
+    "rich>=15.0.0",
+    "typer>=0.26.8",
+]
 test = ["pytest>=7.4.0", "pytest-mock>=3.12.0"]
 
 [tool.uv.sources]

--- a/lab/poc-scripts/tests/test_songset_constructor_catalog.py
+++ b/lab/poc-scripts/tests/test_songset_constructor_catalog.py
@@ -1,0 +1,62 @@
+from poc.songset_constructor.catalog import fetch_catalog
+from poc.songset_constructor.models import ConstructorConfig
+
+
+class FakeCursor:
+    def __init__(self) -> None:
+        self.query = ""
+        self.params = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc):
+        return None
+
+    def execute(self, query, params):
+        self.query = query
+        self.params = params
+
+    def fetchall(self):
+        return [
+            {
+                "song_id": "s1",
+                "title": "赞美",
+                "album_name": "A",
+                "album_series": "PW",
+                "composer": "C",
+                "lyricist": None,
+                "song_key": "C",
+                "lyrics_raw": "赞美",
+                "recording_hash_prefix": "abc123",
+                "tempo_bpm": 120,
+                "musical_key": "C",
+                "musical_mode": "major",
+                "key_confidence": 0.9,
+            }
+        ]
+
+
+class FakeConnection:
+    def __init__(self, cursor: FakeCursor) -> None:
+        self.cursor_obj = cursor
+
+    def cursor(self, row_factory=None):
+        return self.cursor_obj
+
+
+class FakeProvider:
+    def __init__(self) -> None:
+        self.cursor = FakeCursor()
+
+    def get_connection(self):
+        return FakeConnection(self.cursor)
+
+
+def test_fetch_catalog_excludes_cpw_by_default() -> None:
+    provider = FakeProvider()
+    result = fetch_catalog(provider, ConstructorConfig(pool_limit=10))
+
+    assert result[0].recording_hash_prefix == "abc123"
+    assert "NOT ILIKE" in provider.cursor.query
+    assert "%CPW%" in provider.cursor.params

--- a/lab/poc-scripts/tests/test_songset_constructor_catalog.py
+++ b/lab/poc-scripts/tests/test_songset_constructor_catalog.py
@@ -60,3 +60,16 @@ def test_fetch_catalog_excludes_cpw_by_default() -> None:
     assert result[0].recording_hash_prefix == "abc123"
     assert "NOT ILIKE" in provider.cursor.query
     assert "%CPW%" in provider.cursor.params
+
+
+def test_fetch_catalog_requires_lrc_review_or_published_and_active_rows() -> None:
+    provider = FakeProvider()
+    fetch_catalog(provider, ConstructorConfig(pool_limit=10))
+
+    query = provider.cursor.query
+    assert "s.deleted_at IS NULL" in query
+    assert "r.deleted_at IS NULL" in query
+    assert "r.lrc_status = 'completed'" in query
+    assert "r.r2_lrc_url IS NOT NULL" in query
+    assert "r.visibility_status IN ('review', 'published')" in query
+    assert "r.analysis_status = 'completed'" not in query

--- a/lab/poc-scripts/tests/test_songset_constructor_graph.py
+++ b/lab/poc-scripts/tests/test_songset_constructor_graph.py
@@ -1,10 +1,13 @@
 import json
 from pathlib import Path
 
+import pytest
 from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.runnables import RunnableLambda
 
-from poc.songset_constructor.graph import _format_llm_prompt_trace, run_constructor
-from poc.songset_constructor.models import ConstructorConfig, LlmDraft, SongCandidate
+from poc.songset_constructor import graph as graph_mod
+from poc.songset_constructor.graph import _format_llm_prompt_trace, build_llm_planner, run_constructor
+from poc.songset_constructor.models import ConstructorConfig, ConstructorState, LlmDraft, SongCandidate
 
 
 def fixture_pool(config: ConstructorConfig) -> list[SongCandidate]:
@@ -105,3 +108,49 @@ def test_llm_prompt_trace_formats_full_rendered_messages() -> None:
     assert "Need 5 songs." in trace
     assert "赞美之歌" in trace
     assert "Unknown recording hashes: nope" in trace
+
+
+class _TimeoutRunnable:
+    """Fake runnable whose invoke always raises a timeout-like exception."""
+
+    def invoke(self, _vars):
+        raise TimeoutError("Request timed out.")
+
+
+class _FakeChatOpenAI:
+    """Stand-in for ChatOpenAI used by build_llm_planner during tests."""
+
+    def __init__(self, **_kwargs):
+        pass
+
+    def with_structured_output(self, _schema):
+        return RunnableLambda(self._raise_timeout)
+
+    @staticmethod
+    def _raise_timeout(_input):
+        raise TimeoutError("Request timed out.")
+
+
+def test_llm_planner_retry_uses_short_backoff_and_caps_attempts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SOW_LLM_API_KEY", "test-key")
+    monkeypatch.setenv("SOW_LLM_BASE_URL", "https://example.test")
+    monkeypatch.setenv("SOW_LLM_MODEL", "test-model")
+    monkeypatch.setattr(graph_mod, "ChatOpenAI", _FakeChatOpenAI)
+
+    sleeps: list[float] = []
+    monkeypatch.setattr(graph_mod.time, "sleep", lambda s: sleeps.append(s))
+
+    config = ConstructorConfig(songs=5, top_k=2)
+    planner = build_llm_planner(config)
+    state = ConstructorState(config=config)
+
+    with pytest.raises(TimeoutError):
+        planner(state)
+
+    expected_attempts = graph_mod.LLM_MAX_ATTEMPTS
+    assert len(sleeps) == expected_attempts - 1
+    assert all(w <= graph_mod.LLM_MAX_BACKOFF_S for w in sleeps)
+    assert all(w < 120.0 for w in sleeps)
+    assert sleeps == [2.0, 4.0, 8.0, 16.0]

--- a/lab/poc-scripts/tests/test_songset_constructor_graph.py
+++ b/lab/poc-scripts/tests/test_songset_constructor_graph.py
@@ -1,7 +1,9 @@
 import json
 from pathlib import Path
 
-from poc.songset_constructor.graph import run_constructor
+from langchain_core.prompts import ChatPromptTemplate
+
+from poc.songset_constructor.graph import _format_llm_prompt_trace, run_constructor
 from poc.songset_constructor.models import ConstructorConfig, LlmDraft, SongCandidate
 
 
@@ -70,3 +72,36 @@ def test_fixture_loader_honors_cpw_exclusion() -> None:
     config = ConstructorConfig(include_cpw=False)
     pool = fixture_pool(config)
     assert all("CPW" not in (song.album_series or "") for song in pool)
+
+
+def test_llm_prompt_trace_formats_full_rendered_messages() -> None:
+    prompt = ChatPromptTemplate.from_messages(
+        [
+            ("system", "You assemble Chinese worship songsets."),
+            ("human", "Need {songs} songs. Pool JSON: {pool}. Prior drafts/feedback: {feedback}."),
+        ]
+    )
+    messages = prompt.format_messages(
+        songs=5,
+        pool=[
+            {
+                "hash": "h1",
+                "title": "赞美之歌",
+                "bpm": 124,
+                "key": "C",
+                "mode": "major",
+                "themes": ["praise"],
+                "phase": "Praise",
+            }
+        ],
+        feedback=["Unknown recording hashes: nope"],
+    )
+
+    trace = _format_llm_prompt_trace(messages)
+
+    assert "[SYSTEM]" in trace
+    assert "You assemble Chinese worship songsets." in trace
+    assert "[HUMAN]" in trace
+    assert "Need 5 songs." in trace
+    assert "赞美之歌" in trace
+    assert "Unknown recording hashes: nope" in trace

--- a/lab/poc-scripts/tests/test_songset_constructor_graph.py
+++ b/lab/poc-scripts/tests/test_songset_constructor_graph.py
@@ -157,9 +157,10 @@ class _FakeChatOpenAI:
     """Stand-in for ChatOpenAI used by build_llm_planner during tests."""
 
     calls = 0
+    init_kwargs: dict = {}
 
-    def __init__(self, **_kwargs):
-        pass
+    def __init__(self, **kwargs):
+        self.__class__.init_kwargs = kwargs
 
     def with_structured_output(self, _schema):
         return RunnableLambda(self._raise_timeout)
@@ -198,6 +199,7 @@ def test_llm_planner_does_not_outer_retry_non_rate_limit_errors(
     monkeypatch.setenv("SOW_LLM_MODEL", "test-model")
     monkeypatch.setattr(graph_mod, "ChatOpenAI", _FakeChatOpenAI)
     _FakeChatOpenAI.calls = 0
+    _FakeChatOpenAI.init_kwargs = {}
 
     sleeps: list[float] = []
     monkeypatch.setattr(graph_mod.time, "sleep", lambda s: sleeps.append(s))
@@ -211,7 +213,24 @@ def test_llm_planner_does_not_outer_retry_non_rate_limit_errors(
         planner(state)
 
     assert _FakeChatOpenAI.calls == 1
+    assert _FakeChatOpenAI.init_kwargs["timeout"] == graph_mod.LLM_TIMEOUT
+    assert _FakeChatOpenAI.init_kwargs["max_retries"] == 0
     assert sleeps == []
+
+
+def test_llm_planner_honors_configured_openai_retry_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SOW_LLM_API_KEY", "test-key")
+    monkeypatch.setenv("SOW_LLM_BASE_URL", "https://example.test")
+    monkeypatch.setenv("SOW_LLM_MODEL", "test-model")
+    monkeypatch.setattr(graph_mod, "ChatOpenAI", _FakeChatOpenAI)
+    monkeypatch.setattr(graph_mod, "LLM_MAX_RETRIES", 2)
+    _FakeChatOpenAI.init_kwargs = {}
+
+    build_llm_planner(ConstructorConfig(songs=5, top_k=2))
+
+    assert _FakeChatOpenAI.init_kwargs["max_retries"] == 2
 
 
 def test_llm_planner_rate_limit_retry_respects_outer_attempt_count(

--- a/lab/poc-scripts/tests/test_songset_constructor_graph.py
+++ b/lab/poc-scripts/tests/test_songset_constructor_graph.py
@@ -1,0 +1,72 @@
+import json
+from pathlib import Path
+
+from poc.songset_constructor.graph import run_constructor
+from poc.songset_constructor.models import ConstructorConfig, LlmDraft, SongCandidate
+
+
+def fixture_pool(config: ConstructorConfig) -> list[SongCandidate]:
+    rows = [
+        ("s1", "赞美之歌", "h1", 124, "C", "major", "PW", "Alice", "A"),
+        ("s2", "献上感恩", "h2", 108, "G", "major", "PW", "Bob", "B"),
+        ("s3", "深深敬拜", "h3", 88, "D", "major", "PW", "Cara", "C"),
+        ("s4", "十字架前", "h4", 74, "A", "minor", "PW", "Dan", "D"),
+        ("s5", "差遣我们", "h5", 82, "C", "major", "PW", "Eve", "E"),
+        ("s6", "儿童诗歌", "h6", 120, "Gb", "major", "CPW", "Kid", "F"),
+    ]
+    songs = [
+        SongCandidate(
+            song_id=song_id,
+            title=title,
+            recording_hash_prefix=hash_prefix,
+            bpm=bpm,
+            musical_key=key,
+            musical_mode=mode,
+            album_series=series,
+            composer=composer,
+            album_name=album,
+        )
+        for song_id, title, hash_prefix, bpm, key, mode, series, composer, album in rows
+    ]
+    if not config.include_cpw:
+        songs = [song for song in songs if "CPW" not in (song.album_series or "")]
+    return songs[: config.pool_limit]
+
+
+class RepairingPlanner:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def __call__(self, _state):
+        self.calls += 1
+        if self.calls == 1:
+            return [
+                LlmDraft(
+                    recording_hashes=["h1", "h2", "h2", "h3", "h4"],
+                    rationale="bad duplicate",
+                )
+            ]
+        return [LlmDraft(recording_hashes=["h1", "h2", "h3", "h4", "h5"], rationale="repaired")]
+
+
+def test_graph_refines_invalid_llm_draft_and_writes_artifacts(tmp_path: Path) -> None:
+    planner = RepairingPlanner()
+    config = ConstructorConfig(output_dir=str(tmp_path), songs=5, top_k=2)
+
+    state = run_constructor(config, catalog_loader=fixture_pool, planner=planner)
+
+    assert planner.calls == 2
+    assert state.final_proposals
+    assert state.final_proposals[0].items[-1].recording_hash_prefix == "h5"
+    assert (tmp_path / "proposals.json").exists()
+    assert (tmp_path / "proposal_report.md").exists()
+    assert (tmp_path / "candidate_pool.csv").exists()
+    assert (tmp_path / "graph_trace.jsonl").exists()
+    proposals = json.loads((tmp_path / "proposals.json").read_text(encoding="utf-8"))
+    assert proposals[0]["items"][0]["song_id"] == "s1"
+
+
+def test_fixture_loader_honors_cpw_exclusion() -> None:
+    config = ConstructorConfig(include_cpw=False)
+    pool = fixture_pool(config)
+    assert all("CPW" not in (song.album_series or "") for song in pool)

--- a/lab/poc-scripts/tests/test_songset_constructor_graph.py
+++ b/lab/poc-scripts/tests/test_songset_constructor_graph.py
@@ -4,7 +4,9 @@ from pathlib import Path
 import pytest
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.runnables import RunnableLambda
+from typer.testing import CliRunner
 
+from poc.songset_constructor import cli as cli_mod
 from poc.songset_constructor import graph as graph_mod
 from poc.songset_constructor.graph import _format_llm_prompt_trace, build_llm_planner, run_constructor
 from poc.songset_constructor.models import ConstructorConfig, ConstructorState, LlmDraft, SongCandidate
@@ -54,21 +56,55 @@ class RepairingPlanner:
         return [LlmDraft(recording_hashes=["h1", "h2", "h3", "h4", "h5"], rationale="repaired")]
 
 
-def test_graph_refines_invalid_llm_draft_and_writes_artifacts(tmp_path: Path) -> None:
+def test_graph_preserves_valid_beams_when_llm_draft_is_invalid(tmp_path: Path) -> None:
     planner = RepairingPlanner()
     config = ConstructorConfig(output_dir=str(tmp_path), songs=5, top_k=2)
 
     state = run_constructor(config, catalog_loader=fixture_pool, planner=planner)
 
-    assert planner.calls == 2
+    assert planner.calls == 1
     assert state.final_proposals
-    assert state.final_proposals[0].items[-1].recording_hash_prefix == "h5"
     assert (tmp_path / "proposals.json").exists()
     assert (tmp_path / "proposal_report.md").exists()
     assert (tmp_path / "candidate_pool.csv").exists()
     assert (tmp_path / "graph_trace.jsonl").exists()
     proposals = json.loads((tmp_path / "proposals.json").read_text(encoding="utf-8"))
     assert proposals[0]["items"][0]["song_id"] == "s1"
+
+
+def test_no_llm_writes_artifacts_without_constructing_chat_openai(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_chat_openai(**_kwargs):
+        raise AssertionError("ChatOpenAI should not be constructed for no_llm runs")
+
+    monkeypatch.setattr(graph_mod, "ChatOpenAI", fail_chat_openai)
+
+    config = ConstructorConfig(output_dir=str(tmp_path), songs=5, top_k=2, no_llm=True)
+    state = run_constructor(config, catalog_loader=fixture_pool)
+
+    assert state.final_proposals
+    assert "llm_plan" not in {event["node"] for event in state.trace}
+    assert (tmp_path / "proposals.json").exists()
+
+
+def test_cli_exposes_no_llm_flag(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, ConstructorConfig] = {}
+
+    def fake_run_constructor(config: ConstructorConfig) -> ConstructorState:
+        captured["config"] = config
+        return ConstructorState(config=config)
+
+    monkeypatch.setattr(cli_mod, "run_constructor", fake_run_constructor)
+
+    result = CliRunner().invoke(
+        cli_mod.app,
+        ["--no-llm", "--output-dir", str(tmp_path)],
+    )
+
+    assert result.exit_code == 0
+    assert captured["config"].no_llm is True
 
 
 def test_fixture_loader_honors_cpw_exclusion() -> None:
@@ -120,27 +156,52 @@ class _TimeoutRunnable:
 class _FakeChatOpenAI:
     """Stand-in for ChatOpenAI used by build_llm_planner during tests."""
 
+    calls = 0
+
     def __init__(self, **_kwargs):
         pass
 
     def with_structured_output(self, _schema):
         return RunnableLambda(self._raise_timeout)
 
-    @staticmethod
-    def _raise_timeout(_input):
+    @classmethod
+    def _raise_timeout(cls, _input):
+        cls.calls += 1
         raise TimeoutError("Request timed out.")
 
 
-def test_llm_planner_retry_uses_short_backoff_and_caps_attempts(
+class _RetryableRateLimitError(Exception):
+    status_code = 429
+    body = {"code": "concurrent_budget_exceeded", "retry_after": 3}
+
+
+class _RateLimitedChatOpenAI:
+    calls = 0
+
+    def __init__(self, **_kwargs):
+        pass
+
+    def with_structured_output(self, _schema):
+        return RunnableLambda(self._raise_rate_limit)
+
+    @classmethod
+    def _raise_rate_limit(cls, _input):
+        cls.calls += 1
+        raise _RetryableRateLimitError("concurrent_budget_exceeded")
+
+
+def test_llm_planner_does_not_outer_retry_non_rate_limit_errors(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("SOW_LLM_API_KEY", "test-key")
     monkeypatch.setenv("SOW_LLM_BASE_URL", "https://example.test")
     monkeypatch.setenv("SOW_LLM_MODEL", "test-model")
     monkeypatch.setattr(graph_mod, "ChatOpenAI", _FakeChatOpenAI)
+    _FakeChatOpenAI.calls = 0
 
     sleeps: list[float] = []
     monkeypatch.setattr(graph_mod.time, "sleep", lambda s: sleeps.append(s))
+    monkeypatch.setattr(graph_mod, "LLM_MAX_ATTEMPTS", 5)
 
     config = ConstructorConfig(songs=5, top_k=2)
     planner = build_llm_planner(config)
@@ -149,8 +210,30 @@ def test_llm_planner_retry_uses_short_backoff_and_caps_attempts(
     with pytest.raises(TimeoutError):
         planner(state)
 
-    expected_attempts = graph_mod.LLM_MAX_ATTEMPTS
-    assert len(sleeps) == expected_attempts - 1
-    assert all(w <= graph_mod.LLM_MAX_BACKOFF_S for w in sleeps)
-    assert all(w < 120.0 for w in sleeps)
-    assert sleeps == [2.0, 4.0, 8.0, 16.0]
+    assert _FakeChatOpenAI.calls == 1
+    assert sleeps == []
+
+
+def test_llm_planner_rate_limit_retry_respects_outer_attempt_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SOW_LLM_API_KEY", "test-key")
+    monkeypatch.setenv("SOW_LLM_BASE_URL", "https://example.test")
+    monkeypatch.setenv("SOW_LLM_MODEL", "test-model")
+    monkeypatch.setattr(graph_mod, "ChatOpenAI", _RateLimitedChatOpenAI)
+    monkeypatch.setattr(graph_mod, "LLM_MAX_ATTEMPTS", 2)
+    monkeypatch.setattr(graph_mod.random, "uniform", lambda _start, _stop: 0.0)
+    _RateLimitedChatOpenAI.calls = 0
+
+    sleeps: list[float] = []
+    monkeypatch.setattr(graph_mod.time, "sleep", lambda s: sleeps.append(s))
+
+    config = ConstructorConfig(songs=5, top_k=2)
+    planner = build_llm_planner(config)
+    state = ConstructorState(config=config)
+
+    with pytest.raises(_RetryableRateLimitError):
+        planner(state)
+
+    assert _RateLimitedChatOpenAI.calls == 2
+    assert sleeps == [3.0]

--- a/lab/poc-scripts/tests/test_songset_constructor_rules.py
+++ b/lab/poc-scripts/tests/test_songset_constructor_rules.py
@@ -1,0 +1,68 @@
+from poc.songset_constructor.models import ConstructorConfig, SongCandidate
+from poc.songset_constructor.music_rules import (
+    build_transition,
+    cfd,
+    classify_themes,
+    enrich_candidate,
+    infer_phase,
+    key_compatibility_score,
+    suggest_key_shift,
+)
+
+
+def candidate(
+    hash_prefix: str,
+    key: str = "C",
+    mode: str = "major",
+    bpm: float = 100,
+) -> SongCandidate:
+    return SongCandidate(
+        song_id=f"song-{hash_prefix}",
+        title="全心赞美",
+        recording_hash_prefix=hash_prefix,
+        bpm=bpm,
+        musical_key=key,
+        musical_mode=mode,
+    )
+
+
+def test_cfd_normalizes_relative_major_minor() -> None:
+    assert cfd("C", "major", "A", "minor") == 0
+    assert cfd("C", "major", "G", "major") == 1
+    assert cfd("C", "major", "D", "major") == 2
+    assert cfd("C", "major", "Gb", "major") == 6
+    assert key_compatibility_score(0) == 1.0
+    assert key_compatibility_score(6) == 0.0
+
+
+def test_suggest_key_shift_prefers_small_shift_to_compatible_key() -> None:
+    source = candidate("a", key="C")
+    target = candidate("b", key="Gb")
+    shift, distance = suggest_key_shift(source, target)
+    assert shift in {-2, -1, 1, 2}
+    assert distance <= 2
+
+
+def test_build_transition_warns_for_large_tempo_and_low_confidence_shift() -> None:
+    source = candidate("a", key="C", bpm=120)
+    target = candidate("b", key="Gb", bpm=90)
+    target.key_confidence = 0.4
+    transition = build_transition(source, target)
+    assert transition.crossfade_enabled is True
+    assert "tempo_delta_gt_15" in transition.warnings
+    assert "low_key_confidence_for_transposition" in transition.warnings
+
+
+def test_theme_classification_and_phase_inference() -> None:
+    themes = classify_themes("献上感恩", "我献上赞美和感谢")
+    assert "感恩" in themes
+    assert infer_phase(["差遣"], bpm=82) == "Sending"
+    assert infer_phase([], album_series="DEV", bpm=70) == "Response"
+
+
+def test_enrich_candidate_defaults_unclassified_to_worship() -> None:
+    song = candidate("x", key="D", bpm=88)
+    song.title = "普通标题"
+    enriched = enrich_candidate(song)
+    assert enriched.inferred_themes == ["敬拜"]
+    assert enriched.phase == "Worship"

--- a/ops/admin-cli/src/stream_of_worship/admin/commands/audio.py
+++ b/ops/admin-cli/src/stream_of_worship/admin/commands/audio.py
@@ -6497,10 +6497,29 @@ def _apply_manifest_writeback(
     analysis_client: AnalysisClient,
     console: Console,
 ) -> None:
-    """Apply idempotent DB writeback for a completed manifest entry on resume."""
+    """Apply idempotent DB writeback for a completed manifest entry on resume.
+
+    Checks the DB first to skip the HTTP call if the result is already written.
+    """
     try:
         if not job_id:
             return
+
+        # DB-first short-circuit: skip HTTP if already written
+        recording = db_client.get_recording_by_song_id(song_id)
+        if recording:
+            if step == "analyze" and recording.analysis_status in (
+                "partial",
+                "completed",
+            ):
+                return
+            if step == "lrc" and recording.lrc_status == "completed":
+                return
+            if step == "embedding":
+                existing_hash = db_client.get_embedding_content_hash(song_id)
+                if existing_hash:
+                    return
+
         job = analysis_client.get_job(job_id)
         if job.status != "completed":
             return
@@ -6509,7 +6528,6 @@ def _apply_manifest_writeback(
             # LRC writeback is R2-driven; skip if no R2 URL in result
             pass
         elif step == "analyze":
-            recording = db_client.get_recording_by_song_id(song_id)
             if not recording or not job.result:
                 return
             result = job.result

--- a/ops/admin-cli/src/stream_of_worship/admin/commands/audio.py
+++ b/ops/admin-cli/src/stream_of_worship/admin/commands/audio.py
@@ -13,9 +13,9 @@ import tempfile
 import termios
 import time
 import tty
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Dict, List, Optional
 
 import typer
 from botocore.exceptions import ClientError
@@ -4226,10 +4226,20 @@ def batch(
     ),
     stdin: bool = typer.Option(False, "--stdin", help="Read song IDs from stdin (pipe-friendly)"),
     limit: Optional[int] = typer.Option(None, "--limit", help="Maximum number of songs to process"),
-    skip_download: bool = typer.Option(
-        False, "--skip-download", help="Skip download step (assume audio already on R2)"
+    download: bool = typer.Option(False, "--download", help="Run the download step"),
+    lrc: bool = typer.Option(False, "--lrc", help="Run the LRC step"),
+    analyze: bool = typer.Option(False, "--analyze", help="Run the analysis step"),
+    embedding: bool = typer.Option(False, "--embedding", help="Run the embedding step"),
+    all_steps: bool = typer.Option(False, "--all-steps", help="Run all steps in order"),
+    analysis_tier: str = typer.Option(
+        "fast", "--analysis-tier", help="Analysis tier: fast (default) or full"
     ),
-    skip_lrc: bool = typer.Option(False, "--skip-lrc", help="Skip LRC step"),
+    force: bool = typer.Option(
+        False, "--force", help="Force re-run of a single step (requires exactly one step flag)"
+    ),
+    resume: Optional[Path] = typer.Option(
+        None, "--resume", help="Resume from a manifest file (skip submission, only re-poll)"
+    ),
     stale_after: int = typer.Option(
         120,
         "--stale-after",
@@ -4238,23 +4248,20 @@ def batch(
     dry_run: bool = typer.Option(
         False, "--dry-run", help="Show what would be processed without executing"
     ),
-    force_lrc: bool = typer.Option(
-        False,
-        "--force-lrc",
-        help="Force re-generate LRC from scratch (skip R2 check and existing job reuse)",
-    ),
     format: str = typer.Option("rich", "--format", help="Output format (rich, json)"),
     config_path: Optional[Path] = typer.Option(None, "--config", "-c", help="Path to config file"),
 ) -> None:
-    """Batch process songs: download audio and generate LRC.
+    """Batch process songs: download audio, generate LRC, analyze, and embed.
 
-    Processes multiple songs end-to-end: downloads audio (if needed),
-    submits LRC jobs, polls for completion, and prints summary stats.
-    Uses submit-all-then-poll with hybrid polling (service-first, R2-fallback).
+    Each phase is gated strictly by its step flag: --download, --lrc,
+    --analyze, --embedding, or --all-steps. No phase runs as a side effect
+    of another.
 
     Examples:
-        sow-admin audio batch --album "敬拜精选"
-        sow-admin audio list --lrc-status failed --format ids | sow-admin audio batch --stdin
+        sow-admin audio batch --analysis-status incomplete --analyze \\
+            --analysis-tier fast --limit 500
+        sow-admin audio batch --all-steps
+        sow-admin audio batch --resume ~/.local/share/sow-admin/batch/2026-06-30T0215_manifest.json
     """
     # Validate format
     if format not in ("rich", "json"):
@@ -4276,12 +4283,102 @@ def batch(
         )
         raise typer.Exit(1)
 
-    valid_analysis_statuses = {"pending", "processing", "completed", "failed", "incomplete"}
+    valid_analysis_statuses = {
+        "pending",
+        "processing",
+        "partial",
+        "completed",
+        "failed",
+        "incomplete",
+    }
     if analysis_status and analysis_status not in valid_analysis_statuses:
         console.print(
-            f"[red]Invalid analysis status: {analysis_status}. Must be one of: {', '.join(valid_analysis_statuses)}[/red]"
+            f"[red]Invalid analysis status: {analysis_status}. Must be one of: "
+            f"{', '.join(sorted(valid_analysis_statuses))}[/red]"
         )
         raise typer.Exit(1)
+
+    # Validate analysis tier
+    if analysis_tier not in ("fast", "full"):
+        console.print(
+            f"[red]Invalid analysis tier: {analysis_tier}. Must be 'fast' or 'full'[/red]"
+        )
+        raise typer.Exit(1)
+
+    # --resume mutual exclusivity
+    if resume is not None:
+        resume_conflicts = [
+            ("--album", album),
+            ("--song", song),
+            ("--lrc-status", lrc_status),
+            ("--download-status", download_status),
+            ("--analysis-status", analysis_status),
+            ("--stdin", stdin),
+            ("--limit", limit),
+            ("--download", download),
+            ("--lrc", lrc),
+            ("--analyze", analyze),
+            ("--embedding", embedding),
+            ("--all-steps", all_steps),
+            ("--force", force),
+        ]
+        for flag_name, flag_val in resume_conflicts:
+            if flag_val:
+                console.print(
+                    f"[red]--resume is mutually exclusive with {flag_name}.[/red]"
+                )
+                raise typer.Exit(1)
+
+    # Resolve selected steps
+    step_flags = {
+        "download": download,
+        "lrc": lrc,
+        "analyze": analyze,
+        "embedding": embedding,
+    }
+    selected_steps: List[str] = [s for s, v in step_flags.items() if v]
+
+    if all_steps:
+        selected_steps = ["download", "lrc", "analyze", "embedding"]
+    elif not selected_steps and resume is None:
+        console.print(
+            "[red]No step flags selected. Specify at least one of "
+            "--download, --lrc, --analyze, --embedding, or --all-steps.[/red]"
+        )
+        raise typer.Exit(1)
+
+    # Force scoping
+    if force:
+        if all_steps:
+            console.print(
+                "[red]--force with --all-steps is not supported. Cascading overrides "
+                "across download/LRC/analysis/embedding are unsafe; specify exactly "
+                "one step flag alongside --force.[/red]"
+            )
+            raise typer.Exit(1)
+        if len(selected_steps) != 1:
+            console.print(
+                "[red]--force requires exactly one step flag "
+                "(--download, --lrc, --analyze, or --embedding).[/red]"
+            )
+            raise typer.Exit(1)
+        if "download" in selected_steps:
+            console.print(
+                "[red]--force --download is not supported. Re-download changes "
+                "content_hash/hash_prefix and orphans downstream R2 artifacts. "
+                "Use the two-step soft-delete + purge workflow:[/red]\n"
+                "  sow-admin audio delete --recording --hash-prefix <old>\n"
+                "  sow-admin maintenance purge-soft-deletes --entity recordings "
+                "--hash-prefix <old> --confirm\n"
+                "  sow-admin audio batch --song <song_id> --download"
+            )
+            raise typer.Exit(1)
+
+    # Warn if analysis tier given without analyze step
+    if analysis_tier and "analyze" not in selected_steps and resume is None:
+        console.print(
+            f"[yellow]--analysis-tier {analysis_tier} ignored (no --analyze step selected).[/yellow]"
+        )
 
     # Load config
     try:
@@ -4292,7 +4389,42 @@ def batch(
 
     db_client = get_db_client(config)
 
-    # Resolve song IDs to process
+    # --resume path: skip selection, re-poll manifest
+    if resume is not None:
+        manifest_data = _load_manifest(resume)
+        if manifest_data is None:
+            console.print(f"[red]Could not read manifest: {resume}[/red]")
+            raise typer.Exit(1)
+
+        try:
+            r2_client = R2Client(
+                bucket=config.r2_bucket,
+                endpoint_url=config.r2_endpoint_url,
+                region=config.r2_region,
+            )
+        except ValueError as e:
+            console.print(f"[red]R2 configuration error: {e}[/red]")
+            raise typer.Exit(1)
+
+        try:
+            analysis_client = AnalysisClient(config.analysis_url)
+        except ValueError as e:
+            console.print(f"[red]Analysis service not configured: {e}[/red]")
+            raise typer.Exit(1)
+
+        results = _resume_from_manifest(
+            manifest_data=manifest_data,
+            manifest_path=resume,
+            db_client=db_client,
+            r2_client=r2_client,
+            analysis_client=analysis_client,
+            stale_after_minutes=stale_after,
+            console=console,
+        )
+        _print_stats(results, db_client, console, format)
+        return
+
+    # Normal path: resolve song IDs
     song_ids = _resolve_song_ids(
         db_client, album, song, lrc_status, download_status, analysis_status, stdin, limit
     )
@@ -4301,7 +4433,14 @@ def batch(
         raise typer.Exit(0)
 
     if dry_run:
-        _print_dry_run(db_client, song_ids)
+        _print_dry_run_v4(
+            db_client,
+            song_ids,
+            selected_steps,
+            force,
+            analysis_tier,
+            stale_after,
+        )
         return
 
     # Initialize R2 and Analysis clients
@@ -4327,15 +4466,24 @@ def batch(
         r2_client=r2_client,
         analysis_client=analysis_client,
         song_ids=song_ids,
-        skip_download=skip_download,
-        skip_lrc=skip_lrc,
-        force_lrc=force_lrc,
+        selected_steps=selected_steps,
+        force=force,
+        analysis_tier=analysis_tier,
         stale_after_minutes=stale_after,
         console=console,
     )
 
     # Print final stats
     _print_stats(results, db_client, console, format)
+
+    # Exit nonzero if any selected step has a failure
+    failed_any = any(
+        results.get(sid, {}).get(step) == "failed"
+        for sid in song_ids
+        for step in selected_steps
+    )
+    if failed_any:
+        raise typer.Exit(1)
 
 
 def _resolve_song_ids(
@@ -4375,6 +4523,7 @@ def _resolve_song_ids(
         status=analysis_status,
         lrc_status=lrc_status,
         limit=None,
+        sort_by="created",
     )
 
     for recording, song_title, album_name, album_series in rows:
@@ -4436,6 +4585,54 @@ def _print_dry_run(db_client: DatabaseClient, song_ids: list[str]) -> None:
             console.print(f"  [red]•[/red] {song_id} (song not found)")
 
     console.print(f"\n[dim]Total: {len(song_ids)} song(s)[/dim]")
+
+
+def _print_dry_run_v4(
+    db_client: DatabaseClient,
+    song_ids: list[str],
+    selected_steps: List[str],
+    force: bool,
+    analysis_tier: str,
+    stale_after: int,
+) -> None:
+    """Print dry run information for the v4 batch command.
+
+    Args:
+        db_client: Database client
+        song_ids: List of song IDs to show
+        selected_steps: Steps that will run
+        force: Whether force is set
+        analysis_tier: fast or full
+        stale_after: Staleness threshold in minutes
+    """
+    batch_id = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H%M") + "_batch"
+    console.print("[cyan]Dry run mode[/cyan]")
+    console.print()
+    console.print(f"[dim]Batch ID:[/dim] {batch_id}")
+    console.print(f"[dim]Selected steps:[/dim] {', '.join(selected_steps)}")
+    console.print(f"[dim]Force:[/dim] {force}")
+    if "analyze" in selected_steps:
+        console.print(f"[dim]Analysis tier:[/dim] {analysis_tier}")
+    console.print(f"[dim]Stale after:[/dim] {stale_after} minutes")
+    console.print(f"[dim]Ordering:[/dim] recordings.created_at ASC, hash_prefix ASC")
+    console.print(f"[dim]Count:[/dim] {len(song_ids)} song(s)")
+    console.print()
+
+    for song_id in song_ids:
+        song = db_client.get_song(song_id)
+        recording = db_client.get_recording_by_song_id(song_id)
+
+        if song and recording:
+            console.print(f"  [cyan]•[/cyan] {song.title} ({recording.hash_prefix})")
+            console.print(f"    [dim]Album:[/dim] {song.album_name or '-'}")
+            console.print(f"    [dim]Download:[/dim] {recording.download_status}")
+            console.print(f"    [dim]LRC:[/dim] {recording.lrc_status}")
+            console.print(f"    [dim]Analysis:[/dim] {recording.analysis_status}")
+        elif song:
+            console.print(f"  [yellow]•[/yellow] {song.title} (no recording - will download)")
+            console.print(f"    [dim]Album:[/dim] {song.album_name or '-'}")
+        else:
+            console.print(f"  [red]•[/red] {song_id} (song not found)")
 
 
 import re
@@ -4663,227 +4860,555 @@ def _download_if_needed(
         return {"download": "failed", "error": str(e)}
 
 
+def _get_manifest_dir() -> Path:
+    """Get the manifest directory (XDG-aware, overridable via env)."""
+    env_dir = os.environ.get("SOW_BATCH_MANIFEST_DIR")
+    if env_dir:
+        return Path(env_dir)
+    return Path.home() / ".local" / "share" / "sow-admin" / "batch"
+
+
+def _write_manifest(
+    batch_id: str,
+    results: dict,
+    manifest_dir: Path,
+    selected_steps: List[str],
+    analysis_tier: str,
+    stale_after_minutes: int,
+    started_at: str,
+    manifest_entries: List[dict],
+) -> Optional[Path]:
+    """Write (or rewrite) the batch manifest to disk.
+
+    Args:
+        batch_id: Batch identifier
+        results: In-memory results dict
+        manifest_dir: Directory for manifest files
+        selected_steps: Steps selected for this batch
+        analysis_tier: fast or full
+        stale_after_minutes: Staleness threshold
+        started_at: ISO timestamp of batch start
+        manifest_entries: Per-(song_id, step, tier) manifest rows
+
+    Returns:
+        Path to the manifest file, or None on failure
+    """
+    try:
+        manifest_dir.mkdir(parents=True, exist_ok=True)
+        manifest_path = manifest_dir / f"{batch_id}_manifest.json"
+        manifest = {
+            "batch_id": batch_id,
+            "started_at": started_at,
+            "selected_steps": selected_steps,
+            "analysis_tier": analysis_tier,
+            "stale_after_minutes": stale_after_minutes,
+            "songs": manifest_entries,
+        }
+        manifest_path.write_text(json.dumps(manifest, indent=2, ensure_ascii=False))
+        return manifest_path
+    except OSError as e:
+        logger.warning(f"Failed to write manifest: {e}")
+        return None
+
+
+def _load_manifest(manifest_path: Path) -> Optional[dict]:
+    """Load a manifest from disk.
+
+    Args:
+        manifest_path: Path to the manifest file
+
+    Returns:
+        Parsed manifest dict, or None on failure
+    """
+    try:
+        return json.loads(manifest_path.read_text())
+    except (OSError, json.JSONDecodeError) as e:
+        logger.error(f"Failed to load manifest {manifest_path}: {e}")
+        return None
+
+
 def _process_batch(
     db_client: DatabaseClient,
     r2_client: R2Client,
     analysis_client: AnalysisClient,
     song_ids: list[str],
-    skip_download: bool,
-    skip_lrc: bool,
-    force_lrc: bool,
+    selected_steps: List[str],
+    force: bool,
+    analysis_tier: str,
     stale_after_minutes: int,
     console: Console,
 ) -> dict:
-    """Process all songs in batch.
+    """Process all songs in batch with strictly gated phases.
+
+    Each phase runs only if its step is in selected_steps. No phase runs as
+    a side effect of another. Phases run sequentially: download → LRC →
+    analysis → embedding.
 
     Args:
         db_client: Database client
         r2_client: R2 client
         analysis_client: Analysis service client
         song_ids: List of song IDs to process
-        skip_download: Skip download step
-        skip_lrc: Skip LRC step
-        force_lrc: Force re-generate LRC (skip R2 check and existing job reuse)
+        selected_steps: Steps to run (download/lrc/analyze/embedding)
+        force: Force re-run of the single selected step
+        analysis_tier: fast or full
         stale_after_minutes: Staleness threshold for processing jobs
         console: Rich console
 
     Returns:
         Dict with results for each song
     """
-    results = {}
+    results: Dict[str, dict] = {sid: {} for sid in song_ids}
 
-    # Phase 1: Download (if needed)
-    if not skip_download:
-        console.print("[cyan]Phase 1: Downloading audio[/cyan]")
-        downloaded_count = 0
-        skipped_count = 0
-        failed_count = 0
+    batch_id = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H%M") + "_batch"
+    started_at = datetime.now(timezone.utc).isoformat()
+    manifest_dir = _get_manifest_dir()
+    manifest_entries: List[dict] = []
 
-        for i, song_id in enumerate(song_ids, 1):
-            console.print(f"[{i}/{len(song_ids)}] {song_id}...")
+    def _flush_manifest() -> Optional[Path]:
+        return _write_manifest(
+            batch_id,
+            results,
+            manifest_dir,
+            selected_steps,
+            analysis_tier,
+            stale_after_minutes,
+            started_at,
+            manifest_entries,
+        )
 
-            recording = db_client.get_recording_by_song_id(song_id)
-            if not recording:
-                song = db_client.get_song(song_id)
-                if not song:
-                    console.print("  [red]✗ Song not found in database[/red]")
-                    results[song_id] = {
-                        "download": "failed",
-                        "error": "Song not found",
-                    }
-                    failed_count += 1
-                    continue
+    def _add_manifest_entry(
+        song_id: str,
+        hash_prefix: str,
+        step: str,
+        tier: str,
+        job_id: Optional[str],
+        status: str,
+        attempts: int = 1,
+        previous_job_id: Optional[str] = None,
+        error_class: Optional[str] = None,
+        error_message: Optional[str] = None,
+        submitted_at: Optional[str] = None,
+        completed_at: Optional[str] = None,
+    ) -> None:
+        entry = {
+            "song_id": song_id,
+            "hash_prefix": hash_prefix,
+            "step": step,
+            "tier": tier,
+            "job_id": job_id,
+            "status": status,
+            "attempts": attempts,
+            "previous_job_id": previous_job_id,
+            "error_class": error_class,
+            "error_message": error_message,
+            "submitted_at": submitted_at,
+            "completed_at": completed_at,
+        }
+        # Dedup by (song_id, step, tier): overwrite prior entry
+        for i, existing in enumerate(manifest_entries):
+            if (
+                existing["song_id"] == song_id
+                and existing["step"] == step
+                and existing["tier"] == tier
+            ):
+                manifest_entries[i] = entry
+                return
+        manifest_entries.append(entry)
 
-                recording, error = _download_and_create_recording(
-                    song_id, song, db_client, r2_client, console
-                )
+    try:
+        # Phase 1: Download
+        if "download" in selected_steps:
+            console.print("[cyan]Phase 1: Downloading audio[/cyan]")
+            downloaded_count = 0
+            skipped_count = 0
+            failed_count = 0
+
+            for i, song_id in enumerate(song_ids, 1):
+                console.print(f"[{i}/{len(song_ids)}] {song_id}...")
+
+                recording = db_client.get_recording_by_song_id(song_id)
                 if not recording:
-                    results[song_id] = {
-                        "download": "failed",
-                        "error": error,
-                    }
-                    failed_count += 1
-                    continue
+                    song = db_client.get_song(song_id)
+                    if not song:
+                        console.print("  [red]✗ Song not found in database[/red]")
+                        results[song_id]["download"] = "failed"
+                        results[song_id]["error"] = "Song not found"
+                        failed_count += 1
+                        continue
 
-                results[song_id] = {"download": "completed"}
-                downloaded_count += 1
-                continue
-
-            result = _download_if_needed(song_id, recording, db_client, r2_client, console)
-            results[song_id] = result
-
-            if result["download"] == "completed":
-                downloaded_count += 1
-            elif result["download"] == "skipped_r2":
-                skip_reason = result.get("skip_reason", "audio on R2")
-                console.print(f"  [yellow]→ skipped: {skip_reason}[/yellow]")
-                skipped_count += 1
-            else:
-                failed_count += 1
-
-        console.print(f"  [green]Downloaded: {downloaded_count}[/green]")
-        console.print(f"  [dim]Skipped: {skipped_count}[/dim]")
-        console.print(f"  [red]Failed: {failed_count}[/red]")
-        console.print()
-
-    # Phase 2: Submit LRC jobs
-    active_jobs = {}  # song_id -> job_id
-    if not skip_lrc:
-        console.print("[cyan]Phase 2: Submitting LRC jobs[/cyan]")
-
-        for song_id in song_ids:
-            # Skip if download failed
-            if results.get(song_id, {}).get("download") == "failed":
-                console.print(f"  [yellow]→ {song_id} (skipped: download failed)[/yellow]")
-                continue
-
-            # Skip if LRC already completed (from previous run or R2 check)
-            if results.get(song_id, {}).get("lrc") == "completed":
-                console.print(f"  [yellow]→ {song_id} (skipped: LRC completed)[/yellow]")
-                continue
-
-            recording = db_client.get_recording_by_song_id(song_id)
-            if not recording:
-                console.print(f"  [yellow]→ {song_id} (skipped: no recording)[/yellow]")
-                continue
-
-            # Get song for lyrics
-            song = db_client.get_song(song_id)
-            if not song or not song.lyrics_raw:
-                console.print(f"  [yellow]→ {song_id} (skipped: no lyrics)[/yellow]")
-                continue
-
-            # Check if R2 already has LRC (skip when force_lrc)
-            if not force_lrc:
-                lrc_url = r2_client.lrc_exists(recording.hash_prefix)
-                if lrc_url:
-                    db_client.update_recording_lrc(
-                        recording.hash_prefix,
-                        lrc_url,
-                        visibility_status="review",
+                    recording, error = _download_and_create_recording(
+                        song_id, song, db_client, r2_client, console
                     )
-                    results[song_id] = results.get(song_id, {})
-                    results[song_id]["lrc"] = "completed"
-                    results[song_id]["lrc_source"] = "r2_preexisting"
-                    console.print(f"  [yellow]→ {song_id} (skipped: LRC on R2)[/yellow]")
+                    if not recording:
+                        results[song_id]["download"] = "failed"
+                        results[song_id]["error"] = error
+                        failed_count += 1
+                        continue
+
+                    results[song_id]["download"] = "completed"
+                    downloaded_count += 1
                     continue
 
-            # Check for existing processing job (not stale) - skip when force_lrc
-            if not force_lrc and recording.lrc_status == "processing" and recording.lrc_job_id:
-                from datetime import datetime, timezone, timedelta
+                result = _download_if_needed(song_id, recording, db_client, r2_client, console)
+                results[song_id].update(result)
 
-                updated_at = (
-                    datetime.fromisoformat(recording.updated_at) if recording.updated_at else None
+                if result["download"] == "completed":
+                    downloaded_count += 1
+                elif result["download"] == "skipped_r2":
+                    skip_reason = result.get("skip_reason", "audio on R2")
+                    console.print(f"  [yellow]→ skipped: {skip_reason}[/yellow]")
+                    skipped_count += 1
+                else:
+                    failed_count += 1
+
+            console.print(f"  [green]Downloaded: {downloaded_count}[/green]")
+            console.print(f"  [dim]Skipped: {skipped_count}[/dim]")
+            console.print(f"  [red]Failed: {failed_count}[/red]")
+            console.print()
+            _flush_manifest()
+
+        # Phase 2: LRC submit + poll
+        if "lrc" in selected_steps:
+            console.print("[cyan]Phase 2: Submitting LRC jobs[/cyan]")
+            active_lrc_jobs: Dict[str, str] = {}  # song_id -> job_id
+
+            for song_id in song_ids:
+                if results.get(song_id, {}).get("download") == "failed":
+                    console.print(f"  [yellow]→ {song_id} (skipped: download failed)[/yellow]")
+                    continue
+
+                if results.get(song_id, {}).get("lrc") == "completed":
+                    console.print(f"  [yellow]→ {song_id} (skipped: LRC completed)[/yellow]")
+                    continue
+
+                recording = db_client.get_recording_by_song_id(song_id)
+                if not recording:
+                    console.print(f"  [yellow]→ {song_id} (skipped: no recording)[/yellow]")
+                    continue
+
+                song = db_client.get_song(song_id)
+                if not song or not song.lyrics_raw:
+                    console.print(f"  [yellow]→ {song_id} (skipped: no lyrics)[/yellow]")
+                    continue
+
+                # Check R2 (skip when force)
+                if not force:
+                    lrc_url = r2_client.lrc_exists(recording.hash_prefix)
+                    if lrc_url:
+                        db_client.update_recording_lrc(
+                            recording.hash_prefix,
+                            lrc_url,
+                            visibility_status="review",
+                        )
+                        results[song_id]["lrc"] = "completed"
+                        results[song_id]["lrc_source"] = "r2_preexisting"
+                        console.print(f"  [yellow]→ {song_id} (skipped: LRC on R2)[/yellow]")
+                        continue
+
+                # Reuse non-stale processing job (skip when force)
+                if not force and recording.lrc_status == "processing" and recording.lrc_job_id:
+                    updated_at = (
+                        datetime.fromisoformat(recording.updated_at)
+                        if recording.updated_at
+                        else None
+                    )
+                    if updated_at:
+                        if updated_at.tzinfo is None:
+                            updated_at = updated_at.replace(tzinfo=timezone.utc)
+                        staleness = datetime.now(timezone.utc) - updated_at
+                        if staleness < timedelta(minutes=stale_after_minutes):
+                            active_lrc_jobs[song_id] = recording.lrc_job_id
+                            console.print(
+                                f"  [yellow]→ {song_id} (reusing job: {recording.lrc_job_id})[/yellow]"
+                            )
+                            continue
+
+                # Submit new job
+                try:
+                    youtube_url = recording.youtube_url or ""
+                    job = analysis_client.submit_lrc(
+                        audio_url=recording.r2_audio_url,
+                        content_hash=recording.content_hash,
+                        lyrics_text=song.lyrics_raw,
+                        song_title=song.title,
+                        whisper_model="large-v3",
+                        language="auto",
+                        use_vocals_stem=True,
+                        force=force,
+                        force_whisper=False,
+                        youtube_url=youtube_url,
+                        use_qwen3_asr=True,
+                        force_qwen3_asr=False,
+                    )
+
+                    db_client.update_recording_status(
+                        hash_prefix=recording.hash_prefix,
+                        lrc_status="processing",
+                        lrc_job_id=job.job_id,
+                    )
+
+                    active_lrc_jobs[song_id] = job.job_id
+                    _add_manifest_entry(
+                        song_id,
+                        recording.hash_prefix,
+                        "lrc",
+                        "lrc",
+                        job.job_id,
+                        "submitted",
+                        submitted_at=datetime.now(timezone.utc).isoformat(),
+                    )
+                    console.print(f"  [green]→ {song_id} (submitted: {job.job_id})[/green]")
+
+                except AnalysisServiceError as e:
+                    console.print(f"  [red]✗ {song_id} failed to submit: {e}[/red]")
+                    results[song_id]["lrc"] = "failed"
+                    results[song_id]["lrc_error"] = str(e)
+                    _add_manifest_entry(
+                        song_id,
+                        recording.hash_prefix if recording else "",
+                        "lrc",
+                        "lrc",
+                        None,
+                        "failed",
+                        error_class=type(e).__name__,
+                        error_message=str(e),
+                    )
+
+            console.print(f"  Submitted: {len(active_lrc_jobs)} job(s)")
+            console.print()
+            _flush_manifest()
+
+            # Poll LRC jobs
+            if active_lrc_jobs:
+                console.print("[cyan]Phase 2: Polling LRC jobs[/cyan]")
+                _poll_all_jobs(
+                    active_jobs=active_lrc_jobs,
+                    results=results,
+                    db_client=db_client,
+                    analysis_client=analysis_client,
+                    r2_client=r2_client,
+                    force_lrc=force,
+                    stale_after_minutes=stale_after_minutes,
+                    console=console,
+                    manifest_entries=manifest_entries,
+                    _add_manifest_entry=_add_manifest_entry,
                 )
-                if updated_at:
-                    if updated_at.tzinfo is None:
-                        updated_at = updated_at.replace(tzinfo=timezone.utc)
-                    staleness = datetime.now(timezone.utc) - updated_at
-                    if staleness < timedelta(minutes=stale_after_minutes):
-                        active_jobs[song_id] = recording.lrc_job_id
+                _flush_manifest()
+
+        # Phase 3: Analysis submit + poll
+        if "analyze" in selected_steps:
+            console.print(f"[cyan]Phase 3: Submitting analysis jobs (tier: {analysis_tier})[/cyan]")
+            active_analysis_jobs: Dict[str, str] = {}  # song_id -> job_id
+
+            for song_id in song_ids:
+                if results.get(song_id, {}).get("download") == "failed":
+                    console.print(f"  [yellow]→ {song_id} (skipped: download failed)[/yellow]")
+                    continue
+
+                recording = db_client.get_recording_by_song_id(song_id)
+                if not recording or not recording.r2_audio_url:
+                    console.print(f"  [yellow]→ {song_id} (skipped: no recording/audio)[/yellow]")
+                    continue
+
+                # Non-force skip logic
+                if not force:
+                    if analysis_tier == "fast" and recording.analysis_status in (
+                        "partial",
+                        "completed",
+                    ):
                         console.print(
-                            f"  [yellow]→ {song_id} (reusing job: {recording.lrc_job_id})[/yellow]"
+                            f"  [yellow]→ {song_id} (skipped: analysis {recording.analysis_status})[/yellow]"
+                        )
+                        continue
+                    if analysis_tier == "full" and recording.analysis_status == "completed":
+                        console.print(
+                            f"  [yellow]→ {song_id} (skipped: analysis completed)[/yellow]"
                         )
                         continue
 
-            # Submit new job
-            try:
-                youtube_url = recording.youtube_url or ""
+                # Reuse non-stale processing job (skip when force)
+                if (
+                    not force
+                    and recording.analysis_status == "processing"
+                    and recording.analysis_job_id
+                ):
+                    updated_at = (
+                        datetime.fromisoformat(recording.updated_at)
+                        if recording.updated_at
+                        else None
+                    )
+                    if updated_at:
+                        if updated_at.tzinfo is None:
+                            updated_at = updated_at.replace(tzinfo=timezone.utc)
+                        staleness = datetime.now(timezone.utc) - updated_at
+                        if staleness < timedelta(minutes=stale_after_minutes):
+                            active_analysis_jobs[song_id] = recording.analysis_job_id
+                            console.print(
+                                f"  [yellow]→ {song_id} (reusing job: {recording.analysis_job_id})[/yellow]"
+                            )
+                            continue
 
-                job = analysis_client.submit_lrc(
-                    audio_url=recording.r2_audio_url,
-                    content_hash=recording.content_hash,
-                    lyrics_text=song.lyrics_raw,
-                    song_title=song.title,
-                    whisper_model="large-v3",
-                    language="auto",
-                    use_vocals_stem=True,
-                    force=force_lrc,
-                    force_whisper=False,
-                    youtube_url=youtube_url,
-                    use_qwen3_asr=True,
-                    force_qwen3_asr=False,
+                # Submit new job
+                try:
+                    if analysis_tier == "fast":
+                        job = analysis_client.submit_fast_analysis(
+                            audio_url=recording.r2_audio_url,
+                            content_hash=recording.content_hash,
+                            force=force,
+                        )
+                    else:
+                        job = analysis_client.submit_analysis(
+                            audio_url=recording.r2_audio_url,
+                            content_hash=recording.content_hash,
+                            generate_stems=False,
+                            force=force,
+                        )
+
+                    db_client.update_recording_status(
+                        hash_prefix=recording.hash_prefix,
+                        analysis_status="processing",
+                        analysis_job_id=job.job_id,
+                    )
+
+                    active_analysis_jobs[song_id] = job.job_id
+                    _add_manifest_entry(
+                        song_id,
+                        recording.hash_prefix,
+                        "analyze",
+                        analysis_tier,
+                        job.job_id,
+                        "submitted",
+                        submitted_at=datetime.now(timezone.utc).isoformat(),
+                    )
+                    console.print(f"  [green]→ {song_id} (submitted: {job.job_id})[/green]")
+
+                except AnalysisServiceError as e:
+                    console.print(f"  [red]✗ {song_id} failed to submit: {e}[/red]")
+                    results[song_id]["analyze"] = "failed"
+                    results[song_id]["analyze_error"] = str(e)
+                    _add_manifest_entry(
+                        song_id,
+                        recording.hash_prefix if recording else "",
+                        "analyze",
+                        analysis_tier,
+                        None,
+                        "failed",
+                        error_class=type(e).__name__,
+                        error_message=str(e),
+                    )
+
+            console.print(f"  Submitted: {len(active_analysis_jobs)} job(s)")
+            console.print()
+            _flush_manifest()
+
+            # Poll analysis jobs
+            if active_analysis_jobs:
+                console.print("[cyan]Phase 3: Polling analysis jobs[/cyan]")
+                _poll_analysis_jobs(
+                    active_jobs=active_analysis_jobs,
+                    results=results,
+                    db_client=db_client,
+                    analysis_client=analysis_client,
+                    analysis_tier=analysis_tier,
+                    stale_after_minutes=stale_after_minutes,
+                    console=console,
+                    manifest_entries=manifest_entries,
+                    _add_manifest_entry=_add_manifest_entry,
                 )
+                _flush_manifest()
 
-                db_client.update_recording_status(
-                    hash_prefix=recording.hash_prefix,
-                    lrc_status="processing",
-                    lrc_job_id=job.job_id,
+        # Phase 4: Embedding submit + poll
+        if "embedding" in selected_steps:
+            console.print("[cyan]Phase 4: Submitting embedding jobs[/cyan]")
+            active_embedding_jobs: Dict[str, str] = {}  # song_id -> job_id
+
+            for song_id in song_ids:
+                if results.get(song_id, {}).get("download") == "failed":
+                    console.print(f"  [yellow]→ {song_id} (skipped: download failed)[/yellow]")
+                    continue
+
+                song = db_client.get_song(song_id)
+                if not song or not song.lyrics_raw:
+                    console.print(f"  [yellow]→ {song_id} (skipped: no lyrics)[/yellow]")
+                    continue
+
+                recording = db_client.get_recording_by_song_id(song_id)
+                hash_prefix = recording.hash_prefix if recording else ""
+
+                # Non-force: skip if content hash matches
+                if not force:
+                    existing_hash = db_client.get_embedding_content_hash(song_id)
+                    lyrics_list = song.lyrics_list
+                    current_hash = _compute_content_hash(
+                        song.title, song.composer or "", song.lyrics_raw or "", lyrics_list
+                    )
+                    if existing_hash == current_hash:
+                        console.print(
+                            f"  [dim]→ {song_id} (skipped: embedding up-to-date)[/dim]"
+                        )
+                        results[song_id]["embedding"] = "skipped"
+                        continue
+
+                try:
+                    job_info = analysis_client.submit_embedding(
+                        song_id=song.id,
+                        title=song.title,
+                        composer=song.composer or "",
+                        lyrics_raw=song.lyrics_raw or "",
+                        lyrics_lines=song.lyrics_list,
+                    )
+                    active_embedding_jobs[song_id] = job_info.job_id
+                    _add_manifest_entry(
+                        song_id,
+                        hash_prefix,
+                        "embedding",
+                        "embedding",
+                        job_info.job_id,
+                        "submitted",
+                        submitted_at=datetime.now(timezone.utc).isoformat(),
+                    )
+                    console.print(f"  [green]→ {song_id} (submitted: {job_info.job_id})[/green]")
+                except Exception as e:
+                    console.print(f"  [red]✗ {song_id} failed to submit: {e}[/red]")
+                    results[song_id]["embedding"] = "failed"
+                    results[song_id]["embedding_error"] = str(e)
+                    _add_manifest_entry(
+                        song_id,
+                        hash_prefix,
+                        "embedding",
+                        "embedding",
+                        None,
+                        "failed",
+                        error_class=type(e).__name__,
+                        error_message=str(e),
+                    )
+
+            console.print(f"  Submitted: {len(active_embedding_jobs)} job(s)")
+            console.print()
+            _flush_manifest()
+
+            # Poll embedding jobs
+            if active_embedding_jobs:
+                console.print("[cyan]Phase 4: Polling embedding jobs[/cyan]")
+                _poll_embedding_jobs(
+                    active_jobs=active_embedding_jobs,
+                    results=results,
+                    db_client=db_client,
+                    analysis_client=analysis_client,
+                    stale_after_minutes=stale_after_minutes,
+                    console=console,
+                    manifest_entries=manifest_entries,
+                    _add_manifest_entry=_add_manifest_entry,
                 )
+                _flush_manifest()
 
-                active_jobs[song_id] = job.job_id
-                console.print(f"  [green]→ {song_id} (submitted: {job.job_id})[/green]")
+    except KeyboardInterrupt:
+        console.print("\n[yellow]Batch interrupted. Flushing manifest...[/yellow]")
+        _flush_manifest()
+        raise
 
-            except AnalysisServiceError as e:
-                console.print(f"  [red]✗ {song_id} failed to submit: {e}[/red]")
-                results[song_id] = results.get(song_id, {})
-                results[song_id]["lrc"] = "failed"
-                results[song_id]["lrc_error"] = str(e)
-
-        console.print(f"  Submitted: {len(active_jobs)} job(s)")
-        console.print()
-
-    # Phase 3: Poll all jobs
-    if active_jobs and not skip_lrc:
-        console.print("[cyan]Phase 3: Polling LRC jobs[/cyan]")
-        _poll_all_jobs(
-            active_jobs=active_jobs,
-            results=results,
-            db_client=db_client,
-            analysis_client=analysis_client,
-            r2_client=r2_client,
-            force_lrc=force_lrc,
-            stale_after_minutes=stale_after_minutes,
-            console=console,
-        )
-
-    # Phase 3.5: Submit embedding jobs for songs without embeddings
-    embedding_job_ids: list[str] = []
-    songs_needing_embedding = []
-    for song_id in song_ids:
-        if results.get(song_id, {}).get("download") == "failed":
-            continue
-        existing_hash = db_client.get_embedding_content_hash(song_id)
-        if existing_hash is None:
-            song = db_client.get_song(song_id)
-            if song and song.lyrics_raw:
-                songs_needing_embedding.append(song)
-
-    if songs_needing_embedding:
-        console.print(
-            f"[cyan]Phase 3.5: Submitting {len(songs_needing_embedding)} embedding jobs[/cyan]"
-        )
-        for song in songs_needing_embedding:
-            jid = _submit_embedding_single(song, analysis_client, db_client, console, force=False)
-            if jid:
-                embedding_job_ids.append(jid)
-
-        if embedding_job_ids:
-            console.print(f"  Submitted {len(embedding_job_ids)} embedding jobs")
-            console.print("  (Use 'sow-admin audio embed --all --wait' to poll results)")
-        console.print()
-
-    # Phase 4: Print stats (done by caller)
+    _flush_manifest()
     return results
 
 
@@ -4896,8 +5421,10 @@ def _poll_all_jobs(
     force_lrc: bool,
     stale_after_minutes: int,
     console: Console,
+    manifest_entries: Optional[List[dict]] = None,
+    _add_manifest_entry: Optional[Any] = None,
 ) -> None:
-    """Poll all active jobs until terminal state or Ctrl+C.
+    """Poll all active LRC jobs until terminal state or Ctrl+C.
 
     Args:
         active_jobs: Dict of song_id -> job_id
@@ -4908,6 +5435,8 @@ def _poll_all_jobs(
         force_lrc: Force re-generate LRC on resubmit
         stale_after_minutes: Staleness threshold
         console: Rich console
+        manifest_entries: Optional manifest rows list to update
+        _add_manifest_entry: Optional callback to add/update a manifest row
     """
     poll_interval = 30.0
     last_completion_time = time.time()
@@ -4959,6 +5488,17 @@ def _poll_all_jobs(
                             del active_jobs[song_id]
                             any_completed_this_cycle = True
 
+                            if _add_manifest_entry:
+                                _add_manifest_entry(
+                                    song_id,
+                                    recording.hash_prefix,
+                                    "lrc",
+                                    "lrc",
+                                    job_id,
+                                    "completed",
+                                    completed_at=datetime.now(timezone.utc).isoformat(),
+                                )
+
                             # Get song for display
                             song = db_client.get_song(song_id)
                             song_name = song.title if song else song_id
@@ -4972,14 +5512,31 @@ def _poll_all_jobs(
                             continue
 
                     elif job.status == "failed":
+                        # FIX: fetch recording here — previously only assigned in
+                        # completed/404 branches, causing a NameError on direct
+                        # failed status from the service.
+                        recording = db_client.get_recording_by_song_id(song_id)
+                        hash_prefix = recording.hash_prefix if recording else ""
                         db_client.update_recording_status(
-                            hash_prefix=recording.hash_prefix,
+                            hash_prefix=hash_prefix,
                             lrc_status="failed",
                         )
                         results[song_id]["lrc"] = "failed"
                         results[song_id]["lrc_error"] = job.error_message or "Unknown error"
                         del active_jobs[song_id]
                         any_completed_this_cycle = True
+
+                        if _add_manifest_entry:
+                            _add_manifest_entry(
+                                song_id,
+                                hash_prefix,
+                                "lrc",
+                                "lrc",
+                                job_id,
+                                "failed",
+                                error_message=job.error_message or "Unknown error",
+                                completed_at=datetime.now(timezone.utc).isoformat(),
+                            )
 
                         song = db_client.get_song(song_id)
                         song_name = song.title if song else song_id
@@ -5002,6 +5559,17 @@ def _poll_all_jobs(
                             results[song_id]["lrc"] = "completed"
                             del active_jobs[song_id]
                             any_completed_this_cycle = True
+
+                            if _add_manifest_entry:
+                                _add_manifest_entry(
+                                    song_id,
+                                    recording.hash_prefix,
+                                    "lrc",
+                                    "lrc",
+                                    job_id,
+                                    "completed",
+                                    completed_at=datetime.now(timezone.utc).isoformat(),
+                                )
 
                             song = db_client.get_song(song_id)
                             song_name = song.title if song else song_id
@@ -5064,6 +5632,17 @@ def _poll_all_jobs(
                                         lrc_status="processing",
                                         lrc_job_id=new_job.job_id,
                                     )
+                                    if _add_manifest_entry:
+                                        _add_manifest_entry(
+                                            song_id,
+                                            recording.hash_prefix,
+                                            "lrc",
+                                            "lrc",
+                                            new_job.job_id,
+                                            "submitted",
+                                            previous_job_id=job_id,
+                                            submitted_at=datetime.now(timezone.utc).isoformat(),
+                                        )
                                     active_jobs[song_id] = new_job.job_id
                                     resubmit_counts[song_id] = resubmit_count + 1
                                     job_timing[song_id] = (time.time(), 0)
@@ -5201,6 +5780,658 @@ def _reconcile_on_interrupt(
     )
 
 
+def _is_retryable_poll_error(e: Exception) -> bool:
+    """Whether a polling failure should be retried once (transient)."""
+    if isinstance(e, AnalysisServiceError):
+        return e.status_code in {502, 503, 504}
+    import requests as _requests
+
+    return isinstance(e, (_requests.exceptions.ConnectError, _requests.exceptions.TimeoutException))
+
+
+def _poll_analysis_jobs(
+    active_jobs: Dict[str, str],
+    results: dict,
+    db_client: DatabaseClient,
+    analysis_client: AnalysisClient,
+    analysis_tier: str,
+    stale_after_minutes: int,
+    console: Console,
+    manifest_entries: Optional[List[dict]] = None,
+    _add_manifest_entry: Optional[Any] = None,
+) -> None:
+    """Poll active analysis jobs until terminal state or Ctrl+C.
+
+    Separate from the LRC poll loop so failure modes are not coupled. On
+    Ctrl+C, probes final service state once; active/non-responsive jobs are
+    left in analysis_status='processing' for --resume.
+
+    Args:
+        active_jobs: Dict of song_id -> job_id
+        results: Results dict to update
+        db_client: Database client
+        analysis_client: Analysis service client
+        analysis_tier: fast or full
+        stale_after_minutes: Staleness threshold
+        console: Rich console
+        manifest_entries: Optional manifest rows list
+        _add_manifest_entry: Optional manifest callback
+    """
+    poll_interval = 30.0
+    last_completion_time = time.time()
+    stale_warning_seconds = stale_after_minutes * 60
+    batch_start_time = time.time()
+    retried: set = set()
+
+    try:
+        while active_jobs:
+            any_completed_this_cycle = False
+
+            for song_id in list(active_jobs.keys()):
+                job_id = active_jobs[song_id]
+                try:
+                    job = analysis_client.get_job(job_id)
+
+                    if job.status == "completed":
+                        recording = db_client.get_recording_by_song_id(song_id)
+                        if not recording:
+                            console.print(f"  [red]✗ {song_id}: recording vanished[/red]")
+                            results[song_id]["analyze"] = "failed"
+                            del active_jobs[song_id]
+                            any_completed_this_cycle = True
+                            continue
+
+                        if job.result:
+                            result = job.result
+                            status_to_set = "partial" if analysis_tier == "fast" else "completed"
+                            db_client.update_recording_analysis(
+                                hash_prefix=recording.hash_prefix,
+                                duration_seconds=result.duration_seconds,
+                                tempo_bpm=result.tempo_bpm,
+                                musical_key=result.musical_key,
+                                musical_mode=result.musical_mode,
+                                key_confidence=result.key_confidence,
+                                loudness_db=result.loudness_db,
+                                beats=(
+                                    json.dumps(result.beats)
+                                    if analysis_tier == "full" and result.beats
+                                    else None
+                                ),
+                                downbeats=(
+                                    json.dumps(result.downbeats)
+                                    if analysis_tier == "full" and result.downbeats
+                                    else None
+                                ),
+                                sections=(
+                                    json.dumps(result.sections)
+                                    if analysis_tier == "full" and result.sections
+                                    else None
+                                ),
+                                embeddings_shape=(
+                                    json.dumps(result.embeddings_shape)
+                                    if analysis_tier == "full" and result.embeddings_shape
+                                    else None
+                                ),
+                                r2_stems_url=result.stems_url,
+                                analysis_status=status_to_set,
+                            )
+
+                        results[song_id]["analyze"] = "completed"
+                        results[song_id]["analysis_tier"] = analysis_tier
+                        del active_jobs[song_id]
+                        any_completed_this_cycle = True
+
+                        if _add_manifest_entry:
+                            _add_manifest_entry(
+                                song_id,
+                                recording.hash_prefix,
+                                "analyze",
+                                analysis_tier,
+                                job_id,
+                                "completed",
+                                completed_at=datetime.now(timezone.utc).isoformat(),
+                            )
+
+                        song = db_client.get_song(song_id)
+                        song_name = song.title if song else song_id
+                        console.print(
+                            f"  [green]✓[/green] {song_name} — analysis completed ({analysis_tier})"
+                        )
+
+                    elif job.status == "failed":
+                        recording = db_client.get_recording_by_song_id(song_id)
+                        hash_prefix = recording.hash_prefix if recording else ""
+                        db_client.update_recording_status(
+                            hash_prefix=hash_prefix,
+                            analysis_status="failed",
+                        )
+                        results[song_id]["analyze"] = "failed"
+                        results[song_id]["analyze_error"] = job.error_message or "Unknown error"
+                        del active_jobs[song_id]
+                        any_completed_this_cycle = True
+
+                        if _add_manifest_entry:
+                            _add_manifest_entry(
+                                song_id,
+                                hash_prefix,
+                                "analyze",
+                                analysis_tier,
+                                job_id,
+                                "failed",
+                                error_message=job.error_message or "Unknown error",
+                                completed_at=datetime.now(timezone.utc).isoformat(),
+                            )
+
+                        song = db_client.get_song(song_id)
+                        song_name = song.title if song else song_id
+                        console.print(
+                            f"  [red]✗[/red] {song_name} — analysis failed: "
+                            f"{job.error_message or 'Unknown error'}"
+                        )
+
+                except AnalysisServiceError as e:
+                    if e.status_code == 404:
+                        # Job lost — NO R2 fallback for analysis. Mark failed.
+                        recording = db_client.get_recording_by_song_id(song_id)
+                        hash_prefix = recording.hash_prefix if recording else ""
+                        db_client.update_recording_status(
+                            hash_prefix=hash_prefix,
+                            analysis_status="failed",
+                        )
+                        results[song_id]["analyze"] = "failed"
+                        results[song_id]["analyze_error"] = "Job lost (404)"
+                        del active_jobs[song_id]
+                        any_completed_this_cycle = True
+
+                        if _add_manifest_entry:
+                            _add_manifest_entry(
+                                song_id,
+                                hash_prefix,
+                                "analyze",
+                                analysis_tier,
+                                job_id,
+                                "failed",
+                                error_message="Job lost (404)",
+                                completed_at=datetime.now(timezone.utc).isoformat(),
+                            )
+
+                        console.print(f"  [red]✗ {song_id}: analysis job lost (404)[/red]")
+                    elif song_id not in retried and _is_retryable_poll_error(e):
+                        retried.add(song_id)
+                        console.print(
+                            f"  [yellow]→ {song_id}: transient poll error, retrying once...[/yellow]"
+                        )
+                    else:
+                        console.print(f"  [yellow]→ Error polling {job_id}: {e}[/yellow]")
+                except Exception as e:
+                    if song_id not in retried and _is_retryable_poll_error(e):
+                        retried.add(song_id)
+                        console.print(
+                            f"  [yellow]→ {song_id}: transient poll error, retrying once...[/yellow]"
+                        )
+                    else:
+                        console.print(f"  [yellow]→ Error polling {job_id}: {e}[/yellow]")
+
+            if any_completed_this_cycle:
+                last_completion_time = time.time()
+
+            elapsed_since_completion = time.time() - last_completion_time
+            if elapsed_since_completion > stale_warning_seconds and active_jobs:
+                hours = int(elapsed_since_completion // 3600)
+                mins = int((elapsed_since_completion % 3600) // 60)
+                console.print(
+                    f"[yellow]⚠ WARNING: No analysis jobs completed in {hours}h {mins}m.[/yellow]"
+                )
+                last_completion_time = time.time()
+
+            if active_jobs:
+                completed = sum(1 for r in results.values() if r.get("analyze") == "completed")
+                failed = sum(1 for r in results.values() if r.get("analyze") == "failed")
+                elapsed = time.time() - batch_start_time
+                console.print(
+                    f"⏳ Polling {len(active_jobs)} analysis job(s)... "
+                    f"{completed} completed, {failed} failed "
+                    f"(elapsed: {int(elapsed // 60)}m {int(elapsed % 60)}s)"
+                )
+                time.sleep(poll_interval)
+
+    except KeyboardInterrupt:
+        console.print("\n[yellow]Analysis poll interrupted. Probing final state...[/yellow]")
+        for song_id, job_id in list(active_jobs.items()):
+            try:
+                job = analysis_client.get_job(job_id)
+                if job.status == "failed":
+                    recording = db_client.get_recording_by_song_id(song_id)
+                    if recording:
+                        db_client.update_recording_status(
+                            hash_prefix=recording.hash_prefix,
+                            analysis_status="failed",
+                        )
+                    results[song_id]["analyze"] = "failed"
+                    results[song_id]["analyze_error"] = job.error_message or "Unknown error"
+                    del active_jobs[song_id]
+                    console.print(f"  [red]✗ {song_id}: confirmed failed[/red]")
+                else:
+                    console.print(
+                        f"  [yellow]→ {song_id}: left in processing (resume with --resume)[/yellow]"
+                    )
+            except Exception:
+                console.print(
+                    f"  [yellow]→ {song_id}: left in processing (resume with --resume)[/yellow]"
+                )
+
+
+def _poll_embedding_jobs(
+    active_jobs: Dict[str, str],
+    results: dict,
+    db_client: DatabaseClient,
+    analysis_client: AnalysisClient,
+    stale_after_minutes: int,
+    console: Console,
+    manifest_entries: Optional[List[dict]] = None,
+    _add_manifest_entry: Optional[Any] = None,
+) -> None:
+    """Poll active embedding jobs until terminal state or Ctrl+C.
+
+    No R2 fallback (embeddings have no R2 artifact). On Ctrl+C, probes final
+    service state once; active jobs left for --resume.
+
+    Args:
+        active_jobs: Dict of song_id -> job_id
+        results: Results dict to update
+        db_client: Database client
+        analysis_client: Analysis service client
+        stale_after_minutes: Staleness threshold
+        console: Rich console
+        manifest_entries: Optional manifest rows list
+        _add_manifest_entry: Optional manifest callback
+    """
+    poll_interval = 30.0
+    last_completion_time = time.time()
+    stale_warning_seconds = stale_after_minutes * 60
+    batch_start_time = time.time()
+    retried: set = set()
+
+    try:
+        while active_jobs:
+            any_completed_this_cycle = False
+
+            for song_id in list(active_jobs.keys()):
+                job_id = active_jobs[song_id]
+                try:
+                    job = analysis_client.get_job(job_id)
+
+                    if job.status == "completed":
+                        if job.result and hasattr(job.result, "embedding"):
+                            _write_embedding_result(job, db_client, console)
+                        results[song_id]["embedding"] = "completed"
+                        del active_jobs[song_id]
+                        any_completed_this_cycle = True
+
+                        if _add_manifest_entry:
+                            recording = db_client.get_recording_by_song_id(song_id)
+                            _add_manifest_entry(
+                                song_id,
+                                recording.hash_prefix if recording else "",
+                                "embedding",
+                                "embedding",
+                                job_id,
+                                "completed",
+                                completed_at=datetime.now(timezone.utc).isoformat(),
+                            )
+
+                        song = db_client.get_song(song_id)
+                        song_name = song.title if song else song_id
+                        console.print(
+                            f"  [green]✓[/green] {song_name} — embedding completed"
+                        )
+
+                    elif job.status == "failed":
+                        results[song_id]["embedding"] = "failed"
+                        results[song_id]["embedding_error"] = (
+                            job.error_message or "Unknown error"
+                        )
+                        del active_jobs[song_id]
+                        any_completed_this_cycle = True
+
+                        if _add_manifest_entry:
+                            recording = db_client.get_recording_by_song_id(song_id)
+                            _add_manifest_entry(
+                                song_id,
+                                recording.hash_prefix if recording else "",
+                                "embedding",
+                                "embedding",
+                                job_id,
+                                "failed",
+                                error_message=job.error_message or "Unknown error",
+                                completed_at=datetime.now(timezone.utc).isoformat(),
+                            )
+
+                        song = db_client.get_song(song_id)
+                        song_name = song.title if song else song_id
+                        console.print(
+                            f"  [red]✗[/red] {song_name} — embedding failed: "
+                            f"{job.error_message or 'Unknown error'}"
+                        )
+
+                except AnalysisServiceError as e:
+                    if e.status_code == 404:
+                        results[song_id]["embedding"] = "failed"
+                        results[song_id]["embedding_error"] = "Job lost (404)"
+                        del active_jobs[song_id]
+                        any_completed_this_cycle = True
+
+                        if _add_manifest_entry:
+                            recording = db_client.get_recording_by_song_id(song_id)
+                            _add_manifest_entry(
+                                song_id,
+                                recording.hash_prefix if recording else "",
+                                "embedding",
+                                "embedding",
+                                job_id,
+                                "failed",
+                                error_message="Job lost (404)",
+                                completed_at=datetime.now(timezone.utc).isoformat(),
+                            )
+                        console.print(f"  [red]✗ {song_id}: embedding job lost (404)[/red]")
+                    elif song_id not in retried and _is_retryable_poll_error(e):
+                        retried.add(song_id)
+                        console.print(
+                            f"  [yellow]→ {song_id}: transient poll error, retrying once...[/yellow]"
+                        )
+                    else:
+                        console.print(f"  [yellow]→ Error polling {job_id}: {e}[/yellow]")
+                except Exception as e:
+                    if song_id not in retried and _is_retryable_poll_error(e):
+                        retried.add(song_id)
+                        console.print(
+                            f"  [yellow]→ {song_id}: transient poll error, retrying once...[/yellow]"
+                        )
+                    else:
+                        console.print(f"  [yellow]→ Error polling {job_id}: {e}[/yellow]")
+
+            if any_completed_this_cycle:
+                last_completion_time = time.time()
+
+            elapsed_since_completion = time.time() - last_completion_time
+            if elapsed_since_completion > stale_warning_seconds and active_jobs:
+                hours = int(elapsed_since_completion // 3600)
+                mins = int((elapsed_since_completion % 3600) // 60)
+                console.print(
+                    f"[yellow]⚠ WARNING: No embedding jobs completed in {hours}h {mins}m.[/yellow]"
+                )
+                last_completion_time = time.time()
+
+            if active_jobs:
+                completed = sum(1 for r in results.values() if r.get("embedding") == "completed")
+                failed = sum(1 for r in results.values() if r.get("embedding") == "failed")
+                elapsed = time.time() - batch_start_time
+                console.print(
+                    f"⏳ Polling {len(active_jobs)} embedding job(s)... "
+                    f"{completed} completed, {failed} failed "
+                    f"(elapsed: {int(elapsed // 60)}m {int(elapsed % 60)}s)"
+                )
+                time.sleep(poll_interval)
+
+    except KeyboardInterrupt:
+        console.print("\n[yellow]Embedding poll interrupted. Probing final state...[/yellow]")
+        for song_id, job_id in list(active_jobs.items()):
+            try:
+                job = analysis_client.get_job(job_id)
+                if job.status == "failed":
+                    results[song_id]["embedding"] = "failed"
+                    results[song_id]["embedding_error"] = (
+                        job.error_message or "Unknown error"
+                    )
+                    del active_jobs[song_id]
+                    console.print(f"  [red]✗ {song_id}: confirmed failed[/red]")
+                else:
+                    console.print(
+                        f"  [yellow]→ {song_id}: left in processing (resume with --resume)[/yellow]"
+                    )
+            except Exception:
+                console.print(
+                    f"  [yellow]→ {song_id}: left in processing (resume with --resume)[/yellow]"
+                )
+
+
+def _resume_from_manifest(
+    manifest_data: dict,
+    manifest_path: Path,
+    db_client: DatabaseClient,
+    r2_client: R2Client,
+    analysis_client: AnalysisClient,
+    stale_after_minutes: int,
+    console: Console,
+) -> dict:
+    """Resume a batch from a manifest file.
+
+    Re-polls entries with status 'submitted' or 'processing'. Skips
+    'completed'/'failed'/'abandoned' entries. On a completed entry, applies
+    the result writeback to the DB identically to a non-resume run.
+
+    Args:
+        manifest_data: Parsed manifest dict
+        manifest_path: Path to the manifest file
+        db_client: Database client
+        r2_client: R2 client
+        analysis_client: Analysis service client
+        stale_after_minutes: Staleness threshold
+        console: Rich console
+
+    Returns:
+        Results dict
+    """
+    songs = manifest_data.get("songs", [])
+    results: Dict[str, dict] = {}
+    manifest_entries: List[dict] = list(songs)
+
+    def _add_manifest_entry(
+        song_id: str,
+        hash_prefix: str,
+        step: str,
+        tier: str,
+        job_id: Optional[str],
+        status: str,
+        **kwargs,
+    ) -> None:
+        entry = {
+            "song_id": song_id,
+            "hash_prefix": hash_prefix,
+            "step": step,
+            "tier": tier,
+            "job_id": job_id,
+            "status": status,
+            **kwargs,
+        }
+        for i, existing in enumerate(manifest_entries):
+            if (
+                existing["song_id"] == song_id
+                and existing["step"] == step
+                and existing["tier"] == tier
+            ):
+                manifest_entries[i] = {**existing, **entry}
+                return
+        manifest_entries.append(entry)
+
+    # Partition entries
+    active_lrc: Dict[str, str] = {}
+    active_analysis: Dict[str, str] = {}
+    active_embedding: Dict[str, str] = {}
+    skipped = 0
+
+    for entry in songs:
+        song_id = entry["song_id"]
+        step = entry["step"]
+        tier = entry["tier"]
+        job_id = entry.get("job_id")
+        status = entry.get("status", "")
+        hash_prefix = entry.get("hash_prefix", "")
+
+        results.setdefault(song_id, {})
+
+        if status in ("completed", "failed", "abandoned"):
+            skipped += 1
+            # Apply writeback for completed entries (idempotent)
+            if status == "completed":
+                _apply_manifest_writeback(
+                    song_id, step, tier, job_id, hash_prefix,
+                    db_client, analysis_client, console,
+                )
+            continue
+
+        if not job_id:
+            skipped += 1
+            continue
+
+        if step == "lrc":
+            active_lrc[song_id] = job_id
+        elif step == "analyze":
+            active_analysis[song_id] = job_id
+        elif step == "embedding":
+            active_embedding[song_id] = job_id
+
+    if skipped:
+        console.print(f"[dim]Skipped {skipped} terminal entries from manifest.[/dim]")
+
+    batch_id = manifest_data.get("batch_id", manifest_path.stem)
+    started_at = manifest_data.get("started_at", "")
+    selected_steps = manifest_data.get("selected_steps", [])
+    analysis_tier = manifest_data.get("analysis_tier", "fast")
+
+    def _flush() -> None:
+        manifest = {
+            "batch_id": batch_id,
+            "started_at": started_at,
+            "selected_steps": selected_steps,
+            "analysis_tier": analysis_tier,
+            "stale_after_minutes": stale_after_minutes,
+            "songs": manifest_entries,
+        }
+        try:
+            manifest_path.write_text(json.dumps(manifest, indent=2, ensure_ascii=False))
+        except OSError as e:
+            logger.warning(f"Failed to flush manifest on resume: {e}")
+
+    try:
+        if active_lrc:
+            console.print(f"[cyan]Resume: polling {len(active_lrc)} LRC jobs[/cyan]")
+            _poll_all_jobs(
+                active_jobs=active_lrc,
+                results=results,
+                db_client=db_client,
+                analysis_client=analysis_client,
+                r2_client=r2_client,
+                force_lrc=False,
+                stale_after_minutes=stale_after_minutes,
+                console=console,
+                manifest_entries=manifest_entries,
+                _add_manifest_entry=_add_manifest_entry,
+            )
+            _flush()
+
+        if active_analysis:
+            console.print(f"[cyan]Resume: polling {len(active_analysis)} analysis jobs[/cyan]")
+            _poll_analysis_jobs(
+                active_jobs=active_analysis,
+                results=results,
+                db_client=db_client,
+                analysis_client=analysis_client,
+                analysis_tier=analysis_tier,
+                stale_after_minutes=stale_after_minutes,
+                console=console,
+                manifest_entries=manifest_entries,
+                _add_manifest_entry=_add_manifest_entry,
+            )
+            _flush()
+
+        if active_embedding:
+            console.print(f"[cyan]Resume: polling {len(active_embedding)} embedding jobs[/cyan]")
+            _poll_embedding_jobs(
+                active_jobs=active_embedding,
+                results=results,
+                db_client=db_client,
+                analysis_client=analysis_client,
+                stale_after_minutes=stale_after_minutes,
+                console=console,
+                manifest_entries=manifest_entries,
+                _add_manifest_entry=_add_manifest_entry,
+            )
+            _flush()
+    except KeyboardInterrupt:
+        console.print("\n[yellow]Resume interrupted. Flushing manifest...[/yellow]")
+        _flush()
+        raise
+
+    _flush()
+    return results
+
+
+def _apply_manifest_writeback(
+    song_id: str,
+    step: str,
+    tier: str,
+    job_id: Optional[str],
+    hash_prefix: str,
+    db_client: DatabaseClient,
+    analysis_client: AnalysisClient,
+    console: Console,
+) -> None:
+    """Apply idempotent DB writeback for a completed manifest entry on resume."""
+    try:
+        if not job_id:
+            return
+        job = analysis_client.get_job(job_id)
+        if job.status != "completed":
+            return
+
+        if step == "lrc":
+            # LRC writeback is R2-driven; skip if no R2 URL in result
+            pass
+        elif step == "analyze":
+            recording = db_client.get_recording_by_song_id(song_id)
+            if not recording or not job.result:
+                return
+            result = job.result
+            status_to_set = "partial" if tier == "fast" else "completed"
+            db_client.update_recording_analysis(
+                hash_prefix=recording.hash_prefix,
+                duration_seconds=result.duration_seconds,
+                tempo_bpm=result.tempo_bpm,
+                musical_key=result.musical_key,
+                musical_mode=result.musical_mode,
+                key_confidence=result.key_confidence,
+                loudness_db=result.loudness_db,
+                beats=(
+                    json.dumps(result.beats)
+                    if tier == "full" and result.beats
+                    else None
+                ),
+                downbeats=(
+                    json.dumps(result.downbeats)
+                    if tier == "full" and result.downbeats
+                    else None
+                ),
+                sections=(
+                    json.dumps(result.sections)
+                    if tier == "full" and result.sections
+                    else None
+                ),
+                embeddings_shape=(
+                    json.dumps(result.embeddings_shape)
+                    if tier == "full" and result.embeddings_shape
+                    else None
+                ),
+                r2_stems_url=result.stems_url,
+                analysis_status=status_to_set,
+            )
+        elif step == "embedding":
+            if job.result and hasattr(job.result, "embedding"):
+                _write_embedding_result(job, db_client, console)
+    except Exception as e:
+        logger.warning(f"Manifest writeback failed for {song_id}/{step}: {e}")
+
+
 def _print_progress(
     active_jobs: dict,
     results: dict,
@@ -5331,6 +6562,34 @@ def _print_stats(
             ]
         )
 
+    # Analysis stats
+    analysis_completed = sum(1 for r in results.values() if r.get("analyze") == "completed")
+    analysis_failed = sum(1 for r in results.values() if r.get("analyze") == "failed")
+    if analysis_completed or analysis_failed:
+        lines.extend(
+            [
+                f"│ {'':<30} {'':>18} │",
+                f"│ {'Analysis:':<30} {'':>18} │",
+                f"│ {'  Completed:':<30} {analysis_completed:>18} │",
+                f"│ {'  Failed:':<30} {analysis_failed:>18} │",
+            ]
+        )
+
+    # Embedding stats
+    embedding_completed = sum(1 for r in results.values() if r.get("embedding") == "completed")
+    embedding_failed = sum(1 for r in results.values() if r.get("embedding") == "failed")
+    embedding_skipped = sum(1 for r in results.values() if r.get("embedding") == "skipped")
+    if embedding_completed or embedding_failed or embedding_skipped:
+        lines.extend(
+            [
+                f"│ {'':<30} {'':>18} │",
+                f"│ {'Embedding:':<30} {'':>18} │",
+                f"│ {'  Completed:':<30} {embedding_completed:>18} │",
+                f"│ {'  Failed:':<30} {embedding_failed:>18} │",
+                f"│ {'  Skipped:':<30} {embedding_skipped:>18} │",
+            ]
+        )
+
     lines.append("╰" + "─" * 52 + "╯")
 
     console.print("\n".join(lines))
@@ -5353,6 +6612,32 @@ def _print_stats(
     if failed_lrcs:
         console.print("\n[bold red]Failed LRC:[/bold red]")
         for song_id, error in failed_lrcs:
+            song = db_client.get_song(song_id)
+            song_name = song.title if song else song_id
+            console.print(f"  - {song_name}: {error}")
+
+    # Print failed analysis
+    failed_analysis = [
+        (song_id, r.get("analyze_error"))
+        for song_id, r in results.items()
+        if r.get("analyze") == "failed"
+    ]
+    if failed_analysis:
+        console.print("\n[bold red]Failed analysis:[/bold red]")
+        for song_id, error in failed_analysis:
+            song = db_client.get_song(song_id)
+            song_name = song.title if song else song_id
+            console.print(f"  - {song_name}: {error}")
+
+    # Print failed embeddings
+    failed_embeddings = [
+        (song_id, r.get("embedding_error"))
+        for song_id, r in results.items()
+        if r.get("embedding") == "failed"
+    ]
+    if failed_embeddings:
+        console.print("\n[bold red]Failed embedding:[/bold red]")
+        for song_id, error in failed_embeddings:
             song = db_client.get_song(song_id)
             song_name = song.title if song else song_id
             console.print(f"  - {song_name}: {error}")

--- a/ops/admin-cli/src/stream_of_worship/admin/commands/audio.py
+++ b/ops/admin-cli/src/stream_of_worship/admin/commands/audio.py
@@ -4422,6 +4422,13 @@ def batch(
             console=console,
         )
         _print_stats(results, db_client, console, format)
+
+        # Exit nonzero if any step has a failure
+        failed_any = any(
+            v == "failed" for r in results.values() for v in r.values()
+        )
+        if failed_any:
+            raise typer.Exit(1)
         return
 
     # Normal path: resolve song IDs
@@ -5841,9 +5848,28 @@ def _poll_analysis_jobs(
                             any_completed_this_cycle = True
                             continue
 
+                        # Guard against tier mismatch: a fast_analyze job
+                        # polled in a full-tier run (or vice versa) would
+                        # write the wrong columns. Derive the effective
+                        # tier from the job type, not just the CLI flag.
+                        effective_tier = (
+                            "fast"
+                            if job.job_type == "fast_analyze"
+                            else "full"
+                        )
+                        if effective_tier != analysis_tier:
+                            console.print(
+                                f"  [yellow]→ {song_id}: job type "
+                                f"'{job.job_type}' does not match requested "
+                                f"tier '{analysis_tier}', treating as "
+                                f"'{effective_tier}'[/yellow]"
+                            )
+
                         if job.result:
                             result = job.result
-                            status_to_set = "partial" if analysis_tier == "fast" else "completed"
+                            status_to_set = (
+                                "partial" if effective_tier == "fast" else "completed"
+                            )
                             db_client.update_recording_analysis(
                                 hash_prefix=recording.hash_prefix,
                                 duration_seconds=result.duration_seconds,
@@ -5854,22 +5880,22 @@ def _poll_analysis_jobs(
                                 loudness_db=result.loudness_db,
                                 beats=(
                                     json.dumps(result.beats)
-                                    if analysis_tier == "full" and result.beats
+                                    if effective_tier == "full" and result.beats
                                     else None
                                 ),
                                 downbeats=(
                                     json.dumps(result.downbeats)
-                                    if analysis_tier == "full" and result.downbeats
+                                    if effective_tier == "full" and result.downbeats
                                     else None
                                 ),
                                 sections=(
                                     json.dumps(result.sections)
-                                    if analysis_tier == "full" and result.sections
+                                    if effective_tier == "full" and result.sections
                                     else None
                                 ),
                                 embeddings_shape=(
                                     json.dumps(result.embeddings_shape)
-                                    if analysis_tier == "full" and result.embeddings_shape
+                                    if effective_tier == "full" and result.embeddings_shape
                                     else None
                                 ),
                                 r2_stems_url=result.stems_url,
@@ -5877,7 +5903,7 @@ def _poll_analysis_jobs(
                             )
 
                         results[song_id]["analyze"] = "completed"
-                        results[song_id]["analysis_tier"] = analysis_tier
+                        results[song_id]["analysis_tier"] = effective_tier
                         del active_jobs[song_id]
                         any_completed_this_cycle = True
 
@@ -5886,7 +5912,7 @@ def _poll_analysis_jobs(
                                 song_id,
                                 recording.hash_prefix,
                                 "analyze",
-                                analysis_tier,
+                                effective_tier,
                                 job_id,
                                 "completed",
                                 completed_at=datetime.now(timezone.utc).isoformat(),
@@ -5895,7 +5921,7 @@ def _poll_analysis_jobs(
                         song = db_client.get_song(song_id)
                         song_name = song.title if song else song_id
                         console.print(
-                            f"  [green]✓[/green] {song_name} — analysis completed ({analysis_tier})"
+                            f"  [green]✓[/green] {song_name} — analysis completed ({effective_tier})"
                         )
 
                     elif job.status == "failed":
@@ -5962,7 +5988,33 @@ def _poll_analysis_jobs(
                             f"  [yellow]→ {song_id}: transient poll error, retrying once...[/yellow]"
                         )
                     else:
-                        console.print(f"  [yellow]→ Error polling {job_id}: {e}[/yellow]")
+                        # Non-retryable error: mark failed to avoid infinite loop
+                        recording = db_client.get_recording_by_song_id(song_id)
+                        hash_prefix = recording.hash_prefix if recording else ""
+                        db_client.update_recording_status(
+                            hash_prefix=hash_prefix,
+                            analysis_status="failed",
+                        )
+                        results[song_id]["analyze"] = "failed"
+                        results[song_id]["analyze_error"] = str(e)
+                        del active_jobs[song_id]
+                        any_completed_this_cycle = True
+
+                        if _add_manifest_entry:
+                            _add_manifest_entry(
+                                song_id,
+                                hash_prefix,
+                                "analyze",
+                                analysis_tier,
+                                job_id,
+                                "failed",
+                                error_message=str(e),
+                                completed_at=datetime.now(timezone.utc).isoformat(),
+                            )
+
+                        console.print(
+                            f"  [red]✗ {song_id}: analysis poll error: {e}[/red]"
+                        )
                 except Exception as e:
                     if song_id not in retried and _is_retryable_poll_error(e):
                         retried.add(song_id)
@@ -5970,7 +6022,33 @@ def _poll_analysis_jobs(
                             f"  [yellow]→ {song_id}: transient poll error, retrying once...[/yellow]"
                         )
                     else:
-                        console.print(f"  [yellow]→ Error polling {job_id}: {e}[/yellow]")
+                        # Non-retryable error: mark failed to avoid infinite loop
+                        recording = db_client.get_recording_by_song_id(song_id)
+                        hash_prefix = recording.hash_prefix if recording else ""
+                        db_client.update_recording_status(
+                            hash_prefix=hash_prefix,
+                            analysis_status="failed",
+                        )
+                        results[song_id]["analyze"] = "failed"
+                        results[song_id]["analyze_error"] = str(e)
+                        del active_jobs[song_id]
+                        any_completed_this_cycle = True
+
+                        if _add_manifest_entry:
+                            _add_manifest_entry(
+                                song_id,
+                                hash_prefix,
+                                "analyze",
+                                analysis_tier,
+                                job_id,
+                                "failed",
+                                error_message=str(e),
+                                completed_at=datetime.now(timezone.utc).isoformat(),
+                            )
+
+                        console.print(
+                            f"  [red]✗ {song_id}: analysis poll error: {e}[/red]"
+                        )
 
             if any_completed_this_cycle:
                 last_completion_time = time.time()
@@ -6140,7 +6218,28 @@ def _poll_embedding_jobs(
                             f"  [yellow]→ {song_id}: transient poll error, retrying once...[/yellow]"
                         )
                     else:
-                        console.print(f"  [yellow]→ Error polling {job_id}: {e}[/yellow]")
+                        # Non-retryable error: mark failed to avoid infinite loop
+                        results[song_id]["embedding"] = "failed"
+                        results[song_id]["embedding_error"] = str(e)
+                        del active_jobs[song_id]
+                        any_completed_this_cycle = True
+
+                        if _add_manifest_entry:
+                            recording = db_client.get_recording_by_song_id(song_id)
+                            _add_manifest_entry(
+                                song_id,
+                                recording.hash_prefix if recording else "",
+                                "embedding",
+                                "embedding",
+                                job_id,
+                                "failed",
+                                error_message=str(e),
+                                completed_at=datetime.now(timezone.utc).isoformat(),
+                            )
+
+                        console.print(
+                            f"  [red]✗ {song_id}: embedding poll error: {e}[/red]"
+                        )
                 except Exception as e:
                     if song_id not in retried and _is_retryable_poll_error(e):
                         retried.add(song_id)
@@ -6148,7 +6247,28 @@ def _poll_embedding_jobs(
                             f"  [yellow]→ {song_id}: transient poll error, retrying once...[/yellow]"
                         )
                     else:
-                        console.print(f"  [yellow]→ Error polling {job_id}: {e}[/yellow]")
+                        # Non-retryable error: mark failed to avoid infinite loop
+                        results[song_id]["embedding"] = "failed"
+                        results[song_id]["embedding_error"] = str(e)
+                        del active_jobs[song_id]
+                        any_completed_this_cycle = True
+
+                        if _add_manifest_entry:
+                            recording = db_client.get_recording_by_song_id(song_id)
+                            _add_manifest_entry(
+                                song_id,
+                                recording.hash_prefix if recording else "",
+                                "embedding",
+                                "embedding",
+                                job_id,
+                                "failed",
+                                error_message=str(e),
+                                completed_at=datetime.now(timezone.utc).isoformat(),
+                            )
+
+                        console.print(
+                            f"  [red]✗ {song_id}: embedding poll error: {e}[/red]"
+                        )
 
             if any_completed_this_cycle:
                 last_completion_time = time.time()
@@ -6393,7 +6513,11 @@ def _apply_manifest_writeback(
             if not recording or not job.result:
                 return
             result = job.result
-            status_to_set = "partial" if tier == "fast" else "completed"
+            # Derive effective tier from job type to guard against mismatch
+            effective_tier = (
+                "fast" if job.job_type == "fast_analyze" else "full"
+            )
+            status_to_set = "partial" if effective_tier == "fast" else "completed"
             db_client.update_recording_analysis(
                 hash_prefix=recording.hash_prefix,
                 duration_seconds=result.duration_seconds,
@@ -6404,22 +6528,22 @@ def _apply_manifest_writeback(
                 loudness_db=result.loudness_db,
                 beats=(
                     json.dumps(result.beats)
-                    if tier == "full" and result.beats
+                    if effective_tier == "full" and result.beats
                     else None
                 ),
                 downbeats=(
                     json.dumps(result.downbeats)
-                    if tier == "full" and result.downbeats
+                    if effective_tier == "full" and result.downbeats
                     else None
                 ),
                 sections=(
                     json.dumps(result.sections)
-                    if tier == "full" and result.sections
+                    if effective_tier == "full" and result.sections
                     else None
                 ),
                 embeddings_shape=(
                     json.dumps(result.embeddings_shape)
-                    if tier == "full" and result.embeddings_shape
+                    if effective_tier == "full" and result.embeddings_shape
                     else None
                 ),
                 r2_stems_url=result.stems_url,

--- a/ops/admin-cli/src/stream_of_worship/admin/db/client.py
+++ b/ops/admin-cli/src/stream_of_worship/admin/db/client.py
@@ -693,7 +693,10 @@ class DatabaseClient:
 
         if status:
             if status == "incomplete":
-                query += " AND analysis_status IN ('pending', 'processing', 'failed')"
+                query += (
+                    " AND (analysis_status IN ('pending', 'processing', 'failed')"
+                    " OR analysis_status IS NULL)"
+                )
             else:
                 query += " AND analysis_status = %s"
                 params.append(status)
@@ -770,7 +773,10 @@ class DatabaseClient:
 
         if status:
             if status == "incomplete":
-                query += " AND r.analysis_status IN ('pending', 'processing', 'failed')"
+                query += (
+                    " AND (r.analysis_status IN ('pending', 'processing', 'failed')"
+                    " OR r.analysis_status IS NULL)"
+                )
             else:
                 query += " AND r.analysis_status = %s"
                 params.append(status)

--- a/ops/admin-cli/src/stream_of_worship/admin/db/client.py
+++ b/ops/admin-cli/src/stream_of_worship/admin/db/client.py
@@ -769,8 +769,11 @@ class DatabaseClient:
             query += " AND (s.deleted_at IS NULL OR s.id IS NULL)"
 
         if status:
-            query += " AND r.analysis_status = %s"
-            params.append(status)
+            if status == "incomplete":
+                query += " AND r.analysis_status IN ('pending', 'processing', 'failed')"
+            else:
+                query += " AND r.analysis_status = %s"
+                params.append(status)
 
         if visibility:
             query += " AND r.visibility_status = %s"
@@ -792,6 +795,7 @@ class DatabaseClient:
             "series": "s.album_series ASC NULLS LAST, s.album_name ASC NULLS LAST, s.title ASC NULLS LAST",
             "title": "s.title ASC NULLS LAST",
             "imported": "r.imported_at DESC",
+            "created": "r.created_at ASC NULLS LAST, r.hash_prefix ASC",
         }
         query += f" ORDER BY {order_map.get(sort_by, 'r.imported_at DESC')}"
 
@@ -905,6 +909,7 @@ class DatabaseClient:
         sections: Optional[str] = None,
         embeddings_shape: Optional[str] = None,
         r2_stems_url: Optional[str] = None,
+        analysis_status: Optional[str] = None,
     ) -> None:
         """Update recording with analysis results.
 
@@ -921,45 +926,82 @@ class DatabaseClient:
             sections: JSON array of sections.
             embeddings_shape: JSON array of dimensions.
             r2_stems_url: R2 URL for stems directory.
+            analysis_status: Override the analysis_status column. If None
+                (default), preserves the existing behavior of setting
+                'completed'. If 'partial', only fast-tier columns are written
+                and full-only columns (beats, downbeats, sections,
+                embeddings_shape, r2_stems_url) are PRESERVED (not nulled).
+                If 'completed', all columns are written as today.
         """
         with self.transaction() as conn:
             cursor = conn.cursor()
 
-            sql = """
-                UPDATE recordings SET
-                    duration_seconds = %s,
-                    tempo_bpm = %s,
-                    musical_key = %s,
-                    musical_mode = %s,
-                    key_confidence = %s,
-                    loudness_db = %s,
-                    beats = %s,
-                    downbeats = %s,
-                    sections = %s,
-                    embeddings_shape = %s,
-                    r2_stems_url = COALESCE(%s, r2_stems_url),
-                    analysis_status = 'completed',
-                    updated_at = NOW()
-                WHERE hash_prefix = %s
-            """
+            # Resolve the effective analysis_status
+            effective_status = analysis_status if analysis_status is not None else "completed"
 
-            cursor.execute(
-                sql,
-                (
-                    duration_seconds,
-                    tempo_bpm,
-                    musical_key,
-                    musical_mode,
-                    key_confidence,
-                    loudness_db,
-                    beats,
-                    downbeats,
-                    sections,
-                    embeddings_shape,
-                    r2_stems_url,
-                    hash_prefix,
-                ),
-            )
+            if effective_status == "partial":
+                # Fast-tier only: preserve full-only columns on disk by
+                # omitting them from the UPDATE entirely (data-loss protection).
+                sql = """
+                    UPDATE recordings SET
+                        duration_seconds = %s,
+                        tempo_bpm = %s,
+                        musical_key = %s,
+                        musical_mode = %s,
+                        key_confidence = %s,
+                        loudness_db = %s,
+                        analysis_status = 'partial',
+                        updated_at = NOW()
+                    WHERE hash_prefix = %s
+                """
+                cursor.execute(
+                    sql,
+                    (
+                        duration_seconds,
+                        tempo_bpm,
+                        musical_key,
+                        musical_mode,
+                        key_confidence,
+                        loudness_db,
+                        hash_prefix,
+                    ),
+                )
+            else:
+                # Full tier: update all columns, set 'completed'
+                sql = """
+                    UPDATE recordings SET
+                        duration_seconds = %s,
+                        tempo_bpm = %s,
+                        musical_key = %s,
+                        musical_mode = %s,
+                        key_confidence = %s,
+                        loudness_db = %s,
+                        beats = %s,
+                        downbeats = %s,
+                        sections = %s,
+                        embeddings_shape = %s,
+                        r2_stems_url = COALESCE(%s, r2_stems_url),
+                        analysis_status = 'completed',
+                        updated_at = NOW()
+                    WHERE hash_prefix = %s
+                """
+                cursor.execute(
+                    sql,
+                    (
+                        duration_seconds,
+                        tempo_bpm,
+                        musical_key,
+                        musical_mode,
+                        key_confidence,
+                        loudness_db,
+                        beats,
+                        downbeats,
+                        sections,
+                        embeddings_shape,
+                        r2_stems_url,
+                        hash_prefix,
+                    ),
+                )
 
     def update_recording_lrc(
         self,

--- a/ops/admin-cli/src/stream_of_worship/admin/db/models.py
+++ b/ops/admin-cli/src/stream_of_worship/admin/db/models.py
@@ -327,12 +327,30 @@ class Recording:
 
     @property
     def has_analysis(self) -> bool:
-        """Check if analysis is complete.
+        """Check if analysis is complete (fast or full).
+
+        Returns:
+            True if analysis_status is 'partial' or 'completed'.
+        """
+        return self.analysis_status in ("partial", "completed")
+
+    @property
+    def has_full_analysis(self) -> bool:
+        """Check if full analysis is complete.
 
         Returns:
             True if analysis_status is 'completed'.
         """
         return self.analysis_status == "completed"
+
+    @property
+    def has_fast_analysis(self) -> bool:
+        """Check if at least fast analysis is complete.
+
+        Returns:
+            True if analysis_status is 'partial' or 'completed'.
+        """
+        return self.analysis_status in ("partial", "completed")
 
     @property
     def has_lrc(self) -> bool:

--- a/ops/admin-cli/src/stream_of_worship/admin/services/analysis.py
+++ b/ops/admin-cli/src/stream_of_worship/admin/services/analysis.py
@@ -257,6 +257,73 @@ class AnalysisClient:
                 )
             raise AnalysisServiceError(f"Analysis submission failed: {e}")
 
+    def submit_fast_analysis(
+        self,
+        audio_url: str,
+        content_hash: str,
+        force: bool = False,
+        sample_rate: int = 22050,
+        hop_length: int = 4096,
+    ) -> JobInfo:
+        """Submit an audio file for fast analysis (librosa-only).
+
+        Produces only the fast-tier subset: duration, tempo, key, mode, key
+        confidence, loudness. Full-only fields (beats, downbeats, sections,
+        embeddings_shape, stems_url) will be None/absent on the result.
+
+        Args:
+            audio_url: R2 URL of the audio file
+            content_hash: SHA-256 hash of the audio content
+            force: Whether to force re-analysis (bypass cache)
+            sample_rate: Target sample rate for librosa
+            hop_length: Hop length for tempo estimation
+
+        Returns:
+            JobInfo for the submitted job
+
+        Raises:
+            AnalysisServiceError: If submission fails
+        """
+        payload = {
+            "audio_url": audio_url,
+            "content_hash": content_hash,
+            "options": {
+                "force": force,
+                "sample_rate": sample_rate,
+                "hop_length": hop_length,
+            },
+        }
+
+        try:
+            response = requests.post(
+                f"{self.base_url}/api/v1/jobs/fast-analyze",
+                json=payload,
+                headers=self._auth_headers(),
+                timeout=self.timeout,
+            )
+
+            if response.status_code == 401:
+                raise AnalysisServiceError(
+                    "Authentication failed: Invalid API key", status_code=401
+                )
+
+            response.raise_for_status()
+            data = response.json()
+            return self._parse_job_response(data)
+
+        except requests.exceptions.ConnectionError as e:
+            raise AnalysisServiceError(
+                f"Cannot connect to analysis service at {self.base_url}: {e}"
+            )
+        except requests.exceptions.RequestException as e:
+            if hasattr(e.response, "status_code"):
+                status = e.response.status_code
+                raise AnalysisServiceError(
+                    f"Fast analysis submission failed (HTTP {status}): {e}",
+                    status_code=status,
+                )
+            raise AnalysisServiceError(f"Fast analysis submission failed: {e}")
+
     def submit_lrc(
         self,
         audio_url: str,

--- a/ops/admin-cli/tests/admin/test_audio_batch_v4.py
+++ b/ops/admin-cli/tests/admin/test_audio_batch_v4.py
@@ -1,0 +1,275 @@
+"""Tests for the v4 audio batch command (step flags, force scoping, resume).
+
+These tests exercise the CLI argument-validation paths that run before any
+database or R2 access. They use the Typer CliRunner against the real app.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from stream_of_worship.admin.main import app
+
+runner = CliRunner()
+
+WIDE_ENV = {"COLUMNS": "200"}
+
+
+class TestBatchStepFlags:
+    """Step flag selection and validation."""
+
+    def test_no_step_flags_exits_1(self, tmp_path):
+        """No step flags and no --all-steps exits 1 with usage."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text('[database]\npath = "/nonexistent/db.sqlite"\n')
+        result = runner.invoke(
+            app,
+            ["audio", "batch", "--config", str(config_path)],
+            env=WIDE_ENV,
+        )
+        assert result.exit_code == 1
+        assert "No step flags selected" in result.output
+
+    def test_invalid_format_exits_1(self, tmp_path):
+        config_path = tmp_path / "config.toml"
+        config_path.write_text('[database]\npath = "/nonexistent/db.sqlite"\n')
+        result = runner.invoke(
+            app,
+            ["audio", "batch", "--analyze", "--format", "xml", "--config", str(config_path)],
+            env=WIDE_ENV,
+        )
+        assert result.exit_code == 1
+        assert "Invalid format" in result.output
+
+    def test_invalid_analysis_tier_exits_1(self, tmp_path):
+        config_path = tmp_path / "config.toml"
+        config_path.write_text('[database]\npath = "/nonexistent/db.sqlite"\n')
+        result = runner.invoke(
+            app,
+            ["audio", "batch", "--analyze", "--analysis-tier", "medium", "--config", str(config_path)],
+            env=WIDE_ENV,
+        )
+        assert result.exit_code == 1
+        assert "Invalid analysis tier" in result.output
+
+    def test_invalid_analysis_status_exits_1(self, tmp_path):
+        config_path = tmp_path / "config.toml"
+        config_path.write_text('[database]\npath = "/nonexistent/db.sqlite"\n')
+        result = runner.invoke(
+            app,
+            ["audio", "batch", "--analyze", "--analysis-status", "bogus", "--config", str(config_path)],
+            env=WIDE_ENV,
+        )
+        assert result.exit_code == 1
+        assert "Invalid analysis status" in result.output
+
+    def test_partial_is_valid_analysis_status(self, tmp_path):
+        """'partial' is accepted as a valid analysis status filter."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text('[database]\npath = "/nonexistent/db.sqlite"\n')
+        result = runner.invoke(
+            app,
+            ["audio", "batch", "--analyze", "--analysis-status", "partial", "--config", str(config_path)],
+            env=WIDE_ENV,
+        )
+        # Should NOT fail on validation; it will fail later on DB load.
+        assert "Invalid analysis status" not in result.output
+
+
+class TestForceScoping:
+    """--force validation per the v4 spec."""
+
+    def test_force_all_steps_exits_1(self, tmp_path):
+        config_path = tmp_path / "config.toml"
+        config_path.write_text('[database]\npath = "/nonexistent/db.sqlite"\n')
+        result = runner.invoke(
+            app,
+            ["audio", "batch", "--all-steps", "--force", "--config", str(config_path)],
+            env=WIDE_ENV,
+        )
+        assert result.exit_code == 1
+        assert "--force with --all-steps" in result.output
+
+    def test_force_no_step_flags_exits_1(self, tmp_path):
+        config_path = tmp_path / "config.toml"
+        config_path.write_text('[database]\npath = "/nonexistent/db.sqlite"\n')
+        result = runner.invoke(
+            app,
+            ["audio", "batch", "--force", "--config", str(config_path)],
+            env=WIDE_ENV,
+        )
+        assert result.exit_code == 1
+
+    def test_force_download_exits_1_with_hint(self, tmp_path):
+        """--force --download is rejected with the two-step purge hint."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text('[database]\npath = "/nonexistent/db.sqlite"\n')
+        result = runner.invoke(
+            app,
+            ["audio", "batch", "--download", "--force", "--config", str(config_path)],
+            env=WIDE_ENV,
+        )
+        assert result.exit_code == 1
+        assert "--force --download is not supported" in result.output
+        assert "purge-soft-deletes" in result.output
+
+    def test_force_multiple_steps_exits_1(self, tmp_path):
+        """--force with two step flags exits 1."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text('[database]\npath = "/nonexistent/db.sqlite"\n')
+        result = runner.invoke(
+            app,
+            ["audio", "batch", "--lrc", "--analyze", "--force", "--config", str(config_path)],
+            env=WIDE_ENV,
+        )
+        assert result.exit_code == 1
+        assert "exactly one step flag" in result.output
+
+
+class TestResumeMutualExclusivity:
+    """--resume is mutually exclusive with all selection flags and --force."""
+
+    def test_resume_with_force_exits_1(self, tmp_path):
+        config_path = tmp_path / "config.toml"
+        config_path.write_text('[database]\npath = "/nonexistent/db.sqlite"\n')
+        result = runner.invoke(
+            app,
+            ["audio", "batch", "--resume", "/tmp/manifest.json", "--force", "--config", str(config_path)],
+            env=WIDE_ENV,
+        )
+        assert result.exit_code == 1
+        assert "--resume is mutually exclusive" in result.output
+
+    def test_resume_with_analyze_exits_1(self, tmp_path):
+        config_path = tmp_path / "config.toml"
+        config_path.write_text('[database]\npath = "/nonexistent/db.sqlite"\n')
+        result = runner.invoke(
+            app,
+            ["audio", "batch", "--resume", "/tmp/manifest.json", "--analyze", "--config", str(config_path)],
+            env=WIDE_ENV,
+        )
+        assert result.exit_code == 1
+        assert "--resume is mutually exclusive" in result.output
+
+    def test_resume_with_album_exits_1(self, tmp_path):
+        config_path = tmp_path / "config.toml"
+        config_path.write_text('[database]\npath = "/nonexistent/db.sqlite"\n')
+        result = runner.invoke(
+            app,
+            ["audio", "batch", "--resume", "/tmp/manifest.json", "--album", "foo", "--config", str(config_path)],
+            env=WIDE_ENV,
+        )
+        assert result.exit_code == 1
+        assert "--resume is mutually exclusive" in result.output
+
+
+class TestRecordingModelAnalysis:
+    """Tests for the Recording model analysis properties."""
+
+    def test_has_analysis_partial_is_true(self):
+        from stream_of_worship.admin.db.models import Recording
+
+        recording = Recording(
+            content_hash="abc",
+            hash_prefix="abc",
+            original_filename="test.mp3",
+            file_size_bytes=100,
+            imported_at="2024-01-01T00:00:00",
+            analysis_status="partial",
+        )
+        assert recording.has_analysis is True
+        assert recording.has_fast_analysis is True
+        assert recording.has_full_analysis is False
+
+    def test_has_analysis_completed_is_true(self):
+        from stream_of_worship.admin.db.models import Recording
+
+        recording = Recording(
+            content_hash="abc",
+            hash_prefix="abc",
+            original_filename="test.mp3",
+            file_size_bytes=100,
+            imported_at="2024-01-01T00:00:00",
+            analysis_status="completed",
+        )
+        assert recording.has_analysis is True
+        assert recording.has_fast_analysis is True
+        assert recording.has_full_analysis is True
+
+    def test_has_analysis_pending_is_false(self):
+        from stream_of_worship.admin.db.models import Recording
+
+        recording = Recording(
+            content_hash="abc",
+            hash_prefix="abc",
+            original_filename="test.mp3",
+            file_size_bytes=100,
+            imported_at="2024-01-01T00:00:00",
+            analysis_status="pending",
+        )
+        assert recording.has_analysis is False
+        assert recording.has_fast_analysis is False
+        assert recording.has_full_analysis is False
+
+
+class TestManifestHelpers:
+    """Tests for manifest writer/loader helpers."""
+
+    def test_write_and_load_manifest(self, tmp_path):
+        from stream_of_worship.admin.commands.audio import _write_manifest, _load_manifest
+
+        batch_id = "2026-06-30T0215_batch"
+        results = {"song_1": {"analyze": "completed"}}
+        entries = [
+            {
+                "song_id": "song_1",
+                "hash_prefix": "feedface",
+                "step": "analyze",
+                "tier": "fast",
+                "job_id": "job_a1b2",
+                "status": "completed",
+                "attempts": 1,
+                "previous_job_id": None,
+                "error_class": None,
+                "error_message": None,
+                "submitted_at": "2026-06-30T02:15:04Z",
+                "completed_at": "2026-06-30T02:20:00Z",
+            }
+        ]
+        path = _write_manifest(
+            batch_id,
+            results,
+            tmp_path,
+            ["analyze"],
+            "fast",
+            120,
+            "2026-06-30T02:15:00Z",
+            entries,
+        )
+        assert path is not None
+        assert path.exists()
+
+        loaded = _load_manifest(path)
+        assert loaded is not None
+        assert loaded["batch_id"] == batch_id
+        assert loaded["selected_steps"] == ["analyze"]
+        assert loaded["analysis_tier"] == "fast"
+        assert len(loaded["songs"]) == 1
+        assert loaded["songs"][0]["song_id"] == "song_1"
+        assert loaded["songs"][0]["status"] == "completed"
+
+    def test_manifest_dir_env_override(self, tmp_path, monkeypatch):
+        from stream_of_worship.admin.commands.audio import _get_manifest_dir
+
+        custom = tmp_path / "custom_manifests"
+        monkeypatch.setenv("SOW_BATCH_MANIFEST_DIR", str(custom))
+        assert _get_manifest_dir() == custom
+
+    def test_manifest_dir_default(self, monkeypatch):
+        from stream_of_worship.admin.commands.audio import _get_manifest_dir
+
+        monkeypatch.delenv("SOW_BATCH_MANIFEST_DIR", raising=False)
+        result = _get_manifest_dir()
+        assert "sow-admin" in str(result)
+        assert "batch" in str(result)

--- a/ops/analysis-service/docker-compose.yml
+++ b/ops/analysis-service/docker-compose.yml
@@ -50,6 +50,8 @@ x-common-env: &common-env
   # Forced Aligner Configuration (Qwen3ForcedAligner-0.6B, runs in-process)
   SOW_FORCED_ALIGNER_MODEL_PATH: ${SOW_FORCED_ALIGNER_MODEL_PATH:-Qwen/Qwen3-ForcedAligner-0.6B}
   SOW_FORCED_ALIGNER_DEVICE: ${SOW_FORCED_ALIGNER_DEVICE:-auto}
+  # Fast Analysis (librosa-only) Concurrency
+  SOW_FAST_ANALYZE_MAX_CONCURRENT: ${SOW_FAST_ANALYZE_MAX_CONCURRENT:-0}
 
 # Define common GPU configuration using YAML anchor
 x-gpu-deploy: &gpu-deploy

--- a/ops/analysis-service/src/sow_analysis/config.py
+++ b/ops/analysis-service/src/sow_analysis/config.py
@@ -28,6 +28,24 @@ class Settings(BaseSettings):
         1  # Global limit for local model execution (Whisper, Qwen3, audio-separator, allin1, demucs)
     )
 
+    # Fast analysis (librosa-only) concurrency. CPU/memory heavy; distinct from
+    # SOW_MAX_CONCURRENT_LOCAL_MODEL_JOBS. Default is cgroup-aware on Linux.
+    # A value <= 0 means auto-detect (cgroup-aware on Linux, 1 elsewhere), capped at 4.
+    SOW_FAST_ANALYZE_MAX_CONCURRENT: int = 0
+
+    @field_validator("SOW_FAST_ANALYZE_MAX_CONCURRENT")
+    @classmethod
+    def _validate_fast_analyze_concurrent(cls, v: int) -> int:
+        """Compute cgroup-aware default when not explicitly configured (<=0)."""
+        if v > 0:
+            return v
+        import os
+
+        try:
+            return min(4, max(1, len(os.sched_getaffinity(0)) // 2))
+        except (AttributeError, OSError):  # macOS / unsupported
+            return 1
+
     @field_validator("SOW_MAX_CONCURRENT_LOCAL_MODEL_JOBS")
     @classmethod
     def _validate_concurrent_jobs(cls, v: int) -> int:

--- a/ops/analysis-service/src/sow_analysis/models.py
+++ b/ops/analysis-service/src/sow_analysis/models.py
@@ -26,6 +26,7 @@ class JobType(str, Enum):
     STEM_SEPARATION = "stem_separation"
     EMBEDDING = "embedding"
     FORCED_ALIGNMENT = "forced_alignment"
+    FAST_ANALYZE = "fast_analyze"
 
 
 class AnalyzeOptions(BaseModel):
@@ -42,6 +43,28 @@ class AnalyzeJobRequest(BaseModel):
     audio_url: str
     content_hash: str
     options: AnalyzeOptions = Field(default_factory=AnalyzeOptions)
+
+
+class FastAnalyzeOptions(BaseModel):
+    """Options for fast analysis jobs (librosa-only, no allin1/stems)."""
+
+    force: bool = False
+    sample_rate: int = 22050
+    hop_length: int = 4096
+
+
+class FastAnalyzeJobRequest(BaseModel):
+    """Request to submit a fast analysis job.
+
+    Produces only the fast-tier subset: duration_seconds, tempo_bpm,
+    musical_key, musical_mode, key_confidence, loudness_db.
+    Full-only fields (beats, downbeats, sections, embeddings_shape, stems_url)
+    are absent/None on the result.
+    """
+
+    audio_url: str
+    content_hash: str
+    options: FastAnalyzeOptions = Field(default_factory=FastAnalyzeOptions)
 
 
 class LrcOptions(BaseModel):
@@ -211,6 +234,7 @@ class Job:
         StemSeparationJobRequest,
         EmbeddingJobRequest,
         ForcedAlignmentJobRequest,
+        FastAnalyzeJobRequest,
     ]
     result: Optional[Union[JobResult, EmbeddingJobResult]] = None
     error_message: Optional[str] = None

--- a/ops/analysis-service/src/sow_analysis/routes/jobs.py
+++ b/ops/analysis-service/src/sow_analysis/routes/jobs.py
@@ -10,6 +10,7 @@ from ..models import (
     AnalyzeJobRequest,
     EmbeddingJobRequest,
     EmbeddingJobResult,
+    FastAnalyzeJobRequest,
     ForcedAlignmentJobRequest,
     JobResponse,
     JobStatus,
@@ -163,6 +164,31 @@ async def submit_analysis_job(
         raise HTTPException(500, "Job queue not initialized")
 
     job = await job_queue.submit(JobType.ANALYZE, request)
+    return job_to_response(job)
+
+
+@router.post("/jobs/fast-analyze", response_model=JobResponse)
+async def submit_fast_analysis_job(
+    request: FastAnalyzeJobRequest,
+    api_key: str = Depends(verify_api_key),
+) -> JobResponse:
+    """Submit audio for fast analysis (librosa-only).
+
+    Produces only the fast-tier subset: duration, tempo, key, mode, key
+    confidence, loudness. Full-only fields (beats, sections, embeddings,
+    stems) are absent on the result.
+
+    Args:
+        request: Fast analysis job request
+        api_key: Validated API key
+
+    Returns:
+        Job response with status
+    """
+    if job_queue is None:
+        raise HTTPException(500, "Job queue not initialized")
+
+    job = await job_queue.submit(JobType.FAST_ANALYZE, request)
     return job_to_response(job)
 
 

--- a/ops/analysis-service/src/sow_analysis/storage/cache.py
+++ b/ops/analysis-service/src/sow_analysis/storage/cache.py
@@ -1,7 +1,9 @@
 """Local disk cache for analysis results."""
 
 import json
+import os
 import shutil
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
@@ -74,6 +76,61 @@ class CacheManager:
         cache_file = self.cache_dir / f"{hash_prefix}.json"
 
         cache_file.write_text(json.dumps(result, indent=2))
+        return cache_file
+
+    def get_fast_analyze_result(self, content_hash: str) -> Optional[dict]:
+        """Check if fast analysis result exists in cache.
+
+        Distinct from the full-tier {hash_prefix}.json cache. Fast results are
+        stored as {hash_prefix}_fast.json and never overwrite the full cache.
+
+        Args:
+            content_hash: Full SHA-256 content hash
+
+        Returns:
+            Cached fast result dict or None (also None on corrupt JSON)
+        """
+        hash_prefix = self._get_hash_prefix(content_hash)
+        cache_file = self.cache_dir / f"{hash_prefix}_fast.json"
+
+        if cache_file.exists():
+            try:
+                return json.loads(cache_file.read_text())
+            except (json.JSONDecodeError, IOError):
+                # Corrupt cache: delete and treat as miss
+                try:
+                    cache_file.unlink()
+                except OSError:
+                    pass
+                return None
+        return None
+
+    def save_fast_analyze_result(self, content_hash: str, result: dict) -> Path:
+        """Save fast analysis result to cache atomically.
+
+        Uses a NamedTemporaryFile in the same directory followed by os.replace
+        so a mid-write reader sees either the old or new file, never a partial.
+
+        Args:
+            content_hash: Full SHA-256 content hash
+            result: Fast analysis result dictionary
+
+        Returns:
+            Path to saved cache file
+        """
+        hash_prefix = self._get_hash_prefix(content_hash)
+        cache_file = self.cache_dir / f"{hash_prefix}_fast.json"
+
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            dir=str(cache_file.parent),
+            prefix=f".{cache_file.stem}.",
+            suffix=".tmp",
+            delete=False,
+        ) as tmp:
+            tmp.write(json.dumps(result, indent=2))
+            tmp_path = Path(tmp.name)
+        os.replace(str(tmp_path), str(cache_file))
         return cache_file
 
     def save_stems(self, content_hash: str, source_stems_dir: Path) -> Path:

--- a/ops/analysis-service/src/sow_analysis/storage/db.py
+++ b/ops/analysis-service/src/sow_analysis/storage/db.py
@@ -367,9 +367,9 @@ class JobStore:
 
                         INSERT INTO jobs SELECT * FROM jobs_old;
 
-                        CREATE INDEX idx_jobs_status ON jobs(status);
-                        CREATE INDEX idx_jobs_content_hash ON jobs(content_hash);
-                        CREATE INDEX idx_jobs_created_at ON jobs(created_at);
+                        CREATE INDEX IF NOT EXISTS idx_jobs_status ON jobs(status);
+                        CREATE INDEX IF NOT EXISTS idx_jobs_content_hash ON jobs(content_hash);
+                        CREATE INDEX IF NOT EXISTS idx_jobs_created_at ON jobs(created_at);
 
                         DROP TABLE jobs_old;
                         """

--- a/ops/analysis-service/src/sow_analysis/storage/db.py
+++ b/ops/analysis-service/src/sow_analysis/storage/db.py
@@ -57,6 +57,9 @@ class JobStore:
         # Check if we need to migrate from old schema (without 'forced_alignment' job type)
         await self._migrate_forced_alignment_type()
 
+        # Check if we need to migrate from old schema (without 'fast_analyze' job type)
+        await self._migrate_fast_analyze_type()
+
         await self._db.executescript(
             """
             CREATE TABLE IF NOT EXISTS jobs (
@@ -76,7 +79,7 @@ class JobStore:
                 content_hash    TEXT NOT NULL,
 
                 CHECK (status IN ('queued', 'processing', 'completed', 'failed', 'cancelled')),
-                CHECK (type IN ('analyze', 'lrc', 'stem_separation', 'embedding', 'forced_alignment'))
+                CHECK (type IN ('analyze', 'lrc', 'stem_separation', 'embedding', 'forced_alignment', 'fast_analyze'))
             );
 
             CREATE INDEX IF NOT EXISTS idx_jobs_status ON jobs(status);
@@ -308,6 +311,76 @@ class JobStore:
             logger.error(f"Database migration for forced_alignment type failed: {e}")
             raise
 
+    async def _migrate_fast_analyze_type(self) -> None:
+        """Migrate old schema to support 'fast_analyze' job type."""
+        if not self._db:
+            return
+
+        try:
+            async with self._db.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='jobs'"
+            ) as cursor:
+                row = await cursor.fetchone()
+                if not row:
+                    return
+
+                async with self._db.execute(
+                    "SELECT sql FROM sqlite_master WHERE type='table' AND name='jobs'"
+                ) as cursor:
+                    row = await cursor.fetchone()
+                    if not row:
+                        return
+
+                    schema = row[0]
+                    if "'fast_analyze'" in schema:
+                        return
+
+                    logger.warning(
+                        "Migrating database schema to support FAST_ANALYZE job type"
+                    )
+
+                    await self._db.executescript(
+                        """
+                        DROP TABLE IF EXISTS jobs_old;
+
+                        ALTER TABLE jobs RENAME TO jobs_old;
+
+                        CREATE TABLE jobs (
+                            id              TEXT PRIMARY KEY,
+                            type            TEXT NOT NULL,
+                            status          TEXT NOT NULL DEFAULT 'queued',
+                            progress        REAL NOT NULL DEFAULT 0.0,
+                            stage           TEXT NOT NULL DEFAULT '',
+                            error_message   TEXT,
+
+                            request_json    TEXT NOT NULL,
+                            result_json     TEXT,
+
+                            created_at      TEXT NOT NULL,
+                            updated_at      TEXT NOT NULL,
+
+                            content_hash    TEXT NOT NULL,
+
+                            CHECK (status IN ('queued', 'processing', 'completed', 'failed', 'cancelled')),
+                            CHECK (type IN ('analyze', 'lrc', 'stem_separation', 'embedding', 'forced_alignment', 'fast_analyze'))
+                        );
+
+                        INSERT INTO jobs SELECT * FROM jobs_old;
+
+                        CREATE INDEX idx_jobs_status ON jobs(status);
+                        CREATE INDEX idx_jobs_content_hash ON jobs(content_hash);
+                        CREATE INDEX idx_jobs_created_at ON jobs(created_at);
+
+                        DROP TABLE jobs_old;
+                        """
+                    )
+                    await self._db.commit()
+                    logger.info("Database migration for fast_analyze type complete")
+
+        except Exception as e:
+            logger.error(f"Database migration for fast_analyze type failed: {e}")
+            raise
+
     async def insert_job(self, job: Job) -> None:
         """Insert a new job record.
 
@@ -418,6 +491,10 @@ class JobStore:
             request = EmbeddingJobRequest.model_validate_json(request_json)
         elif job_type == JobType.FORCED_ALIGNMENT:
             request = ForcedAlignmentJobRequest.model_validate_json(request_json)
+        elif job_type == JobType.FAST_ANALYZE:
+            from ..models import FastAnalyzeJobRequest
+
+            request = FastAnalyzeJobRequest.model_validate_json(request_json)
         else:
             raise ValueError(f"Unknown job type: {job_type}")
 

--- a/ops/analysis-service/src/sow_analysis/workers/analyzer.py
+++ b/ops/analysis-service/src/sow_analysis/workers/analyzer.py
@@ -218,18 +218,24 @@ async def analyze_audio_fast(
             logger.info(f"Cache hit for fast analysis result: {content_hash[:16]}...")
             return cached
 
-    # Load audio
+    loop = asyncio.get_event_loop()
+
+    # Load audio (blocking — run in executor)
     logger.info(f"Loading audio file for fast analysis: {audio_path}")
     load_start = time.time()
-    y, sr = librosa.load(str(audio_path), sr=sample_rate, mono=True)
-    duration = librosa.get_duration(y=y, sr=sr)
+
+    def _load_audio():
+        y, sr = librosa.load(str(audio_path), sr=sample_rate, mono=True)
+        duration = librosa.get_duration(y=y, sr=sr)
+        return y, sr, duration
+
+    y, sr, duration = await loop.run_in_executor(None, _load_audio)
     load_elapsed = time.time() - load_start
     logger.info(f"Audio loaded in {load_elapsed:.2f}s - Duration: {duration:.2f}s")
 
     # Tempo via librosa.beat.tempo
     logger.info("Estimating tempo...")
     tempo_start = time.time()
-    loop = asyncio.get_event_loop()
 
     def _compute_tempo() -> float:
         onset_env = librosa.onset.onset_strength(y=y, sr=sr, hop_length=hop_length)
@@ -242,15 +248,15 @@ async def analyze_audio_fast(
     tempo_elapsed = time.time() - tempo_start
     logger.info(f"Tempo estimation completed in {tempo_elapsed:.2f}s - {bpm:.1f} BPM")
 
-    # Key detection with librosa
+    # Key detection with librosa (blocking — run in executor)
     logger.info("Detecting musical key...")
     key_start = time.time()
-    mode, key, key_confidence = detect_key(y, sr)
+    mode, key, key_confidence = await loop.run_in_executor(None, detect_key, y, sr)
     key_elapsed = time.time() - key_start
     logger.info(f"Key detection completed in {key_elapsed:.2f}s - Detected: {key} {mode}")
 
-    # Loudness
-    loudness_db = compute_loudness(y)
+    # Loudness (blocking — run in executor)
+    loudness_db = await loop.run_in_executor(None, compute_loudness, y)
 
     total_elapsed = time.time() - load_start
     logger.info(f"Total fast analysis time: {total_elapsed:.2f}s")

--- a/ops/analysis-service/src/sow_analysis/workers/analyzer.py
+++ b/ops/analysis-service/src/sow_analysis/workers/analyzer.py
@@ -180,3 +180,92 @@ async def analyze_audio(
     cache_manager.save_analysis_result(content_hash, analysis_result)
 
     return analysis_result
+
+
+async def analyze_audio_fast(
+    audio_path: Path,
+    cache_manager: CacheManager,
+    content_hash: str,
+    sample_rate: int = 22050,
+    hop_length: int = 4096,
+    force: bool = False,
+) -> dict:
+    """Fast audio analysis using librosa only (no allin1, no stems).
+
+    Produces only the fast-tier subset: duration_seconds, tempo_bpm,
+    musical_key, musical_mode, key_confidence, loudness_db.
+
+    Key/BPM algorithms:
+      - tempo: librosa.beat.tempo over a onset strength envelope
+      - key:   Krumhansl-Schmuckler via librosa.feature.chroma_cqt
+      - loudness: RMS-based dB
+
+    Args:
+        audio_path: Path to audio file
+        cache_manager: Cache manager instance
+        content_hash: SHA-256 hash of audio content for cache key
+        sample_rate: Target sample rate for librosa.load (default 22050)
+        hop_length: Hop length for onset/tempo estimation (default 4096)
+        force: Bypass cache
+
+    Returns:
+        Dictionary with the fast-tier analysis fields
+    """
+    # Check cache first (unless force)
+    if not force:
+        cached = cache_manager.get_fast_analyze_result(content_hash)
+        if cached:
+            logger.info(f"Cache hit for fast analysis result: {content_hash[:16]}...")
+            return cached
+
+    # Load audio
+    logger.info(f"Loading audio file for fast analysis: {audio_path}")
+    load_start = time.time()
+    y, sr = librosa.load(str(audio_path), sr=sample_rate, mono=True)
+    duration = librosa.get_duration(y=y, sr=sr)
+    load_elapsed = time.time() - load_start
+    logger.info(f"Audio loaded in {load_elapsed:.2f}s - Duration: {duration:.2f}s")
+
+    # Tempo via librosa.beat.tempo
+    logger.info("Estimating tempo...")
+    tempo_start = time.time()
+    loop = asyncio.get_event_loop()
+
+    def _compute_tempo() -> float:
+        onset_env = librosa.onset.onset_strength(y=y, sr=sr, hop_length=hop_length)
+        tempo = librosa.beat.tempo(onset_envelope=onset_env, sr=sr, hop_length=hop_length)
+        if hasattr(tempo, "__iter__"):
+            tempo = float(tempo[0])
+        return float(tempo)
+
+    bpm = await loop.run_in_executor(None, _compute_tempo)
+    tempo_elapsed = time.time() - tempo_start
+    logger.info(f"Tempo estimation completed in {tempo_elapsed:.2f}s - {bpm:.1f} BPM")
+
+    # Key detection with librosa
+    logger.info("Detecting musical key...")
+    key_start = time.time()
+    mode, key, key_confidence = detect_key(y, sr)
+    key_elapsed = time.time() - key_start
+    logger.info(f"Key detection completed in {key_elapsed:.2f}s - Detected: {key} {mode}")
+
+    # Loudness
+    loudness_db = compute_loudness(y)
+
+    total_elapsed = time.time() - load_start
+    logger.info(f"Total fast analysis time: {total_elapsed:.2f}s")
+
+    # Build result (fast subset only)
+    analysis_result = {
+        "duration_seconds": duration,
+        "tempo_bpm": bpm,
+        "musical_key": key,
+        "musical_mode": mode,
+        "key_confidence": key_confidence,
+        "loudness_db": loudness_db,
+    }
+
+    # Save to cache (distinct from full-tier cache)
+    cache_manager.save_fast_analyze_result(content_hash, analysis_result)
+
+    return analysis_result

--- a/ops/analysis-service/src/sow_analysis/workers/queue.py
+++ b/ops/analysis-service/src/sow_analysis/workers/queue.py
@@ -64,6 +64,7 @@ from ..models import (
     AnalyzeJobRequest,
     EmbeddingJobRequest,
     EmbeddingJobResult,
+    FastAnalyzeJobRequest,
     ForcedAlignmentJobRequest,
     Job,
     JobResult,
@@ -79,10 +80,11 @@ from ..storage.r2 import R2Client
 
 # Optional imports for heavy dependencies
 try:
-    from .analyzer import analyze_audio
+    from .analyzer import analyze_audio, analyze_audio_fast
     from .separator import separate_stems
 except ImportError:
     analyze_audio = None
+    analyze_audio_fast = None
     separate_stems = None
 
 # Optional LRC imports - require whisper and openai
@@ -165,6 +167,10 @@ class JobQueue:
         self._dashscope_asr_semaphore = asyncio.Semaphore(settings.SOW_DASHSCOPE_ASR_MAX_CONCURRENT)
         # Separate semaphore for embedding jobs (external API, no GPU needed)
         self._embedding_semaphore = asyncio.Semaphore(5)
+        # Separate semaphore for fast analysis (librosa-only, CPU/memory heavy).
+        # Distinct from _local_model_semaphore (allin1/demucs) so fast and full
+        # analysis do not coordinate; operator sizes both together.
+        self._fast_analyze_semaphore = asyncio.Semaphore(settings.SOW_FAST_ANALYZE_MAX_CONCURRENT)
         self._running = False
         self._logging_task: Optional[asyncio.Task] = None
         self._log_interval_seconds: float = 60.0
@@ -265,6 +271,7 @@ class JobQueue:
             StemSeparationJobRequest,
             EmbeddingJobRequest,
             ForcedAlignmentJobRequest,
+            FastAnalyzeJobRequest,
         ],
     ) -> Job:
         """Submit a new job to the queue.
@@ -399,6 +406,11 @@ class JobQueue:
             # Forced alignment: semaphore acquired inside _process_forced_alignment_job()
             # only around the align() call, not the entire job (prevents deadlock with stem separation)
             await self._process_forced_alignment_job(job)
+        elif job.type == JobType.FAST_ANALYZE:
+            # Fast analysis (librosa-only) uses its own semaphore, distinct from
+            # _local_model_semaphore (allin1/demucs) so the two do not coordinate.
+            async with self._fast_analyze_semaphore:
+                await self._process_fast_analyze_job(job)
 
         # Schedule cleanup for finished jobs (to prevent unbounded memory growth)
         if job.status in (JobStatus.COMPLETED, JobStatus.FAILED, JobStatus.CANCELLED):
@@ -580,6 +592,150 @@ class JobQueue:
             logger.error(f"Analysis job failed: {e}")
 
             # Persist failure to database
+            try:
+                await self.job_store.update_job(
+                    job.id, status="failed", stage="error", error_message=str(e)
+                )
+            except Exception as db_err:
+                logger.error(f"Failed to update job {job.id} in database: {db_err}")
+
+        finally:
+            job.updated_at = datetime.now(timezone.utc)
+
+    async def _process_fast_analyze_job(self, job: Job) -> None:
+        """Process a fast analysis job (librosa-only).
+
+        Produces only the fast-tier subset: duration_seconds, tempo_bpm,
+        musical_key, musical_mode, key_confidence, loudness_db. Does NOT
+        upload to R2 and does NOT touch the full-tier {hash_prefix}.json cache.
+
+        Args:
+            job: Job to process
+        """
+        set_job_id(job.id)
+        job_start_time = time.time()
+        logger.info(f"Starting fast analysis job for audio: {job.request.audio_url}")
+
+        job.status = JobStatus.PROCESSING
+        job.updated_at = datetime.now(timezone.utc)
+        job.stage = "downloading"
+        job.progress = 0.1
+
+        try:
+            await self.job_store.update_job(
+                job.id, status="processing", stage="downloading", progress=0.1
+            )
+        except Exception as e:
+            logger.error(f"Failed to update job {job.id} in database: {e}")
+
+        request = job.request
+        if not isinstance(request, FastAnalyzeJobRequest):
+            job.status = JobStatus.FAILED
+            job.error_message = "Invalid request type for fast analysis job"
+            job.updated_at = datetime.now(timezone.utc)
+            try:
+                await self.job_store.update_job(
+                    job.id, status="failed", error_message="Invalid request type"
+                )
+            except Exception as e:
+                logger.error(f"Failed to update job {job.id} in database: {e}")
+            return
+
+        # Check if fast analysis dependency is available
+        if analyze_audio_fast is None:
+            job.status = JobStatus.FAILED
+            job.error_message = "Fast analysis dependency not available (librosa)"
+            job.stage = "missing_dependencies"
+            job.updated_at = datetime.now(timezone.utc)
+            try:
+                await self.job_store.update_job(
+                    job.id,
+                    status="failed",
+                    stage="missing_dependencies",
+                    error_message="Fast analysis dependency not available (librosa)",
+                )
+            except Exception as e:
+                logger.error(f"Failed to update job {job.id} in database: {e}")
+            return
+
+        try:
+            # Validate R2 client configuration before attempting audio fetch
+            if not self.r2_client and settings.SOW_R2_ENDPOINT_URL:
+                self.initialize_r2(settings.SOW_R2_BUCKET, settings.SOW_R2_ENDPOINT_URL)
+
+            if not self.r2_client:
+                raise RuntimeError(
+                    "R2 client not configured; cannot download audio for fast analysis"
+                )
+
+            import tempfile
+
+            with tempfile.TemporaryDirectory() as temp_dir:
+                temp_path = Path(temp_dir)
+                audio_path = temp_path / "audio.mp3"
+
+                logger.info("Downloading audio from R2 for fast analysis...")
+                download_start = time.time()
+                await self.r2_client.download_audio(request.audio_url, audio_path)
+                download_elapsed = time.time() - download_start
+                logger.info(f"Audio download completed in {download_elapsed:.2f}s")
+
+                # Guard for truncated downloads
+                if not audio_path.exists() or audio_path.stat().st_size == 0:
+                    raise RuntimeError("Downloaded audio file is missing or empty")
+
+                job.stage = "analyzing"
+                job.progress = 0.3
+                try:
+                    await self.job_store.update_job(
+                        job.id, stage="analyzing", progress=0.3
+                    )
+                except Exception as e:
+                    logger.error(f"Failed to update job {job.id} in database: {e}")
+
+                analysis_result = await analyze_audio_fast(
+                    audio_path,
+                    self.cache_manager,
+                    request.content_hash,
+                    sample_rate=request.options.sample_rate,
+                    hop_length=request.options.hop_length,
+                    force=request.options.force,
+                )
+
+                # Build job result (fast subset only; full-only fields stay None)
+                job.result = JobResult(
+                    duration_seconds=analysis_result.get("duration_seconds"),
+                    tempo_bpm=analysis_result.get("tempo_bpm"),
+                    musical_key=analysis_result.get("musical_key"),
+                    musical_mode=analysis_result.get("musical_mode"),
+                    key_confidence=analysis_result.get("key_confidence"),
+                    loudness_db=analysis_result.get("loudness_db"),
+                )
+
+                job.status = JobStatus.COMPLETED
+                job.progress = 1.0
+                job.stage = "complete"
+
+                total_elapsed = time.time() - job_start_time
+                logger.info(f"Fast analysis job completed in {total_elapsed:.2f}s")
+
+                try:
+                    await self.job_store.update_job(
+                        job.id,
+                        status="completed",
+                        progress=1.0,
+                        stage="complete",
+                        result_json=job.result.model_dump_json() if job.result else None,
+                    )
+                except Exception as e:
+                    logger.error(f"Failed to update job {job.id} in database: {e}")
+
+        except Exception as e:
+            job.status = JobStatus.FAILED
+            job.error_message = str(e)
+            job.stage = "error"
+            logger.error(f"Fast analysis job failed: {e}")
+
             try:
                 await self.job_store.update_job(
                     job.id, status="failed", stage="error", error_message=str(e)
@@ -1794,6 +1950,7 @@ class JobQueue:
             JobType.STEM_SEPARATION: {status: 0 for status in JobStatus},
             JobType.EMBEDDING: {status: 0 for status in JobStatus},
             JobType.FORCED_ALIGNMENT: {status: 0 for status in JobStatus},
+            JobType.FAST_ANALYZE: {status: 0 for status in JobStatus},
         }
 
         # Track wait times for queued and processing jobs
@@ -1802,12 +1959,14 @@ class JobQueue:
             JobType.LRC: [],
             JobType.STEM_SEPARATION: [],
             JobType.FORCED_ALIGNMENT: [],
+            JobType.FAST_ANALYZE: [],
         }
         processing_durations: Dict[JobType, list] = {
             JobType.ANALYZE: [],
             JobType.LRC: [],
             JobType.STEM_SEPARATION: [],
             JobType.FORCED_ALIGNMENT: [],
+            JobType.FAST_ANALYZE: [],
         }
 
         has_reportable_jobs = False
@@ -1836,6 +1995,7 @@ class JobQueue:
         lrc_stats = f"queued:{stats[JobType.LRC][JobStatus.QUEUED]},processing:{stats[JobType.LRC][JobStatus.PROCESSING]},completed:{stats[JobType.LRC][JobStatus.COMPLETED]},failed:{stats[JobType.LRC][JobStatus.FAILED]}"
         stem_stats = f"queued:{stats[JobType.STEM_SEPARATION][JobStatus.QUEUED]},processing:{stats[JobType.STEM_SEPARATION][JobStatus.PROCESSING]},completed:{stats[JobType.STEM_SEPARATION][JobStatus.COMPLETED]},failed:{stats[JobType.STEM_SEPARATION][JobStatus.FAILED]}"
         fa_stats = f"queued:{stats[JobType.FORCED_ALIGNMENT][JobStatus.QUEUED]},processing:{stats[JobType.FORCED_ALIGNMENT][JobStatus.PROCESSING]},completed:{stats[JobType.FORCED_ALIGNMENT][JobStatus.COMPLETED]},failed:{stats[JobType.FORCED_ALIGNMENT][JobStatus.FAILED]}"
+        fast_stats = f"queued:{stats[JobType.FAST_ANALYZE][JobStatus.QUEUED]},processing:{stats[JobType.FAST_ANALYZE][JobStatus.PROCESSING]},completed:{stats[JobType.FAST_ANALYZE][JobStatus.COMPLETED]},failed:{stats[JobType.FAST_ANALYZE][JobStatus.FAILED]}"
 
         wait_time_str = ""
         if queued_wait_times[JobType.ANALYZE]:
@@ -1858,6 +2018,11 @@ class JobQueue:
             if len(queued_wait_times[JobType.FORCED_ALIGNMENT]) > 3:
                 waits += f",...+{len(queued_wait_times[JobType.FORCED_ALIGNMENT]) - 3}more"
             wait_time_str += f" FA queued=[{waits}]"
+        if queued_wait_times[JobType.FAST_ANALYZE]:
+            waits = ",".join(f"{w:.0f}s" for w in queued_wait_times[JobType.FAST_ANALYZE][:3])
+            if len(queued_wait_times[JobType.FAST_ANALYZE]) > 3:
+                waits += f",...+{len(queued_wait_times[JobType.FAST_ANALYZE]) - 3}more"
+            wait_time_str += f" FAST queued=[{waits}]"
         if processing_durations[JobType.ANALYZE]:
             avg_dur = sum(processing_durations[JobType.ANALYZE]) / len(
                 processing_durations[JobType.ANALYZE]
@@ -1878,9 +2043,14 @@ class JobQueue:
                 processing_durations[JobType.FORCED_ALIGNMENT]
             )
             wait_time_str += f" FA processing={avg_dur:.0f}s"
+        if processing_durations[JobType.FAST_ANALYZE]:
+            avg_dur = sum(processing_durations[JobType.FAST_ANALYZE]) / len(
+                processing_durations[JobType.FAST_ANALYZE]
+            )
+            wait_time_str += f" FAST processing={avg_dur:.0f}s"
 
         logger.info(
-            f"Queue state: ANALYZE[{analyze_stats}] LRC[{lrc_stats}] STEM[{stem_stats}] FA[{fa_stats}] | Wait times:{wait_time_str if wait_time_str else ' none'}"
+            f"Queue state: ANALYZE[{analyze_stats}] LRC[{lrc_stats}] STEM[{stem_stats}] FA[{fa_stats}] FAST[{fast_stats}] | Wait times:{wait_time_str if wait_time_str else ' none'}"
         )
 
     async def _periodic_logging_loop(self) -> None:

--- a/ops/analysis-service/tests/integration/test_api.py
+++ b/ops/analysis-service/tests/integration/test_api.py
@@ -131,6 +131,34 @@ class TestJobsEndpoints:
 
         assert response.status_code == 401
 
+    def test_submit_fast_analysis_job(self, client, mock_job_queue):
+        """Test submitting fast analysis job."""
+        response = client.post(
+            "/api/v1/jobs/fast-analyze",
+            json={
+                "audio_url": "s3://bucket/hash/audio.mp3",
+                "content_hash": "abc123",
+            },
+            headers={"Authorization": "Bearer test-api-key"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["job_id"] == "job_abc123"
+        assert data["status"] == "queued"
+
+    def test_submit_fast_analysis_job_no_auth(self, client):
+        """Test submitting fast analysis without auth fails."""
+        response = client.post(
+            "/api/v1/jobs/fast-analyze",
+            json={
+                "audio_url": "s3://bucket/hash/audio.mp3",
+                "content_hash": "abc123",
+            },
+        )
+
+        assert response.status_code == 401
+
     def test_submit_analysis_job_wrong_auth(self, client):
         """Test submitting with wrong auth fails."""
         response = client.post(

--- a/ops/analysis-service/tests/integration/test_models.py
+++ b/ops/analysis-service/tests/integration/test_models.py
@@ -4,6 +4,8 @@ import pytest
 from sow_analysis.models import (
     AnalyzeJobRequest,
     AnalyzeOptions,
+    FastAnalyzeJobRequest,
+    FastAnalyzeOptions,
     JobResponse,
     JobResult,
     JobStatus,
@@ -188,3 +190,41 @@ class TestJobType:
         """Test enum values."""
         assert JobType.ANALYZE == "analyze"
         assert JobType.LRC == "lrc"
+        assert JobType.FAST_ANALYZE == "fast_analyze"
+
+
+class TestFastAnalyzeOptions:
+    """Test FastAnalyzeOptions model."""
+
+    def test_default_values(self):
+        opts = FastAnalyzeOptions()
+        assert opts.force is False
+        assert opts.sample_rate == 22050
+        assert opts.hop_length == 4096
+
+    def test_custom_values(self):
+        opts = FastAnalyzeOptions(force=True, sample_rate=44100, hop_length=512)
+        assert opts.force is True
+        assert opts.sample_rate == 44100
+        assert opts.hop_length == 512
+
+
+class TestFastAnalyzeJobRequest:
+    """Test FastAnalyzeJobRequest model."""
+
+    def test_required_fields(self):
+        req = FastAnalyzeJobRequest(
+            audio_url="s3://bucket/hash/audio.mp3",
+            content_hash="abc123",
+        )
+        assert req.audio_url == "s3://bucket/hash/audio.mp3"
+        assert req.content_hash == "abc123"
+        assert req.options.force is False
+
+    def test_with_custom_options(self):
+        req = FastAnalyzeJobRequest(
+            audio_url="s3://bucket/hash/audio.mp3",
+            content_hash="abc123",
+            options=FastAnalyzeOptions(force=True),
+        )
+        assert req.options.force is True

--- a/ops/analysis-service/tests/test_cache.py
+++ b/ops/analysis-service/tests/test_cache.py
@@ -152,5 +152,69 @@ class TestWhisperPhraseDataclass:
         assert phrases[1].text == "World"
 
 
+class TestFastAnalyzeCache:
+    """Tests for fast analysis result caching."""
+
+    def test_save_and_get_fast_analyze_result(self):
+        """Test saving and retrieving fast analysis result."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cache_dir = Path(temp_dir)
+            cache_manager = CacheManager(cache_dir)
+
+            content_hash = "a" * 64
+            result = {
+                "duration_seconds": 180.5,
+                "tempo_bpm": 120.0,
+                "musical_key": "C",
+                "musical_mode": "major",
+                "key_confidence": 0.85,
+                "loudness_db": -12.3,
+            }
+
+            assert cache_manager.get_fast_analyze_result(content_hash) is None
+
+            cache_file = cache_manager.save_fast_analyze_result(content_hash, result)
+            assert cache_file.exists()
+            assert cache_file.name.endswith("_fast.json")
+
+            cached = cache_manager.get_fast_analyze_result(content_hash)
+            assert cached is not None
+            assert cached["tempo_bpm"] == 120.0
+            assert cached["musical_key"] == "C"
+
+    def test_fast_cache_distinct_from_full(self):
+        """Fast cache must not overwrite the full-tier cache."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cache_dir = Path(temp_dir)
+            cache_manager = CacheManager(cache_dir)
+
+            content_hash = "b" * 64
+            full_result = {"tempo_bpm": 100.0, "beats": [1.0, 2.0]}
+            fast_result = {"tempo_bpm": 120.0}
+
+            cache_manager.save_analysis_result(content_hash, full_result)
+            cache_manager.save_fast_analyze_result(content_hash, fast_result)
+
+            full_cached = cache_manager.get_analysis_result(content_hash)
+            fast_cached = cache_manager.get_fast_analyze_result(content_hash)
+
+            assert full_cached["tempo_bpm"] == 100.0
+            assert fast_cached["tempo_bpm"] == 120.0
+
+    def test_fast_cache_corrupt_json_falls_back_to_miss(self):
+        """Corrupt fast cache JSON should be deleted and treated as a miss."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cache_dir = Path(temp_dir)
+            cache_manager = CacheManager(cache_dir)
+
+            content_hash = "c" * 64
+            hash_prefix = content_hash[:32]
+            cache_file = cache_dir / f"{hash_prefix}_fast.json"
+            cache_file.write_text("{invalid json")
+
+            assert cache_manager.get_fast_analyze_result(content_hash) is None
+            assert not cache_file.exists()
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/ops/analysis-service/tests/test_job_store.py
+++ b/ops/analysis-service/tests/test_job_store.py
@@ -12,6 +12,8 @@ from sow_analysis.models import (
     AnalyzeOptions,
     EmbeddingJobRequest,
     EmbeddingJobResult,
+    FastAnalyzeJobRequest,
+    FastAnalyzeOptions,
     Job,
     JobStatus,
     JobType,
@@ -100,6 +102,54 @@ async def test_insert_and_get_analyze_job(job_store: JobStore) -> None:
     assert isinstance(retrieved.request, AnalyzeJobRequest)
     assert retrieved.request.audio_url == "s3://test-bucket/audio.mp3"
     assert retrieved.request.options.generate_stems
+
+
+@pytest.mark.asyncio
+async def test_insert_and_get_fast_analyze_job(job_store: JobStore) -> None:
+    """Test round-trip for fast_analyze job."""
+    request = FastAnalyzeJobRequest(
+        audio_url="s3://test-bucket/audio.mp3",
+        content_hash="fast123",
+        options=FastAnalyzeOptions(force=True, sample_rate=44100),
+    )
+
+    job = Job(
+        id="job_fast_test",
+        type=JobType.FAST_ANALYZE,
+        status=JobStatus.QUEUED,
+        request=request,
+    )
+
+    await job_store.insert_job(job)
+
+    retrieved = await job_store.get_job("job_fast_test")
+    assert retrieved is not None
+    assert retrieved.id == "job_fast_test"
+    assert retrieved.type == JobType.FAST_ANALYZE
+    assert retrieved.status == JobStatus.QUEUED
+    assert isinstance(retrieved.request, FastAnalyzeJobRequest)
+    assert retrieved.request.audio_url == "s3://test-bucket/audio.mp3"
+    assert retrieved.request.options.force is True
+    assert retrieved.request.options.sample_rate == 44100
+
+
+@pytest.mark.asyncio
+async def test_fast_analyze_migration_accepts_type(job_store: JobStore) -> None:
+    """Verify the CHECK constraint accepts 'fast_analyze' after initialize()."""
+    request = FastAnalyzeJobRequest(
+        audio_url="s3://test-bucket/audio.mp3",
+        content_hash="mig123",
+    )
+    job = Job(
+        id="job_mig_test",
+        type=JobType.FAST_ANALYZE,
+        status=JobStatus.QUEUED,
+        request=request,
+    )
+    await job_store.insert_job(job)
+    retrieved = await job_store.get_job("job_mig_test")
+    assert retrieved is not None
+    assert retrieved.type == JobType.FAST_ANALYZE
 
 
 @pytest.mark.asyncio

--- a/specs/agentic-songset-constructor-poc.md
+++ b/specs/agentic-songset-constructor-poc.md
@@ -1,0 +1,71 @@
+# Agentic Songset Constructor POC Plan
+
+## Summary
+
+Create a Python POC script under `lab/poc-scripts/` that reads the live published/analyzed catalog, uses LangGraph as an agentic planner/evaluator loop, and writes proposal artifacts only. The POC will not create `songsets` or `songset_items`.
+
+LangGraph guidance used: [overview](https://docs.langchain.com/oss/python/langgraph/overview), [workflows and agents](https://docs.langchain.com/oss/python/langgraph/workflows-agents), [persistence](https://docs.langchain.com/oss/python/langgraph/persistence), and [interrupts](https://docs.langchain.com/oss/python/langgraph/interrupts).
+
+## Key Changes
+
+- Add a POC CLI entry point, e.g. `lab/poc-scripts/construct_songset_agent.py`, plus testable helper modules under `lab/poc-scripts/poc/songset_constructor/`.
+- Add a `songset_constructor` optional dependency group in `lab/poc-scripts/pyproject.toml` with `langgraph`, `langchain-core`, `langchain-openai`, `pydantic`, `typer`, and `rich`.
+- Configure LLM calls through existing-style env vars: `SOW_LLM_API_KEY`, `SOW_LLM_BASE_URL`, and `SOW_LLM_MODEL`; default CLI mode is agentic and fails fast if these are missing.
+- Query active songs with active, published, completed-analysis recordings from Postgres via existing `ConnectionProvider`/`psycopg` patterns; exclude `CPW` by default.
+- Default to 5-song sets because `delivery/webapp/src/lib/constants.ts` currently sets `SONGSET_MAX_SONGS = 5`; allow 4-song compact sets, leave 6-song extended sets as future/non-webapp-compatible.
+
+## Implementation Details
+
+- Define Pydantic models:
+  - `SongCandidate`: song metadata, recording hash, BPM, key/mode/confidence, album/composer, inferred themes, phase.
+  - `TransitionCandidate`: adjacent pair metrics, CFD, BPM delta, shift suggestion, crossfade/gap recommendation, warnings.
+  - `SongsetProposal`: ordered items, transition params, score breakdown, LLM rationale, validation warnings.
+  - `ConstructorState`: graph state containing config, pool, transition matrix, candidate beams, LLM drafts, validation feedback, final proposals.
+- Implement deterministic music rules from `reports/research_report_chinese_worship_songset.md`:
+  - Theme keyword classifier and `infer_phase()`.
+  - Circle-of-Fifths distance, compatibility score, and +/-2 semitone shift suggestion.
+  - Hard gates H1-H8 and weighted fitness: theme 40%, tempo 30%, harmony 20%, diversity 10%.
+  - Dead-end fan-out detection and relaxed fallback warnings for limited pools.
+- LangGraph `StateGraph` nodes:
+  - `load_catalog`: read DB pool and normalize rows.
+  - `enrich_pool`: infer themes/phases and reject unusable rows.
+  - `build_transition_matrix`: precompute tempo/key/shift compatibility.
+  - `beam_seed_candidates`: deterministic beam search creates valid/near-valid candidates.
+  - `llm_plan`: LLM proposes or revises ordered songsets using structured output constrained to known recording hashes.
+  - `validate_score`: deterministic validator rejects invalid drafts and emits actionable feedback.
+  - `llm_refine`: evaluator-optimizer loop, max 3 iterations.
+  - `optional_review`: if `--interactive-review`, use `interrupt()` with JSON-serializable proposal summaries.
+  - `write_artifacts`: write `proposals.json`, `proposal_report.md`, `candidate_pool.csv`, and `graph_trace.jsonl`.
+- Use LangGraph persistence with an in-memory checkpointer for non-interactive runs and a local SQLite checkpointer under the output run directory when `--interactive-review` or `--resume-thread-id` is used.
+- CLI interface:
+  - `--songs 4|5`, default `5`
+  - `--top-k`, default `3`
+  - `--pool-limit`, default `200`
+  - `--output-dir`, default centralized under `lab/poc-scripts/output/songset_constructor/`
+  - `--album-series`, `--include-dev/--no-include-dev`, `--include-cpw`
+  - `--intimate`, `--hymnal-mode`, `--season`
+  - `--interactive-review`, `--resume-thread-id`
+  - `--llm-model` override for `SOW_LLM_MODEL`
+
+## Output Contract
+
+- `proposals.json`: machine-readable top proposals with ordered `song_id`, `recording_hash_prefix`, `position`, `key_shift_semitones`, `tempo_ratio`, `gap_beats`, `crossfade_enabled`, `crossfade_duration_seconds`, score breakdown, and warnings.
+- `proposal_report.md`: human-readable ranked songsets with Chinese titles, phase/theme labels, BPM/key transitions, and why the agent selected each set.
+- `candidate_pool.csv`: normalized catalog subset used by the run.
+- `graph_trace.jsonl`: node-level audit events, LLM draft IDs, validation failures, and final selection metadata.
+
+## Test Plan
+
+- Unit tests for key parsing, CFD, relative major/minor normalization, key scoring, and transposition suggestions.
+- Unit tests for Chinese theme keyword classification, `infer_phase()`, CPW exclusion, and DEV/default phase behavior.
+- Unit tests for H1-H8 validation and weighted fitness with synthetic `SongCandidate` fixtures.
+- Graph tests using a fake structured-output LLM that first emits invalid drafts, then verifies the refinement loop repairs them.
+- CLI smoke test with fixture rows and a temporary output directory; assert all four artifacts are written and no database mutation occurs.
+- Run with:
+  `uv run --project lab/poc-scripts --extra songset_constructor --extra test pytest lab/poc-scripts/tests -v`
+
+## Assumptions
+
+- The POC is read-only against Postgres and output-only on disk.
+- "Agentic planner" means the LLM may propose/revise song ordering, but deterministic validation and scoring are authoritative.
+- The implementation will not add schema columns such as `songs.themes`; theme tags are inferred in-memory for this POC.

--- a/specs/scale-key-bpm-analysis-batch-v4.md
+++ b/specs/scale-key-bpm-analysis-batch-v4.md
@@ -1,0 +1,619 @@
+# Plan: Scale Key/BPM Analysis via Explicit `audio batch` Steps (v4)
+
+> v4 supersedes v3. v3 is preserved unchanged at `specs/scale-key-bpm-analysis-batch-v3.md`
+> for review history. v4 narrows the surface, removes silent footguns v3 left open, and
+> adds an explicit resume mechanism.
+
+## Delta from v3 (why this version exists)
+
+v3 was sound on the fast-analysis service design but under-specified on operator
+safety. v4 closes these gaps:
+
+1. **`--force` is narrowly scoped.** v3 let `--all-steps --force` cascade re-download,
+   re-LRC, re-analyze AND re-embed in a single shot. v4 requires exactly one step flag
+   alongside `--force`.
+2. **`--force --download` is removed from `audio batch`.** Re-download now requires the
+   existing soft-delete + `maintenance purge-soft-deletes` two-step (see
+   `commands/maintenance.py:234` and `db/client.py:1409`). This eliminates the hash-prefix
+   drift problem v3 waved at but never resolved.
+3. **Forced fast analysis does not clear full-tier fields.** v3 handed the implementer
+   a choice between clearing and preserving `beats`/`sections`/etc. v4 fixes the
+   decision: preserve them; only set `analysis_status='partial'`.
+4. **Manifest file on disk + `--resume`.** v3 said "audit and resume manually" but
+   defined no resume surface. v4 adds a manifest writer and a `--resume` flag.
+5. **`incomplete` and `partial` are distinct filter values.** v3 implied `incomplete`
+   would absorb `partial`; v4 keeps them as separate predicates.
+6. **Default ordering is explicit.** v3 silently relied on DB return order for
+   `--limit N`. v4 mandates oldest-pending-first by `recordings.created_at`.
+7. **Fix the existing `_poll_all_jobs` NameError.** The current failed-status branch
+   references `recording.hash_prefix` (`commands/audio.py:4974-4976`) but
+   `recording` is only assigned in completed/404 branches. v4 makes the fix
+   in-scope of this refactor.
+8. **Fast analysis concurrency default is cgroup-aware.** v3's
+   `max(1, os.cpu_count() // 2)` returns host CPU count inside Docker, not the
+   container quota. v4 uses `len(os.sched_getaffinity(0))` (Linux) with a hard cap.
+
+Locked decisions:
+
+- `audio batch` step flags: `--download`, `--lrc`, `--analyze`, `--embedding`,
+  `--all-steps`. No step flag exits 1 with usage.
+- `--analyze` defaults to fast tier; `--analysis-tier full` opts in to full.
+- `--force` is valid only with exactly one of `--download`, `--lrc`, `--analyze`,
+  `--embedding`. With `--all-steps` or zero step flags, exit 1.
+- `--force --download` policy: NOT supported. A recording with existing R2 audio
+  cannot be force-re-downloaded from `audio batch`. Operator must use the explicit
+  two-step soft-delete + purge.
+- Manifest file `{batch_id}_manifest.json` is written to a configured directory each
+  run; `audio batch --resume <manifest_path>` re-polls jobs in the manifest.
+- Existing `_poll_all_jobs` NameError (audio.py:4974-4976) must be fixed as part of
+  this refactor.
+- Stale processing job at submit time: resubmit new; mark old job_id as abandoned in
+  the manifest.
+- `partial` and `incomplete` are distinct `--analysis-status` filter values.
+
+## Current State
+
+`sow-admin audio batch` (`commands/audio.py:4216-4338`) is monolithic:
+
+1. Resolves song IDs via album/song/status filters or `--stdin`
+   (`_resolve_song_ids`, audio.py:4341-4410).
+2. Downloads audio unless `--skip-download` is passed (Phase 1, audio.py:4696-4747).
+3. Submits LRC jobs unless `--skip-lrc` is passed (Phase 2, audio.py:4749-4844).
+4. Polls LRC jobs with service-first + R2 fallback reconciliation
+   (`_poll_all_jobs`, audio.py:4890-5116).
+5. Submits missing embedding jobs as an unconditional side effect after LRC poll
+   ("Phase 3.5", audio.py:4860-4884).
+
+The shape is not safe for an analysis-only overnight run. `audio batch
+--skip-download --skip-lrc` still reaches Phase 3.5 and submits embeddings.
+
+The embedding phase is also fire-and-forget: `_submit_embedding_single`
+(audio.py:2081-2113) submits jobs whose IDs are appended to a local list that is
+discarded at function return. Embedding submissions never appear in `--format json`
+output and are not reconciled on Ctrl+C.
+
+`_print_stats` (audio.py:5233-5358) only serializes `download`/`lrc` subkeys into
+the JSON manifest; embedding and analysis are absent from the runtime model.
+
+`_poll_all_jobs` has a latent NameError: the `failed` branch at 4974-4976 references
+`recording.hash_prefix`, but `recording` is only fetched in the `completed` and 404
+branches. A direct `failed` status from the service will crash the CLI.
+
+The standalone `audio analyze` command (audio.py:1474-1636) submits full analysis
+only. It has no batch input and hardcodes `analysis_status='completed'` via
+`update_recording_analysis` (`db/client.py:894-962`), which forces the column
+unconditionally (db/client.py:941).
+
+`analysis_status` is `TEXT` in Postgres with NO CHECK constraint
+(`db/schema.py:58`), so adding `partial` requires no Postgres migration. The
+SQLite analysis-service job store DOES have a CHECK on `jobs.type`; that migration
+is in scope.
+
+## Command Surface
+
+```bash
+sow-admin audio batch [selection filters] [step flags] [step options]
+```
+
+Selection filters (unchanged from current command):
+
+- `--album`, `--song`, `--stdin`, `--limit`
+- `--download-status`, `--lrc-status`, `--analysis-status`
+  - `--analysis-status` accepts: `pending`, `processing`, `partial`, `completed`,
+    `failed`, `incomplete` (alias for `pending`/`processing`/`failed`). `partial`
+    is a NEW distinct value and is NOT part of `incomplete`.
+
+Step flags:
+
+- `--download`, `--lrc`, `--analyze`, `--embedding`, `--all-steps`
+
+Shared options:
+
+- `--force`: requires exactly one step flag (see "Force scoping" below).
+- `--dry-run`: prints selected songs, selected steps, force behavior, analysis
+  tier, ordering, batch ID, and counts.
+- `--stale-after MINUTES`: reused for processing-job staleness decisions.
+  Default 120 (matches current).
+- `--format rich|json`: serializes the full in-memory results dict, including
+  all four step subkeys per song.
+- `--limit N`: select at most N songs. Default ordering is
+  `recordings.created_at ASC, recordings.hash_prefix ASC` (oldest pending first).
+- `--resume <manifest_path>`: skip submission; only re-poll jobs already
+  recorded in the manifest (see "Resume").
+
+Analysis options:
+
+- `--analysis-tier fast|full`, default `fast`. Only honored when `--analyze`
+  or `--all-steps` is selected; ignored with a warning otherwise.
+
+Rejected/deleted options:
+
+- `--skip-download`, `--skip-lrc`, `--force-lrc` (replaced by positive step flags
+  + `--force`).
+
+### Force scoping
+
+- `--force` with `--all-steps` exits 1 with an error explaining why
+  cascading overrides are unsafe.
+- `--force` with zero step flags exits 1 (same path as no step flags).
+- `--force` with exactly one of `--download`/`--lrc`/`--analyze`/`--embedding`
+  is the only accepted shape.
+- `--force --download` is REJECTED. Re-download on an existing recording is a
+  data-loss hazard (silently changes `content_hash`/`hash_prefix`, orphaning
+  downstream R2 artifacts and service caches). The supported workflow is:
+
+  ```bash
+  sow-admin audio delete --recording --hash-prefix <old>
+  sow-admin maintenance purge-soft-deletes --entity recordings \
+    --hash-prefix <old> --confirm
+  sow-admin audio batch --song <song_id> --download     # creates fresh recording
+  ```
+
+  `purge-soft-deletes` already hard-deletes the DB row and removes the R2 prefix
+  via `r2_client.delete_prefix` (maintenance.py:283, services/r2.py:182).
+  Attempting `--force --download` exits 1 with a hint pointing at the two-step.
+
+### Examples
+
+```bash
+# Overnight fast analysis of incomplete recordings, oldest first.
+sow-admin audio batch --analysis-status incomplete --analyze \
+  --analysis-tier fast --limit 500
+
+# Upgrade previously-fast (partial) recordings to full now that the queue is clear.
+sow-admin audio batch --analysis-status partial --analyze --analysis-tier full
+
+# Re-run LRC for a specific album's failed recordings.
+sow-admin audio batch --album <album_id> --lrc-status failed --lrc --force
+
+# Re-embed after lyrics changed.
+sow-admin audio batch --song <song_id> --embedding --force
+
+# Full pipeline (no force — safe idempotent backfill).
+sow-admin audio batch --all-steps
+
+# Resume a previously-interrupted batch.
+sow-admin audio batch --resume ~/.local/share/sow-admin/batch/2026-06-30T0215_manifest.json
+```
+
+## Batch Step Semantics
+
+Refactor `_process_batch` (`commands/audio.py:4666-4887`) so each phase is gated
+strictly by its step flag:
+
+- Download only runs with `--download` or `--all-steps`.
+- LRC only runs with `--lrc` or `--all-steps`.
+- Analysis only runs with `--analyze` or `--all-steps`.
+- Embedding only runs with `--embedding` or `--all-steps`.
+- No phase may execute as a side effect of another selected phase. Phase 3.5 is
+  deleted.
+
+### Phase ordering (sequential)
+
+1. Download: create/refresh R2 audio for selected songs.
+2. LRC submit + poll (`_poll_all_jobs` with the NameError fixed).
+3. Analysis submit + a NEW analysis poll loop (separate from LRC poll).
+4. Embedding submit + a NEW embedding poll loop (separate from LRC poll).
+
+Phases run sequentially, never concurrently. Rationale: analysis depends on
+download having produced R2 audio; polling concurrency in a single loop would
+couple LRC and analysis failure modes unnecessarily. Sequential also matches
+the current single-phase shape so the refactor is mechanical.
+
+### Non-force behavior
+
+- Download skips recordings where `download_status='completed'` AND R2 audio head
+  exists.
+- LRC skips if `lrc_status='completed'` OR an LRC object exists on R2 OR a
+  non-stale processing job can be reused.
+- Fast analysis skips `analysis_status IN ('partial', 'completed')`.
+- Full analysis skips `analysis_status='completed'`; explicitly includes
+  `partial` rows because upgrading a partial to full is a normal intent.
+- Embedding skips if `get_embedding_content_hash(song_id)` matches a freshly
+  computed hash (services/analysis.py:367-370).
+
+### Force behavior (single step only)
+
+- `--force --lrc`: bypass R2 existence check and existing-job reuse; submit a
+  fresh LRC job.
+- `--force --analyze --analysis-tier fast`: overwrite fast-tier DB columns
+  (`duration_seconds`, `tempo_bpm`, `musical_key`, `musical_mode`,
+  `key_confidence`, `loudness_db`) and set `analysis_status='partial'`.
+  Full-only columns (`beats`, `downbeats`, `sections`, `embeddings_shape`,
+  `r2_stems_url`) are PRESERVED. This is a deliberate status downgrade; existing
+  full data remains on disk so a later `--analyze --analysis-tier full` upgrade
+  does not need to regenerate it.
+- `--force --analyze --analysis-tier full`: overwrite all analysis columns
+  including full-only ones, set `analysis_status='completed'`. (Same as today's
+  `audio analyze --force`.)
+- `--force --embedding`: bypass content-hash match; submit a fresh embedding job.
+
+### Stale job at submit time
+
+Definition of stale: `now - recording.updated_at > stale_after_minutes` for that
+step's `*_job_id`/`*_status='processing'` row.
+
+Action: resubmit a new job via the analysis client, overwrite the recording's
+`*_job_id` with the new ID, set `*_status='processing'`. The OLD job_id is written
+to the manifest with `status='abandoned'` so an operator can still find it in the
+service job store. The old job is NOT cancelled (the analysis service has no
+batch cancel API that wouldn't also nuke other in-flight jobs).
+
+### Interrupt behavior
+
+On Ctrl+C:
+
+1. Flush the manifest immediately so all submitted job_ids are durable.
+2. For LRC: call the existing `_reconcile_on_interrupt` (audio.py:5146-5201),
+   R2-first.
+3. For analysis: probe final service state once; only mark `failed` if the service
+   confirms failure. Active or non-responsive jobs are left in
+   `analysis_status='processing'` and the manifest; the operator resumes with
+   `--resume`.
+4. For embedding: same as analysis. No R2 fallback (embeddings have no R2
+   artifact).
+
+## Manifest and Resume
+
+### Manifest writer
+
+A new helper `_write_manifest(batch_id, results, manifest_dir)` writes
+`{batch_id}_manifest.json` after every submission and poll cycle (so interrupted
+runs persist progress). `batch_id` is derived from start time:
+`{YYYY-MM-DDTHHMM}_batch`.
+
+`manifest_dir` defaults to `~/.local/share/sow-admin/batch/` (XDG-aware) and is
+overridable via `SOW_BATCH_MANIFEST_DIR` env var.
+
+### Manifest row schema
+
+Each entry is keyed by `(song_id, step, tier)` — the dedup key for resume. A
+re-submission of the same `(song_id, step, tier)` overwrites the prior entry;
+completed entries are NEVER re-submitted on resume (defense against duplicate
+work).
+
+```json
+{
+  "batch_id": "2026-06-30T0215_batch",
+  "started_at": "2026-06-30T02:15:00Z",
+  "selected_steps": ["download", "lrc", "analyze"],
+  "analysis_tier": "fast",
+  "stale_after_minutes": 120,
+  "songs": [
+    {
+      "song_id": "abc123",
+      "hash_prefix": "feedface",
+      "step": "analyze",
+      "tier": "fast",
+      "job_id": "job_a1b2c3d4e5f6",
+      "status": "submitted|processing|completed|failed|abandoned",
+      "attempts": 1,
+      "previous_job_id": null,
+      "error_class": null,
+      "error_message": null,
+      "submitted_at": "2026-06-30T02:15:04Z",
+      "completed_at": null
+    }
+  ]
+}
+```
+
+### `--resume <manifest_path>`
+
+Behavior:
+
+- Skip all selection/filter logic. Read the manifest's `songs` list. Ignore
+  filters; they are informational only.
+- Re-poll any entry with `status IN ('submitted', 'processing')`.
+- Skip any entry with `status IN ('completed', 'failed', 'abandoned')` and
+  print a count of skipped entries.
+- On a completed entry, apply the result writeback to the DB exactly as a
+  non-resume run would have done (idempotent via the (song_id, step, tier) key).
+- On Ctrl+C during resume, re-flush the manifest.
+
+`--resume` is mutually exclusive with all selection filters and with `--force`;
+specifying any of them with `--resume` exits 1.
+
+## Failed Job Handling
+
+### Submission failures
+
+- Continue processing later songs when one song fails validation or submission.
+- Record per-song `error_class` (e.g., `AnalysisServiceError`, `ValueError`,
+  `R2ConnectionError`) and `error_message` in both the in-memory results dict
+  and the manifest row.
+- Exit code 1 if any selected phase has at least one failed song. Aggregate
+  failure flags across phases: `failed_any = any(results[s]["<step>"]=="failed"
+  for s in song_ids for step in selected_steps)`.
+
+### Processing failures
+
+- Reuse non-stale processing jobs after probing the analysis service
+  (`analysis_client.get_job(job_id)`).
+- `completed`: store result via `update_recording_analysis` (with the new
+  `analysis_status` parameter, see "DB Changes").
+- `failed`: mark `*_status='failed'` for that step; persist `error_message` to
+  the manifest row.
+- 404 (job lost):
+  - LRC: existing R2 reconciliation fallback (unchanged from current).
+  - Analysis: NO R2 fallback (fast analysis never writes R2; full analysis
+    writes `analysis.json` but that is not a reconciliation source). Mark
+    `failed` and let the operator re-run with `--force --analyze`.
+  - Embedding: NO R2 fallback. Same: failed + operator re-run.
+
+### Retry policy
+
+- Retry transient service/network polling failures AT MOST once
+  (`AnalysisServiceError` with `status_code` in `{502, 503, 504}` or
+  `httpx.ConnectError`/`httpx.TimeoutException`).
+- Do NOT retry deterministic failures: 401 auth, missing recording, missing
+  audio URL, decode failure, invalid request data, 404 job-not-found, 4xx.
+
+### Newly-fixed bug
+
+`_poll_all_jobs` failed branch (audio.py:4974-4976) references `recording` only
+assigned in completed/404 branches. Fix: fetch `recording =
+db_client.get_recording_by_<appropriate_key>` at the top of every status branch
+(`completed`, `failed`, `processing`, 404, network error). The fix lives in the
+same refactor commit as the new analysis/embedding poll loops.
+
+## Fast Analysis Service Changes
+
+### Public API
+
+- `POST /api/v1/jobs/fast-analyze`
+- `JobType.FAST_ANALYZE = "fast_analyze"`
+- `FastAnalyzeJobRequest(audio_url, content_hash, options)`
+- `FastAnalyzeOptions(force=False, sample_rate=22050, hop_length=4096)`
+
+### Implementation requirements
+
+- Add `FAST_ANALYZE` to: `JobType` enum (`models.py:21-29`), the
+  `AnalyzeJobRequest`-style pydantic union, the API route registration in
+  `routes/jobs.py` (mirror `submit_analysis_job` at routes/jobs.py:148-166),
+  the queue dispatch switch in `workers/queue.py:373-405`, the queue stats
+  surface, and `_row_to_job` deserialization in `storage/db.py:381-451`.
+- Add a SQLite migration `_migrate_fast_analyze_type` at `storage/db.py`
+  following the exact `_migrate_embedding_type` / `_migrate_forced_alignment_type`
+  pattern. Add `'fast_analyze'` to the new CHECK constraint on `jobs.type`. Call
+  from `initialize()` (storage/db.py:52-58).
+- Implement fast analysis worker with librosa only:
+  - `duration_seconds`, `tempo_bpm`, `musical_key`, `musical_mode`,
+    `key_confidence`, `loudness_db` (RMS).
+  - Match `AnalyzeOptions` field semantics where overlap exists; key/BPM
+    algorithms should be documented inline (librosa `librosa.beat.tempo` and
+    `librosa.feature.chroma_cqt` + key classifier).
+- Fast cache key: `{hash_prefix}_fast.json` under the existing `CacheManager`
+  (`storage/cache.py`). Cache shape mirrors `JobResult` (the fast subset).
+- DO NOT upload fast results to R2. DO NOT overwrite full-tier
+  `{hash_prefix}.json` cache.
+- Bound concurrency with `SOW_FAST_ANALYZE_MAX_CONCURRENT` (see "Concurrency").
+
+### Runtime safeguards
+
+- Validate R2 client configuration before attempting fast-analysis audio
+  fetch (the worker downloads from R2 via `audio_url`, NOT from YouTube).
+- Ensure the downloaded temp audio file exists before analysis (guard for
+  truncated downloads).
+- `analyze_audio_fast()` is synchronous; if called via
+  `run_in_executor`, do NOT submit an unawaited coroutine (executor silently
+  drops futures).
+- Atomic write of `{hash_prefix}_fast.json` via `tempfile.NamedTemporaryFile`
+  in the same directory + `os.replace`. Reader side (`CacheManager`) must
+  tolerate ENOENT gracefully (treat as cache miss) in case of mid-write read.
+- R2 configuration check failures and decode failures persist the job as
+  `FAILED` with a descriptive `error_message`. The admin CLI surfaces
+  `error_class`/`error_message` in the manifest.
+
+## Admin CLI and DB Changes
+
+### AnalysisClient
+
+Add `AnalysisClient.submit_fast_analysis(audio_url, content_hash, options)`
+(admin/services/analysis.py). Reuse the existing `get_job()` for polling; parse
+fast-analyze responses as normal `AnalysisResult` (no schema divergence from full
+analyze; both populate the same `JobResult` fields). Document that full-only
+fields (`beats`, `downbeats`, `sections`, `embeddings_shape`, `stems_url`) will
+be `None`/absent on fast results.
+
+### Analysis phase helpers
+
+- Submit fast via `POST /api/v1/jobs/fast-analyze`.
+- Submit full via the existing `POST /api/v1/jobs/analyze`.
+- Poll active analysis jobs in a dedicated loop, not interleaved with LRC poll.
+- Store completed fast results with `analysis_status='partial'`.
+- Store completed full results with `analysis_status='completed'`.
+
+### DB helpers
+
+Add an `analysis_status` parameter to `update_recording_analysis`
+(`db/client.py:894-962`). The current implementation force-sets
+`analysis_status='completed'` (db/client.py:941); v4 requires:
+
+- `analysis_status: Optional[str] = None` parameter, default `None`.
+- If caller passes `None`: preserve the EXISTING behavior (set to `'completed'`)
+  to keep migrated callers and `audio analyze` unaffected.
+- If caller passes `'partial'`: set `analysis_status='partial'` and update only
+  fast-tier columns (`duration_seconds`, `tempo_bpm`, `musical_key`,
+  `musical_mode`, `key_confidence`, `loudness_db`).
+- If caller passes `'completed'`: update all columns as today.
+- Full-only column writes: when `analysis_status='partial'`, `beats`,
+  `downbeats`, `sections`, `embeddings_shape`, `r2_stems_url` MUST be omitted
+  from the UPDATE (NOT set to NULL). This is the data-loss protection.
+
+### New `Recording` model API
+
+- `Recording.has_analysis` (db/models.py:328-335): currently returns
+  `analysis_status == "completed"`. v4 changes it to
+  `analysis_status in ("partial", "completed")`. Audit every caller
+  (`grep has_analysis`) — callers that specifically need full-tier data
+  (beats/sections/embeddings) must use the new property.
+- Add `Recording.has_full_analysis`: strict `analysis_status == "completed"`.
+- Add `Recording.has_fast_analysis`:
+  `analysis_status in ("partial", "completed")` (alias of `has_analysis`).
+- Update CLI display, colorization, and status filters in
+  `commands/audio.py` to recognize and color `partial` distinctly
+  (e.g., yellow; `completed` green; `failed` red).
+
+### Status surface
+
+- `partial` is a new DB value. No Postgres migration needed
+  (TEXT without CHECK, db/schema.py:58).
+- `partial` is a new CLI filter value distinct from `incomplete`.
+- The DB-extras (`db/client.py:696` `incomplete` predicate) does NOT include
+  `partial`.
+
+## Operational Concerns
+
+### Recommended fast run
+
+```bash
+# Stage A: fast pass on songs lacking any analysis (oldest pending first).
+sow-admin audio batch --analysis-status incomplete --analyze \
+  --analysis-tier fast --limit 500
+```
+
+### Recommended full upgrade pass
+
+```bash
+# Stage B: upgrade all fast-analyzed recordings to full.
+sow-admin audio batch --analysis-status partial --analyze --analysis-tier full
+```
+
+### Concurrency and resource caps
+
+- Fast analysis loads full audio into memory and is CPU-heavy. Fast semaphore is
+  a NEW asyncio.Semaphore distinct from `_local_model_semaphore`
+  (`workers/queue.py:164-167`), `_dashscope_asr_semaphore`, and
+  `_embedding_semaphore`. They do not coordinate; the operator is responsible for
+  sizing `SOW_MAX_CONCURRENT_LOCAL_MODEL_JOBS`,
+  `SOW_DASHSCOPE_ASR_MAX_CONCURRENT`, `SOW_FAST_ANALYZE_MAX_CONCURRENT`,
+  `SOW_EMBEDDING_MAX_CONCURRENT` together.
+- `SOW_FAST_ANALYZE_MAX_CONCURRENT` default: cgroup-aware.
+  ```python
+  try:
+      default = min(4, max(1, len(os.sched_getaffinity(0)) // 2))
+  except (AttributeError, OSError):  # macOS / unsupported
+      default = 1
+  ```
+  Hard cap 4 prevents memory blowup on big hosts. Override via env. Operator
+  guidance in docs: raise cautiously when memory is plentiful AND songs are
+  short (<5 min).
+- Expose `SOW_FAST_ANALYZE_MAX_CONCURRENT` in `analysis-service/docker-compose.yml`
+  `x-common-env` block alongside other SOW_ variables.
+
+### Statuses
+
+- `partial`: fast key/BPM/loudness/duration only. No beats, sections, embeddings.
+- `completed`: full analysis with beats/sections/embeddings_shape where available.
+- `--force --analyze --analysis-tier fast` downgrades `completed` → `partial`
+  INTENTIONALLY but preserves full-only DB columns on disk.
+
+### Auth
+
+- `POST /api/v1/jobs/fast-analyze` requires `verify_api_key` (routes/jobs.py:39-62)
+  identical to the existing `/jobs/analyze`. No admin key needed for submission;
+  job-store migration is performed automatically by `storage/db.py` on startup.
+
+### Observability
+
+- Each fast analysis job carries the same lifecycle logging as the existing
+  `analyze` job (`workers/queue.py:342-405` — submit, processing started/
+  completed/failed, queue position).
+- Manifest rows include `submitted_at`/`completed_at` so wall-clock per step
+  and per song is derivable.
+- No metrics/tracing changes required; if present today, fast analysis is tagged
+  `job_type=fast_analyze` consistently.
+
+### Out-of-scope risks to flag
+
+- No batch wall-clock timeout. A 500-song batch can run for hours. Operator
+  uses Ctrl+C + `--resume`. Per-song poll timeout remains 600s
+  (`services/analysis.py:524-560`).
+- No isolation from concurrent `audio analyze` single-song runs targeting the
+  same recording. Operator must coordinate manually.
+- Orphaned R2 audio objects under a soft-but-not-hard-purged recording are out
+  of scope; addressed by `maintenance purge-soft-deletes` separately.
+
+## Test Plan
+
+### Admin CLI tests (`ops/admin-cli/tests`)
+
+- `audio batch` with no step flags exits 1.
+- `--download`, `--lrc`, `--analyze`, `--embedding` each run only their selected
+  phase. Assert no cross-phase side effect (especially: no embedding submission
+  when only `--analyze` is selected).
+- `--all-steps` runs all four phases in documented order: download → LRC →
+  analysis → embedding.
+- `--all-steps --force` exits 1 with the cascade-rejection message.
+- `--force` with zero step flags exits 1.
+- `--force --download` exits 1 with the two-step purge hint.
+- `--force --lrc` submits a fresh LRC job ignoring R2/existing-job reuse.
+- `--force --analyze --analysis-tier fast` overwrites fast columns AND sets
+  `partial` AND preserves `beats`/`sections`/etc. assert column values
+  unchanged before/after.
+- `--force --analyze --analysis-tier full` overwrites everything, sets
+  `completed`.
+- `--force --embedding` submits a fresh embedding job even when content hash
+  matches.
+- `--analyze` defaults to fast; `--analysis-tier full` uses the existing full
+  endpoint.
+- `--analysis-status partial` selects partial rows only; `--analysis-status
+  incomplete` selects `pending`/`processing`/`failed` (NOT partial).
+- `--limit N` selects oldest-by-`recordings.created_at` first. Assert ordering
+  in the query.
+- Batch exits nonzero when any selected step has a failure; counterexamples:
+  zero failures exits 0.
+- Manifest writer: produces a parseable `{batch_id}_manifest.json`; contains one
+  row per (song_id, step, tier); row schema matches spec.
+- `--resume`: re-polls entries with `status IN ('submitted', 'processing')`,
+  writes back results to DB identically to a non-resume run, skips
+  `completed`/`failed` entries.
+- `--resume` mutual-exclusivity: exits 1 when combined with any selection flag
+  or `--force`.
+- `_poll_all_jobs` NameError fix: a job whose service status is `failed`
+  without a prior `completed` poll no longer raises NameError.
+
+### Analysis service tests (`ops/analysis-service/tests`)
+
+- `FastAnalyzeJobRequest` model validation (audio_url required, content_hash
+  required, options optional with defaults).
+- `POST /api/v1/jobs/fast-analyze` auth (401 without key, 200 with),
+  validation (400 on bad body).
+- Job-store CHECK migration accepts `fast_analyze`: pre-stuff the DB with a
+  fast_analyze row, call `initialize()`, assert no migration error and
+  round-trip `_row_to_job` reproduces the same `FastAnalyzeJobRequest`.
+- `_row_to_job` reconstructs fast jobs from SQLite.
+- Queue dispatch processes fast jobs under the fast semaphore; assert
+  semaphore cap respected even when `SOW_MAX_CONCURRENT_LOCAL_MODEL_JOBS`
+  is saturated by `analyze` jobs.
+- Fast cache: hit returns cached result without recomputation; miss computes
+  and writes; `force=True` bypasses cache; corrupt JSON falls back to
+  recomputation (catch JSONDecodeError, delete, recompute).
+- Worker failure paths: R2 misconfiguration → job FAILED with descriptive
+  message; audio download failure → job FAILED; audio decode failure (bad
+  bytes) → job FAILED; cache write failure → job FAILED without leaving
+  partial JSON on disk.
+- Restart recovery: `processing` fast jobs are requeued by
+  `get_interrupted_jobs()` (queue.py:240-257).
+- Concurrency default computation: assert default formula yields 1 on
+  macOS/unsupported (uses fallback path) and cgroup-aware count on Linux.
+
+### Integration tests
+
+- Batch across mixed inputs:
+  - skipped (already completed)
+  - submitted (just queued)
+  - completed (resolved during poll)
+  - failed (service returns FAILED)
+  - stale-processing (older than `--stale-after`)
+  - retryable transient failure (502 then 200)
+- Analysis-only batch against already-downloaded + LRC-completed songs
+  submits ZERO LRC and ZERO embedding jobs.
+- `--all-steps` preserves phase order; dependent phases (LRC after download,
+  analysis after LRC) do not run prerequisites for songs whose prior phase
+  failed.
+- Manifest dedup: re-running `--resume` against a manifest with completed
+  entries does NOT re-submit those jobs.
+- Ctrl+C mid-poll: manifest flushed; `_reconcile_on_interrupt` runs;
+  analysis jobs left in `processing` status survive resume.


### PR DESCRIPTION
## Summary

This branch delivers two major features plus their specs:

1. **Scale Key/BPM Analysis via Explicit `audio batch` Steps (v4)** — refactors the monolithic `sow-admin audio batch` command into a step-flag-gated pipeline and adds a new fast-analysis tier (librosa-only key/BPM/loudness/duration) to the analysis service.
2. **Agentic Songset Constructor POC** — a LangGraph-based planner/evaluator loop that reads the live catalog, proposes songsets via an LLM constrained to known recording hashes, and validates them with deterministic music rules. Read-only against Postgres; writes proposal artifacts only.

## Changes by Area

### Specs
- `specs/scale-key-bpm-analysis-batch-v4.md` (new, 619 lines) — full v4 plan: step flags, force scoping, manifest/resume, fast-analysis service surface, DB changes, test plan. Supersedes v3.
- `specs/agentic-songset-constructor-poc.md` (new, 71 lines) — POC plan: LangGraph nodes, Pydantic models, deterministic music rules, output contract, test plan.

### Analysis Service (`ops/analysis-service/`)
- `models.py` — add `FAST_ANALYZE` to `JobType` enum, `FastAnalyzeJobRequest`, `FastAnalyzeOptions`.
- `routes/jobs.py` — register `POST /api/v1/jobs/fast-analyze` (mirrors existing analyze route, same `verify_api_key` auth).
- `workers/analyzer.py` — implement `analyze_audio_fast()` with librosa: duration, tempo, key/mode/confidence, loudness (RMS). Synchronous; documents executor pitfalls.
- `workers/queue.py` — add fast-analyze dispatch under a NEW `SOW_FAST_ANALYZE_MAX_CONCURRENT` semaphore (distinct from local-model/DASH/embedding semaphores). Cgroup-aware default (`os.sched_getaffinity`), hard cap 4.
- `storage/db.py` — add `_migrate_fast_analyze_type` SQLite migration (follows `_migrate_embedding_type` pattern), add `fast_analyze` to CHECK constraint, extend `_row_to_job` deserialization.
- `storage/cache.py` — fast cache key `{hash_prefix}_fast.json` under existing `CacheManager`; atomic write via `NamedTemporaryFile` + `os.replace`; corrupt JSON falls back to recomputation.
- `config.py` — expose `SOW_FAST_ANALYZE_MAX_CONCURRENT`.
- `docker-compose.yml` — add `SOW_FAST_ANALYZE_MAX_CONCURRENT` to `x-common-env`.
- Tests: `test_cache.py`, `test_job_store.py`, `integration/test_api.py`, `integration/test_models.py`.

### Admin CLI (`ops/admin-cli/`)
- `commands/audio.py` (major refactor, +1837/-) — refactor `_process_batch` so each phase is gated strictly by its step flag (`--download`, `--lrc`, `--analyze`, `--embedding`, `--all-steps`). Deletes Phase 3.5 embedding side-effect. Adds dedicated analysis and embedding poll loops (separate from LRC poll). Implements `--force` scoping (single-step only; `--force --download` rejected with two-step purge hint; `--force --all-steps` rejected). Adds `--resume <manifest_path>`, `--dry-run`, `--analysis-tier fast|full`, `partial` as a distinct `--analysis-status` filter value. Oldest-pending-first ordering by `recordings.created_at`. Fixes the `_poll_all_jobs` NameError in the failed branch. Adds manifest writer `_write_manifest` flushing `{batch_id}_manifest.json` after each submission/poll cycle and on Ctrl+C.
- `db/client.py` — add `analysis_status` parameter to `update_recording_analysis` (default `None` preserves old behavior; `'partial'` updates only fast-tier columns and omits full-only columns to prevent data loss; `'completed'` updates all). `incomplete` predicate does NOT include `partial`.
- `db/models.py` — `Recording.has_analysis` now `in ("partial", "completed")`; add `has_full_analysis` (strict `completed`) and `has_fast_analysis` (alias of `has_analysis`). CLI display colorizes `partial` distinctly.
- `services/analysis.py` — add `AnalysisClient.submit_fast_analysis(audio_url, content_hash, options)`.
- Tests: `tests/admin/test_audio_batch_v4.py` (275 lines) covering step-flag gating, force scoping, manifest, resume, ordering, partial filter, NameError fix.

### Agentic Songset Constructor POC (`lab/poc-scripts/`)
- `poc/songset_constructor/models.py` — Pydantic models: `SongCandidate`, `TransitionCandidate`, `SongsetProposal`, `ConstructorState`, `ConstructorConfig`, `LlmDraft`.
- `poc/songset_constructor/music_rules.py` — deterministic rules from research report: theme keyword classifier + `infer_phase()`, Circle-of-Fifths distance, compatibility score, ±2 semitone shift suggestion, hard gates H1-H8, weighted fitness (theme 40% / tempo 30% / harmony 20% / diversity 10%), dead-end fan-out detection.
- `poc/songset_constructor/graph.py` — LangGraph `StateGraph` nodes: `load_catalog`, `enrich_pool`, `build_transition_matrix`, `beam_seed_candidates`, `llm_plan` (structured output constrained to known recording hashes), `validate_score`, `llm_refine` (evaluator-optimizer, max 3 iterations), `optional_review` (interrupt-based), `write_artifacts`. In-memory checkpointer for non-interactive; SQLite checkpointer for `--interactive-review`/`--resume-thread-id`. LLM timeout/retry env-configurable (`SOW_LLM_TIMEOUT`, `SOW_LLM_MAX_ATTEMPTS`, `SOW_LLM_MAX_BACKOFF_S`).
- `poc/songset_constructor/catalog.py` — DB pool reader (active/published/completed-analysis recordings; excludes `CPW` by default).
- `poc/songset_constructor/artifacts.py` — writes `proposals.json`, `proposal_report.md`, `candidate_pool.csv`, `graph_trace.jsonl`.
- `poc/songset_constructor/cli.py` + `construct_songset_agent.py` — Typer CLI: `--songs 4|5`, `--top-k`, `--pool-limit`, `--output-dir`, `--album-series`, `--include-dev`, `--include-cpw`, `--intimate`, `--hymnal-mode`, `--season`, `--interactive-review`, `--resume-thread-id`, `--llm-model`.
- `pyproject.toml` — add `songset_constructor` extra (`langgraph`, `langchain-core`, `langchain-openai`, `pydantic`, `typer`, `rich`).
- Tests: `test_songset_constructor_rules.py`, `test_songset_constructor_catalog.py`, `test_songset_constructor_graph.py` (incl. LLM retry/backoff test with fake structured-output runnable).

## Migration Notes
- **No Postgres migration required.** `analysis_status` is `TEXT` without CHECK; `partial` is a new value only.
- **SQLite job-store migration is automatic** on analysis-service startup (`_migrate_fast_analyze_type`).
- `Recording.has_analysis` semantics changed (now includes `partial`). Callers needing strict full-tier data should use `has_full_analysis`.
- `--skip-download`/`--skip-lrc`/`--force-lrc` are removed; use positive step flags + `--force`.

## Testing Notes
- Admin CLI: `PYTHONPATH=ops/admin-cli/src uv run --project ops/admin-cli --python 3.11 --extra admin --extra test pytest ops/admin-cli/tests -v`
- Analysis service: `cd ops/analysis-service && PYTHONPATH=src pytest tests/ -v`
- Songset constructor: `uv run --project lab/poc-scripts --extra songset_constructor --extra test pytest lab/poc-scripts/tests -v`