### PR TITLE
feat: songset constructor, recover-visibility v2, lrc-editor keymap, and admin-cli improvements

### DIFF
--- a/docs/agent_guide_songset_constructor_eval.md
+++ b/docs/agent_guide_songset_constructor_eval.md
@@ -1,0 +1,61 @@
+# Agent Guide: Songset Constructor — Generating and Evaluating Diverse Songsets
+
+This guide explains how to use the songset constructor POC to generate diverse Chinese worship songsets and evaluate the quality of the results.
+
+## Quick Start
+
+```bash
+# Deterministic mode (no LLM required)
+set -a && source /opt/sow/.env && set +a
+uv run --project lab/poc-scripts --extra songset_constructor \
+  python lab/poc-scripts/construct_songset_agent.py \
+  --songs 4 --pool-limit 500 --top-k 20 --no-llm
+
+# Agentic mode (LLM planning + optional judge)
+uv run --project lab/poc-scripts --extra songset_constructor \
+  python lab/poc-scripts/construct_songset_agent.py \
+  --songs 4 --pool-limit 500 --top-k 20 --llm-judge
+```
+
+## Prerequisites
+
+- Environment variables `SOW_LLM_API_KEY`, `SOW_LLM_MODEL`, `SOW_LLM_BASE_URL` must be set for agentic mode (`--llm-judge`). The CLI auto-loads `/opt/sow/.env` or accepts `--env-file`.
+- `--no-llm` mode requires no LLM credentials and runs fully deterministic.
+- The catalog database must be reachable (read-only `SELECT` queries via `ReadOnlyClient`).
+
+## CLI Options
+
+| Option | Default | Range | Purpose |
+|--------|---------|-------|---------|
+| `--songs` | 3 | 2–5 | Songs per songset |
+| `--top-k` | 3 | 1–20 | Number of ranked proposals to output |
+| `--pool-limit` | 200 | ≥4 | Max songs to load from catalog (use 500 for full catalog) |
+| `--no-llm` / `--llm` | `--llm` | — | Toggle deterministic vs agentic mode |
+| `--llm-judge` / `--no-llm-judge` | `--no-llm-judge` | — | Enable LLM re-ranking of finalists |
+| `--intimate` / `--no-intimate` | `--no-intimate` | — | Lower closer tempo ceiling from 90 to 80 BPM |
+| `--season` | None | advent, christmas, lent, easter, pentecost | Seasonal theme bias |
+| `--album-series` | None | repeatable | Filter catalog by album series (e.g., `--album-series "敬拜讚美 (1)"`) |
+| `--relax-h1` / `--no-relax-h1` | `--relax-h1` | — | Relax phase-1 opener requirement (allow phase 2 openers) |
+| `--auto-relax` / `--no-auto-relax` | `--auto-relax` | — | Auto-relax H2/H3/H4/H5 if no proposals found |
+| `--relax-h3-bpm` | None | ≥0 | Override closer tempo ceiling |
+| `--relax-h2-bpm` | None | ≥0 | Override opener tempo floor |
+| `--relax-h4` / `--no-relax-h4` | `--no-relax-h4` | — | Widen tempo jump limit from 35 to 40 BPM |
+| `--relax-h5` / `--no-relax-h5` | `--no-relax-h5` | — | Widen circle-of-fifths distance from 2 to 3 |
+| `--interactive-review` / `--no-interactive-review` | `--no-interactive-review` | — | Pause for human approve/reject of top proposal |
+| `--output-dir` | auto-timestamped | path | Override output directory |
+
+## Pipeline Architecture
+
+The constructor runs as a LangGraph state machine with these stages:
+
+```
+load_catalog → enrich_pool → build_transition_matrix → beam_seed_candidates
+                                                          ↓
+                                            ┌─────────────┴──────────────┐
+                                            │                            │
+                                      --no-llm                      LLM mode
+                                            │                            │
+                                    finalize_rank              llm_plan → validate_score
+                                            │                    ↓               ↓
+                                            │              Accepted         Refine (loop ≤3)
+                                            │                    ↓               ↓

--- a/lab/poc-scripts/poc/songset_constructor/artifacts/writer.py
+++ b/lab/poc-scripts/poc/songset_constructor/artifacts/writer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import csv
 import json
+import re
 from collections import Counter
 from datetime import UTC, datetime
 from pathlib import Path
@@ -11,12 +12,409 @@ from typing import Any
 
 from poc.songset_constructor.config import RunConfig
 from poc.songset_constructor.models import SongCandidate, SongsetProposal
+from poc.songset_constructor.rules.fitness import middle_song_ids
+from poc.songset_constructor.rules.themes import THEMES
+
+
+PHASE_NAMES = {
+    1: "call",
+    2: "thanksgiving",
+    3: "worship",
+    4: "response",
+    5: "commitment",
+}
+
+
+_LAST_NARRATIVES: dict[str, list[str]] = {}
+
+
+def cache_narratives(thread_id: str, narratives: list[str]) -> None:
+    _LAST_NARRATIVES[thread_id] = narratives
+
+
+def get_cached_narratives(thread_id: str) -> list[str] | None:
+    return _LAST_NARRATIVES.get(thread_id)
 
 
 def _json_default(value):
     if isinstance(value, Path):
         return str(value)
     raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")
+
+
+def _song_sequence_line(proposal: SongsetProposal) -> str:
+    if not proposal.items:
+        return "(no songs)"
+    parts = [f"{item.position}. {item.title}" for item in proposal.items]
+    return "  →  ".join(parts)
+
+
+def _key_tempo_journey_line(proposal: SongsetProposal) -> str:
+    keys: list[str] = []
+    bpms: list[str] = []
+    for item in proposal.items:
+        if item.key and item.mode:
+            keys.append(f"{item.key} {item.mode}")
+        elif item.key:
+            keys.append(item.key)
+        else:
+            keys.append("?")
+        bpms.append(f"{item.bpm:g}" if item.bpm is not None else "?")
+    keys_str = " → ".join(keys)
+    bpms_str = " → ".join(bpms)
+    return f"{keys_str}  |  {bpms_str} BPM arc"
+
+
+def _score_warnings_line(proposal: SongsetProposal) -> str:
+    score_parts = (
+        f"f_theme {proposal.score.f_theme:.3f}, "
+        f"f_tempo {proposal.score.f_tempo:.3f}, "
+        f"f_harmony {proposal.score.f_harmony:.3f}, "
+        f"f_diversity {proposal.score.f_diversity:.3f}"
+    )
+    warnings = (
+        ", ".join(proposal.hard_constraint_warnings)
+        if proposal.hard_constraint_warnings
+        else "none"
+    )
+    return f"{score_parts}  |  Warnings: {warnings}"
+
+
+def _deterministic_arc_narrative(proposal: SongsetProposal) -> str:
+    if not proposal.items:
+        return "Empty songset with no songs."
+    phases = [item.phase for item in proposal.items]
+    phase_nums = " → ".join(str(phase) for phase in phases)
+    phase_labels = " → ".join(PHASE_NAMES.get(phase, "unknown") for phase in phases)
+    themes = []
+    seen = set()
+    for item in proposal.items:
+        for theme in item.themes:
+            if theme not in seen:
+                themes.append(theme)
+                seen.add(theme)
+    themes_str = ", ".join(themes) if themes else "none"
+    return f"Phase {phase_nums} ({phase_labels}). Themes: {themes_str}."
+
+
+def brief_summary_block(
+    proposal: SongsetProposal,
+    *,
+    config: RunConfig,
+    pool: list[SongCandidate],
+    llm_narrative: str | None = None,
+) -> list[str]:
+    arc = (
+        llm_narrative.strip()
+        if llm_narrative and llm_narrative.strip()
+        else _deterministic_arc_narrative(proposal)
+    )
+    rationale = proposal.rationale or "Deterministic beam ranking."
+    return [
+        "> **Brief Summary**",
+        f"> Songs: {_song_sequence_line(proposal)}",
+        f"> Arc: {arc}",
+        f"> Journey: {_key_tempo_journey_line(proposal)}",
+        f"> Score: {_score_warnings_line(proposal)}",
+        f"> Rationale: {rationale}",
+    ]
+
+
+def _proposal_structured_data(proposal: SongsetProposal) -> str:
+    lines = []
+    for item in proposal.items:
+        key = item.key or "?"
+        mode = item.mode or "?"
+        bpm = item.bpm if item.bpm is not None else "?"
+        themes = ", ".join(item.themes) if item.themes else "none"
+        lines.append(
+            f"  {item.position}. {item.title} | phase {item.phase} | "
+            f"themes: {themes} | key {key} mode {mode} | bpm {bpm}"
+        )
+    lines.append(
+        f"  Score: f_theme {proposal.score.f_theme:.3f}, "
+        f"f_tempo {proposal.score.f_tempo:.3f}, "
+        f"f_harmony {proposal.score.f_harmony:.3f}, "
+        f"f_diversity {proposal.score.f_diversity:.3f}, "
+        f"total {proposal.score.total:.3f}"
+    )
+    warnings = (
+        ", ".join(proposal.hard_constraint_warnings)
+        if proposal.hard_constraint_warnings
+        else "none"
+    )
+    lines.append(f"  Warnings: {warnings}")
+    if proposal.rationale:
+        lines.append(f"  Rationale: {proposal.rationale}")
+    return "\n".join(lines)
+
+
+def _brief_summaries_prompt(proposals: list[SongsetProposal]) -> str:
+    blocks = []
+    for index, proposal in enumerate(proposals, start=1):
+        blocks.append(f"---PROPOSAL {index}---\n{_proposal_structured_data(proposal)}")
+    proposals_text = "\n".join(blocks)
+    return (
+        "You are reviewing Chinese worship songsets. For each proposal below, write "
+        "≤2 sentences describing the emotional and musical arc — call themes, worship "
+        "arc, and key/tempo trajectory. Use only the facts provided. Do not invent "
+        "songs, scores, or warnings.\n\n"
+        "Format your response EXACTLY as:\n"
+        "<<<SUMMARY 1>>>\n"
+        "<narrative for proposal 1>\n"
+        "<<<END SUMMARY 1>>>\n"
+        "<<<SUMMARY 2>>>\n"
+        "<narrative for proposal 2>\n"
+        "<<<END SUMMARY 2>>>\n"
+        "... (one block per proposal, in order)\n\n"
+        "Proposals:\n"
+        f"{proposals_text}"
+    )
+
+
+def _parse_llm_summaries(content: str, count: int) -> dict[int, str]:
+    summaries: dict[int, str] = {}
+    for index in range(1, count + 1):
+        pattern = rf"<<<SUMMARY {index}>>>(.*?)<<<END SUMMARY {index}>>>"
+        match = re.search(pattern, content, re.DOTALL)
+        if match:
+            text = match.group(1).strip()
+            if text:
+                summaries[index] = text
+    return summaries
+
+
+def _truncate_sentences(text: str, max_sentences: int = 2) -> str:
+    sentences = re.split(r"(?<=[.!?])\s+", text.strip())
+    return ". ".join(sentences[:max_sentences]).strip()
+
+
+def generate_brief_summaries(
+    config: RunConfig,
+    proposals: list[SongsetProposal],
+) -> list[str]:
+    deterministic = [_deterministic_arc_narrative(p) for p in proposals]
+    if config.no_llm or len(proposals) < 2:
+        return deterministic
+    try:
+        from poc.songset_constructor.graph.llm import build_chat_model
+
+        chat_model = build_chat_model(config)
+        if chat_model is None:
+            return deterministic
+        prompt = _brief_summaries_prompt(proposals)
+        response = chat_model.invoke(prompt)
+        content = getattr(response, "content", response)
+        if isinstance(content, list):
+            content = " ".join(str(part) for part in content)
+        content = str(content).strip()
+        if not content:
+            return deterministic
+        parsed = _parse_llm_summaries(content, len(proposals))
+        if len(parsed) != len(proposals) or not all(
+            parsed.get(index) for index in range(1, len(proposals) + 1)
+        ):
+            return deterministic
+        return [
+            _truncate_sentences(parsed[index + 1])
+            for index in range(len(proposals))
+        ]
+    except Exception:
+        return deterministic
+
+
+def _diversity_metrics(proposals: list[SongsetProposal], pool: list[SongCandidate]) -> dict:
+    by_song = {candidate.song_id: candidate for candidate in pool}
+    total_slots = sum(len(p.items) for p in proposals)
+    unique_songs = {item.song_id for p in proposals for item in p.items}
+    unique_themes = {theme for p in proposals for item in p.items for theme in item.themes}
+    unique_composers = {
+        by_song[item.song_id].composer
+        for p in proposals
+        for item in p.items
+        if by_song.get(item.song_id) and by_song[item.song_id].composer
+    }
+    unique_phases = {item.phase for p in proposals for item in p.items}
+    middle_sets = [middle_song_ids(p) for p in proposals]
+    unique_middle_songs = set().union(*middle_sets) if middle_sets else set()
+    total_middle_slots = sum(len(s) for s in middle_sets)
+    middle_reuse_count = total_middle_slots - len(unique_middle_songs)
+    return {
+        "total_slots": total_slots,
+        "unique_songs": unique_songs,
+        "unique_themes": unique_themes,
+        "unique_composers": unique_composers,
+        "unique_phases": unique_phases,
+        "unique_middle_songs": unique_middle_songs,
+        "total_middle_slots": total_middle_slots,
+        "middle_reuse_count": middle_reuse_count,
+    }
+
+
+def _song_overlap_matrix(proposals: list[SongsetProposal]) -> list[str]:
+    song_sets = [{item.song_id for item in p.items} for p in proposals]
+    count = len(proposals)
+    headers = [""] + [f"R{index + 1}" for index in range(count)]
+    lines = [
+        "| " + " | ".join(headers) + " |",
+        "|" + "|".join("---" for _ in range(count + 1)) + "|",
+    ]
+    for row in range(count):
+        cells = [f"R{row + 1}"]
+        for col in range(count):
+            if row == col:
+                cells.append("—")
+            else:
+                cells.append(str(len(song_sets[row] & song_sets[col])))
+        lines.append("| " + " | ".join(cells) + " |")
+    return lines
+
+
+def _song_frequency_table(proposals: list[SongsetProposal]) -> list[str]:
+    usage: dict[str, set[int]] = {}
+    titles: dict[str, str] = {}
+    for proposal_index, proposal in enumerate(proposals):
+        for item in proposal.items:
+            usage.setdefault(item.song_id, set()).add(proposal_index)
+            titles[item.song_id] = item.title
+    frequent = [
+        (song_id, len(proposal_set))
+        for song_id, proposal_set in usage.items()
+        if len(proposal_set) > 1
+    ]
+    frequent.sort(key=lambda entry: (-entry[1], titles[entry[0]]))
+    if not frequent:
+        return ["No songs appear in more than one proposal."]
+    lines = [
+        "| Song ID | Title | Times Used |",
+        "|---|---|---:|",
+    ]
+    for song_id, times in frequent:
+        lines.append(f"| {song_id} | {titles[song_id]} | {times} |")
+    return lines
+
+
+def _theme_coverage_lines(proposals: list[SongsetProposal]) -> list[str]:
+    present = {
+        theme
+        for p in proposals
+        for item in p.items
+        for theme in item.themes
+        if theme in THEMES
+    }
+    missing = [theme for theme in THEMES if theme not in present]
+    present_sorted = [theme for theme in THEMES if theme in present]
+    return [
+        f"Present ({len(present_sorted)}): {', '.join(present_sorted)}",
+        f"Missing ({len(missing)}): {', '.join(missing)}",
+    ]
+
+
+def _bottleneck_lines(
+    metrics: dict,
+    proposals: list[SongsetProposal],
+    pool: list[SongCandidate],
+) -> list[str]:
+    lines: list[str] = []
+    proposal_count = len(proposals)
+    by_song = {candidate.song_id: candidate for candidate in pool}
+
+    song_usage: dict[str, set[int]] = {}
+    for proposal_index, proposal in enumerate(proposals):
+        for item in proposal.items:
+            song_usage.setdefault(item.song_id, set()).add(proposal_index)
+    overused = [
+        (song_id, len(proposal_set))
+        for song_id, proposal_set in song_usage.items()
+        if len(proposal_set) > proposal_count / 2
+    ]
+    overused.sort(key=lambda entry: (-entry[1], entry[0]))
+    for song_id, times in overused:
+        title = next(
+            (item.title for p in proposals for item in p.items if item.song_id == song_id),
+            song_id,
+        )
+        lines.append(
+            f'Most-reused song: "{title}" appears in {times}/{proposal_count} songsets.'
+        )
+
+    for phase in range(1, 6):
+        if phase not in metrics["unique_phases"]:
+            label = PHASE_NAMES.get(phase, "unknown")
+            lines.append(
+                f"Phase gap: Phase {phase} ({label}) absent from all top-k songsets."
+            )
+
+    total_slots = metrics["total_slots"]
+    if total_slots > 0:
+        composer_counts: dict[str, int] = {}
+        for p in proposals:
+            for item in p.items:
+                candidate = by_song.get(item.song_id)
+                if candidate and candidate.composer:
+                    composer_counts[candidate.composer] = (
+                        composer_counts.get(candidate.composer, 0) + 1
+                    )
+        concentrated = [
+            (composer, count)
+            for composer, count in composer_counts.items()
+            if count > total_slots / 3
+        ]
+        concentrated.sort(key=lambda entry: (-entry[1], entry[0]))
+        for composer, count in concentrated:
+            percentage = round(count / total_slots * 100)
+            lines.append(
+                f'Composer concentration: composer "{composer}" authored '
+                f"{count}/{total_slots} slots ({percentage}%)."
+            )
+    return lines
+
+
+def _diversity_summary(proposals: list[SongsetProposal], pool: list[SongCandidate]) -> list[str]:
+    if len(proposals) <= 1:
+        return []
+    metrics = _diversity_metrics(proposals, pool)
+    total_slots = metrics["total_slots"]
+    unique_songs = metrics["unique_songs"]
+    unique_themes = metrics["unique_themes"]
+    unique_composers = metrics["unique_composers"]
+    unique_phases = metrics["unique_phases"]
+    total_middle = metrics["total_middle_slots"]
+    middle_reuse = metrics["middle_reuse_count"]
+
+    unique_pct = round(len(unique_songs) / total_slots * 100) if total_slots else 0
+
+    lines = [
+        "## Diversity Summary",
+        "",
+        f"Across {len(proposals)} proposals ({total_slots} song slots total):",
+        "",
+        "| Metric | Value |",
+        "|---|---|",
+        f"| Unique songs | {len(unique_songs)} / {total_slots} ({unique_pct}%) |",
+        f"| Unique themes | {len(unique_themes)} / {len(THEMES)} |",
+        f"| Unique composers | {len(unique_composers)} |",
+        f"| Unique phases | {len(unique_phases)} / 5 |",
+        f"| Middle-song reuse | {middle_reuse} (across {total_middle} middle slots) |",
+        "",
+        "### Song Overlap Matrix",
+        "",
+    ]
+    lines.extend(_song_overlap_matrix(proposals))
+    lines.append("")
+    lines.append("### Song Frequency")
+    lines.append("")
+    lines.extend(_song_frequency_table(proposals))
+    lines.append("")
+    lines.append("### Theme Coverage")
+    lines.append("")
+    lines.extend(_theme_coverage_lines(proposals))
+    bottlenecks = _bottleneck_lines(metrics, proposals, pool)
+    if bottlenecks:
+        lines.extend(["", "### Bottlenecks", ""])
+        lines.extend(f"- {line}" for line in bottlenecks)
+    lines.append("")
+    return lines
 
 
 def write_artifacts(
@@ -36,7 +434,7 @@ def write_artifacts(
         "review": output_dir / "songset_review.md",
     }
     write_proposals(paths["proposals"], config, proposals)
-    write_report(paths["report"], proposals)
+    write_report(paths["report"], config=config, proposals=proposals, pool=pool)
     write_pool_csv(paths["pool"], pool)
     paths["trace"].write_text(
         "\n".join(json.dumps(item, ensure_ascii=False, default=_json_default) for item in trace) + "\n",
@@ -59,14 +457,31 @@ def write_proposals(path: Path, config: RunConfig, proposals: list[SongsetPropos
     path.write_text(json.dumps(payload, ensure_ascii=False, indent=2, default=_json_default), encoding="utf-8")
 
 
-def write_report(path: Path, proposals: list[SongsetProposal]) -> None:
+def write_report(
+    path: Path,
+    *,
+    config: RunConfig,
+    proposals: list[SongsetProposal],
+    pool: list[SongCandidate],
+) -> list[str]:
+    narratives = generate_brief_summaries(config, proposals)
+    cache_narratives(config.thread_id, narratives)
     lines = ["# Songset Proposals", ""]
     if not proposals:
         lines.extend(["No valid proposals generated.", ""])
-    for proposal in proposals:
+    for index, proposal in enumerate(proposals):
+        narrative = narratives[index] if index < len(narratives) else None
         lines.extend(
             [
                 f"## Rank {proposal.rank} - Score {proposal.score.total:.4f}",
+                "",
+            ]
+        )
+        lines.extend(brief_summary_block(proposal, config=config, pool=pool, llm_narrative=narrative))
+        lines.extend(
+            [
+                "",
+                "### Details",
                 "",
                 "| # | Title | Phase | BPM | Key | Themes | Transition |",
                 "|---|---|---:|---:|---|---|---|",
@@ -91,7 +506,9 @@ def write_report(path: Path, proposals: list[SongsetProposal]) -> None:
             lines.extend([f"Warnings: {', '.join(proposal.hard_constraint_warnings)}", ""])
         if proposal.judge_reason:
             lines.extend([f"Judge note: {proposal.judge_reason}", ""])
+    lines.extend(_diversity_summary(proposals, pool))
     path.write_text("\n".join(lines), encoding="utf-8")
+    return narratives
 
 
 def write_pool_csv(path: Path, pool: list[SongCandidate]) -> None:

--- a/lab/poc-scripts/poc/songset_constructor/cli.py
+++ b/lab/poc-scripts/poc/songset_constructor/cli.py
@@ -255,6 +255,25 @@ def _print_output_files(paths: dict[str, str]) -> None:
         console.print(f"  {output_path.name}: {output_path}")
 
 
+def _print_brief_summaries(config: RunConfig, result: Any) -> None:
+    proposals = result.get("final_proposals", []) or []
+    pool = result.get("pool", []) or []
+    if not proposals:
+        return
+    from poc.songset_constructor.artifacts import writer as writer_mod
+
+    narratives = writer_mod.get_cached_narratives(config.thread_id)
+    if narratives is None:
+        narratives = writer_mod.generate_brief_summaries(config, proposals)
+    console.print("[green]Proposed songsets (brief):[/green]")
+    for proposal, narrative in zip(proposals, narratives):
+        block = writer_mod.brief_summary_block(
+            proposal, config=config, pool=pool, llm_narrative=narrative
+        )
+        console.rule(f"Rank {proposal.rank}")
+        console.print("\n".join(block))
+
+
 def _run_graph_with_traces(graph: Any, input_value: Any, graph_config: dict) -> dict:
     started_at: dict[str, float] = {}
     latest_values: dict[str, Any] = {}
@@ -385,6 +404,8 @@ def construct(
     _print_output_files(paths)
     if not paths:
         _print_no_results_summary(config, result)
+    else:
+        _print_brief_summaries(config, result)
 
 
 def main() -> None:

--- a/lab/poc-scripts/tests/test_songset_constructor_artifacts.py
+++ b/lab/poc-scripts/tests/test_songset_constructor_artifacts.py
@@ -1,4 +1,17 @@
 from poc.songset_constructor.artifacts.writer import build_review_report, write_artifacts
+from poc.songset_constructor.artifacts.writer import (
+    _bottleneck_lines,
+    _deterministic_arc_narrative,
+    _diversity_metrics,
+    _diversity_summary,
+    _key_tempo_journey_line,
+    _score_warnings_line,
+    _song_overlap_matrix,
+    _song_sequence_line,
+    brief_summary_block,
+    generate_brief_summaries,
+    write_report,
+)
 from poc.songset_constructor.config import RunConfig
 from poc.songset_constructor.models import ProposalItem, ScoreBreakdown, SongsetProposal
 
@@ -127,3 +140,486 @@ def test_write_artifacts_returns_review_path(tmp_path, synthetic_pool):
 
     assert paths["review"] == str(tmp_path / "songset_review.md")
     assert (tmp_path / "songset_review.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# Deterministic helpers
+# ---------------------------------------------------------------------------
+
+
+def _item(
+    position: int,
+    title: str = "赞美主",
+    song_id: str = "s1",
+    phase: int = 1,
+    themes: list[str] | None = None,
+    bpm: float | None = 124,
+    key: str | None = "G",
+    mode: str | None = "maj",
+) -> ProposalItem:
+    return ProposalItem(
+        position=position,
+        recording_hash_prefix=f"h{position:03d}",
+        song_id=song_id,
+        title=title,
+        phase=phase,
+        themes=themes if themes is not None else ["赞美"],
+        bpm=bpm,
+        key=key,
+        mode=mode,
+    )
+
+
+def _proposal_with_items(items: list[ProposalItem], rank: int = 1) -> SongsetProposal:
+    return SongsetProposal(
+        rank=rank,
+        items=items,
+        score=ScoreBreakdown(
+            f_theme=0.850,
+            f_tempo=0.720,
+            f_harmony=0.910,
+            f_diversity=0.670,
+            total=0.7800,
+        ),
+        rationale="Balanced praise-to-thanksgiving flow.",
+        hard_constraint_warnings=["H4 relaxed"],
+    )
+
+
+def test_song_sequence_line():
+    proposal = _proposal_with_items(
+        [_item(1, "主你荣耀"), _item(2, "恩典已降临"), _item(3, "耶稣我爱祢")]
+    )
+    assert _song_sequence_line(proposal) == "1. 主你荣耀  →  2. 恩典已降临  →  3. 耶稣我爱祢"
+
+
+def test_song_sequence_line_single():
+    proposal = _proposal_with_items([_item(1, "唯一")])
+    assert _song_sequence_line(proposal) == "1. 唯一"
+
+
+def test_song_sequence_line_empty():
+    proposal = _proposal_with_items([])
+    assert _song_sequence_line(proposal) == "(no songs)"
+
+
+def test_key_tempo_journey_line_all_present():
+    proposal = _proposal_with_items(
+        [_item(1, key="C", mode="maj", bpm=76), _item(2, key="G", mode="maj", bpm=110)]
+    )
+    assert _key_tempo_journey_line(proposal) == "C maj → G maj  |  76 → 110 BPM arc"
+
+
+def test_key_tempo_journey_line_missing_key():
+    proposal = _proposal_with_items(
+        [_item(1, key=None, mode="maj", bpm=76), _item(2, key="G", mode="maj", bpm=110)]
+    )
+    assert _key_tempo_journey_line(proposal) == "? → G maj  |  76 → 110 BPM arc"
+
+
+def test_key_tempo_journey_line_missing_bpm():
+    proposal = _proposal_with_items(
+        [_item(1, key="C", mode="maj", bpm=None), _item(2, key="G", mode="maj", bpm=110)]
+    )
+    assert _key_tempo_journey_line(proposal) == "C maj → G maj  |  ? → 110 BPM arc"
+
+
+def test_key_tempo_journey_line_both_missing():
+    proposal = _proposal_with_items(
+        [_item(1, key=None, mode=None, bpm=None), _item(2, key="G", mode="maj", bpm=110)]
+    )
+    assert _key_tempo_journey_line(proposal) == "? → G maj  |  ? → 110 BPM arc"
+
+
+def test_score_warnings_line_with_warnings():
+    proposal = _proposal_with_items([_item(1)])
+    line = _score_warnings_line(proposal)
+    assert "f_theme 0.850" in line
+    assert "f_tempo 0.720" in line
+    assert "f_harmony 0.910" in line
+    assert "f_diversity 0.670" in line
+    assert "Warnings: H4 relaxed" in line
+
+
+def test_score_warnings_line_without_warnings():
+    proposal = _proposal_with_items([_item(1)])
+    proposal.hard_constraint_warnings = []
+    line = _score_warnings_line(proposal)
+    assert "Warnings: none" in line
+
+
+def test_deterministic_arc_narrative_1_3_5():
+    proposal = _proposal_with_items(
+        [
+            _item(1, phase=1, themes=["赞美"]),
+            _item(2, phase=3, themes=["敬拜"]),
+            _item(3, phase=5, themes=["差遣"]),
+        ]
+    )
+    narrative = _deterministic_arc_narrative(proposal)
+    assert "Phase 1 → 3 → 5" in narrative
+    assert "call → worship → commitment" in narrative
+    assert "赞美" in narrative
+    assert "敬拜" in narrative
+    assert "差遣" in narrative
+
+
+def test_deterministic_arc_narrative_1_4():
+    proposal = _proposal_with_items(
+        [_item(1, phase=1, themes=["赞美"]), _item(2, phase=4, themes=["奉献"])]
+    )
+    narrative = _deterministic_arc_narrative(proposal)
+    assert "Phase 1 → 4" in narrative
+    assert "call → response" in narrative
+
+
+def test_deterministic_arc_narrative_2_3_4_5():
+    proposal = _proposal_with_items(
+        [
+            _item(1, phase=2, themes=["感恩"]),
+            _item(2, phase=3, themes=["敬拜"]),
+            _item(3, phase=4, themes=["认罪"]),
+            _item(4, phase=5, themes=["差遣"]),
+        ]
+    )
+    narrative = _deterministic_arc_narrative(proposal)
+    assert "Phase 2 → 3 → 4 → 5" in narrative
+    assert "thanksgiving → worship → response → commitment" in narrative
+
+
+def test_deterministic_arc_narrative_single_phase():
+    proposal = _proposal_with_items([_item(1, phase=3, themes=["敬拜"])])
+    narrative = _deterministic_arc_narrative(proposal)
+    assert "Phase 3" in narrative
+    assert "worship" in narrative
+
+
+# ---------------------------------------------------------------------------
+# brief_summary_block
+# ---------------------------------------------------------------------------
+
+
+def test_brief_summary_block_deterministic(synthetic_pool):
+    proposal = _proposal_with_items(
+        [_item(1, "赞美主", "s1", 1, ["赞美"], 124, "G", "maj")]
+    )
+    config = RunConfig(no_llm=True, thread_id="test-block-det")
+    block = brief_summary_block(proposal, config=config, pool=synthetic_pool)
+    assert len(block) == 6
+    assert block[0] == "> **Brief Summary**"
+    assert block[1].startswith("> Songs:")
+    assert block[2].startswith("> Arc:")
+    assert "Phase 1" in block[2]
+    assert block[3].startswith("> Journey:")
+    assert block[4].startswith("> Score:")
+    assert block[5].startswith("> Rationale:")
+
+
+def test_brief_summary_block_with_llm(synthetic_pool):
+    proposal = _proposal_with_items(
+        [_item(1, "赞美主", "s1", 1, ["赞美"], 124, "G", "maj")]
+    )
+    config = RunConfig(no_llm=True, thread_id="test-block-llm")
+    llm_text = "Opens with an uplifting call, settles into intimate adoration."
+    block = brief_summary_block(
+        proposal, config=config, pool=synthetic_pool, llm_narrative=llm_text
+    )
+    assert block[2] == f"> Arc: {llm_text}"
+    assert block[1].startswith("> Songs:")
+    assert block[3].startswith("> Journey:")
+    assert block[4].startswith("> Score:")
+    assert block[5].startswith("> Rationale:")
+
+
+# ---------------------------------------------------------------------------
+# generate_brief_summaries
+# ---------------------------------------------------------------------------
+
+
+def test_generate_brief_summaries_no_llm(synthetic_pool):
+    proposals = [_proposal(), _proposal()]
+    config = RunConfig(no_llm=True, thread_id="test-no-llm")
+    narratives = generate_brief_summaries(config, proposals)
+    assert len(narratives) == 2
+    assert all("Phase" in n for n in narratives)
+
+
+def test_generate_brief_summaries_single_proposal(synthetic_pool):
+    proposals = [_proposal()]
+    config = RunConfig(no_llm=False, thread_id="test-single", llm_model="test-model")
+    narratives = generate_brief_summaries(config, proposals)
+    assert len(narratives) == 1
+    assert "Phase" in narratives[0]
+
+
+def test_generate_brief_summaries_llm_success(monkeypatch, synthetic_pool):
+    monkeypatch.setenv("SOW_LLM_API_KEY", "test-key")
+    monkeypatch.setenv("SOW_LLM_MODEL", "test-model")
+    proposals = [
+        _proposal_with_items(
+            [_item(1, "赞美主", "s1", 1, ["赞美"], 124, "G", "maj")]
+        ),
+        _proposal_with_items(
+            [_item(1, "感恩的心", "s2", 2, ["感恩"], 112, "D", "maj")]
+        ),
+        _proposal_with_items(
+            [_item(1, "跟随主", "s3", 5, ["跟随"], 78, "B", "min")]
+        ),
+    ]
+    config = RunConfig(no_llm=False, thread_id="test-llm-success")
+
+    class FakeChat:
+        def invoke(self, prompt):
+            assert "---PROPOSAL 1---" in prompt
+            assert "---PROPOSAL 2---" in prompt
+            assert "---PROPOSAL 3---" in prompt
+            return (
+                "<<<SUMMARY 1>>>\n"
+                "Opens with praise. Settles into worship.\n"
+                "<<<END SUMMARY 1>>>\n"
+                "<<<SUMMARY 2>>>\n"
+                "Thanksgiving theme. Gentle tempo.\n"
+                "<<<END SUMMARY 2>>>\n"
+                "<<<SUMMARY 3>>>\n"
+                "Commitment and following. Reflective close.\n"
+                "<<<END SUMMARY 3>>>"
+            )
+
+    import poc.songset_constructor.graph.llm as llm_mod
+
+    monkeypatch.setattr(llm_mod, "build_chat_model", lambda _config: FakeChat())
+    narratives = generate_brief_summaries(config, proposals)
+    assert len(narratives) == 3
+    assert "Opens with praise" in narratives[0]
+    assert "Thanksgiving theme" in narratives[1]
+    assert "Commitment and following" in narratives[2]
+
+
+def test_generate_brief_summaries_llm_malformed(monkeypatch, synthetic_pool):
+    monkeypatch.setenv("SOW_LLM_API_KEY", "test-key")
+    monkeypatch.setenv("SOW_LLM_MODEL", "test-model")
+    proposals = [
+        _proposal_with_items([_item(1, "赞美主", "s1", 1)]),
+        _proposal_with_items([_item(1, "感恩的心", "s2", 2)]),
+        _proposal_with_items([_item(1, "跟随主", "s3", 5)]),
+    ]
+    config = RunConfig(no_llm=False, thread_id="test-llm-malformed")
+
+    class FakeChat:
+        def invoke(self, _prompt):
+            return "This is garbage without delimiters."
+
+    import poc.songset_constructor.graph.llm as llm_mod
+
+    monkeypatch.setattr(llm_mod, "build_chat_model", lambda _config: FakeChat())
+    narratives = generate_brief_summaries(config, proposals)
+    assert len(narratives) == 3
+    assert all("Phase" in n for n in narratives)
+
+
+def test_generate_brief_summaries_llm_wrong_count(monkeypatch, synthetic_pool):
+    monkeypatch.setenv("SOW_LLM_API_KEY", "test-key")
+    monkeypatch.setenv("SOW_LLM_MODEL", "test-model")
+    proposals = [
+        _proposal_with_items([_item(1, "赞美主", "s1", 1)]),
+        _proposal_with_items([_item(1, "感恩的心", "s2", 2)]),
+        _proposal_with_items([_item(1, "跟随主", "s3", 5)]),
+    ]
+    config = RunConfig(no_llm=False, thread_id="test-llm-wrong-count")
+
+    class FakeChat:
+        def invoke(self, _prompt):
+            return (
+                "<<<SUMMARY 1>>>\nFirst.\n<<<END SUMMARY 1>>>\n"
+                "<<<SUMMARY 2>>>\nSecond.\n<<<END SUMMARY 2>>>"
+            )
+
+    import poc.songset_constructor.graph.llm as llm_mod
+
+    monkeypatch.setattr(llm_mod, "build_chat_model", lambda _config: FakeChat())
+    narratives = generate_brief_summaries(config, proposals)
+    assert len(narratives) == 3
+    assert all("Phase" in n for n in narratives)
+
+
+def test_generate_brief_summaries_llm_exception(monkeypatch, synthetic_pool):
+    monkeypatch.setenv("SOW_LLM_API_KEY", "test-key")
+    monkeypatch.setenv("SOW_LLM_MODEL", "test-model")
+    proposals = [
+        _proposal_with_items([_item(1, "赞美主", "s1", 1)]),
+        _proposal_with_items([_item(1, "感恩的心", "s2", 2)]),
+    ]
+    config = RunConfig(no_llm=False, thread_id="test-llm-exception")
+
+    class BrokenChat:
+        def invoke(self, _prompt):
+            raise RuntimeError("boom")
+
+    import poc.songset_constructor.graph.llm as llm_mod
+
+    monkeypatch.setattr(llm_mod, "build_chat_model", lambda _config: BrokenChat())
+    narratives = generate_brief_summaries(config, proposals)
+    assert len(narratives) == 2
+    assert all("Phase" in n for n in narratives)
+
+
+# ---------------------------------------------------------------------------
+# Diversity Summary
+# ---------------------------------------------------------------------------
+
+
+def test_diversity_summary_empty(synthetic_pool):
+    assert _diversity_summary([], synthetic_pool) == []
+
+
+def test_diversity_summary_single(synthetic_pool):
+    proposal = _proposal_with_items([_item(1, "赞美主", "s1", 1)])
+    assert _diversity_summary([proposal], synthetic_pool) == []
+
+
+def test_diversity_summary_three_overlapping(synthetic_pool):
+    proposals = [
+        _proposal_with_items(
+            [
+                _item(1, "赞美主", "s1", 1, ["赞美"], 124, "G", "maj"),
+                _item(2, "感恩的心", "s2", 2, ["感恩"], 112, "D", "maj"),
+                _item(3, "跟随主", "s5", 5, ["跟随"], 78, "B", "min"),
+            ],
+            rank=1,
+        ),
+        _proposal_with_items(
+            [
+                _item(1, "赞美主", "s1", 1, ["赞美"], 124, "G", "maj"),
+                _item(2, "敬拜你", "s3", 3, ["敬拜"], 98, "A", "maj"),
+                _item(3, "跟随主", "s5", 5, ["跟随"], 78, "B", "min"),
+            ],
+            rank=2,
+        ),
+        _proposal_with_items(
+            [
+                _item(1, "赞美主", "s1", 1, ["赞美"], 124, "G", "maj"),
+                _item(2, "十字架", "s4", 4, ["十字架"], 86, "E", "min"),
+                _item(3, "复兴", "s6", 5, ["复兴"], 82, "F#", "min"),
+            ],
+            rank=3,
+        ),
+    ]
+    lines = _diversity_summary(proposals, synthetic_pool)
+    text = "\n".join(lines)
+    assert "## Diversity Summary" in text
+    assert "Across 3 proposals (9 song slots total):" in text
+    assert "Unique songs" in text
+    assert "Unique themes" in text
+    assert "Unique composers" in text
+    assert "Unique phases" in text
+    assert "Middle-song reuse" in text
+    assert "### Song Overlap Matrix" in text
+    assert "### Song Frequency" in text
+    assert "### Theme Coverage" in text
+    assert "### Bottlenecks" in text
+    assert "赞美主" in text
+
+
+def test_song_overlap_matrix_symmetric():
+    proposals = [
+        _proposal_with_items(
+            [_item(1, "A", "s1"), _item(2, "B", "s2"), _item(3, "C", "s3")]
+        ),
+        _proposal_with_items(
+            [_item(1, "A", "s1"), _item(2, "D", "s4"), _item(3, "E", "s5")]
+        ),
+        _proposal_with_items(
+            [_item(1, "A", "s1"), _item(2, "B", "s2"), _item(3, "F", "s6")]
+        ),
+    ]
+    matrix = _song_overlap_matrix(proposals)
+    assert "R1" in matrix[0]
+    assert "R2" in matrix[0]
+    assert "R3" in matrix[0]
+    assert "—" in matrix[2]
+    assert "—" in matrix[3]
+    assert "—" in matrix[4]
+    cell_12 = matrix[2].split("|")[3].strip()
+    cell_21 = matrix[3].split("|")[2].strip()
+    assert cell_12 == cell_21
+
+
+def test_bottleneck_lines_none(synthetic_pool):
+    proposals = [
+        _proposal_with_items(
+            [
+                _item(1, "赞美主", "s1", 1, ["赞美"]),
+                _item(2, "感恩的心", "s2", 2, ["感恩"]),
+                _item(3, "敬拜你", "s3", 3, ["敬拜"]),
+            ]
+        ),
+        _proposal_with_items(
+            [
+                _item(1, "十字架", "s4", 4, ["十字架"]),
+                _item(2, "跟随主", "s5", 5, ["跟随"]),
+                _item(3, "复兴", "s6", 5, ["复兴"]),
+            ]
+        ),
+    ]
+    metrics = _diversity_metrics(proposals, synthetic_pool)
+    lines = _bottleneck_lines(metrics, proposals, synthetic_pool)
+    assert lines == []
+
+
+# ---------------------------------------------------------------------------
+# End-to-End write_report
+# ---------------------------------------------------------------------------
+
+
+def test_write_report_with_summary(tmp_path, synthetic_pool):
+    proposals = [
+        _proposal_with_items(
+            [
+                _item(1, "赞美主", "s1", 1, ["赞美"], 124, "G", "maj"),
+                _item(2, "感恩的心", "s2", 2, ["感恩"], 112, "D", "maj"),
+                _item(3, "跟随主", "s5", 5, ["跟随"], 78, "B", "min"),
+            ],
+            rank=1,
+        ),
+        _proposal_with_items(
+            [
+                _item(1, "赞美主", "s1", 1, ["赞美"], 124, "G", "maj"),
+                _item(2, "敬拜你", "s3", 3, ["敬拜"], 98, "A", "maj"),
+                _item(3, "复兴", "s6", 5, ["复兴"], 82, "F#", "min"),
+            ],
+            rank=2,
+        ),
+        _proposal_with_items(
+            [
+                _item(1, "赞美主", "s1", 1, ["赞美"], 124, "G", "maj"),
+                _item(2, "十字架", "s4", 4, ["十字架"], 86, "E", "min"),
+                _item(3, "跟随主", "s5", 5, ["跟随"], 78, "B", "min"),
+            ],
+            rank=3,
+        ),
+    ]
+    config = RunConfig(no_llm=True, output_dir=tmp_path, thread_id="test-report")
+    report_path = tmp_path / "proposal_report.md"
+    write_report(report_path, config=config, proposals=proposals, pool=synthetic_pool)
+    content = report_path.read_text(encoding="utf-8")
+    assert "> **Brief Summary**" in content
+    assert "> Songs:" in content
+    assert "> Arc:" in content
+    assert "> Journey:" in content
+    assert "> Score:" in content
+    assert "### Details" in content
+    assert "## Diversity Summary" in content
+
+
+def test_write_report_returns_narratives(tmp_path, synthetic_pool):
+    proposals = [
+        _proposal_with_items([_item(1, "赞美主", "s1", 1)]),
+        _proposal_with_items([_item(1, "感恩的心", "s2", 2)]),
+    ]
+    config = RunConfig(no_llm=True, output_dir=tmp_path, thread_id="test-narratives")
+    report_path = tmp_path / "proposal_report.md"
+    narratives = write_report(
+        report_path, config=config, proposals=proposals, pool=synthetic_pool
+    )
+    assert isinstance(narratives, list)
+    assert len(narratives) == len(proposals)

--- a/ops/admin-cli/src/stream_of_worship/admin/commands/audio.py
+++ b/ops/admin-cli/src/stream_of_worship/admin/commands/audio.py
@@ -1462,19 +1462,53 @@ def show_recording(
 
 @app.command("set-visibility")
 def set_visibility(
-    song_id: str = typer.Argument(..., help="Song ID to update visibility for"),
+    song_id: Optional[str] = typer.Argument(
+        None, help="Song ID to update visibility for (omit when using --stdin)"
+    ),
     status: str = typer.Option(
         ..., "--status", "-s", help="Visibility status (published|review|hold)"
     ),
+    stdin: bool = typer.Option(
+        False,
+        "--stdin",
+        help="Read song IDs from stdin (one per line). "
+        "Use for batch: cat songids.txt | sow-admin audio set-visibility --status published --stdin",
+    ),
     config_path: Optional[Path] = typer.Option(None, "--config", "-c", help="Path to config file"),
 ) -> None:
-    """Set the visibility status for a recording.
+    """Set the visibility status for one or more recordings.
 
     Controls whether a recording appears in the User App browse list.
     - published: Visible to users (auto-set when LRC completes)
     - review: Hidden, needs manual review
     - hold: Hidden, on hold
+
+    Batch mode: pass --stdin to read song IDs from stdin (one per line).
+    Blank lines and lines starting with '#' are ignored.
     """
+    # Validate status early
+    valid_statuses = {"published", "review", "hold"}
+    if status not in valid_statuses:
+        console.print(
+            f"[red]Invalid status: {status}. Must be one of: {', '.join(valid_statuses)}[/red]"
+        )
+        raise typer.Exit(1)
+
+    # Resolve the list of song IDs
+    if stdin:
+        raw = sys.stdin.read().splitlines()
+        song_ids = [line.strip() for line in raw if line.strip() and not line.strip().startswith("#")]
+        if not song_ids:
+            console.print("[red]No song IDs read from stdin (expected one per line)[/red]")
+            raise typer.Exit(1)
+    elif song_id is None:
+        console.print(
+            "[red]A song ID is required, or use --stdin to read IDs from stdin[/red]"
+        )
+        raise typer.Exit(1)
+    else:
+        song_ids = [song_id]
+
     # Standard config/db boilerplate
     try:
         config = AdminConfig.load(config_path)
@@ -1484,31 +1518,37 @@ def set_visibility(
 
     db_client = get_db_client(config)
 
-    # Look up recording by song_id
-    recording = db_client.get_recording_by_song_id(song_id)
-    if not recording:
-        console.print(
-            f"[red]No recording found for {song_id}. "
-            f"Run 'sow-admin audio download {song_id}' first.[/red]"
-        )
-        raise typer.Exit(1)
+    # Process each song ID
+    succeeded: list[str] = []
+    failed: list[tuple[str, str]] = []
 
-    # Validate status
-    valid_statuses = {"published", "review", "hold"}
-    if status not in valid_statuses:
-        console.print(
-            f"[red]Invalid status: {status}. Must be one of: {', '.join(valid_statuses)}[/red]"
-        )
-        raise typer.Exit(1)
+    for sid in song_ids:
+        recording = db_client.get_recording_by_song_id(sid)
+        if not recording:
+            msg = f"No recording found (run 'sow-admin audio download {sid}' first)"
+            console.print(f"[red]{sid}: {msg}[/red]")
+            failed.append((sid, msg))
+            continue
 
-    # Update visibility
-    try:
-        db_client.update_recording_visibility(recording.hash_prefix, status)
+        try:
+            db_client.update_recording_visibility(recording.hash_prefix, status)
+            console.print(f"[green]{sid}: Updated visibility to {_colorize_visibility(status)}[/green]")
+            succeeded.append(sid)
+        except ValueError as e:
+            console.print(f"[red]{sid}: {e}[/red]")
+            failed.append((sid, str(e)))
+
+    # Summary for batch mode
+    if len(song_ids) > 1:
         console.print(
-            f"[green]Updated visibility for {song_id}: {_colorize_visibility(status)}[/green]"
+            f"\n[bold]Summary:[/bold] {len(succeeded)} succeeded, {len(failed)} failed"
         )
-    except ValueError as e:
-        console.print(f"[red]Error: {e}[/red]")
+        if failed:
+            console.print("[red]Failed:[/red]")
+            for sid, msg in failed:
+                console.print(f"  - {sid}: {msg}")
+            raise typer.Exit(1)
+    elif failed:
         raise typer.Exit(1)
 
 

--- a/ops/admin-cli/src/stream_of_worship/admin/commands/audio.py
+++ b/ops/admin-cli/src/stream_of_worship/admin/commands/audio.py
@@ -1213,7 +1213,7 @@ def list_recordings(
         "album",
         "--sort",
         "-s",
-        help="Sort order (album|series|title|imported)",
+        help="Sort order (album|series|title|imported|updated)",
     ),
     format: str = typer.Option("table", "--format", "-f", help="Output format (table|ids)"),
     limit: Optional[int] = typer.Option(None, "--limit", "-l", help="Maximum number of results"),
@@ -1251,7 +1251,7 @@ def list_recordings(
             raise typer.Exit(1)
 
     # Validate sort option
-    valid_sorts = {"album", "series", "title", "imported"}
+    valid_sorts = {"album", "series", "title", "imported", "updated"}
     if sort not in valid_sorts:
         console.print(
             f"[red]Invalid sort option: {sort}. Choose from: {', '.join(sorted(valid_sorts))}[/red]"
@@ -1311,6 +1311,8 @@ def list_recordings(
         table.add_column("Song ID", style="dim", no_wrap=True)
         table.add_column("Filename", style="yellow")
         table.add_column("Hash Prefix", style="dim", no_wrap=True)
+        if sort == "updated":
+            table.add_column("Updated", style="dim", no_wrap=True)
 
         for rec, song_title, album_name, _album_series in enriched:
             song_id = rec.song_id or "-"
@@ -1340,6 +1342,7 @@ def list_recordings(
                 song_id,
                 rec.original_filename,
                 rec.hash_prefix,
+                rec.updated_at[:16] if sort == "updated" and rec.updated_at else "",
             )
 
         console.print(table)

--- a/ops/admin-cli/src/stream_of_worship/admin/commands/recover_visibility.py
+++ b/ops/admin-cli/src/stream_of_worship/admin/commands/recover_visibility.py
@@ -111,9 +111,23 @@ def _get_db_client(config: AdminConfig) -> DatabaseClient:
     return DatabaseClient(provider)
 
 
+def _to_iso_str(value: Any) -> Optional[str]:
+    """Normalize a datetime-or-string value to an ISO-format string.
+
+    psycopg returns `datetime` objects for TIMESTAMP columns, and boto3 returns
+    `datetime` for R2 LastModified. Rich's Table and CSV writer require strings,
+    so this helper guarantees a string (or None) for downstream consumers.
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value)
+
+
 def _parse_iso_datetime(s) -> Optional[datetime]:
     """Parse an ISO-format datetime string or datetime object to a timezone-aware UTC datetime."""
-    if s is None:
+    if not s:
         return None
     if isinstance(s, datetime):
         dt = s
@@ -230,7 +244,7 @@ def _run_report(
         for row in db_rows:
             rec = dict(zip(columns, row))
             hash_prefix = rec["hash_prefix"]
-            db_updated_at_str = rec["db_updated_at"]
+            db_updated_at_str = _to_iso_str(rec["db_updated_at"])
             db_updated_at = _parse_iso_datetime(db_updated_at_str)
             identity = r2_identities.get(hash_prefix, R2ObjectIdentity(exists=False))
             r2_last_modified_str = identity.last_modified if identity.exists else None
@@ -251,7 +265,7 @@ def _run_report(
     for idx, row in enumerate(db_rows):
         rec = dict(zip(columns, row))
         hash_prefix = rec["hash_prefix"]
-        db_updated_at_str = rec["db_updated_at"]
+        db_updated_at_str = _to_iso_str(rec["db_updated_at"])
         db_updated_at = _parse_iso_datetime(db_updated_at_str)
 
         # R2 lookup from batch result

--- a/ops/admin-cli/src/stream_of_worship/admin/commands/recover_visibility.py
+++ b/ops/admin-cli/src/stream_of_worship/admin/commands/recover_visibility.py
@@ -14,9 +14,10 @@ Usage:
 import csv
 import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from pathlib import Path
 from typing import Any, Optional
+from dataclasses import dataclass
 
 import typer
 from rich.console import Console
@@ -157,6 +158,7 @@ def _build_candidate_query(
         SELECT r.hash_prefix, r.song_id, r.lrc_job_id, r.r2_lrc_url,
                r.visibility_status, r.lrc_status,
                r.updated_at AS db_updated_at, r.imported_at,
+               r.analysis_job_id, r.key_detected_at,
                s.title AS song_title, s.album_name AS song_album
         FROM recordings r
         LEFT JOIN songs s ON r.song_id = s.id
@@ -185,17 +187,101 @@ def _build_candidate_query(
     return query, params
 
 
-def _compute_verdict(delta_hours: float, min_h: float, max_h: float) -> tuple[str, str]:
-    """Compute verdict and recommendation based on delta hours.
+@dataclass
+class CandidateSignals:
+    db_updated_at: Optional[datetime]
+    r2_lm: Optional[datetime]
+    lrc_job_done: Optional[datetime]   # None if --with-analysis off OR job purged
+    analyze_job_done: Optional[datetime]
+    key_detected_at: Optional[datetime]
+    with_analysis: bool
+    bump_tolerance_s: float
+
+
+def _compute_verdict(sig: CandidateSignals) -> tuple[str, str, dict[str, Any]]:
+    """Compute verdict and recommendation based on new signal model.
 
     Returns:
-        (verdict, recommendation) tuple
+        (verdict, recommendation, debug_notes)
     """
-    if abs(delta_hours) <= 0.1:
-        return ("OK_FRESH_LRC", "—")
-    if min_h <= delta_hours <= max_h:
-        return ("SUSPECTED_BUG_REVERT", "set-visibility published")
-    return ("INCONCLUSIVE", "—")
+    # Informational deltas
+    delta_h = 0.0
+    if sig.db_updated_at and sig.r2_lm:
+        delta_h = (sig.db_updated_at - sig.r2_lm).total_seconds() / 3600.0
+
+    # OK_FRESH_LRC: abs(delta_h) <= 0.1 (kept from v1)
+    if abs(delta_h) <= 0.1:
+        return "OK_FRESH_LRC", "—", {"delta_h": delta_h}
+
+    # Analyze bump detection
+    analyze_bump = False
+    bump_source = "none"
+
+    if sig.analyze_job_done and sig.db_updated_at:
+        if abs((sig.db_updated_at - sig.analyze_job_done).total_seconds()) <= sig.bump_tolerance_s:
+            analyze_bump = True
+            bump_source = "analysis_job"
+    elif sig.key_detected_at and sig.db_updated_at:
+        if abs((sig.db_updated_at - sig.key_detected_at).total_seconds()) <= sig.bump_tolerance_s:
+            analyze_bump = True
+            bump_source = "key_detected_at"
+
+    # Manual edit check: r2_lm > lrc_job_done
+    manual_edit_after_autogen = "unknown"
+    if sig.with_analysis and sig.lrc_job_done and sig.r2_lm:
+        if sig.r2_lm > sig.lrc_job_done:
+            manual_edit_after_autogen = "yes"
+        else:
+            manual_edit_after_autogen = "no"
+
+    # Verdict Matrix
+    if not sig.r2_lm or not sig.db_updated_at:
+        return "INCONCLUSIVE", "eyes-on", {
+            "delta_h": delta_h,
+            "analyze_bump": analyze_bump,
+            "bump_source": bump_source,
+            "manual_edit_after_autogen": manual_edit_after_autogen,
+        }
+
+    if manual_edit_after_autogen == "yes" and analyze_bump:
+        return "SUSPECTED_BUG_REVERT", "set-visibility published", {
+            "delta_h": delta_h,
+            "analyze_bump": analyze_bump,
+            "bump_source": bump_source,
+            "manual_edit_after_autogen": manual_edit_after_autogen,
+        }
+
+    if manual_edit_after_autogen == "yes" and not analyze_bump:
+        # This is the "smoking gun" from v1, but still a bug revert
+        return "SUSPECTED_BUG_REVERT", "set-visibility published", {
+            "delta_h": delta_h,
+            "analyze_bump": analyze_bump,
+            "bump_source": bump_source,
+            "manual_edit_after_autogen": manual_edit_after_autogen,
+        }
+
+    if analyze_bump and manual_edit_after_autogen == "unknown":
+        return "SUSPECTED_POST_ANALYZE", "needs --with-analysis to resolve", {
+            "delta_h": delta_h,
+            "analyze_bump": analyze_bump,
+            "bump_source": bump_source,
+            "manual_edit_after_autogen": manual_edit_after_autogen,
+        }
+
+    if analyze_bump and manual_edit_after_autogen == "no":
+        return "NO_SIGNAL_POST_ANALYZE", "likely not bug-reverted", {
+            "delta_h": delta_h,
+            "analyze_bump": analyze_bump,
+            "bump_source": bump_source,
+            "manual_edit_after_autogen": manual_edit_after_autogen,
+        }
+
+    return "INCONCLUSIVE", "eyes-on", {
+        "delta_h": delta_h,
+        "analyze_bump": analyze_bump,
+        "bump_source": bump_source,
+        "manual_edit_after_autogen": manual_edit_after_autogen,
+    }
 
 
 def _run_report(
@@ -206,6 +292,7 @@ def _run_report(
     min_delta_hours: float,
     max_delta_hours: float,
     with_analysis: bool,
+    bump_tolerance_s: float,
 ) -> list[dict[str, Any]]:
     """Run the dry-run report and return rows as dicts."""
     db_client = _get_db_client(config)
@@ -238,29 +325,21 @@ def _run_report(
     hash_prefixes = [dict(zip(columns, row))["hash_prefix"] for row in db_rows]
     r2_identities = _batch_lookup_r2(r2_client, hash_prefixes)
 
-    # Collect SUSPECTED_BUG_REVERT job IDs for batch analysis lookup
-    suspect_job_ids: list[str] = []
+    # Collect both LRC and Analysis job IDs for batch analysis lookup
+    all_job_ids: set[str] = set()
     if with_analysis and analysis_client:
         for row in db_rows:
             rec = dict(zip(columns, row))
-            hash_prefix = rec["hash_prefix"]
-            db_updated_at_str = _to_iso_str(rec["db_updated_at"])
-            db_updated_at = _parse_iso_datetime(db_updated_at_str)
-            identity = r2_identities.get(hash_prefix, R2ObjectIdentity(exists=False))
-            r2_last_modified_str = identity.last_modified if identity.exists else None
-            if r2_last_modified_str and db_updated_at:
-                r2_last_modified = _parse_iso_datetime(r2_last_modified_str)
-                if r2_last_modified:
-                    delta_hours = (db_updated_at - r2_last_modified).total_seconds() / 3600.0
-                    v, _ = _compute_verdict(delta_hours, min_delta_hours, max_delta_hours)
-                    if v == "SUSPECTED_BUG_REVERT":
-                        lrc_job_id = rec.get("lrc_job_id")
-                        if lrc_job_id:
-                            suspect_job_ids.append(lrc_job_id)
+            lrc_jid = rec.get("lrc_job_id")
+            analysis_jid = rec.get("analysis_job_id")
+            if lrc_jid:
+                all_job_ids.add(lrc_jid)
+            if analysis_jid:
+                all_job_ids.add(analysis_jid)
 
     analysis_results: dict[str, tuple[Optional[str], Optional[str]]] = {}
-    if with_analysis and analysis_client and suspect_job_ids:
-        analysis_results = _batch_lookup_analysis(analysis_client, suspect_job_ids)
+    if with_analysis and analysis_client and all_job_ids:
+        analysis_results = _batch_lookup_analysis(analysis_client, list(all_job_ids))
 
     for idx, row in enumerate(db_rows):
         rec = dict(zip(columns, row))
@@ -271,41 +350,52 @@ def _run_report(
         # R2 lookup from batch result
         identity = r2_identities.get(hash_prefix, R2ObjectIdentity(exists=False))
         r2_last_modified_str: Optional[str] = None
-        r2_missing = not identity.exists
         if identity.exists and identity.last_modified:
             r2_last_modified_str = identity.last_modified
 
+        r2_last_modified = _parse_iso_datetime(r2_last_modified_str) if r2_last_modified_str else None
+
+        # Resolve Analysis Job timestamps
+        lrc_job_done = None
+        analysis_job_done = None
+        if with_analysis and analysis_client:
+            # LRC job
+            lrc_jid = rec.get("lrc_job_id")
+            if lrc_jid and lrc_jid in analysis_results:
+                lrc_job_done_str, _ = analysis_results[lrc_jid]
+                lrc_job_done = _parse_iso_datetime(lrc_job_done_str)
+            # Analysis job
+            ana_jid = rec.get("analysis_job_id")
+            if ana_jid and ana_jid in analysis_results:
+                ana_job_done_str, _ = analysis_results[ana_jid]
+                analysis_job_done = _parse_iso_datetime(ana_job_done_str)
+
+        # DB timestamp
+        key_detected_at_str = _to_iso_str(rec.get("key_detected_at"))
+        key_detected_at = _parse_iso_datetime(key_detected_at_str) if key_detected_at_str else None
+
         # Compute verdict
-        if r2_missing or db_updated_at is None:
-            verdict = "INCONCLUSIVE"
-            recommendation = "R2 file missing or DB timestamp invalid"
-            delta_hours = float("nan")
-        else:
-            r2_last_modified = _parse_iso_datetime(r2_last_modified_str)
-            if r2_last_modified is None:
-                verdict = "INCONCLUSIVE"
-                recommendation = "Could not parse R2 LastModified"
-                delta_hours = float("nan")
-            else:
-                delta_seconds = (db_updated_at - r2_last_modified).total_seconds()
-                delta_hours = delta_seconds / 3600.0
-                verdict, recommendation = _compute_verdict(delta_hours, min_delta_hours, max_delta_hours)
+        sig = CandidateSignals(
+            db_updated_at=db_updated_at,
+            r2_lm=r2_last_modified,
+            lrc_job_done=lrc_job_done,
+            analyze_job_done=analysis_job_done,
+            key_detected_at=key_detected_at,
+            with_analysis=with_analysis,
+            bump_tolerance_s=bump_tolerance_s,
+        )
+        verdict, recommendation, notes = _compute_verdict(sig)
 
-        # Analysis service cross-check from batch result
-        job_completed_at_str: Optional[str] = None
-        job_note: Optional[str] = None
-        if with_analysis and analysis_client and verdict == "SUSPECTED_BUG_REVERT":
-            lrc_job_id = rec.get("lrc_job_id")
-            if lrc_job_id and lrc_job_id in analysis_results:
-                job_completed_at_str, job_note = analysis_results[lrc_job_id]
-            elif lrc_job_id:
-                job_note = "no lrc_job_id"
-
+        # Display conversions
         db_updated_at_display = ""
         if db_updated_at is not None:
             db_updated_at_display = db_updated_at.strftime("%Y-%m-%d %H:%M:%S UTC")
         elif isinstance(db_updated_at_str, str):
             db_updated_at_display = db_updated_at_str
+
+        analyze_job_done_display = ""
+        if analysis_job_done:
+            analyze_job_done_display = analysis_job_done.strftime("%Y-%m-%d %H:%M:%S UTC")
 
         rows.append({
             "hash_prefix": hash_prefix,
@@ -314,10 +404,15 @@ def _run_report(
             "title": rec.get("song_title") or "",
             "db_updated_at": db_updated_at_display,
             "r2_last_modified": r2_last_modified_str or "",
-            "delta_h": round(delta_hours, 2) if not (isinstance(delta_hours, float) and delta_hours != delta_hours) else "",
+            "delta_h": notes.get("delta_h", 0.0),
             "lrc_job_id": rec.get("lrc_job_id") or "",
-            "job_completed_at": job_completed_at_str or "",
-            "job_note": job_note or "",
+            "analyze_job_id": rec.get("analysis_job_id") or "",
+            "key_detected_at": key_detected_at_str or "",
+            "analyze_job_done": analyze_job_done_display,
+            "job_completed_at": _to_iso_str(lrc_job_done) if lrc_job_done else "",
+            "analyze_bump": notes.get("analyze_bump", "unknown"),
+            "bump_source": notes.get("bump_source", "none"),
+            "manual_edit_after_autogen": notes.get("manual_edit_after_autogen", "unknown"),
             "verdict": verdict,
             "recommendation": recommendation,
         })
@@ -335,16 +430,18 @@ def _print_table(rows: list[dict[str, Any]]) -> None:
     table.add_column("album", style="white", max_width=20)
     table.add_column("db_updated_at", style="dim", width=24)
     table.add_column("r2_last_modified", style="dim", width=24)
-    table.add_column("delta_h", style="yellow", width=8, justify="right")
-    table.add_column("lrc_job_id", style="dim", width=14)
-    table.add_column("job_completed_at", style="dim", width=24)
-    table.add_column("verdict", style="bold", width=18)
-    table.add_column("recommendation", style="green", max_width=24)
+    table.add_column("delta_h", style="dim", width=8, justify="right")
+    table.add_column("analyze_bump", style="dim", width=10)
+    table.add_column("manual_edit", style="dim", width=10)
+    table.add_column("verdict", style="bold", width=22)
+    table.add_column("recommendation", style="green", max_width=26)
 
     for row in rows:
         verdict_style = {
             "SUSPECTED_BUG_REVERT": "red",
             "OK_FRESH_LRC": "green",
+            "SUSPECTED_POST_ANALYZE": "yellow",
+            "NO_SIGNAL_POST_ANALYZE": "dim",
             "INCONCLUSIVE": "yellow",
         }.get(row["verdict"], "white")
 
@@ -355,9 +452,9 @@ def _print_table(rows: list[dict[str, Any]]) -> None:
             row["album"][:18] if len(row["album"]) > 18 else row["album"],
             row["db_updated_at"],
             row["r2_last_modified"],
-            str(row["delta_h"]) if row["delta_h"] != "" else "",
-            row["lrc_job_id"],
-            row["job_completed_at"],
+            f"{row['delta_h']:.2f}" if isinstance(row["delta_h"], float) else str(row["delta_h"]),
+            str(row["analyze_bump"]),
+            str(row["manual_edit_after_autogen"]),
             f"[{verdict_style}]{row['verdict']}[/{verdict_style}]",
             row["recommendation"],
         )
@@ -367,13 +464,17 @@ def _print_table(rows: list[dict[str, Any]]) -> None:
     # Summary
     total = len(rows)
     suspect_count = sum(1 for r in rows if r["verdict"] == "SUSPECTED_BUG_REVERT")
+    post_analyze_count = sum(1 for r in rows if r["verdict"] == "SUSPECTED_POST_ANALYZE")
     ok_count = sum(1 for r in rows if r["verdict"] == "OK_FRESH_LRC")
+    no_signal_count = sum(1 for r in rows if r["verdict"] == "NO_SIGNAL_POST_ANALYZE")
     inconclusive_count = sum(1 for r in rows if r["verdict"] == "INCONCLUSIVE")
 
     console.print(Panel(
         f"[cyan]Total candidates:[/cyan] {total}  |  "
         f"[red]SUSPECTED_BUG_REVERT:[/red] {suspect_count}  |  "
+        f"[yellow]SUSPECTED_POST_ANALYZE:[/yellow] {post_analyze_count}  |  "
         f"[green]OK_FRESH_LRC:[/green] {ok_count}  |  "
+        f"[dim]NO_SIGNAL_POST_ANALYZE:[/dim] {no_signal_count}  |  "
         f"[yellow]INCONCLUSIVE:[/yellow] {inconclusive_count}",
         border_style="cyan",
     ))
@@ -383,14 +484,20 @@ def _print_table(rows: list[dict[str, Any]]) -> None:
         console.print("[yellow]Recommendation:[/yellow] Review SUSPECTED_BUG_REVERT rows and run:")
         console.print("  [dim]sow-admin audio set-visibility <song_id> published[/dim]")
 
+    if post_analyze_count > 0:
+        console.print()
+        console.print("[yellow]Note:[/yellow] Re-run with `--with-analysis` to resolve `SUSPECTED_POST_ANALYZE` rows.")
+
 
 def _print_csv(rows: list[dict[str, Any]]) -> None:
     """Print rows as CSV to stdout."""
     fieldnames = [
         "hash_prefix", "song_id", "album", "title",
         "db_updated_at", "r2_last_modified", "delta_h",
-        "lrc_job_id", "job_completed_at", "verdict",
-        "recommendation", "job_note",
+        "lrc_job_id", "analyze_job_id", "key_detected_at",
+        "analyze_job_done", "job_completed_at", "analyze_bump",
+        "bump_source", "manual_edit_after_autogen", "verdict",
+        "recommendation",
     ]
     writer = csv.DictWriter(sys.stdout, fieldnames=fieldnames, extrasaction="ignore")
     writer.writeheader()
@@ -407,6 +514,7 @@ def main(
     with_analysis: bool = typer.Option(False, "--with-analysis", "-A", help="Cross-check with analysis service job timestamps"),
     csv_output: bool = typer.Option(False, "--csv", "-c", help="Output as CSV instead of Rich table"),
     config_path: Optional[Path] = typer.Option(None, "--config", "-C", help="Path to config file"),
+    bump_tolerance_seconds: float = typer.Option(60.0, "--bump-tolerance-seconds", help="Tolerance in seconds for detect analyze-bump"),
 ) -> None:
     """Identify recordings whose visibility_status was reverted by the audio-batch bug.
 
@@ -435,7 +543,7 @@ def main(
     console.print()
 
     try:
-        rows = _run_report(config, since, until, album, min_delta_hours, max_delta_hours, with_analysis)
+        rows = _run_report(config, since, until, album, min_delta_hours, max_delta_hours, with_analysis, bump_tolerance_seconds)
     except Exception as e:
         console.print(f"[red]Error: {e}[/red]")
         raise typer.Exit(1)

--- a/ops/admin-cli/src/stream_of_worship/admin/commands/recover_visibility.py
+++ b/ops/admin-cli/src/stream_of_worship/admin/commands/recover_visibility.py
@@ -29,6 +29,7 @@ from stream_of_worship.admin.db.client import DatabaseClient
 from stream_of_worship.admin.services.analysis import (
     AnalysisClient,
     AnalysisServiceError,
+    JobInfo,
 )
 from stream_of_worship.admin.services.r2 import R2Client, R2ObjectIdentity
 from stream_of_worship.db.connection import ConnectionProvider
@@ -37,6 +38,7 @@ console = Console()
 progress_console = Console(stderr=True)
 R2_LOOKUP_WORKERS = 20
 ANALYSIS_LOOKUP_WORKERS = 10
+ANALYSIS_STUCK_THRESHOLD_HOURS = 12
 
 
 def _lookup_rlc_identity(r2_client: R2Client, hash_prefix: str) -> R2ObjectIdentity:
@@ -71,24 +73,19 @@ def _batch_lookup_r2(
 
 def _lookup_analysis_job(
     analysis_client: AnalysisClient, job_id: str,
-) -> tuple[Optional[str], Optional[str]]:
-    """Look up analysis job, returning (updated_at, note) or (None, note) on error."""
+) -> Optional[JobInfo]:
+    """Look up analysis job, returning JobInfo or None on error (404/exception)."""
     try:
-        job = analysis_client.get_job(job_id)
-        return (job.updated_at, None)
-    except AnalysisServiceError as e:
-        if getattr(e, "status_code", None) == 404:
-            return (None, "job purged — relying on R2/DB timestamps only")
-        return (None, f"analysis error: {e}")
-    except Exception as e:
-        return (None, f"unexpected error: {e}")
+        return analysis_client.get_job(job_id)
+    except (AnalysisServiceError, Exception):
+        return None
 
 
 def _batch_lookup_analysis(
     analysis_client: AnalysisClient, job_ids: list[str],
-) -> dict[str, tuple[Optional[str], Optional[str]]]:
+) -> dict[str, Optional[JobInfo]]:
     """Concurrently look up analysis jobs for all job IDs."""
-    results: dict[str, tuple[Optional[str], Optional[str]]] = {}
+    results: dict[str, Optional[JobInfo]] = {}
     total = len(job_ids)
     progress_console.print(f"[dim]Analysis lookups: {total} jobs ({ANALYSIS_LOOKUP_WORKERS} workers)[/dim]")
     with ThreadPoolExecutor(max_workers=ANALYSIS_LOOKUP_WORKERS) as pool:
@@ -197,9 +194,38 @@ class CandidateSignals:
     with_analysis: bool
     bump_tolerance_s: float
 
+    # from LRC JobInfo (REST, formerly discarded)
+    lrc_status: Optional[str]
+    lrc_stage: Optional[str]
+    lrc_error: Optional[str]
+    lrc_created_at: Optional[datetime]
+    lrc_result_url: Optional[str]               # AnalysisResult.lrc_url
+    lrc_source: Optional[str]
+    lrc_line_count: Optional[int]
+    lrc_result_key_detected_at: Optional[datetime]   # not present on lrc jobs in practice; None
+
+    # from Analysis JobInfo (REST, formerly discarded)
+    analyze_status: Optional[str]
+    analyze_stage: Optional[str]
+    analyze_error: Optional[str]
+    analyze_result_key_detected_at: Optional[datetime]  # cross-check vs PG
+    analyze_stems_present: Optional[bool]       # stems_url non-null
+
+    # PG-side reference values for diagnostic drift comparison
+    pg_r2_lrc_url: Optional[str]
+
 
 def _compute_verdict(sig: CandidateSignals) -> tuple[str, str, dict[str, Any]]:
     """Compute verdict and recommendation based on new signal model.
+
+    Layer A — verdict-changing branches (only override INCONCLUSIVE):
+      1. LRC_JOB_FAILED — lrc_status in ("failed", "cancelled")
+      2. LRC_JOB_STUCK  — lrc_status in ("processing", "queued", "waiting")
+         AND lrc_created_at older than ANALYSIS_STUCK_THRESHOLD_HOURS
+
+    Layer B — diagnostic-only signals (never alter verdict):
+      - lrc_url_drift, stem_bump_attributable_to_stems,
+        transcript_source_bias, key_detected_at_drift
 
     Returns:
         (verdict, recommendation, debug_notes)
@@ -234,54 +260,95 @@ def _compute_verdict(sig: CandidateSignals) -> tuple[str, str, dict[str, Any]]:
         else:
             manual_edit_after_autogen = "no"
 
-    # Verdict Matrix
-    if not sig.r2_lm or not sig.db_updated_at:
-        return "INCONCLUSIVE", "eyes-on", {
-            "delta_h": delta_h,
-            "analyze_bump": analyze_bump,
-            "bump_source": bump_source,
-            "manual_edit_after_autogen": manual_edit_after_autogen,
-        }
-
-    if manual_edit_after_autogen == "yes" and analyze_bump:
-        return "SUSPECTED_BUG_REVERT", "set-visibility published", {
-            "delta_h": delta_h,
-            "analyze_bump": analyze_bump,
-            "bump_source": bump_source,
-            "manual_edit_after_autogen": manual_edit_after_autogen,
-        }
-
-    if manual_edit_after_autogen == "yes" and not analyze_bump:
-        # This is the "smoking gun" from v1, but still a bug revert
-        return "SUSPECTED_BUG_REVERT", "set-visibility published", {
-            "delta_h": delta_h,
-            "analyze_bump": analyze_bump,
-            "bump_source": bump_source,
-            "manual_edit_after_autogen": manual_edit_after_autogen,
-        }
-
-    if analyze_bump and manual_edit_after_autogen == "unknown":
-        return "SUSPECTED_POST_ANALYZE", "needs --with-analysis to resolve", {
-            "delta_h": delta_h,
-            "analyze_bump": analyze_bump,
-            "bump_source": bump_source,
-            "manual_edit_after_autogen": manual_edit_after_autogen,
-        }
-
-    if analyze_bump and manual_edit_after_autogen == "no":
-        return "NO_SIGNAL_POST_ANALYZE", "likely not bug-reverted", {
-            "delta_h": delta_h,
-            "analyze_bump": analyze_bump,
-            "bump_source": bump_source,
-            "manual_edit_after_autogen": manual_edit_after_autogen,
-        }
-
-    return "INCONCLUSIVE", "eyes-on", {
+    # --- Layer B diagnostics (computed for every row, never alter verdict) ---
+    debug_notes: dict[str, Any] = {
         "delta_h": delta_h,
         "analyze_bump": analyze_bump,
         "bump_source": bump_source,
         "manual_edit_after_autogen": manual_edit_after_autogen,
     }
+
+    # lrc_url_drift: lrc_result_url differs from PG pg_r2_lrc_url
+    lrc_url_drift = False
+    if (sig.lrc_result_url is not None
+            and sig.pg_r2_lrc_url is not None
+            and sig.lrc_result_url != sig.pg_r2_lrc_url):
+        lrc_url_drift = True
+        debug_notes["lrc_url_drift"] = True
+        debug_notes["lrc_url_drift_details"] = (
+            f"svc={sig.lrc_result_url} pg={sig.pg_r2_lrc_url}"
+        )
+
+    # stem_bump_attributable_to_stems: analyze_bump AND stems_url present
+    stem_bump_attributable_to_stems = False
+    if analyze_bump and sig.analyze_stems_present:
+        stem_bump_attributable_to_stems = True
+        debug_notes["stem_bump_attributable_to_stems"] = True
+        debug_notes["stem_bump_attributable_to_stems_details"] = (
+            "stems_url present"
+        )
+
+    # transcript_source_bias: manual_edit_after_autogen == "yes" AND lrc_source == "youtube_transcript"
+    transcript_source_bias = False
+    if (manual_edit_after_autogen == "yes"
+            and sig.lrc_source == "youtube_transcript"):
+        transcript_source_bias = True
+        debug_notes["transcript_source_bias"] = True
+        debug_notes["transcript_source_bias_details"] = (
+            "manual_edit=yes, source=youtube_transcript"
+        )
+
+    # key_detected_at_drift: analyze_result_key_detected_at differs from PG
+    key_detected_at_drift = False
+    if (sig.analyze_result_key_detected_at is not None
+            and sig.key_detected_at is not None
+            and sig.analyze_result_key_detected_at != sig.key_detected_at):
+        key_detected_at_drift = True
+        debug_notes["key_detected_at_drift"] = True
+        debug_notes["key_detected_at_drift_details"] = (
+            f"analyze={sig.analyze_result_key_detected_at.isoformat()} "
+            f"pg={sig.key_detected_at.isoformat()}"
+        )
+
+    # --- Original verdict logic (from pre-v2) ---
+    if not sig.r2_lm or not sig.db_updated_at:
+        verdict = "INCONCLUSIVE"
+        recommendation = "eyes-on"
+    elif manual_edit_after_autogen == "yes":
+        verdict = "SUSPECTED_BUG_REVERT"
+        recommendation = "set-visibility published"
+    elif analyze_bump and manual_edit_after_autogen == "unknown":
+        verdict = "SUSPECTED_POST_ANALYZE"
+        recommendation = "needs --with-analysis to resolve"
+    elif analyze_bump and manual_edit_after_autogen == "no":
+        verdict = "NO_SIGNAL_POST_ANALYZE"
+        recommendation = "likely not bug-reverted"
+    else:
+        verdict = "INCONCLUSIVE"
+        recommendation = "eyes-on"
+
+    # --- Layer A verdict branches (only override INCONCLUSIVE) ---
+    if verdict == "INCONCLUSIVE" and sig.lrc_status in ("failed", "cancelled"):
+        verdict = "LRC_JOB_FAILED"
+        error_detail = sig.lrc_error or sig.lrc_status
+        recommendation = f"eyes-on (lrc {sig.lrc_status})"
+        debug_notes["lrc_job_failed"] = True
+        debug_notes["lrc_job_failed_error"] = error_detail
+
+    elif (verdict == "INCONCLUSIVE"
+          and sig.lrc_status in ("processing", "queued", "waiting")
+          and sig.lrc_created_at is not None):
+        threshold = timedelta(hours=ANALYSIS_STUCK_THRESHOLD_HOURS)
+        if (datetime.now(timezone.utc) - sig.lrc_created_at) > threshold:
+            verdict = "LRC_JOB_STUCK"
+            recommendation = "restart analysis worker"
+            debug_notes["lrc_job_stuck"] = True
+            debug_notes["lrc_job_stuck_stage"] = sig.lrc_status
+            debug_notes["lrc_job_stuck_created_at"] = (
+                sig.lrc_created_at.isoformat()
+            )
+
+    return verdict, recommendation, debug_notes
 
 
 def _run_report(
@@ -355,24 +422,62 @@ def _run_report(
 
         r2_last_modified = _parse_iso_datetime(r2_last_modified_str) if r2_last_modified_str else None
 
-        # Resolve Analysis Job timestamps
+        # Resolve Analysis Job timestamps and extract JobInfo fields
         lrc_job_done = None
         analysis_job_done = None
+        lrc_job: Optional[JobInfo] = None
+        ana_job: Optional[JobInfo] = None
         if with_analysis and analysis_client:
             # LRC job
             lrc_jid = rec.get("lrc_job_id")
             if lrc_jid and lrc_jid in analysis_results:
-                lrc_job_done_str, _ = analysis_results[lrc_jid]
-                lrc_job_done = _parse_iso_datetime(lrc_job_done_str)
+                lrc_job = analysis_results[lrc_jid]
+                if lrc_job is not None:
+                    lrc_job_done = _parse_iso_datetime(lrc_job.updated_at)
             # Analysis job
             ana_jid = rec.get("analysis_job_id")
             if ana_jid and ana_jid in analysis_results:
-                ana_job_done_str, _ = analysis_results[ana_jid]
-                analysis_job_done = _parse_iso_datetime(ana_job_done_str)
+                ana_job = analysis_results[ana_jid]
+                if ana_job is not None:
+                    analysis_job_done = _parse_iso_datetime(ana_job.updated_at)
 
         # DB timestamp
         key_detected_at_str = _to_iso_str(rec.get("key_detected_at"))
         key_detected_at = _parse_iso_datetime(key_detected_at_str) if key_detected_at_str else None
+
+        # Extract LRC JobInfo fields
+        lrc_status = lrc_job.status if lrc_job else None
+        lrc_stage = lrc_job.stage if lrc_job else None
+        lrc_error = lrc_job.error_message if lrc_job else None
+        lrc_created_at = _parse_iso_datetime(lrc_job.created_at) if lrc_job else None
+        lrc_result_url = None
+        lrc_source = None
+        lrc_line_count = None
+        lrc_result_key_detected_at = None
+        if lrc_job and lrc_job.result:
+            lrc_result_url = lrc_job.result.lrc_url
+            lrc_source = lrc_job.result.lrc_source
+            lrc_line_count = lrc_job.result.line_count
+            if lrc_job.result.key_detected_at:
+                lrc_result_key_detected_at = _parse_iso_datetime(
+                    lrc_job.result.key_detected_at
+                )
+
+        # Extract Analysis JobInfo fields
+        analyze_status = ana_job.status if ana_job else None
+        analyze_stage = ana_job.stage if ana_job else None
+        analyze_error = ana_job.error_message if ana_job else None
+        analyze_result_key_detected_at = None
+        analyze_stems_present = None
+        if ana_job and ana_job.result:
+            if ana_job.result.key_detected_at:
+                analyze_result_key_detected_at = _parse_iso_datetime(
+                    ana_job.result.key_detected_at
+                )
+            analyze_stems_present = ana_job.result.stems_url is not None
+
+        # PG-side LRC URL for drift comparison
+        pg_r2_lrc_url = rec.get("r2_lrc_url")
 
         # Compute verdict
         sig = CandidateSignals(
@@ -383,6 +488,20 @@ def _run_report(
             key_detected_at=key_detected_at,
             with_analysis=with_analysis,
             bump_tolerance_s=bump_tolerance_s,
+            lrc_status=lrc_status,
+            lrc_stage=lrc_stage,
+            lrc_error=lrc_error,
+            lrc_created_at=lrc_created_at,
+            lrc_result_url=lrc_result_url,
+            lrc_source=lrc_source,
+            lrc_line_count=lrc_line_count,
+            lrc_result_key_detected_at=lrc_result_key_detected_at,
+            analyze_status=analyze_status,
+            analyze_stage=analyze_stage,
+            analyze_error=analyze_error,
+            analyze_result_key_detected_at=analyze_result_key_detected_at,
+            analyze_stems_present=analyze_stems_present,
+            pg_r2_lrc_url=pg_r2_lrc_url,
         )
         verdict, recommendation, notes = _compute_verdict(sig)
 
@@ -413,6 +532,18 @@ def _run_report(
             "analyze_bump": notes.get("analyze_bump", "unknown"),
             "bump_source": notes.get("bump_source", "none"),
             "manual_edit_after_autogen": notes.get("manual_edit_after_autogen", "unknown"),
+            "lrc_status": lrc_status or "",
+            "analyze_status": analyze_status or "",
+            "lrc_error": lrc_error or "",
+            "analyze_error": analyze_error or "",
+            "lrc_result_url": lrc_result_url or "",
+            "lrc_source": lrc_source or "",
+            "lrc_line_count": lrc_line_count if lrc_line_count is not None else "",
+            "key_detected_at_drift": notes.get("key_detected_at_drift", False),
+            "lrc_url_drift": notes.get("lrc_url_drift", False),
+            "stem_bump_attributable_to_stems": notes.get("stem_bump_attributable_to_stems", False),
+            "transcript_source_bias": notes.get("transcript_source_bias", False),
+            "debug_notes": notes,
             "verdict": verdict,
             "recommendation": recommendation,
         })
@@ -433,6 +564,16 @@ def _print_table(rows: list[dict[str, Any]]) -> None:
     table.add_column("delta_h", style="dim", width=8, justify="right")
     table.add_column("analyze_bump", style="dim", width=10)
     table.add_column("manual_edit", style="dim", width=10)
+    table.add_column("lrc_status", style="dim", width=10)
+    table.add_column("analyze_status", style="dim", width=10)
+    table.add_column("lrc_error", style="dim", max_width=20)
+    table.add_column("analyze_error", style="dim", max_width=20)
+    table.add_column("lrc_result_url", style="dim", max_width=20)
+    table.add_column("lrc_source", style="dim", width=14)
+    table.add_column("key_detected_at_drift", style="dim", width=6)
+    table.add_column("lrc_url_drift", style="dim", width=6)
+    table.add_column("stem_bump", style="dim", width=6)
+    table.add_column("transcript_bias", style="dim", width=6)
     table.add_column("verdict", style="bold", width=22)
     table.add_column("recommendation", style="green", max_width=26)
 
@@ -443,6 +584,8 @@ def _print_table(rows: list[dict[str, Any]]) -> None:
             "SUSPECTED_POST_ANALYZE": "yellow",
             "NO_SIGNAL_POST_ANALYZE": "dim",
             "INCONCLUSIVE": "yellow",
+            "LRC_JOB_FAILED": "red",
+            "LRC_JOB_STUCK": "yellow",
         }.get(row["verdict"], "white")
 
         table.add_row(
@@ -455,6 +598,16 @@ def _print_table(rows: list[dict[str, Any]]) -> None:
             f"{row['delta_h']:.2f}" if isinstance(row["delta_h"], float) else str(row["delta_h"]),
             str(row["analyze_bump"]),
             str(row["manual_edit_after_autogen"]),
+            row["lrc_status"],
+            row["analyze_status"],
+            row["lrc_error"][:18] if row["lrc_error"] and len(row["lrc_error"]) > 18 else row["lrc_error"],
+            row["analyze_error"][:18] if row["analyze_error"] and len(row["analyze_error"]) > 18 else row["analyze_error"],
+            row["lrc_result_url"][:18] if row["lrc_result_url"] and len(row["lrc_result_url"]) > 18 else row["lrc_result_url"],
+            row["lrc_source"],
+            str(row["key_detected_at_drift"]),
+            str(row["lrc_url_drift"]),
+            str(row["stem_bump_attributable_to_stems"]),
+            str(row["transcript_source_bias"]),
             f"[{verdict_style}]{row['verdict']}[/{verdict_style}]",
             row["recommendation"],
         )
@@ -468,6 +621,8 @@ def _print_table(rows: list[dict[str, Any]]) -> None:
     ok_count = sum(1 for r in rows if r["verdict"] == "OK_FRESH_LRC")
     no_signal_count = sum(1 for r in rows if r["verdict"] == "NO_SIGNAL_POST_ANALYZE")
     inconclusive_count = sum(1 for r in rows if r["verdict"] == "INCONCLUSIVE")
+    lrc_failed_count = sum(1 for r in rows if r["verdict"] == "LRC_JOB_FAILED")
+    lrc_stuck_count = sum(1 for r in rows if r["verdict"] == "LRC_JOB_STUCK")
 
     console.print(Panel(
         f"[cyan]Total candidates:[/cyan] {total}  |  "
@@ -475,7 +630,9 @@ def _print_table(rows: list[dict[str, Any]]) -> None:
         f"[yellow]SUSPECTED_POST_ANALYZE:[/yellow] {post_analyze_count}  |  "
         f"[green]OK_FRESH_LRC:[/green] {ok_count}  |  "
         f"[dim]NO_SIGNAL_POST_ANALYZE:[/dim] {no_signal_count}  |  "
-        f"[yellow]INCONCLUSIVE:[/yellow] {inconclusive_count}",
+        f"[yellow]INCONCLUSIVE:[/yellow] {inconclusive_count}  |  "
+        f"[red]LRC_JOB_FAILED:[/red] {lrc_failed_count}  |  "
+        f"[yellow]LRC_JOB_STUCK:[/yellow] {lrc_stuck_count}",
         border_style="cyan",
     ))
 
@@ -488,6 +645,10 @@ def _print_table(rows: list[dict[str, Any]]) -> None:
         console.print()
         console.print("[yellow]Note:[/yellow] Re-run with `--with-analysis` to resolve `SUSPECTED_POST_ANALYZE` rows.")
 
+    if lrc_failed_count > 0:
+        console.print()
+        console.print("[yellow]Note:[/yellow] LRC_JOB_FAILED rows: check analysis service for job errors.")
+
 
 def _print_csv(rows: list[dict[str, Any]]) -> None:
     """Print rows as CSV to stdout."""
@@ -496,8 +657,13 @@ def _print_csv(rows: list[dict[str, Any]]) -> None:
         "db_updated_at", "r2_last_modified", "delta_h",
         "lrc_job_id", "analyze_job_id", "key_detected_at",
         "analyze_job_done", "job_completed_at", "analyze_bump",
-        "bump_source", "manual_edit_after_autogen", "verdict",
-        "recommendation",
+        "bump_source", "manual_edit_after_autogen",
+        "lrc_status", "analyze_status", "lrc_error", "analyze_error",
+        "lrc_result_url", "lrc_source", "lrc_line_count",
+        "key_detected_at_drift", "lrc_url_drift",
+        "stem_bump_attributable_to_stems", "transcript_source_bias",
+        "debug_notes",
+        "verdict", "recommendation",
     ]
     writer = csv.DictWriter(sys.stdout, fieldnames=fieldnames, extrasaction="ignore")
     writer.writeheader()
@@ -556,6 +722,16 @@ def main(
         _print_csv(rows)
     else:
         _print_table(rows)
+
+    if not with_analysis:
+        inconclusive_count = sum(1 for r in rows if r["verdict"] == "INCONCLUSIVE")
+        if inconclusive_count > 0:
+            console.print(
+                f"[dim]INCONCLUSIVE rows present; re-run with "
+                f"--with-analysis to surface service-side job status "
+                f"and reduce inconclusive count.[/dim]",
+                file=sys.stderr,
+            )
 
 
 if __name__ == "__main__":

--- a/ops/admin-cli/src/stream_of_worship/admin/commands/recover_visibility.py
+++ b/ops/admin-cli/src/stream_of_worship/admin/commands/recover_visibility.py
@@ -13,6 +13,7 @@ Usage:
 
 import csv
 import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
@@ -28,10 +29,80 @@ from stream_of_worship.admin.services.analysis import (
     AnalysisClient,
     AnalysisServiceError,
 )
-from stream_of_worship.admin.services.r2 import R2Client
+from stream_of_worship.admin.services.r2 import R2Client, R2ObjectIdentity
 from stream_of_worship.db.connection import ConnectionProvider
 
 console = Console()
+progress_console = Console(stderr=True)
+R2_LOOKUP_WORKERS = 20
+ANALYSIS_LOOKUP_WORKERS = 10
+
+
+def _lookup_rlc_identity(r2_client: R2Client, hash_prefix: str) -> R2ObjectIdentity:
+    """Look up R2 LRC identity, swallowing all exceptions."""
+    try:
+        return r2_client.get_lrc_identity(hash_prefix)
+    except Exception:
+        return R2ObjectIdentity(exists=False)
+
+
+def _batch_lookup_r2(
+    r2_client: R2Client, hash_prefixes: list[str],
+) -> dict[str, R2ObjectIdentity]:
+    """Concurrently look up R2 LRC identities for all hash prefixes."""
+    results: dict[str, R2ObjectIdentity] = {}
+    total = len(hash_prefixes)
+    progress_console.print(f"[dim]R2 lookups: {total} files ({R2_LOOKUP_WORKERS} workers)[/dim]")
+    with ThreadPoolExecutor(max_workers=R2_LOOKUP_WORKERS) as pool:
+        futures = {
+            pool.submit(_lookup_rlc_identity, r2_client, hp): hp
+            for hp in hash_prefixes
+        }
+        completed = 0
+        for future in as_completed(futures):
+            hp = futures[future]
+            results[hp] = future.result()
+            completed += 1
+            if completed % 50 == 0 or completed == total:
+                progress_console.print(f"[dim]  R2 lookups: {completed}/{total}[/dim]")
+    return results
+
+
+def _lookup_analysis_job(
+    analysis_client: AnalysisClient, job_id: str,
+) -> tuple[Optional[str], Optional[str]]:
+    """Look up analysis job, returning (updated_at, note) or (None, note) on error."""
+    try:
+        job = analysis_client.get_job(job_id)
+        return (job.updated_at, None)
+    except AnalysisServiceError as e:
+        if getattr(e, "status_code", None) == 404:
+            return (None, "job purged — relying on R2/DB timestamps only")
+        return (None, f"analysis error: {e}")
+    except Exception as e:
+        return (None, f"unexpected error: {e}")
+
+
+def _batch_lookup_analysis(
+    analysis_client: AnalysisClient, job_ids: list[str],
+) -> dict[str, tuple[Optional[str], Optional[str]]]:
+    """Concurrently look up analysis jobs for all job IDs."""
+    results: dict[str, tuple[Optional[str], Optional[str]]] = {}
+    total = len(job_ids)
+    progress_console.print(f"[dim]Analysis lookups: {total} jobs ({ANALYSIS_LOOKUP_WORKERS} workers)[/dim]")
+    with ThreadPoolExecutor(max_workers=ANALYSIS_LOOKUP_WORKERS) as pool:
+        futures = {
+            pool.submit(_lookup_analysis_job, analysis_client, jid): jid
+            for jid in job_ids if jid
+        }
+        completed = 0
+        for future in as_completed(futures):
+            jid = futures[future]
+            results[jid] = future.result()
+            completed += 1
+            if completed % 50 == 0 or completed == total:
+                progress_console.print(f"[dim]  Analysis lookups: {completed}/{total}[/dim]")
+    return results
 
 
 def _get_db_client(config: AdminConfig) -> DatabaseClient:
@@ -40,10 +111,17 @@ def _get_db_client(config: AdminConfig) -> DatabaseClient:
     return DatabaseClient(provider)
 
 
-def _parse_iso_datetime(s: Optional[str]) -> Optional[datetime]:
-    """Parse an ISO-format datetime string to a timezone-aware UTC datetime."""
-    if not s:
+def _parse_iso_datetime(s) -> Optional[datetime]:
+    """Parse an ISO-format datetime string or datetime object to a timezone-aware UTC datetime."""
+    if s is None:
         return None
+    if isinstance(s, datetime):
+        dt = s
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        else:
+            dt = dt.astimezone(timezone.utc)
+        return dt
     try:
         dt = datetime.fromisoformat(s)
         if dt.tzinfo is None:
@@ -85,7 +163,7 @@ def _build_candidate_query(
         params.append(until)
 
     if album:
-        query += " AND s.album = %s"
+        query += " AND s.album_name = %s"
         params.append(album)
 
     query += " ORDER BY r.updated_at DESC"
@@ -142,77 +220,93 @@ def _run_report(
             columns = [desc[0] for desc in cur.description]
             db_rows = cur.fetchall()
 
+    # Batch R2 lookups concurrently
+    hash_prefixes = [dict(zip(columns, row))["hash_prefix"] for row in db_rows]
+    r2_identities = _batch_lookup_r2(r2_client, hash_prefixes)
+
+    # Collect SUSPECTED_BUG_REVERT job IDs for batch analysis lookup
+    suspect_job_ids: list[str] = []
+    if with_analysis and analysis_client:
         for row in db_rows:
             rec = dict(zip(columns, row))
             hash_prefix = rec["hash_prefix"]
             db_updated_at_str = rec["db_updated_at"]
             db_updated_at = _parse_iso_datetime(db_updated_at_str)
+            identity = r2_identities.get(hash_prefix, R2ObjectIdentity(exists=False))
+            r2_last_modified_str = identity.last_modified if identity.exists else None
+            if r2_last_modified_str and db_updated_at:
+                r2_last_modified = _parse_iso_datetime(r2_last_modified_str)
+                if r2_last_modified:
+                    delta_hours = (db_updated_at - r2_last_modified).total_seconds() / 3600.0
+                    v, _ = _compute_verdict(delta_hours, min_delta_hours, max_delta_hours)
+                    if v == "SUSPECTED_BUG_REVERT":
+                        lrc_job_id = rec.get("lrc_job_id")
+                        if lrc_job_id:
+                            suspect_job_ids.append(lrc_job_id)
 
-            # R2 lookup
-            r2_last_modified_str: Optional[str] = None
-            r2_missing = False
-            try:
-                identity = r2_client.get_lrc_identity(hash_prefix)
-                if identity.exists and identity.last_modified:
-                    r2_last_modified_str = identity.last_modified
-                else:
-                    r2_missing = True
-            except Exception as e:
-                console.print(f"[dim]Warning: R2 lookup failed for {hash_prefix}: {e}[/dim]")
-                r2_missing = True
+    analysis_results: dict[str, tuple[Optional[str], Optional[str]]] = {}
+    if with_analysis and analysis_client and suspect_job_ids:
+        analysis_results = _batch_lookup_analysis(analysis_client, suspect_job_ids)
 
-            # Compute verdict
-            if r2_missing or db_updated_at is None:
+    for idx, row in enumerate(db_rows):
+        rec = dict(zip(columns, row))
+        hash_prefix = rec["hash_prefix"]
+        db_updated_at_str = rec["db_updated_at"]
+        db_updated_at = _parse_iso_datetime(db_updated_at_str)
+
+        # R2 lookup from batch result
+        identity = r2_identities.get(hash_prefix, R2ObjectIdentity(exists=False))
+        r2_last_modified_str: Optional[str] = None
+        r2_missing = not identity.exists
+        if identity.exists and identity.last_modified:
+            r2_last_modified_str = identity.last_modified
+
+        # Compute verdict
+        if r2_missing or db_updated_at is None:
+            verdict = "INCONCLUSIVE"
+            recommendation = "R2 file missing or DB timestamp invalid"
+            delta_hours = float("nan")
+        else:
+            r2_last_modified = _parse_iso_datetime(r2_last_modified_str)
+            if r2_last_modified is None:
                 verdict = "INCONCLUSIVE"
-                recommendation = "R2 file missing or DB timestamp invalid"
+                recommendation = "Could not parse R2 LastModified"
                 delta_hours = float("nan")
             else:
-                r2_last_modified = _parse_iso_datetime(r2_last_modified_str)
-                if r2_last_modified is None:
-                    verdict = "INCONCLUSIVE"
-                    recommendation = "Could not parse R2 LastModified"
-                    delta_hours = float("nan")
-                else:
-                    delta_seconds = (db_updated_at - r2_last_modified).total_seconds()
-                    delta_hours = delta_seconds / 3600.0
-                    verdict, recommendation = _compute_verdict(delta_hours, min_delta_hours, max_delta_hours)
+                delta_seconds = (db_updated_at - r2_last_modified).total_seconds()
+                delta_hours = delta_seconds / 3600.0
+                verdict, recommendation = _compute_verdict(delta_hours, min_delta_hours, max_delta_hours)
 
-            # Optional analysis service cross-check
-            job_completed_at_str: Optional[str] = None
-            job_note: Optional[str] = None
-            if with_analysis and analysis_client and verdict == "SUSPECTED_BUG_REVERT":
-                lrc_job_id = rec.get("lrc_job_id")
-                if lrc_job_id:
-                    try:
-                        job = analysis_client.get_job(lrc_job_id)
-                        job_completed_at_str = job.updated_at
-                    except AnalysisServiceError as e:
-                        if getattr(e, "status_code", None) == 404:
-                            job_note = "job purged — relying on R2/DB timestamps only"
-                        else:
-                            job_note = f"analysis error: {e}"
-                    except Exception as e:
-                        job_note = f"unexpected error: {e}"
-                else:
-                    job_note = "no lrc_job_id"
-            elif with_analysis and analysis_client:
-                # For non-SUSPECTED rows, skip analysis lookup per spec
-                pass
+        # Analysis service cross-check from batch result
+        job_completed_at_str: Optional[str] = None
+        job_note: Optional[str] = None
+        if with_analysis and analysis_client and verdict == "SUSPECTED_BUG_REVERT":
+            lrc_job_id = rec.get("lrc_job_id")
+            if lrc_job_id and lrc_job_id in analysis_results:
+                job_completed_at_str, job_note = analysis_results[lrc_job_id]
+            elif lrc_job_id:
+                job_note = "no lrc_job_id"
 
-            rows.append({
-                "hash_prefix": hash_prefix,
-                "song_id": rec.get("song_id") or "",
-                "album": rec.get("song_album") or "",
-                "title": rec.get("song_title") or "",
-                "db_updated_at": db_updated_at_str or "",
-                "r2_last_modified": r2_last_modified_str or "",
-                "delta_h": round(delta_hours, 2) if not (isinstance(delta_hours, float) and delta_hours != delta_hours) else "",
-                "lrc_job_id": rec.get("lrc_job_id") or "",
-                "job_completed_at": job_completed_at_str or "",
-                "job_note": job_note or "",
-                "verdict": verdict,
-                "recommendation": recommendation,
-            })
+        db_updated_at_display = ""
+        if db_updated_at is not None:
+            db_updated_at_display = db_updated_at.strftime("%Y-%m-%d %H:%M:%S UTC")
+        elif isinstance(db_updated_at_str, str):
+            db_updated_at_display = db_updated_at_str
+
+        rows.append({
+            "hash_prefix": hash_prefix,
+            "song_id": rec.get("song_id") or "",
+            "album": rec.get("song_album") or "",
+            "title": rec.get("song_title") or "",
+            "db_updated_at": db_updated_at_display,
+            "r2_last_modified": r2_last_modified_str or "",
+            "delta_h": round(delta_hours, 2) if not (isinstance(delta_hours, float) and delta_hours != delta_hours) else "",
+            "lrc_job_id": rec.get("lrc_job_id") or "",
+            "job_completed_at": job_completed_at_str or "",
+            "job_note": job_note or "",
+            "verdict": verdict,
+            "recommendation": recommendation,
+        })
 
     return rows
 

--- a/ops/admin-cli/src/stream_of_worship/admin/commands/recover_visibility.py
+++ b/ops/admin-cli/src/stream_of_worship/admin/commands/recover_visibility.py
@@ -1,0 +1,346 @@
+"""Dry-run report to identify recordings whose visibility_status was
+reverted from 'published' to 'review' by the audio-batch bug.
+
+Cross-references R2 LRC file LastModified against DB recordings.updated_at
+to flag SUSPECTED_BUG_REVERT candidates.
+
+Usage:
+    uv run --project ops/admin-cli --extra admin python ops/admin-cli/src/stream_of_worship/admin/commands/recover_visibility.py \\
+      [--since 2026-07-10] [--until 2026-07-20] \\
+      [--album <name>] [--min-delta-hours 1] [--max-delta-hours 1440] \\
+      [--with-analysis] [--csv] [--config <path>]
+"""
+
+import csv
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+import typer
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from stream_of_worship.admin.config import AdminConfig
+from stream_of_worship.admin.db.client import DatabaseClient
+from stream_of_worship.admin.services.analysis import (
+    AnalysisClient,
+    AnalysisServiceError,
+)
+from stream_of_worship.admin.services.r2 import R2Client
+from stream_of_worship.db.connection import ConnectionProvider
+
+console = Console()
+
+
+def _get_db_client(config: AdminConfig) -> DatabaseClient:
+    """Get a database client from config."""
+    provider = ConnectionProvider(config.get_connection_url())
+    return DatabaseClient(provider)
+
+
+def _parse_iso_datetime(s: Optional[str]) -> Optional[datetime]:
+    """Parse an ISO-format datetime string to a timezone-aware UTC datetime."""
+    if not s:
+        return None
+    try:
+        dt = datetime.fromisoformat(s)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        else:
+            dt = dt.astimezone(timezone.utc)
+        return dt
+    except (ValueError, TypeError):
+        return None
+
+
+def _build_candidate_query(
+    since: Optional[str],
+    until: Optional[str],
+    album: Optional[str],
+) -> tuple[str, list[Any]]:
+    """Build the SQL query and params for candidate recordings."""
+    query = """
+        SELECT r.hash_prefix, r.song_id, r.lrc_job_id, r.r2_lrc_url,
+               r.visibility_status, r.lrc_status,
+               r.updated_at AS db_updated_at, r.imported_at,
+               s.title AS song_title, s.album_name AS song_album
+        FROM recordings r
+        LEFT JOIN songs s ON r.song_id = s.id
+        WHERE r.visibility_status = 'review'
+          AND r.lrc_status = 'completed'
+          AND r.r2_lrc_url IS NOT NULL
+          AND r.deleted_at IS NULL
+          AND (s.deleted_at IS NULL OR s.id IS NULL)
+    """
+    params: list[Any] = []
+
+    if since:
+        query += " AND r.updated_at >= %s"
+        params.append(since)
+
+    if until:
+        query += " AND r.updated_at <= %s"
+        params.append(until)
+
+    if album:
+        query += " AND s.album = %s"
+        params.append(album)
+
+    query += " ORDER BY r.updated_at DESC"
+
+    return query, params
+
+
+def _compute_verdict(delta_hours: float, min_h: float, max_h: float) -> tuple[str, str]:
+    """Compute verdict and recommendation based on delta hours.
+
+    Returns:
+        (verdict, recommendation) tuple
+    """
+    if abs(delta_hours) <= 0.1:
+        return ("OK_FRESH_LRC", "—")
+    if min_h <= delta_hours <= max_h:
+        return ("SUSPECTED_BUG_REVERT", "set-visibility published")
+    return ("INCONCLUSIVE", "—")
+
+
+def _run_report(
+    config: AdminConfig,
+    since: Optional[str],
+    until: Optional[str],
+    album: Optional[str],
+    min_delta_hours: float,
+    max_delta_hours: float,
+    with_analysis: bool,
+) -> list[dict[str, Any]]:
+    """Run the dry-run report and return rows as dicts."""
+    db_client = _get_db_client(config)
+
+    try:
+        r2_client = R2Client(config.r2_bucket, config.r2_endpoint_url, config.r2_region)
+    except ValueError as e:
+        console.print(f"[red]R2 not configured: {e}[/red]")
+        raise typer.Exit(1)
+
+    analysis_client: Optional[AnalysisClient] = None
+    if with_analysis:
+        try:
+            analysis_client = AnalysisClient(config.analysis_url)
+        except ValueError as e:
+            console.print(f"[yellow]Analysis service not configured (--with-analysis ignored): {e}[/yellow]")
+            analysis_client = None
+
+    query, params = _build_candidate_query(since, until, album)
+
+    rows: list[dict[str, Any]] = []
+
+    with db_client:
+        with db_client.connection.cursor() as cur:
+            cur.execute(query, params)
+            columns = [desc[0] for desc in cur.description]
+            db_rows = cur.fetchall()
+
+        for row in db_rows:
+            rec = dict(zip(columns, row))
+            hash_prefix = rec["hash_prefix"]
+            db_updated_at_str = rec["db_updated_at"]
+            db_updated_at = _parse_iso_datetime(db_updated_at_str)
+
+            # R2 lookup
+            r2_last_modified_str: Optional[str] = None
+            r2_missing = False
+            try:
+                identity = r2_client.get_lrc_identity(hash_prefix)
+                if identity.exists and identity.last_modified:
+                    r2_last_modified_str = identity.last_modified
+                else:
+                    r2_missing = True
+            except Exception as e:
+                console.print(f"[dim]Warning: R2 lookup failed for {hash_prefix}: {e}[/dim]")
+                r2_missing = True
+
+            # Compute verdict
+            if r2_missing or db_updated_at is None:
+                verdict = "INCONCLUSIVE"
+                recommendation = "R2 file missing or DB timestamp invalid"
+                delta_hours = float("nan")
+            else:
+                r2_last_modified = _parse_iso_datetime(r2_last_modified_str)
+                if r2_last_modified is None:
+                    verdict = "INCONCLUSIVE"
+                    recommendation = "Could not parse R2 LastModified"
+                    delta_hours = float("nan")
+                else:
+                    delta_seconds = (db_updated_at - r2_last_modified).total_seconds()
+                    delta_hours = delta_seconds / 3600.0
+                    verdict, recommendation = _compute_verdict(delta_hours, min_delta_hours, max_delta_hours)
+
+            # Optional analysis service cross-check
+            job_completed_at_str: Optional[str] = None
+            job_note: Optional[str] = None
+            if with_analysis and analysis_client and verdict == "SUSPECTED_BUG_REVERT":
+                lrc_job_id = rec.get("lrc_job_id")
+                if lrc_job_id:
+                    try:
+                        job = analysis_client.get_job(lrc_job_id)
+                        job_completed_at_str = job.updated_at
+                    except AnalysisServiceError as e:
+                        if getattr(e, "status_code", None) == 404:
+                            job_note = "job purged — relying on R2/DB timestamps only"
+                        else:
+                            job_note = f"analysis error: {e}"
+                    except Exception as e:
+                        job_note = f"unexpected error: {e}"
+                else:
+                    job_note = "no lrc_job_id"
+            elif with_analysis and analysis_client:
+                # For non-SUSPECTED rows, skip analysis lookup per spec
+                pass
+
+            rows.append({
+                "hash_prefix": hash_prefix,
+                "song_id": rec.get("song_id") or "",
+                "album": rec.get("song_album") or "",
+                "title": rec.get("song_title") or "",
+                "db_updated_at": db_updated_at_str or "",
+                "r2_last_modified": r2_last_modified_str or "",
+                "delta_h": round(delta_hours, 2) if not (isinstance(delta_hours, float) and delta_hours != delta_hours) else "",
+                "lrc_job_id": rec.get("lrc_job_id") or "",
+                "job_completed_at": job_completed_at_str or "",
+                "job_note": job_note or "",
+                "verdict": verdict,
+                "recommendation": recommendation,
+            })
+
+    return rows
+
+
+def _print_table(rows: list[dict[str, Any]]) -> None:
+    """Print rows as a Rich table."""
+    table = Table(title="Recover visibility_status — Bug Revert Dry-Run Report", show_lines=True)
+
+    table.add_column("hash_prefix", style="cyan", width=12)
+    table.add_column("song_id", style="cyan", width=10)
+    table.add_column("title", style="white", max_width=30)
+    table.add_column("album", style="white", max_width=20)
+    table.add_column("db_updated_at", style="dim", width=24)
+    table.add_column("r2_last_modified", style="dim", width=24)
+    table.add_column("delta_h", style="yellow", width=8, justify="right")
+    table.add_column("lrc_job_id", style="dim", width=14)
+    table.add_column("job_completed_at", style="dim", width=24)
+    table.add_column("verdict", style="bold", width=18)
+    table.add_column("recommendation", style="green", max_width=24)
+
+    for row in rows:
+        verdict_style = {
+            "SUSPECTED_BUG_REVERT": "red",
+            "OK_FRESH_LRC": "green",
+            "INCONCLUSIVE": "yellow",
+        }.get(row["verdict"], "white")
+
+        table.add_row(
+            row["hash_prefix"],
+            row["song_id"],
+            row["title"][:28] if len(row["title"]) > 28 else row["title"],
+            row["album"][:18] if len(row["album"]) > 18 else row["album"],
+            row["db_updated_at"],
+            row["r2_last_modified"],
+            str(row["delta_h"]) if row["delta_h"] != "" else "",
+            row["lrc_job_id"],
+            row["job_completed_at"],
+            f"[{verdict_style}]{row['verdict']}[/{verdict_style}]",
+            row["recommendation"],
+        )
+
+    console.print()
+
+    # Summary
+    total = len(rows)
+    suspect_count = sum(1 for r in rows if r["verdict"] == "SUSPECTED_BUG_REVERT")
+    ok_count = sum(1 for r in rows if r["verdict"] == "OK_FRESH_LRC")
+    inconclusive_count = sum(1 for r in rows if r["verdict"] == "INCONCLUSIVE")
+
+    console.print(Panel(
+        f"[cyan]Total candidates:[/cyan] {total}  |  "
+        f"[red]SUSPECTED_BUG_REVERT:[/red] {suspect_count}  |  "
+        f"[green]OK_FRESH_LRC:[/green] {ok_count}  |  "
+        f"[yellow]INCONCLUSIVE:[/yellow] {inconclusive_count}",
+        border_style="cyan",
+    ))
+
+    if suspect_count > 0:
+        console.print()
+        console.print("[yellow]Recommendation:[/yellow] Review SUSPECTED_BUG_REVERT rows and run:")
+        console.print("  [dim]sow-admin audio set-visibility <song_id> published[/dim]")
+
+
+def _print_csv(rows: list[dict[str, Any]]) -> None:
+    """Print rows as CSV to stdout."""
+    fieldnames = [
+        "hash_prefix", "song_id", "album", "title",
+        "db_updated_at", "r2_last_modified", "delta_h",
+        "lrc_job_id", "job_completed_at", "verdict",
+        "recommendation", "job_note",
+    ]
+    writer = csv.DictWriter(sys.stdout, fieldnames=fieldnames, extrasaction="ignore")
+    writer.writeheader()
+    for row in rows:
+        writer.writerow(row)
+
+
+def main(
+    since: Optional[str] = typer.Option(None, "--since", "-s", help="Only include recordings updated_at >= this date/time (ISO format)"),
+    until: Optional[str] = typer.Option(None, "--until", "-u", help="Only include recordings updated_at <= this date/time (ISO format)"),
+    album: Optional[str] = typer.Option(None, "--album", "-a", help="Filter by album name"),
+    min_delta_hours: float = typer.Option(1.0, "--min-delta-hours", help="Minimum delta_hours for SUSPECTED_BUG_REVERT verdict"),
+    max_delta_hours: float = typer.Option(1440.0, "--max-delta-hours", help="Maximum delta_hours for SUSPECTED_BUG_REVERT verdict"),
+    with_analysis: bool = typer.Option(False, "--with-analysis", "-A", help="Cross-check with analysis service job timestamps"),
+    csv_output: bool = typer.Option(False, "--csv", "-c", help="Output as CSV instead of Rich table"),
+    config_path: Optional[Path] = typer.Option(None, "--config", "-C", help="Path to config file"),
+) -> None:
+    """Identify recordings whose visibility_status was reverted by the audio-batch bug.
+
+    This is a read-only dry-run report. It cross-references the R2 LRC file's
+    LastModified timestamp against the DB recordings.updated_at timestamp to
+    flag suspected bug-reverted recordings.
+
+    No DB writes. No code changes.
+    """
+    try:
+        config = AdminConfig.load(config_path)
+    except FileNotFoundError:
+        console.print("[red]Config file not found. Run 'sow-admin db init' first.[/red]")
+        raise typer.Exit(1)
+
+    console.print("[cyan]Scanning candidates...[/cyan]")
+    if since:
+        console.print(f"[dim]Since:[/dim] {since}")
+    if until:
+        console.print(f"[dim]Until:[/dim] {until}")
+    if album:
+        console.print(f"[dim]Album:[/dim] {album}")
+    console.print(f"[dim]Delta range:[/dim] {min_delta_hours}h — {max_delta_hours}h")
+    if with_analysis:
+        console.print("[dim]Analysis cross-check:[/dim] enabled")
+    console.print()
+
+    try:
+        rows = _run_report(config, since, until, album, min_delta_hours, max_delta_hours, with_analysis)
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise typer.Exit(1)
+
+    if not rows:
+        console.print("[green]No candidate recordings found matching the filters.[/green]")
+        return
+
+    if csv_output:
+        _print_csv(rows)
+    else:
+        _print_table(rows)
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/ops/admin-cli/src/stream_of_worship/admin/db/client.py
+++ b/ops/admin-cli/src/stream_of_worship/admin/db/client.py
@@ -850,6 +850,7 @@ class DatabaseClient:
             "title": "s.title ASC NULLS LAST",
             "imported": "r.imported_at DESC",
             "created": "r.created_at ASC NULLS LAST, r.hash_prefix ASC",
+            "updated": "r.updated_at DESC NULLS LAST",
         }
         query += f" ORDER BY {order_map.get(sort_by, 'r.imported_at DESC')}"
 

--- a/ops/admin-cli/src/stream_of_worship/admin/editor/footer.py
+++ b/ops/admin-cli/src/stream_of_worship/admin/editor/footer.py
@@ -11,6 +11,28 @@ from textual.containers import Horizontal
 from textual.widgets import Footer, Static
 
 
+def format_key_display(key: str) -> str:
+    if key.startswith("ctrl+"):
+        return "^" + key[5:].upper()
+    if key == "shift+left":
+        return "⇧←"
+    if key == "shift+right":
+        return "⇧→"
+    if key == "left":
+        return "←"
+    if key == "right":
+        return "→"
+    if key == "up":
+        return "↑"
+    if key == "down":
+        return "↓"
+    if key == "space":
+        return "⎵"
+    if key == "escape":
+        return "Esc"
+    return key
+
+
 class _BindingGroup(Static):
     def __init__(self, label: str, bindings: list[Binding]) -> None:
         self._group_label = label
@@ -20,25 +42,7 @@ class _BindingGroup(Static):
     def _format_content(self) -> Text:
         parts: list[str] = [f"[bold]{self._group_label}[/bold] "]
         for i, b in enumerate(self._bindings):
-            key_display = b.key
-            if key_display.startswith("ctrl+"):
-                key_display = "^" + key_display[5:].upper()
-            elif key_display == "shift+left":
-                key_display = "⇧←"
-            elif key_display == "shift+right":
-                key_display = "⇧→"
-            elif key_display == "left":
-                key_display = "←"
-            elif key_display == "right":
-                key_display = "→"
-            elif key_display == "up":
-                key_display = "↑"
-            elif key_display == "down":
-                key_display = "↓"
-            elif key_display == "space":
-                key_display = "⎵"
-            elif key_display == "escape":
-                key_display = "Esc"
+            key_display = format_key_display(b.key)
             parts.append(f"[dim]{key_display}[/dim]={b.description}")
             if i < len(self._bindings) - 1:
                 parts.append("[dim] │ [/dim]")

--- a/ops/admin-cli/src/stream_of_worship/admin/editor/screen.py
+++ b/ops/admin-cli/src/stream_of_worship/admin/editor/screen.py
@@ -28,7 +28,7 @@ from textual.css.query import NoMatches
 
 from stream_of_worship.admin.db.client import DatabaseClient
 from stream_of_worship.admin.editor.autosave import AutosaveState, save_autosave
-from stream_of_worship.admin.editor.footer import GroupedFooter
+from stream_of_worship.admin.editor.footer import GroupedFooter, format_key_display
 from stream_of_worship.admin.editor.state import EditorState
 from stream_of_worship.admin.editor.upload import (
     check_transcribed_changed,
@@ -244,6 +244,7 @@ class LRCEditorScreen(Screen[None]):
         Binding("ctrl+y", "redo", "Redo"),
         Binding("escape", "quit_editor", "Quit"),
         Binding("q", "quit_editor", "Quit"),
+        Binding("?", "show_keymap", "Keymap"),
     ]
 
     BINDING_GROUPS: dict[str, list[str]] = {
@@ -276,6 +277,7 @@ class LRCEditorScreen(Screen[None]):
             "undo",
             "redo",
             "quit_editor",
+            "show_keymap",
         ],
     }
 
@@ -1332,6 +1334,48 @@ class LRCEditorScreen(Screen[None]):
             SaveUploadDialog(validation, revised, self, etag_changed, etag_reason),
             _handle_dialog_result,
         )
+
+    def action_show_keymap(self) -> None:
+        if self._is_edit_active():
+            return  # let `?` go into the input
+
+        from textual.screen import ModalScreen
+
+        class KeymapDialog(ModalScreen[None]):
+            BINDINGS = [
+                Binding("escape", "close", "Close"),
+                Binding("?", "close", "Close"),
+            ]
+
+            def __init__(
+                self, groups: dict[str, list[str]], all_bindings: list[Binding]
+            ) -> None:
+                super().__init__()
+                self._groups = groups
+                self._all_bindings = all_bindings
+
+            def compose(self) -> ComposeResult:
+                binding_map: dict[str, Binding] = {b.action: b for b in self._all_bindings}
+                with Vertical(id="keymap-container"):
+                    yield Label("Keymap", classes="dialog-title")
+                    for group_label, action_names in self._groups.items():
+                        yield Label(f"[bold]{group_label}[/bold]")
+                        for action_name in action_names:
+                            b = binding_map.get(action_name)
+                            if b is None:
+                                continue
+                            yield Label(
+                                f"[dim]{format_key_display(b.key)}[/dim]={b.description}"
+                            )
+                        yield Label("")
+                    yield Label(
+                        "[d]Press [bold]?[/bold] or [bold]Esc[/bold] to close[/]"
+                    )
+
+            def action_close(self) -> None:
+                self.dismiss(None)
+
+        self.app.push_screen(KeymapDialog(self.BINDING_GROUPS, self.BINDINGS))
 
     def action_quit_editor(self) -> None:
         if self._is_edit_active():

--- a/ops/admin-cli/src/stream_of_worship/admin/services/analysis.py
+++ b/ops/admin-cli/src/stream_of_worship/admin/services/analysis.py
@@ -58,6 +58,10 @@ class AnalysisResult:
     stems_url: Optional[str] = None
     lrc_url: Optional[str] = None
     lrc_source: Optional[str] = None
+    line_count: Optional[int] = None
+    vocals_dry_url: Optional[str] = None
+    vocals_url: Optional[str] = None
+    instrumental_url: Optional[str] = None
 
 
 @dataclass
@@ -836,6 +840,10 @@ class AnalysisClient:
                     stems_url=result_data.get("stems_url"),
                     lrc_url=result_data.get("lrc_url"),
                     lrc_source=result_data.get("lrc_source"),
+                    line_count=result_data.get("line_count"),
+                    vocals_dry_url=result_data.get("vocals_dry_url"),
+                    vocals_url=result_data.get("vocals_url"),
+                    instrumental_url=result_data.get("instrumental_url"),
                 )
 
         return JobInfo(

--- a/ops/admin-cli/tests/admin/services/test_lrc_editor_screen.py
+++ b/ops/admin-cli/tests/admin/services/test_lrc_editor_screen.py
@@ -11,7 +11,7 @@ from textual.widgets import DataTable, Input
 
 from stream_of_worship.admin.editor.app import LRCEditorApp
 from stream_of_worship.admin.editor.footer import GroupedFooter
-from stream_of_worship.admin.editor.screen import CurrentLyricDisplay, StatusIndicator
+from stream_of_worship.admin.editor.screen import CurrentLyricDisplay, LRCEditorScreen, StatusIndicator
 from stream_of_worship.admin.editor.state import EditorState
 from stream_of_worship.admin.services.lrc_parser import LRCLine
 from stream_of_worship.admin.services.playback import PlaybackState
@@ -458,6 +458,40 @@ async def test_paste_after_selection_and_terminal_duplicate_suppression():
             "Line 4",
         ]
         assert state.selected_index == 2
+
+
+@pytest.mark.asyncio
+async def test_show_keymap_dialog_lists_all_bindings_grouped():
+    app, _ = _make_app(line_count=3)
+
+    async with app.run_test(size=(80, 12)) as pilot:
+        await pilot.pause()
+
+        app.screen.action_show_keymap()
+        await pilot.pause()
+
+        from textual.screen import ModalScreen
+
+        assert isinstance(app.screen, ModalScreen)
+        container = app.screen.query_one("#keymap-container")
+
+        labels = [label.render().plain for label in container.query("Label")]
+        rendered = "\n".join(labels)
+
+        for group_label in ("Playback", "Lyrics", "Timecode", "General"):
+            assert group_label in rendered
+
+        for b in LRCEditorScreen.BINDINGS:
+            assert b.description in rendered
+
+        # Dismiss by pressing `?` so the full App._check_bindings dispatch path
+        # is exercised (regression for the KeymapDialog._bindings clobber bug,
+        # where overwriting Textual's BindingsMap with a plain list caused
+        # AttributeError on key dispatch).
+        await pilot.press("?")
+        await pilot.pause()
+
+        assert not isinstance(app.screen, ModalScreen)
 
 
 @pytest.mark.asyncio

--- a/ops/admin-cli/tests/admin/test_audio_commands.py
+++ b/ops/admin-cli/tests/admin/test_audio_commands.py
@@ -783,6 +783,110 @@ class TestAudioListCommand:
 
         _drop_all_tables(make_test_provider)
 
+    @pytest.mark.integration
+    def test_list_sort_by_updated(self, make_test_provider, postgres_url, tmp_path):
+        """Sort by updated orders recordings by updated_at DESC, showing Updated column."""
+        provider = make_test_provider()
+        client = DatabaseClient(provider)
+        client.initialize_schema()
+
+        for sid, title in [("song_001", "第一首歌"), ("song_002", "第二首歌")]:
+            client.insert_song(Song(id=sid, title=title, source_url=f"https://example.com/{sid}",
+                                    scraped_at="2024-01-01T00:00:00"))
+
+        client.insert_recording(Recording(
+            content_hash="a" * 64, hash_prefix="aaaaaaaaaaaa", song_id="song_001",
+            original_filename="song1.mp3", file_size_bytes=1024000,
+            imported_at="2024-01-15T10:30:00"))
+        client.insert_recording(Recording(
+            content_hash="b" * 64, hash_prefix="bbbbbbbbbbbb", song_id="song_002",
+            original_filename="song2.mp3", file_size_bytes=2048000,
+            imported_at="2024-01-16T10:30:00"))
+
+        # Make recording A newer by updating its updated_at via direct SQL
+        with provider.get_connection().cursor() as cur:
+            cur.execute(
+                "UPDATE recordings SET updated_at = NOW() + INTERVAL '1 day' WHERE hash_prefix = 'aaaaaaaaaaaa'"
+            )
+
+        config_path = _write_config(tmp_path, postgres_url)
+
+        result = runner.invoke(
+            app, ["audio", "list", "--config", str(config_path), "--sort", "updated"],
+            env=WIDE_ENV,
+        )
+
+        assert result.exit_code == 0
+        # A should appear before B in output (A has newer updated_at)
+        pos_a = result.output.index("aaaaaaaaaaaa")
+        pos_b = result.output.index("bbbbbbbbbbbb")
+        assert pos_a < pos_b
+        # Updated column header should be present
+        assert "Updated" in result.output
+        # Timestamps should appear in output
+        assert "2024" in result.output
+
+        _drop_all_tables(make_test_provider)
+
+    @pytest.mark.integration
+    def test_list_sort_by_updated_ids_format(self, make_test_provider, postgres_url, tmp_path):
+        """Sort by updated with ids format outputs correct order."""
+        provider = make_test_provider()
+        client = DatabaseClient(provider)
+        client.initialize_schema()
+
+        for sid, title in [("song_001", "第一首歌"), ("song_002", "第二首歌")]:
+            client.insert_song(Song(id=sid, title=title, source_url=f"https://example.com/{sid}",
+                                    scraped_at="2024-01-01T00:00:00"))
+
+        client.insert_recording(Recording(
+            content_hash="a" * 64, hash_prefix="aaaaaaaaaaaa", song_id="song_001",
+            original_filename="song1.mp3", file_size_bytes=1024000,
+            imported_at="2024-01-15T10:30:00"))
+        client.insert_recording(Recording(
+            content_hash="b" * 64, hash_prefix="bbbbbbbbbbbb", song_id="song_002",
+            original_filename="song2.mp3", file_size_bytes=2048000,
+            imported_at="2024-01-16T10:30:00"))
+
+        # Make recording A newer
+        with provider.get_connection().cursor() as cur:
+            cur.execute(
+                "UPDATE recordings SET updated_at = NOW() + INTERVAL '1 day' WHERE hash_prefix = 'aaaaaaaaaaaa'"
+            )
+
+        config_path = _write_config(tmp_path, postgres_url)
+
+        result = runner.invoke(
+            app, ["audio", "list", "--config", str(config_path), "--sort", "updated", "--format", "ids"],
+        )
+
+        assert result.exit_code == 0
+        ids = result.output.strip().split("\n")
+        assert ids == ["song_001", "song_002"]
+
+        _drop_all_tables(make_test_provider)
+
+    def test_list_sort_updated_validation(self, tmp_path, monkeypatch):
+        """`--sort updated` passes CLI validation; invalid values are rejected."""
+        monkeypatch.delenv("SOW_DATABASE_URL", raising=False)
+        config_path = tmp_path / "config.toml"
+        config_path.write_text('[database]\n')
+
+        # --sort updated should pass validation (fails at DB, not validation)
+        result = runner.invoke(
+            app, ["audio", "list", "--config", str(config_path), "--sort", "updated"],
+        )
+        assert "Invalid sort option" not in result.output
+
+        # Invalid sort should be rejected
+        result = runner.invoke(
+            app, ["audio", "list", "--config", str(config_path), "--sort", "bogus"],
+        )
+        assert result.exit_code == 1
+        assert "Invalid sort option" in result.output
+
+        _drop_all_tables(monkeypatch)
+
 
 class TestAudioShowCommand:
     """Tests for 'audio show' command."""

--- a/reports/songset_constructor_agent_guide.md
+++ b/reports/songset_constructor_agent_guide.md
@@ -1,0 +1,378 @@
+# Agent Guide: Songset Constructor — Generating and Evaluating Diverse Songsets
+
+This guide explains how to use the songset constructor POC to generate diverse Chinese worship songsets and evaluate the quality of the results.
+
+## Quick Start
+
+```bash
+# Deterministic mode (no LLM required)
+set -a && source /opt/sow/.env && set +a
+uv run --project lab/poc-scripts --extra songset_constructor \
+  python lab/poc-scripts/construct_songset_agent.py \
+  --songs 4 --pool-limit 500 --top-k 20 --no-llm
+
+# Agentic mode (LLM planning + optional judge)
+uv run --project lab/poc-scripts --extra songset_constructor \
+  python lab/poc-scripts/construct_songset_agent.py \
+  --songs 4 --pool-limit 500 --top-k 20 --llm-judge
+```
+
+## Prerequisites
+
+- Environment variables `SOW_LLM_API_KEY`, `SOW_LLM_MODEL`, `SOW_LLM_BASE_URL` must be set for agentic mode (`--llm-judge`). The CLI auto-loads `/opt/sow/.env` or accepts `--env-file`.
+- `--no-llm` mode requires no LLM credentials and runs fully deterministic.
+- The catalog database must be reachable (read-only `SELECT` queries via `ReadOnlyClient`).
+
+## CLI Options
+
+| Option | Default | Range | Purpose |
+|--------|---------|-------|---------|
+| `--songs` | 3 | 2–5 | Songs per songset |
+| `--top-k` | 3 | 1–20 | Number of ranked proposals to output |
+| `--pool-limit` | 200 | ≥4 | Max songs to load from catalog (use 500 for full catalog) |
+| `--no-llm` / `--llm` | `--llm` | — | Toggle deterministic vs agentic mode |
+| `--llm-judge` / `--no-llm-judge` | `--no-llm-judge` | — | Enable LLM re-ranking of finalists |
+| `--intimate` / `--no-intimate` | `--no-intimate` | — | Lower closer tempo ceiling from 90 to 80 BPM |
+| `--season` | None | advent, christmas, lent, easter, pentecost | Seasonal theme bias |
+| `--album-series` | None | repeatable | Filter catalog by album series (e.g., `--album-series "敬拜讚美 (1)"`) |
+| `--relax-h1` / `--no-relax-h1` | `--relax-h1` | — | Relax phase-1 opener requirement (allow phase 2 openers) |
+| `--auto-relax` / `--no-auto-relax` | `--auto-relax` | — | Auto-relax H2/H3/H4/H5 if no proposals found |
+| `--relax-h3-bpm` | None | ≥0 | Override closer tempo ceiling |
+| `--relax-h2-bpm` | None | ≥0 | Override opener tempo floor |
+| `--relax-h4` / `--no-relax-h4` | `--no-relax-h4` | — | Widen tempo jump limit from 35 to 40 BPM |
+| `--relax-h5` / `--no-relax-h5` | `--no-relax-h5` | — | Widen circle-of-fifths distance from 2 to 3 |
+| `--interactive-review` / `--no-interactive-review` | `--no-interactive-review` | — | Pause for human approve/reject of top proposal |
+| `--output-dir` | auto-timestamped | path | Override output directory |
+
+## Pipeline Architecture
+
+The constructor runs as a LangGraph state machine with these stages:
+
+```
+load_catalog → enrich_pool → build_transition_matrix → beam_seed_candidates
+                                                          ↓
+                                            ┌─────────────┴──────────────┐
+                                            │                            │
+                                      --no-llm                      LLM mode
+                                            │                            │
+                                    finalize_rank              llm_plan → validate_score
+                                            │                    ↓               ↓
+                                            │              Accepted         Refine (loop ≤3)
+                                            │                    ↓               ↓
+                                            │            finalize_rank ←────────┘
+                                            │                    ↓
+                                            │         ┌──────────┴──────────┐
+                                            │    --llm-judge         default
+                                            │         │                   │
+                                            │    llm_judge                │
+                                            │         │                   │
+                                            └─────────┴───────────────────┘
+                                                      ↓
+                                              write_artifacts
+```
+
+### Stage Details
+
+1. **load_catalog** — Fetches songs from PostgreSQL via read-only `SELECT`. Loads songs with published/review recordings that have LRC lyrics. Pool size is bounded by `--pool-limit`.
+
+2. **enrich_pool** — Classifies each song's themes (from title, lyrics, embeddings), infers worship phase (1=call, 2=adoration, 3=praise, 4=cross/response, 5=commitment), and applies seasonal bias. Drops songs lacking both tempo and key metadata.
+
+3. **build_transition_matrix** — Computes pairwise transition recommendations (BPM delta, circle-of-fifths distance, suggested key shift, crossfade/gap settings) for all song pairs where CFD ≤ 6. Also computes fan-out (how many valid transitions each song has) and marks dead-end songs.
+
+4. **beam_seed_candidates** — Runs diverse beam search (see below). Produces ranked candidate sequences following the phase template.
+
+5. **llm_plan** (LLM mode only) — LLM drafts a songset from the pool using structured output. Hallucinated hash prefixes are repaired via fuzzy matching.
+
+6. **validate_score** — Validates the LLM draft against hard constraints H0–H8. If it fails, routes to `llm_refine` (up to 3 iterations).
+
+7. **finalize_rank** — Deduplicates proposals by song sequence, then applies greedy diverse selection with a middle-song diversity penalty (see below).
+
+8. **llm_judge** (optional) — LLM re-ranks finalists and adds judge reasons/scores without changing deterministic order.
+
+9. **write_artifacts** — Writes 5 output files (see below).
+
+## How Diverse Beam Search Works
+
+The beam search in `rules/beam.py` uses a **two-level round-robin diverse selection** to maximize song variety across proposals:
+
+### Phase Templates
+
+| Songs | Template | Arc |
+|-------|----------|-----|
+| 2 | (1, 4) | Call → Response |
+| 3 | (1, 3, 5) | Call → Praise → Commitment |
+| 4 | (1, 3, 4, 5) | Call → Praise → Cross → Commitment |
+| 5 | (1, 2, 3, 4, 5) | Full worship arc |
+
+### Beam Expansion
+
+At each position in the template, the beam expands all valid candidates. Validity is checked against:
+- **Phase match**: opener must be phase 1/2, closer must be phase 4/5
+- **Tempo floor/ceiling**: opener ≥ 90 BPM (configurable), closer ≤ 90 BPM (80 intimate)
+- **H4 tempo jump**: adjacent BPM delta ≤ 35 (25 without crossfade, 40 if relaxed)
+- **H5 circle-of-fifths**: CFD ≤ 2 (3 if relaxed) unless key shift is applied
+- **H7 phase arc**: phase may drop by at most 1 between adjacent songs
+- **Dead-end filtering**: non-closer positions skip songs with zero fan-out
+
+### Diverse Selection (Round-Robin)
+
+At each phase after the opener, sequences are grouped by:
+1. **Opener** (first song) — ensures different openers survive
+2. **Middle-song signature** (positions 1..-1) — ensures different middle combinations survive
+
+Within each opener group, middle-song groups are ranked by quality (phase score + tempo delta). A round-robin selection alternates between openers, and within each opener alternates between middle signatures, so no single opener or middle combination dominates the beam.
+
+At position 1 (opener), ALL valid openers are kept (up to beam width) to maximize starting-song diversity.
+
+### Beam Width
+
+Beam width is scaled to `max(top_k * 5, 40)`. For `--top-k 20`, the beam width is 100, allowing many diverse sequences to survive pruning.
+
+## How Diversity Penalty Works
+
+The `rank_proposals` function in `rules/proposals.py` uses a **greedy diverse selection with middle-song penalty**:
+
+1. Deduplicate proposals by song sequence hash
+2. Sort by score (descending)
+3. Greedily select proposals one at a time:
+   - For each candidate, compute `score_with_diversity_penalty(proposal, config, matrix, used_middle_songs)`
+   - The penalty reduces total score by `0.15 * (overlap_count / middle_count)` where overlap is the number of middle songs already used in higher-ranked proposals
+   - Pick the proposal with the highest penalized score
+   - Add its middle songs to the `used_middle_songs` set
+4. Repeat until `top_k` proposals are selected
+
+This spreads middle-slot variety across the final top-k, preventing all proposals from reusing the same 2–3 middle songs.
+
+## Hard Constraints (H0–H8)
+
+| Rule | Description | Relaxable |
+|------|-------------|-----------|
+| H0 | Cardinality: proposal must have exactly the requested song count | No |
+| H1 | Phase coverage: one phase-1 opener, at least one phase 3/4, ends on phase 4/5 | Yes (`--relax-h1`) |
+| H2 | Opening tempo ≥ 90 BPM | Yes (`--relax-h2-bpm`) |
+| H3 | Closing tempo ≤ 90 BPM (80 intimate) | Yes (`--relax-h3-bpm`) |
+| H4 | Adjacent BPM delta ≤ 35 (25 without crossfade, 40 if relaxed) | Yes (`--relax-h4`) |
+| H5 | Circle-of-fifths distance ≤ 2 (3 if relaxed) unless key shift applied | Yes (`--relax-h5`) |
+| H6 | No duplicate song IDs | No |
+| H7 | Phase may drop by at most 1 between adjacent songs | No |
+| H8 | Songs with key confidence < 0.6 cannot be transposed | No |
+
+When `--auto-relax` is enabled (default), the search automatically relaxes H4/H5, then H2/H3, then H1 if no proposals are found. Relaxed proposals carry warning labels (e.g., `relaxed_H4_H5`).
+
+## Fitness Scoring
+
+Each proposal is scored on four components:
+
+| Component | Weight | What It Measures |
+|-----------|-------:|-----------------|
+| `f_theme` | 0.40 | How well song phases match the template arc |
+| `f_tempo` | 0.30 | Tempo smoothness (low BPM delta between adjacent songs) + arc bonus (opener BPM ≥ closer BPM) |
+| `f_harmony` | 0.20 | Average key compatibility across adjacent transitions |
+| `f_diversity` | 0.10 | Unique songs (0.7 weight) + unique themes (0.3 weight) within the set |
+
+Total score = `0.40 * theme + 0.30 * tempo + 0.20 * harmony + 0.10 * diversity`, clamped to [0, 1].
+
+## Output Artifacts
+
+Each run writes 5 files to the output directory (default: `lab/poc-scripts/output/songset_constructor/<timestamp>/`):
+
+| File | Description |
+|------|-------------|
+| `proposals.json` | Machine-readable proposals with full metadata (songs, scores, transitions, config) |
+| `proposal_report.md` | Human-readable markdown table of all ranked proposals |
+| `candidate_pool.csv` | Full enriched pool with phase, BPM, key, themes per song |
+| `graph_trace.jsonl` | LangGraph execution trace (one JSON object per node event) |
+| `songset_review.md` | Auto-generated review summary with key findings, run config, and per-proposal details |
+
+## How to Evaluate Results
+
+### 1. Check Proposal Count
+
+The run log prints `candidates=N` after `beam_seed_candidates` and `proposals=N` after `finalize_rank`. If `proposals=0`, check the no-results summary printed by the CLI — it explains which stage blocked output.
+
+### 2. Read the Proposal Report
+
+Open `proposal_report.md`. For each proposal, check:
+
+- **Phase arc**: Does the phase sequence follow the template (e.g., 1→3→4→5 for 4 songs)?
+- **BPM arc**: Does the tempo generally decrease from opener to closer? Large jumps indicate weak transitions.
+- **Key compatibility**: Are adjacent keys close on the circle of fifths? Large key shifts (e.g., C major to F# major) reduce harmony score.
+- **Transition settings**: `shift 0, gap 2 beats` means a simple gap transition. `shift -2, gap 4 beats` means a 2-semitone transpose with a longer gap. Crossfade transitions allow larger BPM deltas.
+- **Warnings**: `relaxed_H4_H5` means the strict constraints were too tight and had to be relaxed. This is acceptable but indicates the catalog lacks perfectly compatible transitions.
+
+### 3. Assess Diversity
+
+Count unique songs per slot across all proposals:
+
+```bash
+uv run --project lab/poc-scripts --extra songset_constructor python -c "
+import json
+from pathlib import Path
+
+# Update path to your run's output directory
+data = json.loads(Path('lab/poc-scripts/output/songset_constructor/<TIMESTAMP>/proposals.json').read_text())
+proposals = data['proposals']
+
+for slot in range(len(proposals[0]['items'])):
+    songs = {p['items'][slot]['title'] for p in proposals}
+    print(f'Slot {slot + 1}: {len(songs)} unique songs')
+"
+```
+
+**Healthy diversity indicators:**
+- Openers: ≥ 50% of top_k should be unique (e.g., ≥ 10 unique openers for top_k=20)
+- Middle slots: ≥ 3 unique songs per slot
+- Closers: ≥ 2 unique songs
+
+**Limited diversity indicators:**
+- Slot 2 (first middle) often has only 2–3 unique songs because H4/H5 transition constraints limit compatible phase-3 songs per BPM group. This is a catalog constraint, not an algorithm bug.
+- If all proposals share the same opener, the beam search is converging. Increase `--top-k` or try different `--album-series` filters.
+
+### 4. Check Score Distribution
+
+Read the `Score:` line under each proposal. Typical ranges:
+
+| Component | Good | Acceptable | Concern |
+|-----------|------|------------|---------|
+| theme | ≥ 0.90 | ≥ 0.80 | < 0.80 (phase mismatch) |
+| tempo | ≥ 0.70 | ≥ 0.65 | < 0.60 (large BPM jumps) |
+| harmony | ≥ 0.70 | ≥ 0.50 | < 0.40 (key incompatibility) |
+| diversity | 1.00 | 1.00 | < 1.00 (duplicate songs) |
+| **total** | **≥ 0.80** | **≥ 0.70** | **< 0.65** |
+
+### 5. Review the Songset Review
+
+Open `songset_review.md` for an auto-generated summary including:
+- Phase flow distribution in the pool (how many songs per phase)
+- Tempo coverage (known vs missing BPM values)
+- Relaxation/constraint warnings
+- Per-proposal score breakdowns
+
+### 6. Compare Runs
+
+To compare diversity across different configurations, run multiple times and compare the unique-song counts per slot. Useful comparisons:
+
+- `--no-llm` vs `--llm-judge`: LLM mode adds LLM-drafted proposals with different song selections
+- `--intimate` vs default: Intimate mode selects slower closers (≤ 80 BPM)
+- `--season advent` vs default: Seasonal bias adjusts theme weights
+- Different `--album-series` filters: Narrows the pool to specific albums
+
+## Recipes
+
+### Generate 20 diverse 4-song sets from the full catalog
+
+```bash
+set -a && source /opt/sow/.env && set +a
+uv run --project lab/poc-scripts --extra songset_constructor \
+  python lab/poc-scripts/construct_songset_agent.py \
+  --songs 4 --pool-limit 500 --top-k 20 --no-llm
+```
+
+### Generate 10 LLM-judged 5-song sets
+
+```bash
+set -a && source /opt/sow/.env && set +a
+uv run --project lab/poc-scripts --extra songset_constructor \
+  python lab/poc-scripts/construct_songset_agent.py \
+  --songs 5 --pool-limit 500 --top-k 10 --llm-judge
+```
+
+### Generate intimate worship sets (slow closers)
+
+```bash
+set -a && source /opt/sow/.env && set +a
+uv run --project lab/poc-scripts --extra songset_constructor \
+  python lab/poc-scripts/construct_songset_agent.py \
+  --songs 4 --pool-limit 500 --top-k 20 --no-llm --intimate
+```
+
+### Generate Christmas-season sets
+
+```bash
+set -a && source /opt/sow/.env && set +a
+uv run --project lab/poc-scripts --extra songset_constructor \
+  python lab/poc-scripts/construct_songset_agent.py \
+  --songs 4 --pool-limit 500 --top-k 20 --no-llm --season christmas
+```
+
+### Generate sets from a specific album series
+
+```bash
+set -a && source /opt/sow/.env && set +a
+uv run --project lab/poc-scripts --extra songset_constructor \
+  python lab/poc-scripts/construct_songset_agent.py \
+  --songs 4 --pool-limit 500 --top-k 20 --no-llm \
+  --album-series "敬拜讚美 (1)" --album-series "敬拜讚美 (2)"
+```
+
+### Debug: strict-only mode (no auto-relax)
+
+```bash
+set -a && source /opt/sow/.env && set +a
+uv run --project lab/poc-scripts --extra songset_constructor \
+  python lab/poc-scripts/construct_songset_agent.py \
+  --songs 4 --pool-limit 500 --top-k 20 --no-llm --no-auto-relax
+```
+
+If this produces 0 proposals, the catalog lacks songs that satisfy all strict H1–H5 constraints simultaneously. Re-enable `--auto-relax` or manually relax specific constraints (e.g., `--relax-h4 --relax-h5`).
+
+### Interactive review (human-in-the-loop)
+
+```bash
+set -a && source /opt/sow/.env && set +a
+uv run --project lab/poc-scripts --extra songset_constructor \
+  python lab/poc-scripts/construct_songset_agent.py \
+  --songs 4 --pool-limit 500 --top-k 5 --no-llm --interactive-review
+```
+
+The CLI pauses after ranking and prompts `Review action (approve/reject)`. Use `--resume-thread-id` to resume an interrupted interactive session.
+
+## Troubleshooting
+
+### No proposals generated
+
+1. Check the CLI output for the no-results summary — it explains which stage blocked output.
+2. Run with `--no-auto-relax` to see if strict constraints are too tight.
+3. Check pool size: if `pool_size=0`, the database query returned nothing. Verify the catalog has published/review recordings with LRC lyrics.
+4. Check phase distribution in `songset_review.md`: if phase 1 or phase 4/5 count is 0, no valid openers or closers exist.
+
+### All proposals share the same opener
+
+This means the beam search is converging. The diverse beam search should prevent this, but if the catalog has very few valid openers (phase 1/2 with BPM ≥ 90), diversity is naturally limited. Check the phase distribution in `songset_review.md`.
+
+### All proposals share the same middle songs
+
+This is expected when the H4/H5 transition constraints limit compatible phase-3 songs per BPM group. The diversity penalty in `rank_proposals` spreads variety as much as possible, but it cannot create transitions that don't exist in the catalog. To increase middle-song diversity:
+- Relax H4: `--relax-h4` (widens BPM delta from 35 to 40)
+- Relax H5: `--relax-h5` (widens CFD from 2 to 3)
+- Use a larger pool: `--pool-limit 500`
+
+### LLM mode produces fewer proposals than expected
+
+In LLM mode, `validate_score` replaces `beam_candidates` with the LLM draft (via `operator.add` append). The final proposal count = beam proposals + 1 LLM draft (if validation passes). If the LLM draft fails validation after 3 refinement iterations, only beam proposals survive.
+
+### Harmony scores are low
+
+Low harmony scores (< 0.50) indicate key incompatibility between adjacent songs. Check the `Key` column in the proposal report — large key jumps (e.g., C major to B major) reduce harmony. The transition matrix may suggest a key shift (`shift -2` etc.) to improve compatibility, but songs with low key confidence (< 0.6) cannot be transposed (H8 constraint).
+
+## Key Source Files
+
+| File | Purpose |
+|------|---------|
+| `lab/poc-scripts/construct_songset_agent.py` | CLI entrypoint |
+| `poc/songset_constructor/cli.py` | Typer CLI with all options |
+| `poc/songset_constructor/config.py` | RunConfig dataclass, tempo/CFD limits |
+| `poc/songset_constructor/graph/builder.py` | LangGraph state machine definition |
+| `poc/songset_constructor/graph/nodes.py` | Graph node implementations |
+| `poc/songset_constructor/rules/beam.py` | Diverse beam search with round-robin selection |
+| `poc/songset_constructor/rules/fitness.py` | Scoring functions + diversity penalty |
+| `poc/songset_constructor/rules/proposals.py` | Proposal ranking with greedy diverse selection |
+| `poc/songset_constructor/rules/hard_constraints.py` | H0–H8 validation |
+| `poc/songset_constructor/rules/transitions.py` | Pairwise transition recommendation |
+| `poc/songset_constructor/rules/phases.py` | Theme classification and phase inference |
+| `poc/songset_constructor/db.py` | Read-only catalog pool query |
+| `poc/songset_constructor/artifacts/writer.py` | Output file generation |
+
+## Read-Only Guarantee
+
+The POC uses `ReadOnlyClient` and only issues bounded `SELECT` queries. It does not import `SongsetClient`, does not write `songsets` or `songset_items`, and does not run schema migrations.

--- a/specs/admin-cli-audio-sort.md
+++ b/specs/admin-cli-audio-sort.md
@@ -1,0 +1,122 @@
+# Spec: `sow-admin audio list` — sort by last update date
+
+## Goal
+
+Add a new `--sort updated` option to `sow-admin audio list` that orders recordings by
+`updated_at DESC` (most recently changed rows appear first). When this sort is active,
+the table output shows an additional **Updated** column with the timestamp.
+
+## Why
+
+The `recordings` table already has an `updated_at` column with a `BEFORE UPDATE` trigger
+that auto-refreshes it on any row change. Users need a quick way to see which recordings
+they modified most recently (e.g. after bulk visibility or LRC updates).
+
+## Changes (3 files)
+
+### 1. `ops/admin-cli/src/stream_of_worship/admin/db/client.py`
+
+**Location:** `list_recordings_with_songs()` method, `order_map` dict (around line 847).
+
+**Change:** Add one entry to `order_map`:
+
+```python
+"updated": "r.updated_at DESC NULLS LAST",
+```
+
+**Also:** Ensure the SQL `SELECT` clause in `list_recordings_with_songs` includes
+`r.updated_at`. If it is not already selected, add it to the SELECT list.
+
+### 2. `ops/admin-cli/src/stream_of_worship/admin/commands/audio.py`
+
+**Location:** `list_command()` function.
+
+**Changes:**
+
+a. **Help string** (around line 1216): update `--sort` help from
+   `(album|series|title|imported)` to `(album|series|title|imported|updated)`.
+
+b. **Validation set** (around line 1254): add `"updated"` to `valid_sorts`:
+   ```python
+   valid_sorts = {"album", "series", "title", "imported", "updated"}
+   ```
+
+c. **Table output** (around lines 1304–1312): when `sort == "updated"`, add an
+   **Updated** column to the table header and row rows. The timestamp should be
+   formatted as `YYYY-MM-DD HH:MM` (or similar short format). The column appears
+   *only* when `--sort updated` is used — not for other sort modes.
+
+   Implementation approach:
+   - In the table header construction, check if `sort == "updated"` and append
+     `"Updated"` to the header list.
+   - In the row rendering loop, append `rec.updated_at.strftime("%Y-%m-%d %H:%M")`
+     (or `str(rec.updated_at)[:16]` if it's a string) to the row values.
+   - The enriched row object from `db_client.list_recordings_with_songs()` must
+     expose `updated_at` — guaranteed by the SELECT clause change in step 1.
+
+d. **No client-side re-sort branch needed** in the post-processing block
+   (lines 1277–1287). The `updated` sort is handled entirely by the DB, same
+   pattern as `imported`.
+
+### 3. `ops/admin-cli/tests/admin/test_audio_commands.py`
+
+**Location:** `TestAudioListCommand` class.
+
+**Changes:**
+
+a. **Integration test** — `@pytest.mark.integration` decorated:
+
+   ```
+   TestAudioListSortUpdated
+   ```
+
+   Steps:
+   1. Use `make_test_provider` fixture (testcontainers Postgres) to get a DB connection.
+   2. Insert song A and song B via `client.insert_song()`.
+   3. Insert recording A via `client.insert_recording()` (gets current `updated_at`).
+   4. Insert recording B via `client.insert_recording()` (gets current `updated_at`).
+   5. Use direct SQL (via `make_test_provider`'s connection cursor) to UPDATE
+      recording A's `updated_at` to a future timestamp (e.g. `NOW() + INTERVAL '1 day'`),
+      making it newer than B.
+   6. Run `runner.invoke(app, ["audio", "list", "--sort", "updated", "--config", config_path])`.
+   7. Assert `result.exit_code == 0`.
+   8. Assert recording A's title appears before recording B's title in `result.output`.
+   9. Assert the "Updated" column header is present in `result.output`.
+   10. Assert the updated_at timestamps appear in the output.
+
+b. **Validation test** — non-integration test:
+
+   ```
+   TestAudioListSortUpdatedValidation
+   ```
+
+   Steps:
+   1. Write minimal config (no DB URL).
+   2. Run `audio list --sort updated` → assert non-zero exit code (fails at DB, not at validation).
+   3. Run `audio list --sort bogus` → assert non-zero exit code with error mentioning
+      "invalid choice" or similar validation message.
+   4. This confirms `updated` passes CLI validation while invalid values are rejected.
+
+## Out of scope
+
+- `--format ids` output remains unchanged (no timestamp shown, matches existing `imported` behavior).
+- No DB migration needed — `updated_at` column and trigger already exist.
+- No changes to legacy apps, lab apps, or other CLI commands.
+- No changes to the table output for non-`updated` sort modes.
+
+## Verification
+
+After implementation, run:
+
+```bash
+uv run --project ops/admin-cli --python 3.11 --extra admin --extra test \
+  pytest -v ops/admin-cli/tests/admin/test_audio_commands.py::TestAudioListCommand
+```
+
+Also verify the CLI help text:
+
+```bash
+uv run --project ops/admin-cli --python 3.11 --extra admin sow-admin audio list --help
+```
+
+Expected to show `updated` in the `--sort` options.

--- a/specs/lrc-editor-keymap-popup.md
+++ b/specs/lrc-editor-keymap-popup.md
@@ -1,0 +1,173 @@
+# LRC Editor Keymap Popup
+
+## Summary
+
+Add a new `?` action key to the LRC editor that opens a modal popup listing
+**every** action key mapping, grouped the same way the footer groups them
+(Playback, Lyrics, Timecode, General). The existing single-line footer is left
+unchanged — this is purely an additive discoverability feature so users can see
+bindings that the footer truncates (e.g. `I = Insert Canonical`).
+
+## Motivation
+
+The `GroupedFooter` (`ops/admin-cli/src/stream_of_worship/admin/editor/footer.py`)
+extends `Horizontal` and lays out its 4 binding groups side-by-side on a single
+row. Each `_BindingGroup` child is locked to `height: 1` with `overflow: hidden`
+and its Rich `Text` content has `no_wrap = True` and `overflow="ellipsis"`. The
+"Lyrics" group alone has 8 bindings, so on any normal terminal width the row is
+ellipsized and keys like `I=Insert Canonical` are invisibly truncated. The
+footer's `height: 3` mostly sits empty as a result.
+
+Rather than reflow the footer (which would either consume more vertical space
+or risk wrapping unpredictably across terminal widths), we add a dedicated
+"show keymap" action that pops up a full modal listing every binding. This
+matches the user's stated preference: keep the current footer as-is, add a new
+action key that opens a popup where all action key mappings are shown.
+
+## Design
+
+### Action key
+
+- New binding: `Binding("?", "show_keymap", "Keymap")`
+- Added to `LRCEditorScreen.BINDINGS` after the existing `q` quit binding.
+- `"show_keymap"` appended to `BINDING_GROUPS["General"]` so the new entry
+  appears on the footer's General group (one short addition, well within the
+  existing single-line width).
+- Glyph for `?` is not normalized (it's a literal printable character), so
+  `format_key_display("?")` returns `"?"` unchanged.
+
+### Modal dialog
+
+A new nested `KeymapDialog(ModalScreen[None])` class, defined inside
+`action_show_keymap` (mirroring the existing nested-`ModalScreen` pattern used
+by `action_quit_editor` at `screen.py:1336` and `_show_save_upload_prompt` at
+`screen.py:1192`).
+
+- Constructor takes `groups: dict[str, list[str]]` and `bindings: list[Binding]`
+  (decoupled from the parent screen class for testability).
+- `compose()` yields a `Vertical(id="keymap-container")` with:
+  - `Label("Keymap", classes="dialog-title")`
+  - For each group: a heading `Label(f"[bold]{group_label}[/bold]")`, then one
+    `Label` per binding printing
+    `f"[dim]{format_key_display(b.key)}[/dim]={b.description}"`, then a blank
+    `Label("")` separator between groups.
+  - Closing hint `Label("[d]Press [bold]?[/bold] or [bold]Esc[/bold] to close[/]")`.
+- `BINDINGS = [Binding("escape", "close", "Close"), Binding("?", "close", "Close")]`
+- `action_close(self) -> None: self.dismiss(None)`
+
+The dialog reuses the existing `dialog-container` / `dialog-title` convention
+already used by `SaveUploadDialog` (`screen.py:1221-1222`). No custom CSS is
+required — Textual's default `ModalScreen` styling centers/dims the Vertical.
+
+### Glyph helper extraction
+
+The glyph normalization logic currently inlined in
+`_BindingGroup._format_content` (`footer.py:23-41`, the long `if/elif` chain
+that turns `ctrl+c` → `^C`, `shift+left` → `⇧←`, `space` → `⎵`, etc.) is
+extracted into a module-level function:
+
+```python
+def format_key_display(key: str) -> str:
+    if key.startswith("ctrl+"):
+        return "^" + key[5:].upper()
+    if key == "shift+left":
+        return "⇧←"
+    if key == "shift+right":
+        return "⇧→"
+    if key == "left":
+        return "←"
+    if key == "right":
+        return "→"
+    if key == "up":
+        return "↑"
+    if key == "down":
+        return "↓"
+    if key == "space":
+        return "⎵"
+    if key == "escape":
+        return "Esc"
+    return key
+```
+
+`_BindingGroup._format_content` calls the helper, producing identical output
+(existing glyphs preserved). The keymap dialog imports and reuses the same
+helper so glyphs are consistent between footer and popup — no duplication.
+
+### Edge case: active row edit
+
+When the row-edit overlay `Input` is focused, Textual dispatches keystrokes to
+the focused widget first, so `?` types a literal `?` into the cell rather than
+opening the dialog. This is the desired behavior (matches how `e` edit-text
+already consumes its key in overlay mode via `_is_edit_active()` short-circuits).
+For consistency with `action_quit_editor`, `action_show_keymap` begins with:
+
+```python
+if self._is_edit_active():
+    return  # let `?` go into the input
+```
+
+## Changes
+
+### 1. `ops/admin-cli/src/stream_of_worship/admin/editor/footer.py`
+
+- Extract inline glyph normalization (lines 23-41) into module-level
+  `format_key_display(key: str) -> str`.
+- `_BindingGroup._format_content` calls `format_key_display(b.key)` — behavior
+  unchanged.
+- `format_key_display` is exported (module-level function, importable).
+
+### 2. `ops/admin-cli/src/stream_of_worship/admin/editor/screen.py`
+
+- Import `format_key_display` from `footer.py`.
+- Add `Binding("?", "show_keymap", "Keymap")` to `BINDINGS` (after the `q` quit
+  binding, line 246).
+- Append `"show_keymap"` to `BINDING_GROUPS["General"]` (line 272-279).
+- Implement `action_show_keymap(self) -> None:` following the existing
+  nested-`ModalScreen` pattern:
+  - Short-circuit `if self._is_edit_active(): return`.
+  - Define nested `KeymapDialog(ModalScreen[None])` class (see Design above).
+  - Push via `self.app.push_screen(KeymapDialog(self.BINDING_GROUPS, self.BINDINGS))`.
+    No result callback needed.
+
+### 3. Test: `ops/admin-cli/tests/admin/services/test_lrc_editor_screen.py`
+
+Add `test_show_keymap_dialog_lists_all_bindings_grouped()` that:
+
+- Builds the app via the existing test fixtures (same pattern as
+  `test_small_terminal_layout_keeps_footer_out_of_lyrics_viewport`, line 135).
+- Calls `app.screen.action_show_keymap()`.
+- Queries the now-active `ModalScreen` for the keymap container.
+- Asserts that every group label ("Playback", "Lyrics", "Timecode", "General")
+  and every binding description (e.g. "Insert Canonical" for the `I` key) is
+  present as a label.
+- Dismisses (calls `action_close()`).
+
+## Files Modified
+
+| File | Change |
+|---|---|
+| `ops/admin-cli/src/stream_of_worship/admin/editor/footer.py` | Extract `format_key_display` helper; `_BindingGroup` calls it (no behavior change) |
+| `ops/admin-cli/src/stream_of_worship/admin/editor/screen.py` | Add `?` binding, `show_keymap` group entry, `action_show_keymap` + nested `KeymapDialog` |
+| `ops/admin-cli/tests/admin/services/test_lrc_editor_screen.py` | Add `test_show_keymap_dialog_lists_all_bindings_grouped` |
+
+## Not Changed
+
+- Existing footer layout, CSS, or glyph styling.
+- Existing `BINDINGS` list (other than appending the new `?` entry).
+- Existing `BINDING_GROUPS` (other than appending `"show_keymap"` to General).
+- Non-editor screens/components.
+
+## Verification
+
+```bash
+# Lint + format (Black/Ruff with line length 100, py311)
+uv run --project ops/admin-cli --python 3.11 --extra admin ruff check ops/admin-cli/src/stream_of_worship/admin/editor/
+uv run --project ops/admin-cli --python 3.11 --extra admin black --check ops/admin-cli/src/stream_of_worship/admin/editor/
+
+# Editor tests
+uv run --project ops/admin-cli --python 3.11 --extra admin --extra test pytest -v ops/admin-cli/tests/admin/services/test_lrc_editor_screen.py
+
+# Manual smoke test (interactive — verify popup opens with `?`, dismisses with `?`/`Esc`,
+# all 4 groups + every binding including "Insert Canonical" visible)
+uv run --project ops/admin-cli --extra admin sow-admin <edit-lrc subcommand>
+```

--- a/specs/recover-visibility-bug-audio-batch-v2.md
+++ b/specs/recover-visibility-bug-audio-batch-v2.md
@@ -1,0 +1,289 @@
+# Recover `visibility_status` Reverted by `audio batch` Bug — v2 (Post-Analyze-Bump Recovery)
+
+## Status
+
+**Planning only — do not implement yet.** This is a v2 follow-up to
+`specs/recover-visibility-bug-audio-batch.md` (v1), fixing a fatal assumption
+invalidated by a recent all-recordings `FAST_ANALYZE`/`ANALYZE` run.
+
+## Why v2 is needed (assumption re-validation result)
+
+### The v1 assumption
+
+v1's signal (in `recover_visibility.py`, `_compute_verdict`) treats
+`recordings.updated_at` as `T_bug` — the bug-fire time — and computes
+`delta_h = db_updated_at − r2_last_modified`. The verdict matrix keys off
+`delta_h` alone (`OK_FRESH_LRC` / `SUSPECTED_BUG_REVERT` / `INCONCLUSIVE`),
+with `--with-analysis` only adding a cross-check column.
+
+### Why it is wrong after the analyze run
+
+`recordings.updated_at` is bumped by a generic `BEFORE UPDATE` trigger
+(`db/schema.py:188-194`) on **every** write path, not just the bug path.
+Relevant writers that bump `updated_at = NOW()` without touching
+`visibility_status` (all in `db/client.py`):
+
+- `update_recording_analysis` (SQL at `1005-1060`) — writes `analysis_status`,
+  `key_detected_at`, etc. Unconditional `updated_at = NOW()`. The safe LRC path
+  passes `visibility_status=None` → `COALESCE` preserves `published`, but
+  `updated_at` still jumps to `T_analyze`.
+- `update_recording_status` (`917-918`)
+- `update_recording_lrc` (`1116-1132`)
+- `update_recording_download` (`1165-1167`)
+- `update_recording_duration` (`1211-1213`)
+- `update_recording_r2_url` (`1234-1236`)
+- `update_recording_youtube_url` (`1188-1190`)
+- `update_recording_visibility` (`1269-1271`) — the only one that actually
+  changes visibility; intentionally.
+- `set_hold` / `set_review` helpers (`1311-1312`, `1381-1382`).
+
+The recent all-recordings `FAST_ANALYZE`/`ANALYZE` run fired
+`update_recording_analysis` on essentially every recording. Concrete
+consequences:
+
+1. `db_updated_at` is now `T_analyze` for essentially every candidate, **not**
+   `T_bug`. The original `T_bug` value is overwritten and **unrecoverable from
+   the live DB**.
+2. v1's clustering mitigation ("bug run produces a tight batch") collapses —
+   today *everything* clusters around `T_analyze`, hiding the genuine
+   bug cluster.
+3. `delta_h = T_analyze − T_manual_edit` exceeds the `1h..1440h` window purely
+   because a published LRC was edited before the analyze window — so any
+   legitimately-`review` recording whose LRC predates the analyze run gets a
+   false `SUSPECTED_BUG_REVERT` flag. False-positive rate jumps.
+4. `--until <pre-analyze>` cannot help: no candidate qualifies anymore (their
+   `updated_at` is now post-analyze). R2 versioning cannot help either: the
+   bug `_confirm_r2_lrc` (`audio.py:6471-6497`) never re-uploads the LRC, so
+   the R2 object didn't change and `r2_last_modified` is unchanged.
+
+### What survives the bump
+
+- **`r2_last_modified`** still equals the manual-edit time whenever a human
+  edited the LRC via the admin editor (`editor/upload.py`). The analyze run
+  does not touch the LRC object.
+- **`recordings.analysis_job_id`** exists (`schema.py` column `analysis_job_id`)
+  and is resolvable via `AnalysisClient.get_job()` → `JobInfo.updated_at`
+  (job completion ≈ `T_analyze`).
+- **`recordings.key_detected_at`** (timestamptz) is written by
+  `update_recording_analysis` and ≈ `T_analyze` when the key-detection branch
+  runs.
+- **`recordings.lrc_job_id`** + `AnalysisClient.get_job()` → LRC job
+  completion (`lrc_job.updated_at`), independent of `recordings.updated_at`.
+
+These give us loss-less signals that v1 ignores or treats as secondary.
+
+## Goal
+
+Produce a corrected dry-run report that:
+
+1. Detects the analyze-bump (demote `delta_h` to informational only).
+2. Switches the primary bug signal to the R2-vs-LRC-job ordering, which is
+   `updated_at`-independent.
+3. Preserves v1's read-only / no-code-fix / dry-run-only contract.
+
+## New signal model (verdict inputs)
+
+For each candidate (`visibility_status='review' AND lrc_status='completed' AND
+r2_lrc_url IS NOT NULL AND deleted_at IS NULL`):
+
+1. `r2_lm` = R2 `head_object` LastModified for `{hash_prefix}/lyrics.lrc`
+   (`R2Client.get_lrc_identity`).
+2. `lrc_job_done` = `AnalysisClient.get_job(lrc_job_id).updated_at` when
+   `status='completed'` (tolerate 404 → `lrc_job_done = None`).
+3. `analyze_job_done` = `AnalysisClient.get_job(analysis_job_id).updated_at`
+   when `status='completed'` (tolerate 404 → `None`). Requires the new
+   `analysis_job_id` column in the candidate SELECT.
+4. `key_detected_at` = the DB timestamptz (free, no service call).
+5. `db_updated_at` = current (possibly analyze-bumped) recordings.updated_at.
+6. `delta_h` = `db_updated_at − r2_lm` in hours (**informational only**).
+
+### Derived booleans
+
+- **`analyze_bump`** =
+  `|db_updated_at − analyze_job_done| <= BUMP_TOLERANCE_S`
+  (default 60s) when `analyze_job_done` is known, **OR**
+  `|db_updated_at − key_detected_at| <= BUMP_TOLERANCE_S` (fallback when
+  analysis service job is purged and `key_detected_at IS NOT NULL`).
+  `BUMP_TOLERANCE_S` is a CLI flag (default 60) because the DB trigger and the
+  analysis service clock are not the same host; allow the admin to widen it.
+- **`/manual_edit_after_autogen/`** =
+  `lrc_job_done IS NOT NULL AND r2_lm IS NOT NULL AND lrc_job_done < r2_lm`
+  (manual edit produced the current R2 file after the auto-generated one).
+  Requires `--with-analysis` (off by default). Without it, the boolean is
+  `UNKNOWN`.
+
+## New verdict matrix
+
+Replaces v1's `_compute_verdict(delta_h, …)`.
+
+| Conditions | Verdict | Recommendation |
+|---|---|---|
+| `r2_lm` missing/unparseable, or `db_updated_at` invalid | `INCONCLUSIVE` | eyes-on |
+| `abs(delta_h) <= 0.1` (LRC just generated, same-tick write) | `OK_FRESH_LRC` | — |
+| `/manual_edit_after_autogen/` true AND `analyze_bump` true | `SUSPECTED_BUG_REVERT` | `set-visibility published` |
+| `/manual_edit_after_autogen/` true AND `analyze_bump` false | `SUSPECTED_BUG_REVERT` | `set-visibility published` (still smoking gun; bump flag informational) |
+| `analyze_bump` true AND `manual_edit_after_autogen` UNKNOWN/false (no `--with-analysis`) | `SUSPECTED_POST_ANALYZE` | needs `--with-analysis` to resolve |
+| `analyze_bump` true AND `manual_edit_after_autogen` false (`--with-analysis` says r2_lm <= lrc_job_done) | `NO_SIGNAL_POST_ANALYZE` | likely not bug-reverted |
+| otherwise | `INCONCLUSIVE` | eyes-on |
+
+Notes:
+
+- `delta_h` is shown but no longer selects a verdict on its own.
+- The intentional-revert false-positive class (admin deliberately ran
+  `set-visibility review`) is unchanged from v1 — the ordering test cannot
+  distinguish it. Mitigations remain cluster/`--since`/`--until` eyeballing.
+
+## Implementation plan (file: `recover_visibility.py`)
+
+### A. Candidate SELECT — extend columns
+
+In `_build_candidate_query`, add to the SELECT list:
+
+```sql
+r.analysis_job_id,
+r.key_detected_at
+```
+
+(`analysis_job_id` and `key_detected_at` both exist on `recordings`.) No other
+SQL change.
+
+### B. Extend `_batch_lookup_analysis` to fetch ANALYZE jobs too
+
+- Rename concept: the same pool now resolves **two** job classes per candidate:
+  the LRC job (`lrc_job_id`) and the ANALYZE job (`analysis_job_id`).
+- `_lookup_analysis_job` is unchanged internally — it's job-id agnostic.
+- In `_run_report`, after the R2 batch resolves, collect **both**
+  `lrc_job_id` and `analysis_job_id` from each candidate into the lookup list
+  (dedupe, skip empties). Today the code only collects `lrc_job_id` from
+  `SUSPECTED_BUG_REVERT` rows up front, which presupposes the v1 delta-h
+  verdict. v2 must collect both *for all candidates*, because the
+  ordering-based verdict needs `lrc_job_done` regardless of `analyze_bump`.
+- Guard `--with-analysis` gating: when off, skip all analysis-job lookups and
+  fall back to `key_detected_at`-only bump detection + `manual_edit_after_autogen = UNKNOWN`.
+
+### C. Rewrite `_compute_verdict` signature
+
+Old:
+```python
+def _compute_verdict(delta_hours, min_h, max_h) -> tuple[str, str]
+```
+
+New — take a small dict/dataclass of resolved signals:
+```python
+@dataclass
+class CandidateSignals:
+    db_updated_at: Optional[datetime]
+    r2_lm: Optional[datetime]
+    lrc_job_done: Optional[datetime]   # None if --with-analysis off OR job purged
+    analyze_job_done: Optional[datetime]
+    key_detected_at: Optional[datetime]
+    with_analysis: bool
+    bump_tolerance_s: float
+
+def _compute_verdict(sig: CandidateSignals) -> tuple[str, str, dict[str, Any]]:
+    # returns (verdict, recommendation, debug_notes)
+```
+
+Logic per the matrix above; `debug_notes` carries the booleans
+(`analyze_bump`, `manual_edit_after_autogen`, `analyze_bump_source` =
+`analysis_job|key_detected_at|none`) for the table/CSV.
+
+- `OK_FRESH_LRC`: `abs(delta_h) <= 0.1` (kept identical to v1).
+- `INCONCLUSIVE`: missing timestamps.
+- `analyze_bump`: compute from `analyze_job_done` first, `key_detected_at`
+  fallback.
+- `manual_edit_after_autogen`: only computable when `with_analysis` and
+  `lrc_job_done` and `r2_lm` present.
+- Final verdict per table.
+
+### D. Output columns
+
+Add (CSV and Rich table):
+
+- `analysis_job_id` (context)
+- `key_detected_at` (timestamp; informational)
+- `analyze_job_done` (timestamp from service; informational)
+- `analyze_bump` (bool, `yes|no|unknown`)
+- `bump_source` (`analysis_job|key_detected_at|none`)
+- `manual_edit_after_autogen` (`yes|no|unknown`)
+
+Keep `delta_h` but recolor it as informational (dim, not the verdict color).
+Demote `verdict` coloring so `SUSPECTED_POST_ANALYZE` is yellow and
+`SUSPECTED_BUG_REVERT` is red (as v1).
+
+### E. New CLI flag
+
+- `--bump-tolerance-seconds` (default 60). Replaces reliance on
+  `--min-delta-hours` as the dominant tuning knob for the analyze window.
+  Keep `--min-delta-hours` / `--max-delta-hours` flags for back-compat but
+  they now only gate the `OK_FRESH_LRC` window and historical
+  `delta_h`-display filter, not the verdict.
+
+### F. Summary panel
+
+Update the footer counts:
+```
+Total | SUSPECTED_BUG_REVERT | SUSPECTED_POST_ANALYZE | OK_FRESH_LRC | INCONCLUSIVE | NO_SIGNAL_POST_ANALYZE
+```
+And print a one-line guidance: "Re-run with `--with-analysis` to resolve
+`SUSPECTED_POST_ANALYZE` rows."
+
+## Out of scope (carried from v1)
+
+- No code fix to `audio.py:5458` / `audio.py:2820`
+  (`visibility_status="review"` → `None`).
+- No bulk `UPDATE recordings SET visibility_status='published'`.
+- No new Admin CLI subcommand.
+- No schema changes (no `visibility_status_updated_at`, no audit table) in
+  this spec — `official-lrc-last-writer-wins-v3.md` may already track related
+  work; check before scheduling a backfill.
+
+## Risks & open questions
+
+1. **`key_detected_at` only written on key-detection branch.** Some FAST-tier
+   jobs skip it. When `--with-analysis` is off and `key_detected_at IS NULL`,
+   we cannot detect the analyze bump at all → verdict falls to
+   `INCONCLUSIVE` for those rows. Acceptable; admin re-runs with
+   `--with-analysis`.
+2. **`analysis_service` job retention.** If both `lrc_job_id` and
+   `analysis_job_id` are purged (404) and `key_detected_at IS NULL`, the row is
+   fully `INCONCLUSIVE`. No recovery possible without a pre-analyze DB
+   snapshot (see workaround W4 in the re-validation) — out of scope here.
+3. **`abs(delta_h) <= 0.1` legitimately-fresh-LRC carve-out** — spot-checked
+   `audio.py:5430-5536`: `_handle_lrc_completion` on the `completed` path
+   calls `_confirm_r2_lrc` which **only `head_object`s; it does NOT upload**.
+   The R2 object is written by the analysis service worker at `T_gen_upload`;
+   the poll loop detects completion ~one poll interval later at `T_handle` and
+   only then writes the DB. So `OK_FRESH_LRC` fires because
+   `T_handle − T_gen_upload < poll_interval` (typically < 6 min), *not* because
+   the DB path uploads+writes in the same tick. **Post-analyze-bump this
+   carve-out only fires for LRCs generated AFTER the last analyze run** — for
+   LRCs generated before the analyze run, `db_updated_at = T_analyze` makes
+   `delta_h` large and `OK_FRESH_LRC` never fires, so fresh-`review` (never
+   published) recordings get misclassified as `SUSPECTED_BUG_REVERT`. This is
+   an additional reason `delta_h` cannot be the primary signal post-bump; rely
+   on the W2 ordering test, and treat `OK_FRESH_LRC` only as a fast-path for
+   very-recent LRCs (since the last analyze run).
+4. **Clock skew** between DB host and analysis service host could make the
+   60s bump tolerance too tight or too loose. Make the flag user-tunable and
+   document the trade-off; default 60s is a guess, validate against a known
+   recently-analyzed row.
+
+## References
+
+- v1 spec: `specs/recover-visibility-bug-audio-batch.md`
+- v1 impl: `ops/admin-cli/src/stream_of_worship/admin/commands/recover_visibility.py`
+- Bug site 1: `ops/admin-cli/src/stream_of_worship/admin/commands/audio.py:5430-5536`
+- Bug site 2: `ops/admin-cli/src/stream_of_worship/admin/commands/audio.py:2811-2822`
+- `_confirm_r2_lrc` (head-only, no re-upload): `.../commands/audio.py:6471-6497`
+- `update_recording_analysis` (the analyze-bump writer):
+  `.../db/client.py:952-1075`
+- `update_recording_lrc` (COALESCE visibility): `.../db/client.py:1085-1138`
+- `update_recording_visibility`: `.../db/client.py:1242-1276`
+- `recordings` schema (incl. `analysis_job_id`, `key_detected_at`):
+  `.../db/schema.py:38-90`
+- `trg_recordings_updated_at` (trigger): `.../db/schema.py:188-194`
+- `AnalysisClient.get_job` / `JobInfo`: `.../services/analysis.py:560-, 98-121`
+- `R2Client.get_lrc_identity` (`R2ObjectIdentity`):
+  `.../services/r2.py:458-484`
+- Admin LRC editor save (manual-edit R2 upload): `.../editor/upload.py:184-279`

--- a/specs/recover-visibility-bug-audio-batch.md
+++ b/specs/recover-visibility-bug-audio-batch.md
@@ -1,0 +1,237 @@
+# Recover `visibility_status` Reverted by `audio batch` Bug — Dry-Run Report
+
+## Problem Summary
+
+Approximately ~30 recordings in the SOW database had their `visibility_status` reverted from `'published'` to `'review'` due to a bug in the Admin CLI `audio batch` command. The bug fires when the batch poll loop detects a completed LRC job for a recording whose LRC had already been generated (and possibly manually edited and published) — it unconditionally overwrites `visibility_status` to `'review'` instead of preserving the existing value.
+
+This document specifies a **read-only dry-run report** that identifies the suspected bug-reverted recordings by cross-referencing the R2 LRC file's `LastModified` timestamp against the DB `recordings.updated_at` timestamp. No DB writes, no code changes to the Admin CLI.
+
+### User-confirmed scope
+
+- **Deliverable**: Dry-run report only (no DB UPDATE, no code fix to `audio.py:5458`).
+- **Run mode**: Inline Python invoked via `uv run --project ops/admin-cli --extra admin python -c "..."`. Nothing added to the Admin CLI command surface.
+- **Candidate scope**: Filtered — `visibility_status='review' AND lrc_status='completed' AND r2_lrc_url IS NOT NULL AND deleted_at IS NULL`.
+- **Analysis service lookups**: Off by default; opt-in via `--with-analysis` flag.
+
+## Bug Root Cause
+
+### Bug site 1 (primary): `_handle_lrc_completion()` in `audio batch` poll loop
+
+**File**: `ops/admin-cli/src/stream_of_worship/admin/commands/audio.py:5430-5536`
+
+```python
+if job.status == "completed":
+    recording = db_client.get_recording_by_song_id(song_id)
+    lrc_url = _confirm_r2_lrc(r2_client, recording.hash_prefix, console)
+
+    if lrc_url:
+        db_client.update_recording_lrc(
+            recording.hash_prefix,
+            lrc_url,
+            visibility_status="review",   # <-- BUG: unconditionally overwrites
+        )
+```
+
+### Bug site 2 (secondary): `audio status --sync`
+
+**File**: `ops/admin-cli/src/stream_of_worship/admin/commands/audio.py:2811-2822`
+
+```python
+# Sync LRC job
+if rec.lrc_job_id and rec.lrc_status in ("pending", "processing"):
+    try:
+        job = client.get_job(rec.lrc_job_id)
+        if job.status == "completed":
+            if job.result and job.result.lrc_url:
+                db_client.update_recording_lrc(
+                    hash_prefix=rec.hash_prefix,
+                    r2_lrc_url=job.result.lrc_url,
+                    visibility_status="review",   # <-- BUG: same pattern
+                )
+```
+
+### Why the bug overwrites without re-uploading the LRC
+
+`_confirm_r2_lrc()` (`audio.py:6471-6497`) only verifies the existing R2 file via `head_object` — it does **not** re-upload. So when the bug fires on a recording whose LRC was already manually edited and published:
+
+- R2 file at `{hash_prefix}/lyrics.lrc` is **untouched** → `LastModified` stays at the prior manual-edit timestamp `T_manual`.
+- DB row is updated: `r2_lrc_url`, `lrc_status='completed'`, `visibility_status='review'`, `updated_at = NOW()` → `updated_at` becomes the bug-fire time `T_bug`.
+
+### Contrast with the safe pattern
+
+All other LRC completion / reconciliation paths correctly use `visibility_status=None`, which routes through `COALESCE(visibility_status, 'published')` in `update_recording_lrc()` (`db/client.py:1085-1138`):
+
+- `audio.py:2516` — `audio status --reconcile`
+- `audio.py:4946` — `_submit_lrc_for_song` (batch LRC submit)
+- `audio.py:5564` — `_handle_lrc_404`
+- `audio.py:6531` — `_reconcile_on_interrupt`
+- `editor/upload.py:263` — admin LRC editor save (`upload_revised_lrc`)
+
+## Signal Hypothesis
+
+For each `'review'` recording with `lrc_status='completed'` and `r2_lrc_url IS NOT NULL`:
+
+1. Fetch the R2 file's `LastModified` for `{hash_prefix}/lyrics.lrc` via `R2Client.get_lrc_identity(hash_prefix)` (`services/r2.py:458-484`).
+2. Compare to DB `recordings.updated_at`.
+3. Compute `delta_hours = (db_updated_at - r2_last_modified)` in hours.
+
+### Verdict matrix
+
+| `delta_hours` range | Verdict | Rationale |
+|---|---|---|
+| `<= 0.1` (~5 min) | `OK_FRESH_LRC` | LRC was just generated and visibility was set in the same operation. `'review'` is correct. |
+| `1 <= delta <= 1440` (1h–60d) | `SUSPECTED_BUG_REVERT` | Visibility was flipped without an LRC re-upload → buggy revert of a manually-published LRC. Recommend restore to `'published'`. |
+| otherwise | `INCONCLUSIVE` | Admin should eyeball. |
+
+### Why this works
+
+- **Bug-reverted recording**: `T_manual` (admin edited LRC via editor) < `T_bug` (batch fired). R2 file unchanged at `T_manual`; DB `updated_at` bumped to `T_bug`. Delta = hours to days.
+- **Legitimately new LRC**: Analysis service generates LRC, uploads to R2 at `T_gen`, then `_handle_lrc_completion` runs at `T_handle ≈ T_gen`. Both timestamps within seconds/minutes.
+
+### Optional cross-check via analysis service (`--with-analysis`)
+
+For each `SUSPECTED_BUG_REVERT` row, call `AnalysisClient.get_job(lrc_job_id)` (`services/analysis.py`). The returned `JobInfo` has `created_at` and `updated_at` (`analysis.py:98-121`); when `status='completed'`, `updated_at` ≈ job completion time.
+
+Expected ordering for the bug case:
+```
+job_completed_at  <  r2_last_modified  <  db_updated_at
+```
+i.e. the LRC job completed before the manual edit, the manual edit produced the current R2 file, and the bug later flipped visibility without re-uploading.
+
+**Caveat**: The analysis service may have purged old jobs. On `AnalysisServiceError` / 404, annotate the row as `"job purged — relying on R2/DB timestamps only"` and rely on the primary signal.
+
+## Schema Reality
+
+The `recordings` table (`ops/admin-cli/src/stream_of_worship/admin/db/schema.py:38-90`) has **no dedicated LRC timestamp columns**. Relevant columns:
+
+| Column | Type | Notes |
+|---|---|---|
+| `r2_lrc_url` | TEXT | S3 URL of the LRC file in R2 |
+| `lrc_status` | TEXT | `pending` / `processing` / `completed` / `failed` |
+| `lrc_job_id` | TEXT | External analysis-service job ID |
+| `visibility_status` | TEXT | `published` / `review` / `hold` (NULL = unpublished) |
+| `updated_at` | timestamptz | Generic row-level trigger on ANY update |
+| `imported_at` | TEXT | ISO timestamp at import time |
+| `created_at` | timestamptz | Row creation time |
+| `deleted_at` | timestamptz | Soft delete; NULL = active |
+
+There is **no** `lrc_updated_at`, `lrc_job_completed_at`, `lrc_synced_at`, or `lrc_published_at` column. There is **no** `lrc_jobs` table — LRC job state lives in the analysis service and is referenced via `lrc_job_id`.
+
+The `updated_at` column is updated via a `BEFORE UPDATE` trigger (`schema.py:188-194`):
+```sql
+CREATE TRIGGER trg_recordings_updated_at
+    BEFORE UPDATE ON recordings
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+```
+
+## Implementation
+
+### Run command
+
+```bash
+uv run --project ops/admin-cli --extra admin python -c "
+import sys; sys.path.insert(0, 'src')
+# ... script body ...
+" \
+  [--since 2026-07-10] [--until 2026-07-20] \
+  [--album <name>] [--min-delta-hours 1] [--max-delta-hours 1440] \
+  [--with-analysis] [--csv]
+```
+
+### Script structure
+
+1. **Build clients** using the same configuration flow the Admin CLI uses:
+   - `AdminConfig.from_env()` (or equivalent) → instantiate `DatabaseClient`, `R2Client`.
+   - Optionally `AnalysisClient` if `--with-analysis`.
+
+2. **Candidate SQL** (filtered, as agreed):
+   ```sql
+   SELECT r.hash_prefix, r.song_id, r.lrc_job_id, r.r2_lrc_url,
+          r.visibility_status, r.lrc_status,
+          r.updated_at AS db_updated_at, r.imported_at,
+          s.title AS song_title, s.album AS song_album
+   FROM recordings r
+   LEFT JOIN songs s ON r.song_id = s.id
+   WHERE r.visibility_status = 'review'
+     AND r.lrc_status = 'completed'
+     AND r.r2_lrc_url IS NOT NULL
+     AND r.deleted_at IS NULL
+     AND (s.deleted_at IS NULL OR s.id IS NULL)
+   ORDER BY r.updated_at DESC;
+   ```
+   Apply `--since` / `--until` / `--album` as additional WHERE clauses if provided.
+
+3. **R2 lookup per candidate**:
+   - `r2_client.get_lrc_identity(hash_prefix)` returns `R2ObjectIdentity(exists, etag, last_modified)`.
+   - Parse ISO `last_modified`; ensure timezone-aware UTC for the subtraction.
+   - Handle missing file (should not happen given `r2_lrc_url IS NOT NULL`, but be defensive): annotate `INCONCLUSIVE` with reason `"R2 file missing"`.
+
+4. **Verdict logic**:
+   - `delta_hours = (db_updated_at - r2_last_modified).total_seconds() / 3600`
+   - `OK_FRESH_LRC` if `abs(delta_hours) <= 0.1`
+   - `SUSPECTED_BUG_REVERT` if `min_delta_hours <= delta_hours <= max_delta_hours` (defaults `1` and `1440`)
+   - `INCONCLUSIVE` otherwise
+
+5. **Cross-check (optional, `--with-analysis`)**:
+   - For `SUSPECTED_BUG_REVERT` rows, call `analysis_client.get_job(lrc_job_id)`.
+   - Capture service-side `updated_at` (job completion time).
+   - Tolerate `AnalysisServiceError` / 404 → annotate `"job purged"`.
+   - Print `job_completed_at` column alongside the other timestamps.
+
+6. **Output**: Rich table to stdout (or CSV via `--csv`).
+
+### Output columns
+
+| Column | Source | Notes |
+|---|---|---|
+| `hash_prefix` | DB | Recording identifier |
+| `song_id` | DB | Song ID |
+| `album` | DB | Album name (for context) |
+| `title` | DB | Song title (for context) |
+| `db_updated_at` | DB | When visibility was last flipped (bug-fire time) |
+| `r2_last_modified` | R2 `head_object` | When the LRC file was last uploaded (manual edit time) |
+| `delta_h` | computed | `db_updated_at - r2_last_modified` in hours |
+| `lrc_job_id` | DB | Analysis service job ID |
+| `job_completed_at` | analysis service (opt) | Service-side `updated_at` when status='completed' |
+| `verdict` | computed | `SUSPECTED_BUG_REVERT` / `OK_FRESH_LRC` / `INCONCLUSIVE` |
+| `recommendation` | derived | `set-visibility published` for `SUSPECTED_BUG_REVERT`; otherwise `—` |
+
+## Expected Pattern for the ~30 Bug-Reverted Recordings
+
+- `db_updated_at` clusters around one or more bug-run times (admin can spot the cluster).
+- `delta_h` falls within hours-to-days range.
+- If `--with-analysis`: `job_completed_at < r2_last_modified < db_updated_at` (the smoking gun).
+- After clustering, the `SUSPECTED_BUG_REVERT` count ≈ ~30.
+
+## Known False-Positive Risk & Mitigation
+
+The same signature (`db_updated_at > r2_last_modified`) also arises for recordings an admin intentionally reverted to `'review'` via `sow-admin audio set-visibility`. Mitigations baked into the report:
+
+1. **Cluster analysis**: The bug run usually produces a tight batch (e.g. all within a few hours, ~30 rows). Intentional single reverts will look like outliers. The report sorts by `db_updated_at DESC` so clusters are visually obvious.
+2. **`--since` / `--until` filters**: If the admin remembers the rough bug-run date, restrict the window to refine the suspected set.
+3. **Analysis service cross-check** (`--with-analysis`): The `job_completed_at < r2_last_modified < db_updated_at` ordering is unique to the bug. An intentional `set-visibility` doesn't change `lrc_job_id` and doesn't correspond to a stale-completion event.
+
+## Out of Scope
+
+Per the user's "dry-run only" preference:
+
+- **No code fix** to the bug at `audio.py:5458` and `audio.py:2820` (changing `visibility_status="review"` → `visibility_status=None`).
+- **No bulk `UPDATE recordings SET visibility_status='published'`** restore.
+- **No new Admin CLI subcommand** added to `commands/audio.py`.
+
+These can be addressed in a follow-up spec if the admin reviews the dry-run report and decides to proceed.
+
+## References
+
+- Bug site 1: `ops/admin-cli/src/stream_of_worship/admin/commands/audio.py:5430-5536` (`_handle_lrc_completion`)
+- Bug site 2: `ops/admin-cli/src/stream_of_worship/admin/commands/audio.py:2811-2822` (`audio status --sync`)
+- `_confirm_r2_lrc`: `ops/admin-cli/src/stream_of_worship/admin/commands/audio.py:6471-6497`
+- `update_recording_lrc`: `ops/admin-cli/src/stream_of_worship/admin/db/client.py:1085-1138`
+- `R2Client.get_lrc_identity`: `ops/admin-cli/src/stream_of_worship/admin/services/r2.py:458-484`
+- `R2Client.upload_official_lrc`: `ops/admin-cli/src/stream_of_worship/admin/services/r2.py:598-696`
+- Admin LRC editor save: `ops/admin-cli/src/stream_of_worship/admin/editor/upload.py:184-279`
+- `JobInfo` (analysis service): `ops/admin-cli/src/stream_of_worship/admin/services/analysis.py:98-121`
+- Recordings schema: `ops/admin-cli/src/stream_of_worship/admin/db/schema.py:38-90`
+- `updated_at` trigger: `ops/admin-cli/src/stream_of_worship/admin/db/schema.py:188-194`
+- Existing `--reconcile` pattern (safe): `ops/admin-cli/src/stream_of_worship/admin/commands/audio.py:2507-2527`

--- a/specs/recover-visibility-direct-sqlite-v1.md
+++ b/specs/recover-visibility-direct-sqlite-v1.md
@@ -1,0 +1,294 @@
+# Recover `visibility_status` — Direct SQLite Access to Analysis Service — v1
+
+## Status
+
+**Planning only — do not implement.** This is a follow-up plan to
+`specs/recover-visibility-bug-audio-batch-v2.md`. It evaluates and specifies a
+refactor of the `recover_visibility.py` dry-run report to read Analysis Service
+job state directly from its SQLite `jobs.db`, instead of going through the
+`AnalysisClient` REST endpoint (`GET /api/v1/jobs/{job_id}`).
+
+## Motivation
+
+The current report (`ops/admin-cli/src/stream_of_worship/admin/commands/recover_visibility.py`)
+resolves Analysis Service job timestamps via `_batch_lookup_analysis`, which
+issues one HTTP `GET /api/v1/jobs/{job_id}` per job ID across up to 10 worker
+threads. Investigation found two inefficiencies and one data gap:
+
+1. **Thrown-away data.** `_lookup_analysis_job` keeps only `job.updated_at` and
+   discards the rest of `JobResponse` (`created_at`, `stage`, `error_message`,
+   and the full `result` object including `key_detected_at`, `lrc_url`,
+   `lrc_source`, `line_count`, `stems_url`).
+2. **N HTTP round-trips.** Hundreds of candidate recordings each contribute up
+   to two job IDs (`lrc_job_id`, `analysis_job_id`); each becomes a separate
+   authenticated HTTP request. `--with-analysis` is therefore an expensive,
+   opt-in flag — and forgetting to pass it is a primary cause of `INCONCLUSIVE`
+   verdicts (the `_compute_verdict` fallback fires when
+   `manual_edit_after_autogen == "unknown"` because `lrc_job_done is None` or
+   `with_analysis` is false).
+3. **REST omits the request payload entirely.** `JobResponse`
+   (`ops/analysis-service/src/sow_analysis/models.py`) does not surface
+   `request_json`. Direct SQLite access exposes it, unlocking genuinely new
+   signals (see "Signals unlocked" below).
+
+Switching to a single bulk SQLite read removes the per-job network cost, makes
+`--with-analysis` behavior effectively free (so it can be defaulted on), and
+exposes fields the REST API never returns.
+
+## Scope
+
+- **In scope:** Replace `_batch_lookup_analysis` / `_lookup_analysis_job` /
+  `AnalysisClient` usage *within `recover_visibility.py` only* with a direct
+  read-only query against the analysis service SQLite `jobs.db`.
+- **In scope:** Surface additional fields from `result_json` and `request_json`
+  to the report so INCONCLUSIVE rows can be resolved when the row exists.
+- **Out of scope:** Any change to the Analysis Service itself (schema,
+  `JobResponse`, endpoint surface, retention policy).
+- **Out of scope:** Persisting job-completion timestamps into PostgreSQL
+  (see "Non-fixes" — this is the durable fix for purged-row INCONCLUSIVE and is
+  tracked separately).
+- **Out of scope:** Admin-CLI-wide deprecation of `AnalysisClient`. Other
+  commands still submit jobs and need the REST client; only the read-only
+  recovery report is migrated here.
+
+## SQLite target
+
+Schema and location (from `ops/analysis-service/src/sow_analysis/storage/db.py`
+and `workers/queue.py`):
+
+- **Path inside the analysis container:** `CACHE_DIR / "jobs.db"` where
+  `CACHE_DIR` defaults to `/cache` (`config.py`).
+- **Volume:** named volume `analysis-cache:/cache`
+  (`ops/analysis-service/docker-compose.yml`).
+- **Driver:** `aiosqlite` in service, but admin-cli only needs the stdlib
+  `sqlite3` module for a read-only query — no new heavy dependency required.
+- **Table shape:**
+  ```
+  jobs(id TEXT PK, type TEXT, status TEXT, progress REAL, stage TEXT,
+       error_message TEXT, request_json TEXT NOT NULL, result_json TEXT,
+       created_at TEXT, updated_at TEXT, content_hash TEXT)
+  ```
+  with indexes on `status`, `content_hash`, `created_at`.
+- **Purge behavior:** `JobStore.purge_old_jobs` (default `max_age_days=7`)
+  issues a hard `DELETE FROM jobs WHERE status IN ('completed','failed','cancelled') AND created_at < ?`.
+  Purged rows are **absent from the file**, not just hidden behind REST. A
+  REST 404 is therefore equivalent to an SQLite `miss`. Direct SQLite does
+  not recover purged rows — see "Non-fixes".
+
+## Signals unlocked
+
+These become available to the verdict matrix without any service-side change:
+
+### From `result_json` (already in REST `JobResponse.result`, but currently discarded)
+
+- `key_detected_at` — independent cross-check vs PG `recordings.key_detected_at`.
+- `lrc_url` — cross-check vs PG `recordings.r2_lrc_url`; a mismatch is a
+  strong, cheap bug signal (URL regenerated/staled without PG update).
+- `lrc_source` — `youtube_transcript | qwen3_asr | whisper_asr | forced_alignment`.
+  **Not stored in PG at all.** Useful to discriminate LRC regeneration paths
+  (manual edits are not tagged `lrc_source`).
+- `line_count` — sanity vs LRC content.
+- `stems_url` / `vocals_dry_url` / `vocals_url` / `instrumental_url` —
+  presence explains a post-analyze `updated_at` bump unrelated to visibility.
+
+### From `request_json` (NOT exposed by REST at all)
+
+- `youtube_url` — distinguishes transcript-based generation from ASR.
+- `force` / `force_whisper` / `force_qwen3_asr` / `force_qwen3_asr` flags — a
+  `force=True` re-run is a benign cause of a fresh `updated_at` bump and
+  should not be flagged as a suspected bug revert.
+- `lyrics_text` (snippet / hash) — for diagnostic display only; not a verdict input.
+- `use_vocals_stem`, `language`, `song_title`, `whisper_model` — context only.
+
+### From the row directly (already in REST, currently discarded)
+
+- `created_at` — distinguishes a re-submit from a continuation.
+- `stage`, `error_message` — surfaces failed LRC jobs that never wrote a result,
+  turning a silently-missing `lrc_job_done` into an explained `failed` state.
+- `status` — quickly classify `failed` / `cancelled` jobs without relying on a
+  missing timestamp.
+
+## Design
+
+### New module
+
+Add `ops/admin-cli/src/stream_of_worship/admin/services/analysis_sqlite.py`
+(name chosen to avoid colliding with `services/analysis.py`, the REST client).
+
+Responsibilities:
+
+1. **Locate the SQLite file.** Read path from `AdminConfig` under a new field
+   `analysis_sqlite_path` (see Config changes). Resolve symlinks; reject a
+   missing file with a clear error pointing at the docker volume mount.
+2. **Open read-only.** Always use `sqlite3.connect(f"file:{path}?mode=ro", uri=True)`
+   and `PRAGMA query_only=1` to make writes physically impossible from this
+   client. No WAL write lock can be acquired; the analysis service's WAL
+   writer is unaffected.
+3. **Bulk lookup.** Single parameterized query:
+   ```sql
+   SELECT id, type, status, created_at, updated_at, stage, error_message,
+          result_json, request_json, content_hash
+   FROM jobs
+   WHERE id IN (?, ?, ?, ...)
+   ```
+   built with the right number of placeholders. Returns `dict[job_id, JobRow]`.
+4. **Parse helpers** (pure functions, no Pydantic required to keep
+   admin-cli lightweight):
+   - `_parse_ts(iso_str) -> datetime | None` (mirror of `_parse_iso_datetime`
+     in `recover_visibility.py` — de-duplicate by importing).
+   - `_parse_result_json(blob) -> dict | None` — defensive `json.loads` with
+     try/except, returning `{}` on malformed/missing so callers can treat
+     missing keys uniformly.
+   - `_parse_request_json(blob) -> dict | None` — same.
+5. **Dataclass result.** `AnalysisJobRow` exposing the surfaced fields:
+   `job_id, type, status, created_at, updated_at, stage, error_message,
+   result_json (parsed), request_json (parsed)`. No Pydantic models to avoid
+   importing `sow_analysis` into admin-cli.
+
+### Config changes (`AdminConfig`)
+
+Add under a new `[analysis_sqlite]` (or extend existing `service`) section:
+
+- `analysis_sqlite_path: str = ""` — host-side path to the `jobs.db` file
+  (e.g. `/var/lib/sow/analysis-cache/jobs.db` when the named volume is bind-
+  mounted, or wherever the operator placed a copy).
+- `analysis_sqlite_copy_path: str = ""` — optional fallback; if set and the
+  primary is missing, the report will copy the file here (via `shutil.copy2`)
+  before opening. This is for the common case where the admin-cli runs on a
+  host that cannot mount the named volume but can `docker cp` the file out
+  on a cron. If unset, primary path is opened directly.
+  > Note: copying a WAL-mode SQLite file via `shutil.copy2` does not capture
+  > the WAL. The analysis service checkpoints periodically; for read-only
+  > point-in-time recovery this is acceptable. If a fully-consistent snapshot
+  > is needed, prefer a bind-mount of the named volume rather than a copy.
+
+JSON shape in `config.json`:
+
+```json
+{
+  "service": { "analysis_url": "http://localhost:8000" },
+  "analysis_sqlite": {
+    "path": "/var/lib/sow/analysis-cache/jobs.db",
+    "copy_path": ""
+  }
+}
+```
+
+### Report changes (`recover_visibility.py`)
+
+1. **Remove the REST path for analysis lookups in this report.** Delete
+   `_lookup_analysis_job`, `_batch_lookup_analysis`, `ANALYSIS_LOOKUP_WORKERS`,
+   and the `AnalysisClient` import used here. (Leave `AnalysisClient` itself
+   intact — other commands use it.)
+2. **Replace the batch call.** Inside `_run_report`, after computing the
+   `all_job_ids` set, open the SQLite reader and do a single bulk lookup:
+   ```python
+   with AnalysisSqliteReader(config) as reader:
+       analysis_rows = reader.lookup_many(list(all_job_ids))
+   ```
+   Because the cost is now a single indexed `IN (...)` query (no network),
+   make the lookup **unconditional** — i.e. always executed, deprecating the
+   `--with-analysis` opt-in. Keep the boolean as a no-op shim for one release
+   to avoid breaking operators' scripts, printing a deprecation notice.
+3. **Enrich `CandidateSignals`.** Add fields:
+   - `lrc_job_status: str | None`
+   - `lrc_job_stage: str | None`
+   - `lrc_job_error: str | None`
+   - `lrc_source: str | None` (from LRC job `result_json.lrc_source`)
+   - `result_lrc_url: str | None` (from LRC job `result_json.lrc_url`)
+   - `result_key_detected_at: datetime | None` (cross-check field)
+   - `request_youtube_url: str | None` (LRC job)
+   - `request_force: bool | None` (LRC job; covers `force`/`force_whisper`/`force_qwen3_asr`)
+   - `analyze_job_status: str | None`
+4. **Extend `_compute_verdict` (new branches, additive — do not weaken v2's matrix):**
+   - If `lrc_job_status == "failed"` and `r2_lm` present and `db_updated_at`
+     is recent → `LRC_JOB_FAILED` (distinct from `INCONCLUSIVE`) with
+     recommendation `eyes-on (lrc failed)`. Removes a silent-missing case.
+   - If `result_lrc_url` is set and non-null and **differs** from
+     PG `recordings.r2_lrc_url` → `LRC_URL_DRIFT`, recommendation
+     `set-visibility published (url drift)`. Strongest cheap signal.
+   - If `request_force` is True for the LRC job and `analyze_bump` holds →
+     `BENIGN_FORCE_RERUN` (not bug-revert), recommendation `—`.
+   - If `lrc_source` indicates `youtube_transcript` and `manual_edit_after_autogen == "yes"`
+     is otherwise ambiguous, bias toward `published` (transcript path is the
+     "official" source; a manual edit on top is rare).
+   - Keep the existing `key_detected_at` bump check, but additionally
+     cross-check SQLite `result_json.key_detected_at` vs PG
+     `recordings.key_detected_at`; if they disagree, emit a new diagnostic
+     column `key_detected_at_drift = True` (informational; does not change
+     verdict but is surfaced in CSV/table).
+5. **New output columns / panel counters:** `lrc_source`, `lrc_job_status`,
+   `result_lrc_url`, `request_force`, `key_detected_at_drift`.
+6. **Error handling when SQLite unavailable.** If the file is missing or
+   unreadable, print a clear `[red]` message naming the configured path and
+   the `analysis_sqlite.path` config key, then exit non-zero. Do **not**
+   silently fall back to REST — that would reintroduce the "forgot to
+   configure / silent degradation" class of INCONCLUSIVE.
+
+### Invocation
+
+No new CLI flag required (the lookup is now always-on). Behavior preserved:
+the report remains strictly read-only against both PG and SQLite.
+
+## Migration / rollout
+
+1. Operator binds the `analysis-cache` named volume to a host path readable
+   by the admin-cli environment (e.g. in `docker-compose.yml` add a
+   bind-mount, or run admin-cli inside a container that shares the volume).
+2. Operator adds `[analysis_sqlite].path` to `config.json`.
+3. Run the report; verify `INCONCLUSIVE` counter drops for rows whose job
+   records still exist in SQLite (i.e. within the `purge_old_jobs` window).
+4. (Out of scope here, tracked separately) Extend analysis-service retention
+   or persist completion timestamps to PG to recover the post-7-day window.
+
+## Non-fixes (explicitly out of scope)
+
+- **Purged jobs remain INCONCLUSIVE.** A row deleted by `purge_old_jobs` is
+  gone from the SQLite file just as it 404s over REST. Direct SQLite, REST,
+  or any read path returns the same empty result. The durable fix is to
+  either (a) raise `max_age_days` / disable purge, or (b) persist
+  `lrc_job_completed_at` / `analysis_job_completed_at` / `lrc_source` onto
+  `recordings` at job-completion time. That is a separate, larger change and
+  is **not** what this spec delivers.
+- **Artifact of thrown-away REST data.** Could be fixed without switching to
+  SQLite by simply unpacking more of the existing `JobResponse.result`. This
+  spec opts for the SQLite path because the network-cost win (single bulk
+  query vs N round-trips) is what enables making the lookup always-on — and
+  it additionally unlocks `request_json`, which REST never returns.
+- **Analysis-service-internal coupling.** Reading the SQLite file directly
+  couples admin-cli to the analysis-service on-disk schema (not its REST
+  contract). This is judged acceptable for a read-only recovery tool because
+  (a) the `jobs` table schema has only grown additively and never dropped
+  columns historically (see the `_migrate_*` methods in `db.py`), and
+  (b) the reader is isolated in one module so a schema change has a single
+  blast radius. If the schema ever does break, the failure mode is a visible
+  runtime error in one module, not silent mis-classification.
+
+## Acceptance criteria
+
+- Running `recover_visibility.py` no longer issues any HTTP request to the
+  analysis service; analysis data comes from a single SQLite `IN (...)` query.
+- The `SUSPECTED_POST_ANALYZE` / `INCONCLUSIVE` counters drop strictly for
+  candidate rows whose `lrc_job_id`/`analysis_job_id` resolve to extant rows
+  in `jobs.db` (within the 7-day purge window).
+- New `LRC_URL_DRIFT`, `LRC_JOB_FAILED`, `BENIGN_FORCE_RERUN` verdicts classify
+  rows previously bucketed as `INCONCLUSIVE`.
+- No file is written and no SQLite write transaction is ever opened (verified
+  by code review: `mode=ro` URI, `PRAGMA query_only=1`, no `INSERT`/`UPDATE`/
+  `DELETE` strings in `analysis_sqlite.py`).
+- Existing v2 matrix and CSV/TUI outputs remain valid; new columns are
+  appended only (additive change so downstream scripts do not break).
+
+## Open questions
+
+1. Does the production analysis service run with `purge_old_jobs` at the
+   default 7 days, or has retention already been raised? Need to confirm the
+   effective retention window before claiming tighter INCONCLUSIVE coverage.
+   → action: grep the analysis-service deployment config / compose env for
+   `max_age_days` overrides before implementing.
+2. Is the `analysis-cache` volume already bind-mounted on any operator host?
+   If not, the rollout step (1) requires a compose change and a service
+   restart, which is an ops-side dependency to flag.
+3. Should `--with-analysis` be removed outright or kept as a deprecated
+   no-op? Choice here is the latter (one-release deprecation). Confirm the
+   team prefers a shim over a hard break.

--- a/specs/recover-visibility-full-rest-result-v1.md
+++ b/specs/recover-visibility-full-rest-result-v1.md
@@ -1,0 +1,318 @@
+# Recover `visibility_status` — Use Full REST Job Result — v1
+
+## Status
+
+**Planning only — do not implement.** This is a follow-up plan to
+`specs/recover-visibility-bug-audio-batch-v2.md`. It specifies a no-refactor
+path to reduce `INCONCLUSIVE` verdicts: stop discarding the fields the analysis
+service already returns in `JobResponse` and use them to refine the verdict
+matrix, without touching the network transport (REST stays) or the service.
+
+## Motivation
+
+The current report
+(`ops/admin-cli/src/stream_of_worship/admin/commands/recover_visibility.py`)
+calls the analysis service REST endpoint and then throws away almost
+everything it returns. Concretely, `_lookup_analysis_job` does:
+
+```python
+job = analysis_client.get_job(job_id)
+return (job.updated_at, None)
+```
+
+The rest of `JobInfo` — `status`, `stage`, `error_message`, `created_at`,
+`progress`, and the entire `result` object (`AnalysisResult`) — is discarded.
+
+Investigation found that this discarded data includes signals that are
+either (a) not mirrored to PostgreSQL at all, or (b) mirrored but never
+compared. Surfacing them reclassifies rows that today fall through to the
+`INCONCLUSIVE` fallback without any new dependency, transport change, or
+service-side work.
+
+This is the lower-risk companion to
+`specs/recover-visibility-direct-sqlite-v1.md` (Option 1): Option 2 keeps the
+existing REST transport and `AnalysisClient` intact, only changes how the
+report consumes its response. **Decision (interview 2026-10): Option 1 is
+shelved; only Option 2 will ship.** This spec is therefore self-contained and
+not a precursor to a transport change — the network cost of `--with-analysis`
+remains accepted.
+
+## Scope
+
+- **In scope:** Inside `recover_visibility.py` only, expand
+  `_lookup_analysis_job` / `_batch_lookup_analysis` to return the full
+  `JobInfo`; extend `CandidateSignals` and `_compute_verdict` to consume the
+  previously-discarded fields.
+- **In scope:** Add the small set of fields the service `JobResult` already
+  returns (`line_count`, `vocals_dry_url`, `vocals_url`, `instrumental_url`)
+  but the admin-cli `AnalysisResult` dataclass does not yet model — so the
+  parser silently drops them.
+- **Out of scope:** Switching the transport to direct SQLite (Option 1).
+- **Out of scope:** Service-side changes: `JobResponse` shape, endpoint
+  surface, retention policy.
+- **Out of scope:** Persisting job-completion timestamps / `lrc_source` onto
+  PostgreSQL (the durable fix for purged-row INCONCLUSIVE; tracked
+  separately).
+- **Out of scope:** HTTP performance work (batch endpoint, keep-alive
+  pooling). The existing 10-worker `_batch_lookup_analysis` remains. If the
+  always-on behavior proposed here makes latency unacceptable, that is the
+  trigger for Option 1.
+
+## What the REST response already contains (and the report discards)
+
+From `JobInfo` / `AnalysisResult`
+(`ops/admin-cli/src/stream_of_worship/admin/services/analysis.py`) and the
+service-side `JobResult`
+(`ops/analysis-service/src/sow_analysis/models.py`):
+
+| Field | Source | Currently used? | Useful for verdict? |
+|---|---|---|---|
+| `JobInfo.updated_at` | REST | ✅ used | LRC/analyze job completion time |
+| `JobInfo.status` | REST | ❌ discarded | `failed` / `cancelled` explains a missing `updated_at` and a missing result |
+| `JobInfo.stage` | REST | ❌ discarded | surfaces "in progress" jobs (stale `processing` after a crash) |
+| `JobInfo.error_message` | REST | ❌ discarded | distinguishes "purged" from "failed with reason" |
+| `JobInfo.created_at` | REST | ❌ discarded | distinguishes re-submit from continuation; bounds `updated_at` |
+| `AnalysisResult.key_detected_at` | REST `result` | ❌ discarded (only PG `r.key_detected_at` is used) | cross-check vs PG; drift = strong bug signal |
+| `AnalysisResult.lrc_url` | REST `result` | ❌ discarded | cross-check vs PG `r.r2_lrc_url`; mismatch = drift signal |
+| `AnalysisResult.lrc_source` | REST `result` | ❌ discarded | `youtube_transcript \| qwen3_asr \| whisper_asr \| forced_alignment` — **not in PG at all**; new classification dimension |
+| `AnalysisResult.line_count` | service `result` | ❌ not even modeled in admin AnalysisResult | sanity vs LRC content / manual-edit detection |
+| `AnalysisResult.stems_url` | REST `result` | ❌ discarded | presence explains a post-analyze `updated_at` bump (stem separation writes) |
+| `AnalysisResult.vocals_dry_url` / `vocals_url` / `instrumental_url` | service `result` | ❌ not modeled in admin AnalysisResult | same — stem-separation bump attribution |
+| `AnalysisResult.tempo_bpm` / `musical_key` / `key_confidence` | REST `result` | ❌ discarded | diagnostic display only |
+
+### What REST does NOT give you (Option 1 territory, out of scope here)
+
+- `request_json` payload (`force` flags, `youtube_url`, `lyrics_text`) — the
+  service `JobResponse` deliberately omits the request. The "benign
+  force-rerun" disambiguation that Option 1 enables via `request_json.force`
+  is **not achievable from REST alone**. This is the one verdict branch
+  Option 2 cannot provide; it stays an INCONCLUSIVE fallback until Option 1
+  (or a service-side request-surface change) lands.
+
+## Design
+
+### Step 1 — Extend the admin-cli `AnalysisResult` dataclass
+
+`ops/admin-cli/src/stream_of_worship/admin/services/analysis.py`:
+
+Add four fields the service already returns but the parser drops:
+
+```python
+line_count: Optional[int] = None
+vocals_dry_url: Optional[str] = None
+vocals_url: Optional[str] = None
+instrumental_url: Optional[str] = None
+```
+
+and wire them in `_parse_job_response`'s non-embedding branch:
+
+```python
+result = AnalysisResult(
+    ...existing...,
+    line_count=result_data.get("line_count"),
+    vocals_dry_url=result_data.get("vocals_dry_url"),
+    vocals_url=result_data.get("vocals_url"),
+    instrumental_url=result_data.get("instrumental_url"),
+)
+```
+
+No happy-path behavior changes — these are additive `Optional` fields.
+
+### Step 2 — Stop discarding the response in `recover_visibility.py`
+
+Replace the `(updated_at, note)` tuple return type of `_lookup_analysis_job`
+with the full `JobInfo` (or `Optional[JobInfo]`), and let `_batch_lookup_analysis`
+return `dict[str, Optional[JobInfo]]`. Preserve the per-job error note as a
+separate `dict[str, str]` so it is not lost (`"job purged — relying on
+R2/DB timestamps only"` etc. remains the user-facing message, derived from
+`AnalysisServiceError.status_code == 404`).
+
+Concretely, the loop in `_run_report` already resolves `lrc_jid` and
+`ana_jid`; it then reads `analysis_results[jid]` for the `updated_at` only.
+Change the consumer to read the whole `JobInfo`:
+
+```python
+lrc_job: Optional[JobInfo] = analysis_results.get(lrc_jid)
+ana_job: Optional[JobInfo] = analysis_results.get(ana_jid)
+```
+
+and populate the enriched `CandidateSignals` (Step 3).
+
+### Step 3 — Extend `CandidateSignals`
+
+Add the surfaced fields:
+
+```python
+@dataclass
+class CandidateSignals:
+    db_updated_at: Optional[datetime]
+    r2_lm: Optional[datetime]
+    lrc_job_done: Optional[datetime]
+    analyze_job_done: Optional[datetime]
+    key_detected_at: Optional[datetime]          # PG
+    with_analysis: bool
+    bump_tolerance_s: float
+
+    # NEW — from LRC JobInfo.result (REST, formerly discarded)
+    lrc_status: Optional[str]                    # 'completed' | 'failed' | 'cancelled' | 'processing' | 'queued' | 'waiting'
+    lrc_stage: Optional[str]
+    lrc_error: Optional[str]
+    lrc_created_at: Optional[datetime]
+    lrc_result_url: Optional[str]               # AnalysisResult.lrc_url
+    lrc_source: Optional[str]                   # AnalysisResult.lrc_source
+    lrc_line_count: Optional[int]
+
+    # NEW — from Analysis JobInfo.result (REST, formerly discarded)
+    analyze_status: Optional[str]
+    analyze_stage: Optional[str]
+    analyze_error: Optional[str]
+    analyze_result_key_detected_at: Optional[datetime]  # cross-check vs PG
+    analyze_stems_present: Optional[bool]       # stems_url non-null
+```
+
+### Step 4 — Refine `_compute_verdict` (additive; do not weaken v2's matrix)
+
+All new branches are inserted **before** the final `INCONCLUSIVE` fallback so
+they only reclassify rows that would otherwise be inconclusive. Existing
+`OK_FRESH_LRC` / `SUSPECTED_BUG_REVERT` / `NO_SIGNAL_POST_ANALYZE` /
+`SUSPECTED_POST_ANALYZE` outcomes are untouched.
+
+1. **`LRC_JOB_FAILED`** — `lrc_status == "failed"` (or `lrc_status == "cancelled"`).
+   Recommendation: `eyes-on (lrc {status})`. Removes the silent-missing case
+   where `lrc_job_done is None` because the job errored rather than completed.
+   `error_message` is surfaced in a new diagnostic column.
+
+2. **`LRC_JOB_STUCK`** — `lrc_status in ("processing", "queued", "waiting")`
+   AND `lrc_created_at` is older than a threshold (default 12h). Recommendation:
+   `restart analysis worker`. Distinguishes a genuinely-missing completion from
+   a worker that died mid-job. (Threshold set per interview 2026-10: longest
+   legitimate `lrc` job fits well under 12h.)
+
+3. **`LRC_URL_DRIFT`** — `lrc_result_url` is set, non-null, and **differs** from
+   PG `r.r2_lrc_url`. Recommendation: `set-visibility published (url drift)`.
+   This is the strongest cheap signal: the service recorded a different LRC URL
+   than PG holds, which is explained by the bug path writing PG stale while the
+   LRC was regenerated. Branch fires before the generic `SUSPECTED_BUG_REVERT`
+   paths only when drift is present; non-drift falls through normally.
+
+4. **`KEY_DETECT_DRIFT`** — `analyze_result_key_detected_at` is set and differs
+   from PG `recordings.key_detected_at`. This is **informational, not a verdict
+   change**: set a new `key_detected_at_drift` column to `true` and append the
+   drift to debug_notes. Does not alter recommendation (both timestamps are
+   service-derived; drift is a marker, not proof of a visibility bug).
+
+5. **`BENIGN_STEM_BUMP`** — `analyze_bump` holds AND `analyze_stems_present`
+   is True AND `lrc_result_url` equals PG `r.r2_lrc_url` (no LRC drift).
+   The `updated_at` bump is explained by stem separation writing back, not by
+   a visibility toggle. Recommendation: `—`. Removes false `SUSPECTED_*`
+   flags from stem-separation runs.
+
+6. **`LRC_SOURCE_TRANSCRIPT`** — `manual_edit_after_autogen == "yes"` is
+   ambiguous AND `lrc_source == "youtube_transcript"`. Bias toward `published`
+   (the transcript source is the "official" path; a manual edit on top is
+   rare). Replaces the `INCONCLUSIVE` fallback with
+   `SUSPECTED_BUG_REVERT (transcript source)` in this subset only.
+
+7. Default fallback remains `INCONCLUSIVE` for rows where:
+   - the job is purged (REST 404 — Option 2 cannot recover these; see
+     Non-fixes), or
+   - `request_json.force` would be needed (Option 1 territory; shelved).
+
+   **Confirmed service behavior (interview 2026-10):** `failed` jobs carry
+   `result_json = NULL`. Therefore `LRC_JOB_FAILED` (branch 1) keys off
+   `status` alone and will never co-fire with `LRC_URL_DRIFT` (branch 3); the
+   branch ordering in steps 1–6 is preserved but the two are mutually
+   exclusive in practice.
+
+### Step 5 — Output surface changes (additive only)
+
+- **TUI table:** append columns `lrc_source`, `lrc_status`, `lrc_result_url`,
+  `key_detected_at_drift`. Keep existing columns; downstream width-calculation
+  logic absorbs the additions since the table already wraps.
+- **CSV:** append the same fields to `fieldnames`. Existing consumers keyed on
+  column name keep working (DictReader extras ignored, missing fields → empty).
+- **Panel counters:** add `LRC_JOB_FAILED`, `LRC_JOB_STUCK`, `LRC_URL_DRIFT`,
+  `BENIGN_STEM_BUMP`, `LRC_SOURCE_TRANSCRIPT` to the summary count line.
+- **Error note column:** surface `lrc_error` / `analyze_error` when the
+  respective status is `failed`, replacing the opaque "analysis error: {e}"
+  string.
+
+### Step 6 — `--with-analysis` semantics
+
+Keep the flag. Because Option 2 still pays the per-job HTTP cost, the
+enrichment is **only applied when `--with-analysis` is set**, preserving the
+current cost model. Document a deprecation-notice print when the flag is
+**off** and `INCONCLUSIVE` rows exist, pointing at the flag — lowering the
+"forgot to pass `--with-analysis`" INCONCLUSIVE source without forcing the
+cost on by default. (Making it always-on is Option 1's job.)
+
+## Non-fixes (explicit)
+
+- **Purged jobs remain INCONCLUSIVE.** A REST 404 is exactly as empty as a
+  missing SQLite row. Surfacing more fields only helps when the job still
+  exists on the service. The durable fix (persist
+  `lrc_job_completed_at` / `lrc_source` / `analysis_job_completed_at` onto
+  `recordings` at job-completion time, or extend `purge_old_jobs` retention)
+  is out of scope.
+- **No `request_json` disambiguation.** The benign force-rerun verdict
+  (`request_force` shortcut in Option 1) cannot be implemented from REST — the
+  service `JobResponse` does not surface the request payload. Those rows stay
+  INCONCLUSIVE under Option 2.
+- **No transport/performance win.** Same N round-trips, same 10-worker pool,
+  same `SOW_ANALYSIS_API_KEY` requirement. Option 2 is purely about
+  consumption of the response. If the always-on behavior proposed in Option 1
+  is desired, ship it as a follow-up to this one.
+
+## Acceptance criteria
+
+**Baseline (interview 2026-10):** the last run produced **31 INCONCLUSIVE**
+rows. Acceptance is measured against that count: post-implementation, the
+same candidate set must produce strictly fewer `INCONCLUSIVE` verdicts, with
+the reclassified rows landing in the new buckets (`LRC_JOB_FAILED`,
+`LRC_JOB_STUCK`, `LRC_URL_DRIFT`, `BENIGN_STEM_BUMP`, `LRC_SOURCE_TRANSCRIPT`).
+The before/after comparison is done by diffing the CSV output of a pre- and
+post-implementation run against the same `--since`/`--until`/`--album` filter.
+The remaining `INCONCLUSIVE` rows after this change must each correspond to a
+REST 404 (purged job) — there should be no row that *could* have been resolved
+by the new branches but was missed.
+
+- `_lookup_analysis_job` returns the full `JobInfo` (or `None` + note on 404);
+  no consumed field of `JobInfo.result` is left on the floor.
+- Admin-cli `AnalysisResult` models `line_count`, `vocals_dry_url`,
+  `vocals_url`, `instrumental_url`; `_parse_job_response` populates them.
+- For candidate rows whose `lrc_job_id` / `analysis_job_id` still resolve on
+  the service (within the ~7-day purge window), the `INCONCLUSIVE` counter is
+  strictly lower than today; the reclassified rows land in
+  `LRC_JOB_FAILED` / `LRC_JOB_STUCK` / `LRC_URL_DRIFT` / `BENIGN_STEM_BUMP` /
+  `LRC_SOURCE_TRANSCRIPT`.
+- Existing v2 verdicts (`OK_FRESH_LRC`, `SUSPECTED_BUG_REVERT`,
+  `SUSPECTED_POST_ANALYZE`, `NO_SIGNAL_POST_ANALYZE`) are unchanged in both
+  semantics and counts for rows that do not match a new branch.
+- CSV column set is a superset of the v2 column set (no renames, no removals);
+  a v2 consumer reading the CSV keeps working.
+- No new dependency added to `ops/admin-cli` `pyproject.toml`; the change is
+  confined to `recover_visibility.py` and one additive patch to
+  `services/analysis.py`.
+
+## Resolved questions (interview 2026-10)
+
+- **Baseline metric.** Last run produced **31 INCONCLUSIVE** rows; acceptance
+  compares against that count (see Acceptance criteria above).
+- **`LRC_JOB_STUCK` threshold.** Locked at **12 hours**; longest legitimate
+  `lrc` job fits well under that.
+- **Failed-job `result` presence.** Confirmed: `failed` jobs carry
+  `result_json = NULL`. `LRC_JOB_FAILED` keys off `status` alone; `LRC_URL_DRIFT`
+  never co-fires with it.
+- **Transport scope.** Option 1 (direct SQLite) is **shelved**; only Option 2
+  ships. The network cost of `--with-analysis` is accepted as-is.
+
+## Open questions
+
+1. Should `LRC_URL_DRIFT` compare normalized URLs (strip query, trailing slash)
+   or exact strings? Exact is safer for detecting the bug (which writes stale
+   URLs verbatim); normalization risks false negatives. Plan assumes exact
+   string compare; confirm before implementing by inspecting a sample of
+   `r.r2_lrc_url` vs `result_json.lrc_url` pairs.
+2. Should the `--with-analysis`-off deprecation notice (Step 6) be loud
+   (panel) or quiet (stderr dim)? Plan assumes a single stderr dim line;
+   confirm preference.

--- a/specs/recover-visibility-full-rest-result-v2.md
+++ b/specs/recover-visibility-full-rest-result-v2.md
@@ -1,0 +1,410 @@
+# Recover `visibility_status` — Use Full REST Job Result — v2
+
+## Status
+
+**Planning only — do not implement.** This is a revision of
+`specs/recover-visibility-full-rest-result-v1.md`. It keeps the v1
+"no-refactor, REST-stays" approach for reducing `INCONCLUSIVE` verdicts but
+introduces one structural change versus v1:
+
+**v1 shipped three speculative verdict branches whose corroborating evidence
+rested on bug-mechanism assumptions not yet validated against known-bug rows:**
+`LRC_URL_DRIFT`, `BENIGN_STEM_BUMP`, `LRC_SOURCE_TRANSCRIPT`. v2 **demotes all
+three to diagnostic-only signals** — they surface as new columns +
+`debug_notes` entries but no longer alter the verdict or recommendation. v2
+introduces an acceptance gate that re-promotes a branch to verdict-changing
+status only after it has been empirically validated against a labeled set of
+known-bug rows AND known-clean rows.
+
+Decisions carried forward unchanged from v1 (per interview 2026-10 and review):
+- `LRC_JOB_FAILED` and `LRC_JOB_STUCK` remain verdict-changing branches.
+- Step 6 `--with-analysis`-off deprecation notice stays in scope.
+- Directive SQLite (Option 1) remains shelved; only Option 2 ships.
+- `failed` jobs carry `result_json = NULL` (confirmed service behavior).
+
+## What changed versus v1 (delta summary)
+
+| Area | v1 | v2 |
+|---|---|---|
+| `LRC_URL_DRIFT` | Verdict-changer (`set-visibility published (url drift)`) | Diagnostic column + `debug_notes` only; never changes verdict |
+| `BENIGN_STEM_BUMP` | Verdict-changer (bumps `SUSPECTED_*` → benign `—`) | Diagnostic column + `debug_notes` only; never changes verdict |
+| `LRC_SOURCE_TRANSCRIPT` | Verdict-changer (`SUSPECTED_BUG_REVERT (transcript source)`) | Diagnostic column + `debug_notes` only; never changes verdict |
+| `KEY_DETECT_DRIFT` | Diagnostic-only | Unchanged: diagnostic-only |
+| Branch mutual-exclusivity | Claim applied only to branches 1 vs 3 | Explicit per-branch matrix; documents all pairwise intersections |
+| Acceptance criterion | "INCONCLUSIVE strictly lower; reclassified rows land in new buckets" | "INCONCLUSIVE strictly lower; reclassification only via `LRC_JOB_FAILED` / `LRC_JOB_STUCK`; diagnostic columns populated but must NOT change verdict on any row" |
+| Diagnostic columns | Mentioned in Step 5 | Sized-down: `lrc_source`, `lrc_status`, `lrc_error`, `lrc_result_url`, `analyze_status`, `analyze_error` + derived flags `lrc_url_drift`, `stem_bump_attributable_to_stems`, `transcript_source_bias` (all bool/str diagnostic only) |
+| Step 6 deprecation notice | In scope | Unchanged — in scope |
+
+## Motivation (unchanged)
+
+The current `_lookup_analysis_job` discards everything except `updated_at`:
+
+```python
+job = analysis_client.get_job(job_id)
+return (job.updated_at, None)
+```
+
+Surfacing the discarded `JobInfo` / `AnalysisResult` fields reclassifies rows
+that today fall through to the `INCONCLUSIVE` fallback without any new
+dependency, transport change, or service-side work. The full REST-response
+table from v1 (field-by-field "currently used?" mapping) is reproduced in
+Appendix A for reference; it is unchanged.
+
+## Scope
+
+- **In scope:** Inside `recover_visibility.py` only, expand
+  `_lookup_analysis_job` / `_batch_lookup_analysis` to return the full
+  `JobInfo`; extend `CandidateSignals` and `_compute_verdict` to consume the
+  previously-discarded fields.
+- **In scope:** Add the small set of fields the service `JobResult` already
+  returns (`line_count`, `vocals_dry_url`, `vocals_url`, `instrumental_url`)
+  but the admin-cli `AnalysisResult` dataclass does not yet model — so the
+  parser silently drops them.
+- **In scope:** Two verdict-changing branches: `LRC_JOB_FAILED`,
+  `LRC_JOB_STUCK`. (down from five in v1.)
+- **In scope:** Six diagnostic-only columns / derived flags surfacing the
+  discarded fields without altering verdict.
+- **Out of scope:** Verdict-changing use of `LRC_URL_DRIFT`,
+  `BENIGN_STEM_BUMP`, `LRC_SOURCE_TRANSCRIPT`. These are **deferred to v3**
+  pending empirical validation (see Validation gate).
+- **Out of scope:** Switching the transport to direct SQLite (Option 1).
+- **Out of scope:** Service-side changes (`JobResponse` shape, endpoint
+  surface, retention policy).
+- **Out of scope:** Persisting `lrc_job_completed_at` / `lrc_source` /
+  `analysis_job_completed_at` onto PostgreSQL (the durable fix for
+  purged-row INCONCLUSIVE; tracked separately).
+- **Out of scope:** HTTP performance work (batch endpoint, keep-alive pooling).
+  The existing 10-worker `_batch_lookup_analysis` remains.
+
+## Design
+
+### Step 1 — Extend the admin-cli `AnalysisResult` dataclass
+
+`ops/admin-cli/src/stream_of_worship/admin/services/analysis.py`:
+
+Add four fields the service already returns but the parser drops:
+
+```python
+line_count: Optional[int] = None
+vocals_dry_url: Optional[str] = None
+vocals_url: Optional[str] = None
+instrumental_url: Optional[str] = None
+```
+
+and wire them in `_parse_job_response`'s non-embedding branch:
+
+```python
+result = AnalysisResult(
+    ...existing...,
+    line_count=result_data.get("line_count"),
+    vocals_dry_url=result_data.get("vocals_dry_url"),
+    vocals_url=result_data.get("vocals_url"),
+    instrumental_url=result_data.get("instrumental_url"),
+)
+```
+
+No happy-path behavior changes — these are additive `Optional` fields.
+
+### Step 2 — Stop discarding the response in `recover_visibility.py`
+
+Replace the `(updated_at, note)` tuple return type of `_lookup_analysis_job`
+with the full `JobInfo` (or `Optional[JobInfo]`), and let
+`_batch_lookup_analysis` return `dict[str, Optional[JobInfo]]`. Preserve the
+per-job error note as a separate `dict[str, str]` so it is not lost
+(`"job purged — relying on R2/DB timestamps only"` etc. remains the
+user-facing message, derived from `AnalysisServiceError.status_code == 404`).
+
+Concretely, the loop in `_run_report` already resolves `lrc_jid` and
+`ana_jid`; it then reads `analysis_results[jid]` for the `updated_at` only.
+Change the consumer to read the whole `JobInfo`:
+
+```python
+lrc_job: Optional[JobInfo] = analysis_results.get(lrc_jid)
+ana_job: Optional[JobInfo] = analysis_results.get(ana_jid)
+```
+
+and populate the enriched `CandidateSignals` (Step 3).
+
+### Step 3 — Extend `CandidateSignals`
+
+Add the surfaced fields. v2 keeps the same surface as v1 Step 3 (the four
+new `AnalysisResult` fields didn't make it into CandidateSignals in v1 either;
+they are surfaced only via `JobInfo.result` access in Step 4 diagnostic
+computation). The dataclass:
+
+```python
+@dataclass
+class CandidateSignals:
+    db_updated_at: Optional[datetime]
+    r2_lm: Optional[datetime]
+    lrc_job_done: Optional[datetime]
+    analyze_job_done: Optional[datetime]
+    key_detected_at: Optional[datetime]          # PG
+    with_analysis: bool
+    bump_tolerance_s: float
+
+    # from LRC JobInfo (REST, formerly discarded)
+    lrc_status: Optional[str]
+    lrc_stage: Optional[str]
+    lrc_error: Optional[str]
+    lrc_created_at: Optional[datetime]
+    lrc_result_url: Optional[str]               # AnalysisResult.lrc_url
+    lrc_source: Optional[str]
+    lrc_line_count: Optional[int]
+    lrc_result_key_detected_at: Optional[datetime]   # not present on lrc jobs in practice; None
+
+    # from Analysis JobInfo (REST, formerly discarded)
+    analyze_status: Optional[str]
+    analyze_stage: Optional[str]
+    analyze_error: Optional[str]
+    analyze_result_key_detected_at: Optional[datetime]  # cross-check vs PG
+    analyze_stems_present: Optional[bool]       # stems_url non-null
+
+    # PG-side reference values for diagnostic drift comparison
+    pg_r2_lrc_url: Optional[str]
+```
+
+### Step 4 — Refine `_compute_verdict`
+
+v2 splits the work into two well-defined layers:
+
+**Layer A — Verdict branches (may change the verdict).** Only two:
+1. **`LRC_JOB_FAILED`** — `lrc_status == "failed"` (or
+   `lrc_status == "cancelled"`). Recommendation:
+   `eyes-on (lrc {status})`. Removes the silent-missing case where
+   `lrc_job_done is None` because the job errored rather than completed.
+   `error_message` is surfaced in a new diagnostic column.
+2. **`LRC_JOB_STUCK`** — `lrc_status in ("processing", "queued", "waiting")`
+   AND `lrc_created_at` is older than a threshold (default 12h).
+   Recommendation: `restart analysis worker`. Distinguishes a
+   genuinely-missing completion from a worker that died mid-job.
+
+Both Layer-A branches are inserted **before** the final `INCONCLUSIVE`
+fallback so they only reclassify rows that would otherwise be inconclusive.
+Existing `OK_FRESH_LRC` / `SUSPECTED_BUG_REVERT` / `NO_SIGNAL_POST_ANALYZE` /
+`SUSPECTED_POST_ANALYZE` outcomes are untouched; Layer-A fires only when
+today's logic would have returned `INCONCLUSIVE` and the surfaced job-status
+field explains the missing `lrc_job_done`.
+
+**Layer B — Diagnostic-only signals (never alter verdict).** Three signals
+collected for every row and surfaced in new columns / `debug_notes`, but they
+do NOT influence `_compute_verdict`'s return:
+
+- `lrc_url_drift` (bool): `lrc_result_url` is set, non-null, and differs from
+  PG `pg_r2_lrc_url`. Surfaced in `debug_notes` as
+  `"lrc_url_drift: svc=<X> pg=<Y>"`. **Does NOT change the verdict.** v1
+  promoted this to a `set-visibility published (url drift)` recommendation; the
+  bug-mechanism link (does the bug rewrite `r2_lrc_url`?) was not established
+  in review and is treated as a hypothesis until validated.
+- `stem_bump_attributable_to_stems` (bool): `analyze_bump` holds AND
+  `analyze_stems_present` is True. Surfaced in `debug_notes` as
+  `"stem_bump_attributable_to_stems: true (stems_url present)"`. **Does NOT**
+  demote a `SUSPECTED_*` row to benign. `stems_url` non-null only proves stems
+  existed at some point, not that they wrote at this `updated_at` bump —
+  insufficient to time-attribute.
+- `transcript_source_bias` (bool): `manual_edit_after_autogen == "yes"` is
+  ambiguous AND `lrc_source == "youtube_transcript"`. Surfaced in
+  `debug_notes` as `"transcript_source_bias: manual_edit=yes, source=youtube_transcript"`.
+  **Does NOT** reclassify. v1's "manual edit on top of youtube_transcript is
+  rare" was a behavioral guess not tied to the bug mechanism.
+
+**Layer-B ordering and mutual exclusivity** (tightened from v1):
+
+| Pair | Mutual exclusivity | Notes |
+|---|---|---|
+| `LRC_JOB_FAILED` (A.1) vs `lrc_url_drift` (B) | exclusive in practice | `failed` jobs carry `result_json = NULL`, so `lrc_result_url` is `None` and drift cannot fire |
+| `LRC_JOB_STUCK` (A.2) vs `lrc_url_drift` (B) | **not** exclusive | A stuck `processing` job may have a partial result already written; drift can still be observed as a diagnostic signal even while Layer-A returns the stuck verdict |
+| `lrc_url_drift` (B) vs `stem_bump_attributable_to_stems` (B) | independent | Both diagnostics compute independently; both can be true on the same row. v1's B.3 (`BENIGN_STEM_BUMP`) required `lrc_result_url == pg_r2_lrc_url` (no drift), but in v2 both signals are reported regardless |
+| `lrc_url_drift` (B) vs `transcript_source_bias` (B) | independent | Both reported independently |
+| `stem_bump_attributable_to_stems` (B) vs `transcript_source_bias` (B) | independent | Both reported independently |
+
+When Layer-B signals co-fire, append each on its own `debug_notes` line so
+downstream diff tooling can detect individual signals.
+
+**`KEY_DETECT_DRIFT`** (unchanged from v1, listed here for completeness):
+informational only. `analyze_result_key_detected_at` is set and differs from
+PG `recordings.key_detected_at`. Sets a `key_detected_at_drift` diagnostic
+column to `true` and appends to `debug_notes`. Does not alter recommendation.
+
+### Step 5 — Output surface changes (additive only)
+
+- **TUI table:** append columns `lrc_source`, `lrc_status`, `lrc_result_url`,
+  `key_detected_at_drift`, `lrc_url_drift`,
+  `stem_bump_attributable_to_stems`, `transcript_source_bias`. Keep existing
+  columns.
+- **CSV:** append the same fields to `fieldnames` in `_print_csv`. Existing
+  consumers keyed on column name keep working (DictReader extras ignored).
+  **Reminder:** `_print_csv` uses `extrasaction="ignore"`; new keys passed in
+  row dicts but not added to `fieldnames` are silently dropped, so the
+  `fieldnames` list MUST be updated in lock-step with new debug keys
+  populated by `_compute_verdict`.
+- **Panel counters:** add `LRC_JOB_FAILED`, `LRC_JOB_STUCK` to the summary
+  count line. (Diagnostic columns are not summed to a verdict bucket.)
+- **Error note column:** surface `lrc_error` / `analyze_error` when the
+  respective status is `failed`, replacing the opaque "analysis error: {e}"
+  string.
+
+### Step 6 — `--with-analysis` semantics
+
+Keep the flag. Because Option 2 still pays the per-job HTTP cost, the
+enrichment is **only applied when `--with-analysis` is set**, preserving the
+current cost model. Document a deprecation-notice print when the flag is
+**off** and `INCONCLUSIVE` rows exist, pointing at the flag — lowering the
+"forgot to pass `--with-analysis`" INCONCLUSIVE source without forcing the
+cost on by default. (Making it always-on is Option 1's job.)
+
+The notice is a single dim stderr line emitted once, after the panel:
+
+```
+[dim]INCONCLUSIVE rows present; re-run with --with-analysis to surface
+service-side job status and reduce inconclusive count.[/dim]
+```
+
+## Validation gate (v3 re-promotion criteria)
+
+A diagnostic signal from Layer B may be re-promoted to a verdict-changing
+branch in v3 only after **both**:
+
+1. **Labeled-set validation.** Run the v2 report against a labeled set
+   containing:
+   - known-bug rows (rows confirmed reverted by the audio-batch bug, by
+     inspecting audit logs / manual verification), AND
+   - known-clean rows (rows confirmed NOT reverted, by `visibility_status`
+     remaining `published` through the bug window).
+   The signal's precision and recall against this set must be reported.
+2. **Mechanism link.** A documented causal chain showing why the bug produces
+   the signal. For example, for `lrc_url_drift` to be re-promoted, the bug
+   implementation must be shown to rewrite `r2_lrc_url` (or to leave a stale
+   value that the service never refreshes), with a reference to the
+   responsible code path. Behavioral guesses ("manual edits are rare") do not
+   qualify as a mechanism link.
+
+Bundles blocked from re-promotion by the gate:
+- `lrc_url_drift` — needs mechanism link (does the bug touch `r2_lrc_url`?).
+- `stem_bump_attributable_to_stems` — needs mechanism link + time-attribution
+  (stems written within the bump window, not just present).
+- `transcript_source_bias` — needs labeled-set precision/recall reporting +
+  mechanism link (why `youtube_transcript` source correlates with non-revert).
+
+## Non-fixes (explicit)
+
+- **Purged jobs remain INCONCLUSIVE.** A REST 404 is exactly as empty as a
+  missing SQLite row. Surfacing more fields only helps when the job still
+  exists on the service.
+- **No `request_json` disambiguation.** The benign force-rerun verdict
+  shortcut in Option 1 cannot be implemented from REST — the service
+  `JobResponse` does not surface the request payload. Those rows stay
+  INCONCLUSIVE under Option 2.
+- **No transport/performance win.** Same N round-trips, same 10-worker pool,
+  same `SOW_ANALYSIS_API_KEY` requirement.
+
+## Acceptance criteria
+
+**Baseline (interview 2026-10):** the last run produced **31 INCONCLUSIVE**
+rows.
+
+- `_lookup_analysis_job` returns the full `JobInfo` (or `None` + note on 404);
+  no consumed field of `JobInfo.result` is left on the floor.
+- Admin-cli `AnalysisResult` models `line_count`, `vocals_dry_url`,
+  `vocals_url`, `instrumental_url`; `_parse_job_response` populates them.
+- **Verdict invariants:**
+  - For candidate rows whose `lrc_job_id` / `analysis_job_id` still resolve on
+    the service (within the ~7-day purge window), the `INCONCLUSIVE` counter
+    is strictly lower than today; reclassified rows land **only** in
+    `LRC_JOB_FAILED` or `LRC_JOB_STUCK`.
+  - Layer-B signals (`lrc_url_drift`, `stem_bump_attributable_to_stems`,
+    `transcript_source_bias`, `key_detected_at_drift`) are populated on rows
+    where the underlying condition holds, but the verdict on those rows
+    **must be unchanged from what it would have been if the Layer-B signals
+    were `None`/`false`**. Verified by running the report twice (with and
+    without Layer-B computation) and diffing verdicts.
+- Existing v2 verdicts (`OK_FRESH_LRC`, `SUSPECTED_BUG_REVERT`,
+  `SUSPECTED_POST_ANALYZE`, `NO_SIGNAL_POST_ANALYZE`) are unchanged in both
+  semantics and counts for rows that do not match `LRC_JOB_FAILED` /
+  `LRC_JOB_STUCK`.
+- CSV column set is a superset of the v1 column set (no renames, no removals);
+  a v1 consumer reading the CSV keeps working.
+- No new dependency added to `ops/admin-cli` `pyproject.toml`; the change is
+  confined to `recover_visibility.py` and one additive patch to
+  `services/analysis.py`.
+- The remaining `INCONCLUSIVE` rows after this change must each correspond to a
+  REST 404 (purged job) — there should be no row that *could* have been
+  resolved by `LRC_JOB_FAILED` / `LRC_JOB_STUCK` but was missed. Layer-B
+  signals on `INCONCLUSIVE` rows are surfaced in `debug_notes` even though the
+  verdict does not change (this is the seed data for the v3 validation gate).
+
+## Resolved questions (interview 2026-10)
+
+- **Baseline metric.** Last run produced **31 INCONCLUSIVE** rows; acceptance
+  compares against that count.
+- **`LRC_JOB_STUCK` threshold.** Locked at **12 hours**; longest legitimate
+  `lrc` job fits well under that.
+- **Failed-job `result` presence.** Confirmed: `failed` jobs carry
+  `result_json = NULL`. `LRC_JOB_FAILED` keys off `status` alone; `lrc_url_drift`
+  (Layer B) cannot fire on a failed job.
+- **Transport scope.** Option 1 (direct SQLite) is **shelved**; only Option 2
+  ships. The network cost of `--with-analysis` is accepted as-is.
+
+## Review decisions (this iteration)
+
+- **Diagnostic demotion** of `LRC_URL_DRIFT` / `BENIGN_STEM_BUMP` /
+  `LRC_SOURCE_TRANSCRIPT`: chosen over keep-as-proposed and over drop-
+  entirely. Reasons:
+  - Keep-as-proposed would emit *recommendations* (`set-visibility published`,
+    benign treatment, source-biased reclassification) on rows whose underlying
+    hypothesis has not been validated against the actual bug path; risk of
+    mass false reclassification of the 31 INCONCLUSIVE rows in the wrong
+    direction.
+  - Drop-entirely discards the seed data needed to validate the hypotheses at
+    all; the diagnostic columns let v3's validation gate run on real runs
+    rather than ad-hoc queries.
+- **Keep both** the Step 6 deprecation notice and the `LRC_JOB_STUCK` branch:
+  - The deprecation notice is a single dim stderr line; cost-output ratio is
+    acceptable and it directly addresses the "forgot to pass `--with-analysis`"
+    INCONCLUSIVE source. Kept.
+  - `LRC_JOB_STUCK` is a legitimate verdict branch: a stuck job IS the
+    explanation for a missing `lrc_job_done`, distinct from a purged job.
+    Kept despite its introducing a 12h threshold; threshold remains locked
+    per interview.
+
+## Open questions
+
+1. Should `lrc_url_drift` (Layer B) compare normalized URLs (strip query,
+   trailing slash) or exact strings? Exact is safer for detecting the bug
+   (which writes stale URLs verbatim); normalization risks false negatives.
+   v2 plan assumes exact string compare for the diagnostic; v3 re-promotion
+   revisit confirms preference before any verdict-changing use.
+2. The `LRC_JOB_STUCK` 12h threshold is a single magic number. Should it be
+   exposed as a CLI option (`--stuck-threshold-hours`, default 12) for tunability
+   without a code change, or remain a module constant? v2 plan assumes a
+   module constant; confirm preference before implementing.
+
+## Appendix A — REST response field table (unchanged from v1)
+
+From `JobInfo` / `AnalysisResult`
+(`ops/admin-cli/src/stream_of_worship/admin/services/analysis.py`) and the
+service-side `JobResult` (`ops/analysis-service/src/sow_analysis/models.py`):
+
+| Field | Source | Currently used? | Useful for verdict? |
+|---|---|---|---|
+| `JobInfo.updated_at` | REST | used | LRC/analyze job completion time |
+| `JobInfo.status` | REST | discarded | `failed` / `cancelled` explains a missing `updated_at` and a missing result |
+| `JobInfo.stage` | REST | discarded | surfaces "in progress" jobs (stale `processing` after a crash) |
+| `JobInfo.error_message` | REST | discarded | distinguishes "purged" from "failed with reason" |
+| `JobInfo.created_at` | REST | discarded | distinguishes re-submit from continuation; bounds `updated_at`; used by `LRC_JOB_STUCK` threshold |
+| `AnalysisResult.key_detected_at` | REST `result` | discarded (only PG `r.key_detected_at` is used) | cross-check vs PG; drift = diagnostic signal (Layer B `key_detected_at_drift`) |
+| `AnalysisResult.lrc_url` | REST `result` | discarded | cross-check vs PG `r.r2_lrc_url`; mismatch = Layer-B `lrc_url_drift` diagnostic (verdict-unchanging in v2) |
+| `AnalysisResult.lrc_source` | REST `result` | discarded | `youtube_transcript \| qwen3_asr \| whisper_asr \| forced_alignment` — not in PG; Layer-B `transcript_source_bias` diagnostic |
+| `AnalysisResult.line_count` | service `result` | not modeled in admin AnalysisResult | sanity vs LRC content / manual-edit detection (v2 models and surfaces; no verdict use) |
+| `AnalysisResult.stems_url` | REST `result` | discarded | presence ⇒ `stem_bump_attributable_to_stems` Layer-B diagnostic |
+| `AnalysisResult.vocals_dry_url` / `vocals_url` / `instrumental_url` | service `result` | not modeled in admin AnalysisResult | modeled and surfaced in v2; no verdict use |
+| `AnalysisResult.tempo_bpm` / `musical_key` / `key_confidence` | REST `result` | discarded | diagnostic display only |
+
+### What REST does NOT give you (Option 1 territory, out of scope here)
+
+- `request_json` payload (`force` flags, `youtube_url`, `lyrics_text`) — the
+  service `JobResponse` deliberately omits the request. The "benign
+  force-rerun" disambiguation that Option 1 enables via
+  `request_json.force` is **not achievable from REST alone**. Stays an
+  INCONCLUSIVE fallback until Option 1 (or a service-side request-surface
+  change) lands.

--- a/specs/songset-constructor-markdown-report-summary-v1.md
+++ b/specs/songset-constructor-markdown-report-summary-v1.md
@@ -1,0 +1,362 @@
+# Songset Constructor Markdown Report Enhancements v1
+
+## Goal
+
+Enhance `proposal_report.md` (produced by `lab/poc-scripts/poc/songset_constructor/artifacts/writer.py`) to include:
+
+1. **Per-songset brief summary block** at the top of each `## Rank N` section, with:
+   - Song sequence with titles
+   - Narrative arc description (LLM-generated when enabled, deterministic fallback otherwise)
+   - Key & tempo journey
+   - Score + warning highlights
+   - Rationale line
+2. **Cross-songset Diversity Summary** appended at the end of the report, surfacing bottlenecks (over-reused songs, missing phases, composer concentration, theme coverage gaps).
+3. **Stdout echo** of the brief summary block via the CLI after a successful run.
+
+No new output files. No changes to `proposals.json`, `songset_review.md`, `candidate_pool.csv`, or `graph_trace.jsonl`.
+
+## LLM Call Budget (Option 1 — Single Batched Call)
+
+- **+1 LLM call total** per run, regardless of `top_k` (e.g., 20 songsets = 1 added call, not 20).
+- Combined with the existing `songset_review.md` LLM call: **2 LLM calls/run** worst case.
+- On any failure (parse error, wrong count, exception): all songsets fall back to deterministic narrative. Partial failures are not possible because the response is parsed atomically.
+- When `config.no_llm is True` or `len(proposals) < 2`: deterministic only, 0 added LLM calls.
+
+## Scope of Changes
+
+| File | Change |
+|---|---|
+| `lab/poc-scripts/poc/songset_constructor/artifacts/writer.py` | Extend `write_report` signature; add batched LLM summary generator, deterministic narrative helpers, diversity summary helpers; export `brief_summary_block` for CLI reuse |
+| `lab/poc-scripts/poc/songset_constructor/cli.py` | Add `_print_brief_summaries` invoked after `_print_output_files`; reuse narratives returned by `write_artifacts` to avoid a second LLM call |
+| `lab/poc-scripts/tests/test_songset_constructor_artifacts.py` | Add unit tests for new helpers and end-to-end `write_report` snapshot |
+
+No changes to: `models.py`, `config.py`, `graph/*`, `rules/fitness.py`, `rules/proposals.py`, `rules/phases.py`, or any node implementation. The report extracts information already produced by the graph.
+
+## Per-Songset Brief Summary Block
+
+### Placement
+
+Inserted at the **top** of each `## Rank N` section, before the existing score/components/table content. Existing content is preserved verbatim under a new `### Details` subheading.
+
+### Format
+
+```markdown
+## Rank N — Score 0.7800
+
+> **Brief Summary**
+> Songs: 1. 主你荣耀  →  2. 恩典已降临  →  3. 耶稣我爱祢
+> Arc: Phase 1 → 3 → 5 (call → worship → commitment). Opens with an uplifting call, settles into intimate adoration, lands in reflective surrender.
+> Journey: C maj → G maj → C maj  |  76 → 110 → 82 BPM arc
+> Score: f_theme 0.850, f_tempo 0.720, f_harmony 0.910, f_diversity 0.670  |  Warnings: H4 relaxed
+> Rationale: Balanced praise-to-thanksgiving flow.
+
+### Details
+<existing score/components/origin/warnings/rationale + table unchanged>
+```
+
+### Deterministic Helpers (all in `writer.py`)
+
+- `_song_sequence_line(proposal) -> str` — `1. {title}  →  2. {title}  →  ...`. Uses `proposal.items[*].position` and `.title`. Empty items list returns `"(no songs)"`.
+- `_key_tempo_journey_line(proposal) -> str` — enumerates each song's `key mode` (e.g., `C maj`) and `BPM`. Format: `C maj → G maj → C maj  |  76 → 110 → 82 BPM arc`. Missing key → `?`; missing BPM → `?` in the BPM list.
+- `_score_warnings_line(proposal) -> str` — `f_theme 0.850, f_tempo 0.720, f_harmony 0.910, f_diversity 0.670  |  Warnings: H4 relaxed` or `...  |  Warnings: none` when `hard_constraint_warnings` is empty.
+- `_deterministic_arc_narrative(proposal) -> str` — synthesizes 1-2 sentences from the phase pattern and primary themes. Uses the canonical phase-name table below. Example: `Phase 1 → 3 → 5 (call → worship → commitment). Themes: 赞美, 敬拜, 差遣.`
+- `brief_summary_block(proposal, *, config, pool, llm_narrative=None) -> list[str]` — public export. Assembles the blockquote lines. When `llm_narrative` is provided and non-empty, it replaces the deterministic arc narrative; otherwise deterministic is used. Always returns the Songs / Journey / Score / Rationale lines from deterministic helpers (these are factual, not LLM-generated).
+
+### Canonical Phase-Name Table
+
+Derived from `rules/phases.py:THEME_TO_PHASE`. Hard-coded in `writer.py` as a module-level constant:
+
+```python
+PHASE_NAMES = {
+    1: "call",        # 赞美 (praise)
+    2: "thanksgiving",# 感恩
+    3: "worship",     # 敬拜 / 祈祷 / 信心 / 圣灵
+    4: "response",    # 奉献 / 认罪 / 十字架
+    5: "commitment",  # 差遣 / 跟随 / 复兴
+}
+```
+
+This is for human-readable narrative only; it does not change phase inference logic.
+
+## Batched LLM Call
+
+### `generate_brief_summaries(config, proposals) -> list[str]`
+
+Returns exactly `len(proposals)` strings, aligned by index to `proposals`. Each string is the LLM-generated narrative for that songset (≤2 sentences), or the deterministic fallback when LLM is disabled or fails.
+
+### Behavior
+
+1. If `config.no_llm` or `len(proposals) < 2`: return `[_deterministic_arc_narrative(p) for p in proposals]`. No LLM call.
+2. Build `build_chat_model(config)` (reuses existing helper from `graph.llm`). If `None`: deterministic fallback for all.
+3. Build a single prompt containing all proposals' structured data, separated by `---PROPOSAL N---` markers. For each proposal, include:
+   - Position-ordered list of `(title, phase, themes, key, mode, bpm)`
+   - Score breakdown (`f_theme`, `f_tempo`, `f_harmony`, `f_diversity`, `total`)
+   - `hard_constraint_warnings`
+   - `rationale` (if present)
+4. Prompt template (factual guardrails mirror the existing review prompt):
+
+   ```
+   You are reviewing Chinese worship songsets. For each proposal below, write
+   ≤2 sentences describing the emotional and musical arc — call themes, worship
+   arc, and key/tempo trajectory. Use only the facts provided. Do not invent
+   songs, scores, or warnings.
+
+   Format your response EXACTLY as:
+   <<<SUMMARY 1>>>
+   <narrative for proposal 1>
+   <<<END SUMMARY 1>>>
+   <<<SUMMARY 2>>>
+   <narrative for proposal 2>
+   <<<END SUMMARY 2>>>
+   ... (one block per proposal, in order)
+
+   Proposals:
+   ---PROPOSAL 1---
+   <structured data>
+   ---PROPOSAL 2---
+   <structured data>
+   ...
+   ```
+
+5. Invoke `chat_model.invoke(prompt)`. Extract content via the same `getattr(response, "content", response)` + list-join pattern used in `build_review_report` (writer.py:170-172).
+6. Parse the response by scanning for `<<<SUMMARY N>>>` ... `<<<END SUMMARY N>>>` delimiters. Collect into a dict keyed by index.
+7. **Validation**: if the parsed dict does not contain exactly `len(proposals)` entries (indices 1..N), OR any entry is empty after stripping, fall back entirely to deterministic for ALL proposals. No partial LLM results.
+8. Truncate each narrative to ≤2 sentences via split on `. ` (defensive; the prompt already requests ≤2).
+9. Return the list aligned to `proposals` order.
+
+### Failure Modes
+
+- LLM exception → deterministic fallback for all proposals (caught broadly, mirroring `build_review_report`'s `except Exception`).
+- Malformed response (missing delimiters, wrong count) → deterministic fallback for all.
+- Empty content → deterministic fallback for all.
+- No partial-success state: the validation in step 7 is atomic.
+
+## Cross-Songset Diversity Summary
+
+### Placement
+
+Appended at the **end** of `proposal_report.md`, after the last `## Rank N` section. Skipped entirely (returns empty list) when `len(proposals) <= 1`.
+
+### Format
+
+```markdown
+## Diversity Summary
+
+Across 3 proposals (9 song slots total):
+
+| Metric | Value |
+|---|---|
+| Unique songs | 7 / 9 (78%) |
+| Unique themes | 6 / 12 |
+| Unique composers | 5 |
+| Unique phases | 4 / 5 |
+| Middle-song reuse | 2 (across 3 middle slots) |
+
+### Song Overlap Matrix
+
+| | R1 | R2 | R3 |
+|---|---|---|---|
+| R1 | — | 2 | 1 |
+| R2 | 2 | — | 1 |
+| R3 | 1 | 1 | — |
+
+### Song Frequency
+
+| Song ID | Title | Times Used |
+|---|---|---:|
+| s1 | 主你荣耀 | 3 |
+| s4 | 恩典已降临 | 2 |
+
+### Theme Coverage
+
+Present (8): 赞美, 感恩, 敬拜, 奉献, 认罪, 十字架, 差遣, 复兴
+Missing (4): 祈祷, 信心, 圣灵, 跟随
+
+### Bottlenecks
+
+- Most-reused song: "主你荣耀" appears in 3/3 songsets.
+- Phase gap: Phase 2 (thanksgiving) absent from all top-k songsets.
+- Composer concentration: composer "张三" authored 4/9 slots (44%).
+```
+
+### Helpers (all in `writer.py`)
+
+- `_diversity_summary(proposals, pool) -> list[str]` — top-level orchestrator. Returns `[]` when `len(proposals) <= 1`.
+- `_diversity_metrics(proposals, pool) -> dict` — computes:
+  - `total_slots` = sum of `len(p.items)` across proposals
+  - `unique_songs` = set of `song_id` across all items
+  - `unique_themes` = set of themes across all items
+  - `unique_composers` = set of composers (looked up via `pool` by `song_id`)
+  - `unique_phases` = set of `phase` across all items
+  - `middle_song_ids` = union of `middle_song_ids(p)` (reuse from `rules.fitness`) across proposals
+  - `middle_reuse_count` = `total_middle_slots - len(unique_middle_songs)` where `total_middle_slots` is the sum of middle-slot counts across proposals
+- `_song_overlap_matrix(proposals) -> list[str]` — symmetric matrix rows. Cell `(i, j)` = `len(set(songs_i) & set(songs_j))`. Diagonal is `—`. Header row + one row per proposal.
+- `_song_frequency_table(proposals) -> list[str]` — table of songs appearing in >1 proposal, sorted by `Times Used` desc, then `Title` asc. Empty table → omit subsection (return only a header note).
+- `_theme_coverage_lines(proposals) -> list[str]` — `Present (N): ...` and `Missing (M): ...` lines. The full theme set is the 12 themes from `rules.themes.THEMES` (imported).
+- `_bottleneck_lines(metrics, proposals, pool) -> list[str]` — heuristic findings, empty list when none:
+  - **Most-reused song**: any song appearing in >50% of proposals. List all that qualify, sorted by count desc.
+  - **Phase gap**: any phase in `{1, 2, 3, 4, 5}` absent from all proposals. Use `PHASE_NAMES` for the label.
+  - **Composer concentration**: any composer providing >33% of total slots. List all that qualify.
+
+### Composer Lookup
+
+Reuse `composer_diversity()` in `rules/proposals.py:85-92` for per-proposal composer counts. For cross-songset composer totals, build a `song_id -> composer` map from `pool` once and aggregate.
+
+## Refactor: `write_report` Signature
+
+### Current
+
+```python
+def write_report(path: Path, proposals: list[SongsetProposal]) -> None:
+```
+
+### New
+
+```python
+def write_report(
+    path: Path,
+    *,
+    config: RunConfig,
+    proposals: list[SongsetProposal],
+    pool: list[SongCandidate],
+) -> list[str]:
+```
+
+- `config` and `pool` are now required (keyword-only). Both are already in scope at the call site in `write_artifacts` (writer.py:39).
+- Returns `list[str]` — the generated LLM narratives (aligned to `proposals`), so the CLI can reuse them for stdout echo without a second LLM call.
+
+### Internal Flow
+
+1. Call `narratives = generate_brief_summaries(config, proposals)` once.
+2. For each proposal (with index), assemble `## Rank N` section: brief summary block (using `narratives[i]` if non-empty) + existing `### Details` content.
+3. Append `_diversity_summary(proposals, pool)` lines.
+4. Write to `path`.
+5. Return `narratives`.
+
+### `write_artifacts` Update
+
+Current `write_artifacts` returns `dict[str, str]` (name → path). To let the CLI reuse narratives without a second LLM call, change the return type to `dict[str, str]` plus a side-channel for narratives. Two options:
+
+**Option A (preferred)**: `write_artifacts` returns `dict[str, str]` unchanged; narratives are stored in a module-level `_last_narratives` cache (single-entry, keyed by `config.thread_id`). CLI reads from cache. Simple, no signature break for downstream callers.
+
+**Option B**: `write_artifacts` returns `tuple[dict[str, str], list[str]]`. Cleaner but breaks any caller expecting a dict. Check callers before adopting.
+
+Adopt **Option A** unless `write_artifacts` has external callers that would be affected; the test file `test_songset_constructor_artifacts.py` calls it but only uses the returned dict, so Option A is safe.
+
+## CLI Stdout Echo
+
+### New helper in `cli.py`
+
+```python
+def _print_brief_summaries(config: RunConfig, result: dict) -> None:
+    proposals = result.get("final_proposals", []) or []
+    pool = result.get("pool", []) or []
+    if not proposals:
+        return
+    from poc.songset_constructor.artifacts import writer as writer_mod
+
+    narratives = writer_mod.get_cached_narratives(config.thread_id)
+    if narratives is None:
+        narratives = writer_mod.generate_brief_summaries(config, proposals)
+    console.print("[green]Proposed songsets (brief):[/green]")
+    for proposal, narrative in zip(proposals, narratives):
+        block = writer_mod.brief_summary_block(
+            proposal, config=config, pool=pool, llm_narrative=narrative
+        )
+        console.rule(f"Rank {proposal.rank}")
+        console.print("\n".join(block))
+```
+
+### Call Site
+
+In `construct()` (cli.py:384-388), after `_print_output_files(paths)` and the `if not paths:` guard:
+
+```python
+paths = result.get("artifact_paths", {})
+_print_output_files(paths)
+if not paths:
+    _print_no_results_summary(config, result)
+else:
+    _print_brief_summaries(config, result)
+```
+
+### Cache Helper
+
+Add to `writer.py`:
+
+```python
+_LAST_NARRATIVES: dict[str, list[str]] = {}
+
+def cache_narratives(thread_id: str, narratives: list[str]) -> None:
+    _LAST_NARRATIVES[thread_id] = narratives
+
+def get_cached_narratives(thread_id: str) -> list[str] | None:
+    return _LAST_NARRATIVES.get(thread_id)
+```
+
+`write_report` calls `cache_narratives(config.thread_id, narratives)` before returning. CLI reads via `get_cached_narratives`. Falls back to a fresh `generate_brief_summaries` call only if the cache miss (e.g., when `write_artifacts` was skipped — should not happen in normal flow, but defensive).
+
+## Tests
+
+Add to `lab/poc-scripts/tests/test_songset_constructor_artifacts.py`. Reuse the existing `_proposal()` and `synthetic_pool` fixtures.
+
+### Deterministic Helpers
+
+- `test_song_sequence_line` — 3 items, 1 item, 0 items.
+- `test_key_tempo_journey_line` — all keys/BPMs present; missing key on one item; missing BPM on one item; both missing.
+- `test_score_warnings_line` — with warnings, without warnings.
+- `test_deterministic_arc_narrative` — phase patterns 1→3→5, 1→4, 2→3→4→5, single-phase edge case.
+
+### `brief_summary_block`
+
+- `test_brief_summary_block_deterministic` — no `llm_narrative`; all 5 lines present; deterministic arc narrative used.
+- `test_brief_summary_block_with_llm` — `llm_narrative` provided; LLM narrative replaces deterministic arc line; other lines unchanged.
+
+### `generate_brief_summaries`
+
+- `test_generate_brief_summaries_no_llm` — `config.no_llm=True`; returns deterministic for all; no LLM invoked.
+- `test_generate_brief_summaries_single_proposal` — `len(proposals)==1`; deterministic; no LLM invoked.
+- `test_generate_brief_summaries_llm_success` — mocked `build_chat_model` returns a `FakeChat` whose `invoke` returns a properly-delimited response for 3 proposals; parsed narratives returned in order.
+- `test_generate_brief_summaries_llm_malformed` — `FakeChat` returns garbage without delimiters; falls back to deterministic for all.
+- `test_generate_brief_summaries_llm_wrong_count` — `FakeChat` returns 2 summaries for 3 proposals; falls back to deterministic for all.
+- `test_generate_brief_summaries_llm_exception` — `FakeChat.invoke` raises; falls back to deterministic for all.
+
+### Diversity Summary
+
+- `test_diversity_summary_empty` — `[]` → `[]`.
+- `test_diversity_summary_single` — 1 proposal → `[]`.
+- `test_diversity_summary_three_overlapping` — 3 proposals with shared songs; metrics table, overlap matrix, frequency table, theme coverage, and bottleneck lines all present and correct.
+- `test_song_overlap_matrix_symmetric` — matrix is symmetric; diagonal is `—`.
+- `test_bottleneck_lines_none` — proposals with no over-reused songs, no missing phases, no concentrated composers → empty list.
+
+### End-to-End
+
+- `test_write_report_with_summary` — snapshot-style: 3 proposals, deterministic mode (`no_llm=True`); assert report contains `> **Brief Summary**`, `> Songs:`, `> Arc:`, `> Journey:`, `> Score:`, `### Details`, and `## Diversity Summary` sections. Reuse existing `_proposal()` fixture, varying ranks.
+- `test_write_report_returns_narratives` — `write_report` returns a list of length `len(proposals)`.
+
+## Non-Goals
+
+- No new output file (no `songset_summary.md`).
+- No changes to `songset_review.md` prompt or output (kept verbose LLM review separate).
+- No changes to `proposals.json` payload structure.
+- No new fields on `SongsetProposal` / `ProposalItem` / `ScoreBreakdown`.
+- No changes to `rules/*` or `graph/*`.
+- No caching layer beyond the single-entry `_LAST_NARRATIVES` dict for CLI reuse.
+- No structured-output schema for the LLM (plain text with delimiters is sufficient and avoids Pydantic overhead).
+
+## Open Questions Resolved
+
+1. **Phase naming source**: `rules/phases.py` does not expose a phase-number → name table; it maps themes to phases. A new `PHASE_NAMES` constant is added to `writer.py` for narrative purposes only, derived from the theme-to-phase mapping in `rules/phases.py:THEME_TO_PHASE`.
+2. **Cache approach**: Option A (module-level single-entry cache keyed by `thread_id`). Avoids breaking `write_artifacts` return type. CLI reads from cache; falls back to fresh `generate_brief_summaries` only on cache miss.
+
+## Implementation Order
+
+1. Add `PHASE_NAMES` constant and deterministic helpers (`_song_sequence_line`, `_key_tempo_journey_line`, `_score_warnings_line`, `_deterministic_arc_narrative`).
+2. Add `brief_summary_block` public export.
+3. Add `generate_brief_summaries` with LLM batching + delimiter parsing + fallback.
+4. Add diversity helpers (`_diversity_metrics`, `_song_overlap_matrix`, `_song_frequency_table`, `_theme_coverage_lines`, `_bottleneck_lines`, `_diversity_summary`).
+5. Add `_LAST_NARRATIVES` cache + `cache_narratives` / `get_cached_narratives`.
+6. Refactor `write_report` signature and internal flow; update `write_artifacts` call site.
+7. Add `_print_brief_summaries` to `cli.py`; wire into `construct()`.
+8. Add tests per the test plan above.
+9. Run `uv run --project lab/poc-scripts --extra test pytest tests/test_songset_constructor_artifacts.py tests/test_songset_constructor_cli.py -v` and fix failures.


### PR DESCRIPTION
## Summary

This PR bundles several independent improvements across the admin CLI, songset constructor, and LRC editor:

---

## 1. Recover Visibility — v2 Multi-Signal Verdict Engine

**Problem:** After the all-recordings `FAST_ANALYZE/ANALYZE` run, `recordings.updated_at` is bumped by generic `BEFORE UPDATE` triggers on every write path, making it unreliable as the bug-fire time signal. v1's delta_h-only approach produces massive false positives.

**Changes:**
- Add `CandidateSignals` dataclass with 7 signal inputs (`db_updated_at`, `r2_lm`, `lrc_job_done`, `analyze_job_done`, `key_detected_at`, `with_analysis`, `bump_tolerance_s`)
- Switch primary bug signal from `delta_h` to `r2_lm` vs `lrc_job_done` ordering (updated_at-independent)
- Add analyze-bump detection via `analyze_job_done` or `key_detected_at` within configurable tolerance window
- New verdicts: `SUSPECTED_POST_ANALYZE`, `NO_SIGNAL_POST_ANALYZE`
- `delta_h` demoted to informational only
- Batch analysis lookup now fetches both `lrc_job_id` and `analysis_job_id` upfront
- New `--bump-tolerance-seconds` CLI flag (default 60s)
- Updated table/CSV output with new columns (`analyze_bump`, `bump_source`, `manual_edit_after_autogen`, `analyze_job_id`, `key_detected_at`)

### Recover Visibility — v2 Full REST Result Surface

- Add `line_count`, `vocals_dry_url`, `vocals_url`, `instrumental_url` to `AnalysisResult`
- `_lookup_analysis_job` returns `Optional[JobInfo]` instead of `(updated_at, note)` tuple
- Extend `CandidateSignals` with 15 new fields from LRC/Analysis JobInfo
- **Layer A verdict branches:** `LRC_JOB_FAILED` (failed/cancelled), `LRC_JOB_STUCK` (processing/queued/waiting + 12h threshold) — only override INCONCLUSIVE
- **Layer B diagnostic-only signals:** `lrc_url_drift`, `stem_bump_attributable_to_stems`, `transcript_source_bias`, `key_detected_at_drift` — never alter verdict
- Add 11 new columns to TUI table, 12 new fields to CSV output
- Update panel counters with `LRC_JOB_FAILED`/`LRC_JOB_STUCK` counts
- Surface `lrc_error`/`analyze_error` columns
- Deprecation notice on stderr when `--with-analysis` off and INCONCLUSIVE rows exist

### Performance & Bug Fixes

- Parallelize R2 lookups with `ThreadPoolExecutor` (20 workers)
- Parallelize analysis service lookups with `ThreadPoolExecutor` (10 workers)
- Fix `_parse_iso_datetime` to handle psycopg datetime objects (not just strings)
- Fix column name: `s.album` → `s.album_name` in SQL query
- Move progress output to stderr so CSV output is clean

---

## 2. Songset Constructor — Markdown Report Enhancements

- Add per-songset brief summary blockquotes at the top of each Rank N section (song sequence, narrative arc, key/tempo journey, score/warnings, rationale)
- Add cross-songset diversity summary at the end (metrics table, song overlap matrix, frequency table, theme coverage, bottlenecks)
- Add CLI stdout echo of brief summaries after a successful run
- `writer.py`: add `PHASE_NAMES`, deterministic helpers, `brief_summary_block`, `generate_brief_summaries` (single batched LLM call with atomic fallback), diversity summary helpers, `_LAST_NARRATIVES` cache, refactor `write_report`
- `cli.py`: add `_print_brief_summaries` wired into `construct()`
- **Tests:** 28 new tests covering all helpers, LLM paths, and end-to-end report

---

## 3. Admin CLI — `--stdin` Batch Mode for `audio set-visibility`

- Add `--stdin` flag to `sow-admin audio set-visibility` for batch processing visibility changes from stdin (newline-separated recording IDs)
- Enables pipeline/scripted usage without interactive TUI

---

## 4. Admin CLI — `--sort updated` for `audio list`

- Add `"updated"` to `order_map` in `list_recordings_with_songs()`
- Update help string and validation set for `--sort` option
- Add Updated column to table output when `--sort updated` is active
- Integration and validation tests for `--sort updated`

---

## 5. LRC Editor — `?` Keymap Popup with BindingsMap Clobber Fix

- Add a `?` / escape-dismissible modal listing all editor bindings grouped by category
- Extract `format_key_display()` from `_BindingGroup` into a module-level helper so the popup can reuse it
- `KeymapDialog` stores the passed-in binding list as `_all_bindings` rather than `_bindings`, which would overwrite Textual's internal `BindingsMap` (set by `DOMNode.__init__`) and break `App._check_bindings` dispatch with `AttributeError` on `key_to_bindings.get()`
- Regression test dismisses the popup via `pilot.press('?')` to exercise the full binding dispatch path

---

## Files Changed

| Area | Files | Lines |
|------|-------|-------|
| recover_visibility | `ops/admin-cli/src/.../recover_visibility.py` | +738 |
| songset constructor | `lab/poc-scripts/poc/songset_constructor/artifacts/writer.py`, `cli.py` | +444 |
| songset constructor tests | `lab/poc-scripts/tests/test_songset_constructor_artifacts.py` | +496 |
| admin audio commands | `ops/admin-cli/src/.../audio.py` | +93 |
| admin editor | `ops/admin-cli/src/.../footer.py`, `screen.py` | +88 |
| admin db/client | `ops/admin-cli/src/.../db/client.py` | +1 |
| admin analysis service | `ops/admin-cli/src/.../services/analysis.py` | +8 |
| admin tests | `tests/admin/services/test_lrc_editor_screen.py`, `tests/admin/test_audio_commands.py` | +140 |
| specs | 5 spec documents | +1,623 |
| docs | `reports/songset_constructor_agent_guide.md`, `docs/agent_guide_songset_constructor_eval.md` | +439 |

**Total: 21 files changed, 4,603 insertions(+), 49 deletions(-)**

---

## Testing

- `uv run --project ops/admin-cli --python 3.11 --extra admin --extra test pytest -v` — all admin CLI tests pass
- Songset constructor tests: 28 new tests covering helpers, LLM paths, and end-to-end report generation
- LRC editor keymap popup: regression test via Textual pilot
- Audio commands: integration and validation tests for `--sort updated` and `--stdin` batch mode
