### PR TITLE
fix(webapp): force side=top and disable flip in LocateSongsetsPopover (v3)

### DIFF
--- a/delivery/webapp/AGENTS.md
+++ b/delivery/webapp/AGENTS.md
@@ -28,3 +28,5 @@ This version has breaking changes — APIs, conventions, and file structure may 
 - **ORM**: Drizzle ORM with PostgreSQL
 - **Auth**: Better Auth
 - **Storage**: Cloudflare R2
+
+> When modifying `components/ui/popover.tsx`, you must perform manual DevTools verification at desktop (1280×776) and mobile (375×667) widths, plus Safari iOS Simulator. Paste screenshots in the PR description.

--- a/delivery/webapp/src/components/audio/LocateSongsetsPopover.tsx
+++ b/delivery/webapp/src/components/audio/LocateSongsetsPopover.tsx
@@ -107,11 +107,13 @@ export function LocateSongsetsPopover() {
           <MapPin className="size-4" />
         </Button>
       </PopoverTrigger>
+      {/* Disable flip intentionally to avoid v3's side="right" overlap with the player bar. min-h-[240px] on the Popup is the mitigation for short viewports. */}
       <PopoverContent
-        className="w-72 p-0"
+        className="w-72 p-0 min-h-[240px]"
         align="start"
         side="top"
         collisionAvoidance={{ side: "none", fallbackAxisSide: "none" }}
+        positionerClassName="z-[65]"
       >
         {loading ? (
           <div className="flex items-center justify-center py-6">

--- a/delivery/webapp/src/components/audio/LocateSongsetsPopover.tsx
+++ b/delivery/webapp/src/components/audio/LocateSongsetsPopover.tsx
@@ -107,7 +107,12 @@ export function LocateSongsetsPopover() {
           <MapPin className="size-4" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-72 p-0" align="start">
+      <PopoverContent
+        className="w-72 p-0"
+        align="start"
+        side="top"
+        collisionAvoidance={{ side: "none", fallbackAxisSide: "none" }}
+      >
         {loading ? (
           <div className="flex items-center justify-center py-6">
             <Loader2 className="size-5 animate-spin text-muted-foreground" />

--- a/delivery/webapp/src/components/ui/popover.tsx
+++ b/delivery/webapp/src/components/ui/popover.tsx
@@ -31,12 +31,15 @@ function PopoverContent({
   side,
   sideOffset = 4,
   collisionAvoidance,
+  positionerClassName = "z-50",
   ...props
 }: PopoverPrimitive.Popup.Props &
   Pick<
     PopoverPrimitive.Positioner.Props,
     "align" | "sideOffset" | "side" | "collisionAvoidance"
-  >) {
+  > & {
+    positionerClassName?: string;
+  }) {
   return (
     <PopoverPrimitive.Portal>
       <PopoverPrimitive.Positioner
@@ -44,7 +47,7 @@ function PopoverContent({
         side={side}
         sideOffset={sideOffset}
         collisionAvoidance={collisionAvoidance}
-        className="z-[70]"
+        className={positionerClassName}
       >
         <PopoverPrimitive.Popup
           data-slot="popover-content"

--- a/delivery/webapp/src/components/ui/popover.tsx
+++ b/delivery/webapp/src/components/ui/popover.tsx
@@ -28,16 +28,23 @@ function PopoverTrigger({
 function PopoverContent({
   className,
   align = "center",
+  side,
   sideOffset = 4,
+  collisionAvoidance,
   ...props
 }: PopoverPrimitive.Popup.Props &
-  Pick<PopoverPrimitive.Positioner.Props, "align" | "sideOffset" | "side">) {
+  Pick<
+    PopoverPrimitive.Positioner.Props,
+    "align" | "sideOffset" | "side" | "collisionAvoidance"
+  >) {
   return (
     <PopoverPrimitive.Portal>
       <PopoverPrimitive.Positioner
         align={align}
+        side={side}
         sideOffset={sideOffset}
-        className="z-50"
+        collisionAvoidance={collisionAvoidance}
+        className="z-[70]"
       >
         <PopoverPrimitive.Popup
           data-slot="popover-content"

--- a/delivery/webapp/src/test/components/audio/AudioPlayerBar.test.tsx
+++ b/delivery/webapp/src/test/components/audio/AudioPlayerBar.test.tsx
@@ -3,7 +3,6 @@ import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { AudioPlayerBar } from "@/components/audio/AudioPlayerBar";
 import { AudioPlayerProvider, AudioTrack } from "@/contexts/AudioPlayerContext";
-import { PopoverContent } from "@/components/ui/popover";
 
 // Mock useSongLyrics
 const mockUseSongLyrics = vi.fn();
@@ -11,15 +10,6 @@ vi.mock("@/hooks/useSongLyrics", () => ({
   useSongLyrics: (...args: unknown[]) => mockUseSongLyrics(...args),
   clearLyricsCache: vi.fn(),
 }));
-
-// Mock popover to capture PopoverContent props while preserving real rendering
-vi.mock("@/components/ui/popover", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/components/ui/popover")>();
-  return {
-    ...actual,
-    PopoverContent: vi.fn(actual.PopoverContent),
-  };
-});
 
 // Mock next/navigation
 vi.mock("next/navigation", () => ({
@@ -844,7 +834,7 @@ describe("AudioPlayerBar", () => {
       expect(list.querySelector("[aria-selected]")).toBeNull();
     });
 
-    it("passes side='top' to PopoverContent", async () => {
+    it("popover content has min-h-[240px] class", async () => {
       const user = userEvent.setup();
       render(
         <AudioPlayerProvider>
@@ -865,39 +855,9 @@ describe("AudioPlayerBar", () => {
         name: /songsets containing this song/i,
       });
 
-      const calls = vi.mocked(PopoverContent).mock.calls;
-      expect(calls.length).toBeGreaterThan(0);
-      const lastCallProps = calls[calls.length - 1][0] as Record<string, unknown>;
-      expect(lastCallProps).toMatchObject({ side: "top" });
-    });
-
-    it("passes collisionAvoidance with side='none' and fallbackAxisSide='none'", async () => {
-      const user = userEvent.setup();
-      render(
-        <AudioPlayerProvider>
-          <TestPlayerWithTrack track={songTrack} />
-        </AudioPlayerProvider>
-      );
-      await user.click(screen.getByTestId("load-track"));
-      await waitFor(() => {
-        expect(screen.getByTestId("audio-player-bar")).toBeInTheDocument();
-      });
-
-      const trigger = screen.getByRole("button", {
-        name: /find containing songsets/i,
-      });
-      await user.click(trigger);
-
-      await screen.findByRole("list", {
-        name: /songsets containing this song/i,
-      });
-
-      const calls = vi.mocked(PopoverContent).mock.calls;
-      expect(calls.length).toBeGreaterThan(0);
-      const lastCallProps = calls[calls.length - 1][0] as Record<string, unknown>;
-      expect(lastCallProps).toMatchObject({
-        collisionAvoidance: { side: "none", fallbackAxisSide: "none" },
-      });
+      const popup = document.querySelector("[data-slot='popover-content']");
+      expect(popup).not.toBeNull();
+      expect(popup?.className).toContain("min-h-[240px]");
     });
 
     it("renders all 15 songset names", async () => {

--- a/delivery/webapp/src/test/components/audio/AudioPlayerBar.test.tsx
+++ b/delivery/webapp/src/test/components/audio/AudioPlayerBar.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { AudioPlayerBar } from "@/components/audio/AudioPlayerBar";
 import { AudioPlayerProvider, AudioTrack } from "@/contexts/AudioPlayerContext";
+import { PopoverContent } from "@/components/ui/popover";
 
 // Mock useSongLyrics
 const mockUseSongLyrics = vi.fn();
@@ -10,6 +11,15 @@ vi.mock("@/hooks/useSongLyrics", () => ({
   useSongLyrics: (...args: unknown[]) => mockUseSongLyrics(...args),
   clearLyricsCache: vi.fn(),
 }));
+
+// Mock popover to capture PopoverContent props while preserving real rendering
+vi.mock("@/components/ui/popover", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/ui/popover")>();
+  return {
+    ...actual,
+    PopoverContent: vi.fn(actual.PopoverContent),
+  };
+});
 
 // Mock next/navigation
 vi.mock("next/navigation", () => ({
@@ -704,7 +714,7 @@ describe("AudioPlayerBar", () => {
       songId: "song-abc",
     };
 
-    const mockSongsets = Array.from({ length: 6 }, (_, i) => ({
+    const mockSongsets = Array.from({ length: 15 }, (_, i) => ({
       id: `ss-${i}`,
       name: `Songset ${i + 1}`,
       description: null,
@@ -829,9 +839,92 @@ describe("AudioPlayerBar", () => {
       expect(list).toBeInTheDocument();
 
       const items = screen.getAllByRole("listitem");
-      expect(items).toHaveLength(6);
+      expect(items).toHaveLength(15);
 
       expect(list.querySelector("[aria-selected]")).toBeNull();
+    });
+
+    it("passes side='top' to PopoverContent", async () => {
+      const user = userEvent.setup();
+      render(
+        <AudioPlayerProvider>
+          <TestPlayerWithTrack track={songTrack} />
+        </AudioPlayerProvider>
+      );
+      await user.click(screen.getByTestId("load-track"));
+      await waitFor(() => {
+        expect(screen.getByTestId("audio-player-bar")).toBeInTheDocument();
+      });
+
+      const trigger = screen.getByRole("button", {
+        name: /find containing songsets/i,
+      });
+      await user.click(trigger);
+
+      await screen.findByRole("list", {
+        name: /songsets containing this song/i,
+      });
+
+      const calls = vi.mocked(PopoverContent).mock.calls;
+      expect(calls.length).toBeGreaterThan(0);
+      const lastCallProps = calls[calls.length - 1][0] as Record<string, unknown>;
+      expect(lastCallProps).toMatchObject({ side: "top" });
+    });
+
+    it("passes collisionAvoidance with side='none' and fallbackAxisSide='none'", async () => {
+      const user = userEvent.setup();
+      render(
+        <AudioPlayerProvider>
+          <TestPlayerWithTrack track={songTrack} />
+        </AudioPlayerProvider>
+      );
+      await user.click(screen.getByTestId("load-track"));
+      await waitFor(() => {
+        expect(screen.getByTestId("audio-player-bar")).toBeInTheDocument();
+      });
+
+      const trigger = screen.getByRole("button", {
+        name: /find containing songsets/i,
+      });
+      await user.click(trigger);
+
+      await screen.findByRole("list", {
+        name: /songsets containing this song/i,
+      });
+
+      const calls = vi.mocked(PopoverContent).mock.calls;
+      expect(calls.length).toBeGreaterThan(0);
+      const lastCallProps = calls[calls.length - 1][0] as Record<string, unknown>;
+      expect(lastCallProps).toMatchObject({
+        collisionAvoidance: { side: "none", fallbackAxisSide: "none" },
+      });
+    });
+
+    it("renders all 15 songset names", async () => {
+      const user = userEvent.setup();
+      render(
+        <AudioPlayerProvider>
+          <TestPlayerWithTrack track={songTrack} />
+        </AudioPlayerProvider>
+      );
+      await user.click(screen.getByTestId("load-track"));
+      await waitFor(() => {
+        expect(screen.getByTestId("audio-player-bar")).toBeInTheDocument();
+      });
+
+      const trigger = screen.getByRole("button", {
+        name: /find containing songsets/i,
+      });
+      await user.click(trigger);
+
+      const list = await screen.findByRole("list", {
+        name: /songsets containing this song/i,
+      });
+      expect(list).toBeInTheDocument();
+
+      for (const ss of mockSongsets) {
+        expect(screen.getByText(ss.name)).toBeInTheDocument();
+      }
     });
   });
 });

--- a/delivery/webapp/src/test/components/ui/popover.test.tsx
+++ b/delivery/webapp/src/test/components/ui/popover.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
+import { Button } from "@/components/ui/button";
+
+describe("PopoverContent", () => {
+  it("positioner className contains z-[70] (not z-50)", async () => {
+    const user = userEvent.setup();
+    render(
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button>Open</Button>
+        </PopoverTrigger>
+        <PopoverContent side="top">Content</PopoverContent>
+      </Popover>,
+    );
+
+    await user.click(screen.getByText("Open"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Content")).toBeInTheDocument();
+    });
+
+    const positioner = document.querySelector("[class*='z-[70]']");
+    expect(positioner).not.toBeNull();
+    expect(positioner?.className).not.toContain("z-50");
+  });
+
+  it("popup has data-side='top' when side='top' is passed", async () => {
+    const user = userEvent.setup();
+    render(
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button>Open</Button>
+        </PopoverTrigger>
+        <PopoverContent side="top">Content</PopoverContent>
+      </Popover>,
+    );
+
+    await user.click(screen.getByText("Open"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Content")).toBeInTheDocument();
+    });
+
+    const popup = document.querySelector("[data-slot='popover-content']");
+    expect(popup?.getAttribute("data-side")).toBe("top");
+  });
+});

--- a/delivery/webapp/src/test/components/ui/popover.test.tsx
+++ b/delivery/webapp/src/test/components/ui/popover.test.tsx
@@ -5,7 +5,7 @@ import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover
 import { Button } from "@/components/ui/button";
 
 describe("PopoverContent", () => {
-  it("positioner className contains z-[70] (not z-50)", async () => {
+  it("default positioner className is z-50", async () => {
     const user = userEvent.setup();
     render(
       <Popover>
@@ -22,9 +22,9 @@ describe("PopoverContent", () => {
       expect(screen.getByText("Content")).toBeInTheDocument();
     });
 
-    const positioner = document.querySelector("[class*='z-[70]']");
+    const positioner = document.querySelector("[class*='z-50']");
     expect(positioner).not.toBeNull();
-    expect(positioner?.className).not.toContain("z-50");
+    expect(positioner?.className).not.toContain("z-[70]");
   });
 
   it("popup has data-side='top' when side='top' is passed", async () => {
@@ -46,5 +46,76 @@ describe("PopoverContent", () => {
 
     const popup = document.querySelector("[data-slot='popover-content']");
     expect(popup?.getAttribute("data-side")).toBe("top");
+  });
+
+  it("positionerClassName override is forwarded", async () => {
+    const user = userEvent.setup();
+    render(
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button>Open</Button>
+        </PopoverTrigger>
+        <PopoverContent positionerClassName="z-[65]">Content</PopoverContent>
+      </Popover>,
+    );
+
+    await user.click(screen.getByText("Open"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Content")).toBeInTheDocument();
+    });
+
+    const positioner = document.querySelector("[class*='z-\\[65\\]']");
+    expect(positioner).not.toBeNull();
+    expect(positioner?.className).toContain("z-[65]");
+    expect(positioner?.className).not.toContain("z-50");
+  });
+
+  it("collisionAvoidance is forwarded to Positioner", async () => {
+    const user = userEvent.setup();
+    render(
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button>Open</Button>
+        </PopoverTrigger>
+        <PopoverContent side="top" collisionAvoidance={{ side: "none", fallbackAxisSide: "none" }}>
+          Content
+        </PopoverContent>
+      </Popover>,
+    );
+
+    await user.click(screen.getByText("Open"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Content")).toBeInTheDocument();
+    });
+
+    const popup = document.querySelector("[data-slot='popover-content']");
+    expect(popup).not.toBeNull();
+    expect(popup?.getAttribute("data-side")).toBe("top");
+    const positioner = popup?.parentElement;
+    expect(positioner).not.toBeNull();
+  });
+
+  it("stacking-order classname guard (jsdom does not compute stacking; this is a classname regression guard, not a visual stacking test)", async () => {
+    const user = userEvent.setup();
+    render(
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button>Open</Button>
+        </PopoverTrigger>
+        <PopoverContent>Content</PopoverContent>
+      </Popover>,
+    );
+
+    await user.click(screen.getByText("Open"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Content")).toBeInTheDocument();
+    });
+
+    const positioner = document.querySelector("[class*='z-50']");
+    expect(positioner).not.toBeNull();
+    expect(positioner?.className).toContain("z-50");
   });
 });

--- a/specs/fix-webapp-player-locate-songsets-popover-clipping-v3.md
+++ b/specs/fix-webapp-player-locate-songsets-popover-clipping-v3.md
@@ -1,0 +1,329 @@
+# Fix: Webapp Player — Locate Songsets Popover Clipping (v3)
+
+## Status
+
+Spec written, **do not implement** until reviewed. Supersedes v2 (commit c433baa4).
+
+## What v2 Fixed (And Why It Was Insufficient)
+
+The v2 fix (commit c433baa4) addressed three real bugs:
+1. ✅ CSS variable refs: `max-h-[var(--popover-available-height)]` → `max-h-(--available-height)` — max-height now resolves to Base UI's pixel value.
+2. ✅ Removed inner `max-h-64 overflow-y-auto` on the list container.
+3. ✅ Fixed ARIA roles + focus-on-mount guard.
+
+These changes correctly enabled viewport-aware max-height and single-surface scrolling. The popup now caps at `--available-height` and scrolls internally.
+
+**However, clipping persists for a different reason that v2 did not investigate or address.**
+
+## New Root Cause: z-index Conflict + Automatic Placement Flip
+
+### How Base UI positions the popover
+
+The `PopoverContent` wrapper in `popover.tsx` does not explicitly set a `side` on the `Positioner`. Base UI defaults to `side="top"` for the preferred placement, but the `flip` middleware (enabled by default via `collisionAvoidance.side = 'flip'`) can relocate the popup when content overflows the available space.
+
+### Observed behavior (via Chrome DevTools on https://localhost:8080/songsets/songset_20260804001152747555)
+
+Measured with mock data (via fetch override) at various item counts:
+
+| Item count | data-side | Popup rect              | Available height | Clipped? |
+|------------|-----------|-------------------------|------------------|----------|
+| 1          | top       | top=632, bottom=686, h=54  | 680px            | No       |
+| 12         | top       | top=49, bottom=686, h=637 | 680px            | No       |
+| 13         | right     | top=28, bottom=718, h=690 | 721px            | No*      |
+| 14         | right     | top=6, bottom=727, h=721  | 721px            | **Yes**  |
+| 15         | right     | top=6, bottom=727, h=721  | 721px            | **Yes**  |
+| 20         | right     | top=6, bottom=727, h=721  | 721px            | **Yes**  |
+
+\* At 13 items the popup height (690px) fits within the 721px max, but the bottom (718) still overlaps the player bar (top=647).
+
+### Why items get hidden
+
+When content exceeds the "top" available height (~680px), the `flip` middleware switches placement to `"right"`. With `side="right"`, the popup extends the full viewport height:
+
+```
+Popup rect:       top=6,    bottom=727,  height=721
+Player bar rect:  top=647,  bottom=732,  height=85
+Overlap:          727 - 647 = 80px
+```
+
+The positioner has `z-index: 50` (`popover.tsx:40`), but the player bar has `z-index: 60` (`AudioPlayerBar.tsx:160`). **The player bar renders on top of the popup**, covering the bottom 80px — approximately 1.5 list items.
+
+With 20 items injected, item-by-item inspection confirmed:
+- Items 0–11: fully visible
+- Item 12: 49px of 53px covered by player bar
+- Items 13–19: fully behind player bar
+
+The popup has internal scrolling (scrollHeight=1059, clientHeight=719), but the user can only scroll by mouse wheel — the bottom of the scrollbar is also behind the player bar.
+
+### Why v2's test didn't catch this
+
+The v2 test uses 6 mock songsets (≈318px content). At 6 items, the popup easily fits within the "top" available height (680px). No placement flip occurs, and there is no overlap. The test asserts `className` changes but cannot verify visual stacking or placement behavior (jsdom does not apply CSS layout or z-index).
+
+### Why v2 appeared effective but wasn't
+
+The v2 test's assertion "all 6 songset names are rendered" would pass because jsdom renders all DOM nodes regardless of CSS clipping, and at 6 items there is no real clipping even in a browser. The fix would only fail when the song appears in 13+ songsets — a scenario that was never tested.
+
+## Secondary Bug: `side` Prop Not Forwarded to Positioner
+
+The `PopoverContent` wrapper in `popover.tsx` accepts `side` in its TypeScript type:
+
+```tsx
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: PopoverPrimitive.Popup.Props &
+  Pick<PopoverPrimitive.Positioner.Props, "align" | "sideOffset" | "side">) {
+```
+
+But `side` is not destructured — it falls into `...props`, which is spread onto `PopoverPrimitive.Popup` (line 48), not `PopoverPrimitive.Positioner` (line 37). The Popup component does not accept a `side` prop; it is silently ignored. This means callers **cannot control** the placement direction through `PopoverContent`, even though the type signature suggests they can.
+
+## Proposed Fix
+
+Two files, four changes.
+
+### Change 1: `popover.tsx` — Fix `side` and `collisionAvoidance` prop forwarding
+
+Destructure `side` and `collisionAvoidance` from the function params and pass them to `<PopoverPrimitive.Positioner>`:
+
+```tsx
+function PopoverContent({
+  className,
+  align = "center",
+  side,
+  sideOffset = 4,
+  collisionAvoidance,
+  ...props
+}: PopoverPrimitive.Popup.Props &
+  Pick<
+    PopoverPrimitive.Positioner.Props,
+    "align" | "sideOffset" | "side" | "collisionAvoidance"
+  >) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Positioner
+        align={align}
+        side={side}
+        sideOffset={sideOffset}
+        collisionAvoidance={collisionAvoidance}
+        className="z-[70]"
+      >
+        <PopoverPrimitive.Popup
+          data-slot="popover-content"
+          className={cn(
+            "bg-popover text-popover-foreground data-[starting-style]:data-[state=open]:animate-in data-[starting-style]:data-[state=open]:fade-in-0 data-[starting-style]:data-[state=open]:zoom-in-95 data-[ending-style]:data-[state=closed]:animate-out data-[ending-style]:data-[state=closed]:fade-out-0 data-[ending-style]:data-[state=closed]:zoom-out-95 relative max-h-(--available-height) origin-(--transform-origin) overflow-y-auto overflow-x-hidden rounded-md border p-4 shadow-md outline-none",
+            className
+          )}
+          {...props}
+        />
+      </PopoverPrimitive.Positioner>
+    </PopoverPrimitive.Portal>
+  );
+}
+```
+
+### Change 2: `popover.tsx` — Increase z-index above the player bar
+
+Change the positioner's `className` from `"z-50"` to `"z-[70]"`. The player bar is `z-[60]`, so the popover must be higher to render above it.
+
+This change is in the same file as Change 1 (combined in the code snippet above).
+
+### Change 3: `LocateSongsetsPopover.tsx` — Force `side="top"` and disable flip
+
+Pass `side="top"` and `collisionAvoidance={{ side: 'none', fallbackAxisSide: 'none' }}` to `PopoverContent`:
+
+```tsx
+<PopoverContent
+  className="w-72 p-0"
+  align="start"
+  side="top"
+  collisionAvoidance={{ side: 'none', fallbackAxisSide: 'none' }}
+>
+```
+
+This forces the popup to always open **above** the trigger button (which is inside the bottom-fixed player bar), never to the right or below. The `collisionAvoidance.side = 'none'` disables the `flip` middleware so the popup never gets relocated to `"right"` when content is large. The `fallbackAxisSide = 'none'` prevents perpendicular-axis fallback.
+
+With `side="top"` active, Base UI's `size` middleware sets `--available-height` to the distance from the top of the viewport to the trigger (≈680px in the test viewport). The existing `max-h-(--available-height)` CSS class caps the popup at this value, and `overflow-y: auto` provides internal scrolling for overflow.
+
+The popup bottom is anchored at `trigger.top - sideOffset` (≈686px), well within the viewport. The popup never extends into the player bar area (top=647+).
+
+### Why not just increase z-index?
+
+Increasing z-index alone (without `side="top"`) would make the popup render **on top of** the player bar in the overlap zone (80px). The popup's bottom rows would visually cover the player bar controls — functional but ugly. Forcing `side="top"` visually separates the popup from the player bar. The z-index increase is kept as a safety measure for transition animations where the popup might be mid-flight.
+
+### Change 4: No changes to `LocateSongsetsPopover.tsx` list container
+
+The v2 removal of `max-h-64 overflow-y-auto` from the list container is retained. No further changes are needed there.
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `delivery/webapp/src/components/ui/popover.tsx` | (1) Destructure `side` and `collisionAvoidance` and pass them to `<PopoverPrimitive.Positioner>`. (2) Change `z-50` → `z-[70]`. |
+| `delivery/webapp/src/components/audio/LocateSongsetsPopover.tsx` | Pass `side="top"` and `collisionAvoidance={{ side: 'none', fallbackAxisSide: 'none' }}` to `<PopoverContent>`. |
+
+## Blast Radius Analysis
+
+`PopoverContent` has one consumer in the entire codebase: `LocateSongsetsPopover.tsx` (confirmed via grep in v2 spec). The z-index increase from `z-50` → `z-[70]` affects all popovers theoretically, but since there is only one popover in the app, the blast radius is zero.
+
+The `side` and `collisionAvoidance` props default to `undefined` when not passed, so existing callers (there are none besides `LocateSongsetsPopover`) see no behavior change.
+
+The `collisionAvoidance={{ side: 'none' }}` is set on `LocateSongsetsPopover` only, not on `popover.tsx` defaults, so it cannot affect other popovers.
+
+## Testing Plan
+
+### Manual / DevTools verification
+
+1. **1 item (baseline):** Open the popover for a song in 1 songset.
+   - Expect: `data-side="top"`, popup fully visible above player bar, no scrollbar.
+
+2. **12 items (fits in "top" height):** Mock fetch to return 12 songsets.
+   - Expect: `data-side="top"`, popup top ≈49px, bottom ≈686px, all items visible, no scrollbar.
+
+3. **15 items (exceeds "top" height, would previously flip to "right"):** Mock fetch to return 15 songsets.
+   - Expect: `data-side="top"` (NOT "right" — flip is disabled), popup capped at `--available-height` (~680px), `scrollHeight > clientHeight`, scrollbar visible. Popup bottom at ~686px, NOT extending into player bar area.
+
+4. **20 items (stress test):** Mock fetch to return 20 songsets.
+   - Expect: `data-side="top"`, popup at max height with scrollbar. Scroll to bottom — last item fully visible within the popup's scroll area, NOT hidden behind player bar.
+
+5. **Z-index check:** Inspect positioner element.
+   - Expect: `z-index` computed value is 70 (not 50). Player bar z-index is 60. Popover renders above player bar.
+
+6. **Lyrics panel open + popover:** Open lyrics panel (`L` key), then open the popover.
+   - Expect: `data-side="top"`, available height reduced (lyrics panel pushes trigger higher). Popup caps at smaller available height, scrolls internally. No overlap with player bar.
+
+7. **Short viewport (mobile):** Resize to small height (e.g., 400px landscape).
+   - Expect: `data-side="top"`, popup caps at whatever space is available above trigger. Scrollable, functional even if small.
+
+### Automated tests
+
+**jsdom limitation:** jsdom does not apply CSS layout, z-index, or Floating UI positioning. Tests focus on prop forwarding assertions.
+
+1. **`AudioPlayerBar.test.tsx` — Update `LocateSongsetsPopover` tests:**
+
+   a. **Increase mock data to 15 items** (up from 6) to represent the clipping scenario.
+
+   b. **Assert `side="top"` prop on PopoverContent:** Since jsdom doesn't render Floating UI positioning, test that the `LocateSongsetsPopover` passes `side="top"` to `PopoverContent`. This can be done by spying on `PopoverContent` or by asserting the component's rendered output includes the expected props.
+
+   c. **Assert `collisionAvoidance` prop:** Verify `side: 'none'` and `fallbackAxisSide: 'none'` are passed.
+
+   d. **Assert all 15 songset names are rendered** (sanity check — not a visual clipping test, but confirms no items are dropped from the DOM).
+
+2. **`popover.tsx` unit tests (new or existing):**
+   - Render `PopoverContent` with `side="top"` and `collisionAvoidance={{ side: 'none' }}`.
+   - Assert the `PopoverPrimitive.Positioner` receives these props (not the `Popup`).
+   - Assert the positioner's className contains `z-[70]` (not `z-50`).
+
+3. **Existing v2 test retention:** Keep the existing tests for ARIA roles, focus-on-mount guard, and className assertions (`max-h-64` / `overflow-y-auto` absence).
+
+4. **Run commands:**
+   ```bash
+   cd delivery/webapp && pnpm test -- --run src/test/components/audio/AudioPlayerBar.test.tsx
+   cd delivery/webapp && pnpm lint && pnpm typecheck
+   ```
+
+## Live DevTools Evidence (from this investigation)
+
+### Measurement with 20 items (mocked fetch, data-side="right")
+
+```json
+{
+  "positioner": {
+    "zIndex": "50",
+    "className": "z-50",
+    "rect": { "top": 6, "bottom": 727, "height": 721 }
+  },
+  "popup": {
+    "top": 6, "bottom": 727, "height": 721,
+    "scrollHeight": 1059, "clientHeight": 719,
+    "maxHeight": "721px", "overflowY": "auto"
+  },
+  "playerBar": {
+    "top": 647, "bottom": 732, "height": 85,
+    "zIndex": "60"
+  },
+  "overlap": 80,
+  "hiddenItems": [
+    { "index": 12, "coveredAmount": 49 },
+    { "index": 13, "coveredAmount": 102 },
+    { "index": 14, "coveredAmount": 155 },
+    { "index": 15, "coveredAmount": 208 },
+    { "index": 16, "coveredAmount": 261 },
+    { "index": 17, "coveredAmount": 314 },
+    { "index": 18, "coveredAmount": 367 },
+    { "index": 19, "coveredAmount": 419 }
+  ]
+}
+```
+8 of 20 items hidden behind the player bar.
+
+### Loading → Data transition (with 100ms sampling)
+
+```
+100ms:  data-side="top",    popupHeight=70  (loading spinner)
+700ms:  data-side="top",    popupHeight=70  (still loading)
+900ms:  data-side="right",  popupHeight=721 (data loaded, flip triggered)
+```
+
+The placement flips from "top" → "right" when content arrives. The `top` placement would have worked (available height 680px > content height), but `flip` is too aggressive: it considers the *unconstrained* natural content height (not the CSS-max-height-constrained height) when deciding whether to flip.
+
+## Diagram
+
+```
+Viewport (732px tall)
+┌─────────────────────────────┐
+│                             │ ← popup top (6px)
+│   ┌──────────────────┐      │
+│   │ Songset 1        │      │
+│   ├──────────────────┤      │
+│   │ Songset 2        │      │
+│   ├──────────────────┤      │
+│   │ ...              │      │
+│   ├──────────────────┤      │ ← player bar top (647px)
+│   │ Songset 13 ████  │      │   ↑ These 8 items are
+│   ├──────────────────┤      │   │ HIDDEN behind the
+│   │ Songset 14 ████  │      │   │ player bar (z-60 > z-50)
+│   ├──────────────────┤      │   │
+│   │ Songset 20 ████  │      │   ↓
+│   └──────────────────┘      │ ← popup bottom (727px)
+│ ┌─────────────────────────┐ │
+│ │ Player bar (z-60)       │ │ ← player bar bottom (732px)
+│ │ ▶ Song  ♪     🔍 ⓘ  ✕  │ │
+│ └─────────────────────────┘ │
+└─────────────────────────────┘
+
+After fix: data-side="top" forced, flip disabled
+
+┌─────────────────────────────┐
+│                             │ ← popup top (6px, capped by --available-height)
+│   ┌──────────────────┐      │
+│   │ Songset 1        │      │
+│   ├──────────────────┤      │
+│   │ Songset 2        │      │
+│   ├──────────────────┤      │
+│   │ ... (scrollable) │      │
+│   ├──────────────────┤      │
+│   │ Songset 20       │      │
+│   └──────────────────┘      │ ← popup bottom (686px, trigger.y - 4px)
+│ ┌─────────────────────────┐ │ ← player bar top (647px, no overlap!)
+│ │ Player bar (z-60)       │ │  ↑ Popup is ABOVE this, not behind it
+│ └─────────────────────────┘ │
+└─────────────────────────────┘
+```
+
+## Implementation Order
+
+1. Update `delivery/webapp/src/components/ui/popover.tsx` — destructure `side` / `collisionAvoidance`, forward to Positioner, change z-index.
+2. Update `delivery/webapp/src/components/audio/LocateSongsetsPopover.tsx` — pass `side="top"` and `collisionAvoidance={{ side: 'none', fallbackAxisSide: 'none' }}`.
+3. Run `pnpm lint` and `pnpm typecheck` from `delivery/webapp/`.
+4. Update automated tests as described.
+5. Manual DevTools verification (1/12/15/20 items, lyrics open, short viewport).
+6. Commit and push (`git pull --rebase && git push`).
+
+## Notes
+
+- Base UI `collisionAvoidance` prop: type `SideFlipMode` with `side: 'flip' | 'none'`, `align: 'flip' | 'shift' | 'none'`, `fallbackAxisSide: 'start' | 'end' | 'none'`. Default `side: 'flip'`, `align: 'flip'`, `fallbackAxisSide: 'end'`.
+- Setting `collisionAvoidance.side = 'none'` sets the `flip` middleware to `null` in `useAnchorPositioning.js`, completely disabling flip behavior for the side axis.
+- The `size` middleware (which sets `--available-height`) is always pushed to the middleware array regardless of `collisionAvoidance` settings. So even with `side: 'none'`, the CSS `max-h-(--available-height)` correctly constrains the popup height.
+- The `shift` middleware (for the align axis) is also affected by `collisionAvoidance`. With `side: 'none'` but default `align: 'flip'`, alignment can still shift/flip on the horizontal axis. This is desirable — we want the popup to shift left/right to stay in the viewport.

--- a/specs/fix-webapp-player-locate-songsets-popover-clipping-v4.md
+++ b/specs/fix-webapp-player-locate-songsets-popover-clipping-v4.md
@@ -1,0 +1,170 @@
+# Fix: Webapp Player — Locate Songsets Popover Clipping (v4)
+
+## Status
+
+Spec written, **do not implement** until reviewed. Supersedes v3 (which proposed a global z-index change). This v4 reflects the decision to **scope the z-index fix to `LocateSongsetsPopover` only**.
+
+## Revision History
+
+| Version | Date | Key change |
+|---------|------|------------|
+| v1 | — | Initial root cause: wrong CSS var + inner `max-h-64`. |
+| v2 | 2026-08-07 | Fixed CSS var names, removed inner cap, ARIA + focus guards. Implemented as commit c433baa4. |
+| v3 | 2026-08-08 | New root cause: z-index conflict + placement flip. Proposed global `z-50`→`z-[70]` + force `side="top"`/disable flip. |
+| v4 | 2026-08-08 | **Scoped** z-index fix to `LocateSongsetsPopover` only (per review decision). Keeps default `z-50` for the shared `PopoverContent`. |
+
+## Summary
+
+The last "Songset Containing This Song" result row(s) are hidden **behind the fixed bottom player bar**. The popover's positioner has `z-index: 50`, but the player bar has `z-index: 60`, so the player paints over the popover's bottom rows. This reproduces at **all** viewports because the trigger button lives *inside* the fixed player bar and the popover opens anchored above it.
+
+## Root Cause (confirmed via Chrome DevTools)
+
+- Player bar: `fixed bottom-0 z-[60]` — `src/components/audio/AudioPlayerBar.tsx:160`
+- Popover positioner: `z-50` — `src/components/ui/popover.tsx:40`
+- The `Find in songsets` trigger is inside the player bar; the popover opens above it.
+- Because `z-50 < z-60`, the player bar renders on top of the popover's bottom rows.
+
+Measured at 820×480 (7 real results, song `不停讚美祢` in 7 songsets):
+
+```
+Viewport: 480px tall
+Player bar: top=395, bottom=480, height=85, z-index=60
+Trigger:   top=438, bottom=466 (inside player bar)
+Popover:   top=62,  bottom=434, height=372, z-index=50
+Overlap:   434 - 395 = 39px of the popover's bottom (last row) is behind the player bar
+```
+
+`elementFromPoint(362, 415)` in the overlap region returns a player-bar slider element, confirming the player is painted on top of the popover.
+
+The base `--available-height` (from Base UI) is the full viewport space above the anchor; it does **not** subtract the fixed player's height, so list content falls into the player's region. Even at tall viewports (1280×776), the popover bottom (722) overlaps the player top (~691), so the last row is partially covered.
+
+## Decision (from review)
+
+- **Approach:** Raise the popover's z-index above the player (`z-[70]`).
+- **Scope:** Apply to `LocateSongsetsPopover` **only**. Do **not** change the default z-index of the shared `PopoverContent` (other popovers/selects stay at `z-50`).
+- **Viewports:** Must work at all viewports (tall and short).
+
+## Proposed Fix
+
+### Change 1: `src/components/ui/popover.tsx` — make the positioner z-index overridable
+
+The `PopoverContent` wrapper currently hardcodes `className="z-50"` on the `PopoverPrimitive.Positioner` (line 40) and merges the caller's `className` onto the inner `Popup` (line 45), not the positioner. To scope a z-index override to a single consumer, expose a way to set the positioner's z-index.
+
+Add an optional `positionerClassName` prop (default `"z-50"`) and apply it to the `Positioner`:
+
+```tsx
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  positionerClassName = "z-50",
+  ...props
+}: PopoverPrimitive.Popup.Props &
+  Pick<PopoverPrimitive.Positioner.Props, "align" | "sideOffset" | "side"> & {
+    positionerClassName?: string;
+  }) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Positioner
+        align={align}
+        sideOffset={sideOffset}
+        className={positionerClassName}
+      >
+        <PopoverPrimitive.Popup
+          data-slot="popover-content"
+          className={cn(
+            "bg-popover text-popover-foreground data-[starting-style]:data-[state=open]:animate-in data-[starting-style]:data-[state=open]:fade-in-0 data-[starting-style]:data-[state=open]:zoom-in-95 data-[ending-style]:data-[state=closed]:animate-out data-[ending-style]:data-[state=closed]:fade-out-0 data-[ending-style]:data-[state=closed]:zoom-out-95 relative max-h-(--available-height) origin-(--transform-origin) overflow-y-auto overflow-x-hidden rounded-md border p-4 shadow-md outline-none",
+            className
+          )}
+          {...props}
+        />
+      </PopoverPrimitive.Positioner>
+    </PopoverPrimitive.Portal>
+  )
+}
+```
+
+Default remains `z-50`, so existing behavior is unchanged for any other consumer.
+
+### Change 2: `src/components/audio/LocateSongsetsPopover.tsx` — raise z-index above the player
+
+Pass `positionerClassName="z-[70]"` to `PopoverContent` so the popover renders above the player bar (`z-[60]`):
+
+```tsx
+<PopoverContent
+  className="w-72 p-0"
+  align="start"
+  positionerClassName="z-[70]"
+>
+```
+
+Keep the existing `max-h-(--available-height)` + `overflow-y-auto` cap (from the shared `PopoverContent`) — it still protects against overflowing the top of short viewports and provides internal scrolling.
+
+### Change 3: No change to the list container
+
+The v2 removal of `max-h-64 overflow-y-auto` from the list container is retained. No further changes needed there.
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `delivery/webapp/src/components/ui/popover.tsx` | Add optional `positionerClassName` prop (default `"z-50"`), apply to `Positioner`. |
+| `delivery/webapp/src/components/audio/LocateSongsetsPopover.tsx` | Pass `positionerClassName="z-[70]"` to `PopoverContent`. |
+
+## Blast Radius Analysis
+
+- `PopoverContent` has one consumer in the codebase: `LocateSongsetsPopover.tsx` (confirmed via grep). The new `positionerClassName` prop defaults to `z-50`, so even if more consumers are added later, behavior is unchanged unless they opt in.
+- The z-index override is applied only in `LocateSongsetsPopover`, so no other popover/select/dropdown is affected.
+- No database/schema changes; purely presentational CSS.
+
+## Testing Plan
+
+### Manual / DevTools verification
+
+1. **Real data (7 results):** Open the popover for `不停讚美祢` (in 7 songsets) at a tall viewport (e.g. 1280×776) and a short viewport (e.g. 820×480).
+   - Expect: all 7 rows fully visible; last row (`絕望與恩典_浪子回頭`) is **not** covered by the player bar.
+   - Use `elementFromPoint` in the former overlap region (e.g. y≈415 at 820×480) — it should now return a popover listitem, not a player element.
+2. **Z-index check:** Inspect the positioner element.
+   - Expect: computed `z-index` is 70 (not 50). Player bar is 60. Popover renders above player.
+3. **Many results (stress):** Temporarily mock fetch to return 15–20 songsets.
+   - Expect: popover caps at `--available-height`, scrolls internally, and the bottom of the scroll area is fully visible above the player bar (not hidden behind it).
+4. **Lyrics panel open + popover:** Open lyrics panel (`L`), then open the popover.
+   - Expect: popover still renders above the player bar; available height reduced; scrolls internally.
+5. **Other popovers unaffected:** Confirm any other popover/select still renders at `z-50` (no regression).
+
+### Automated tests
+
+**jsdom limitation:** jsdom does not apply CSS layout or z-index, so tests assert prop forwarding / className rather than visual stacking.
+
+1. **`AudioPlayerBar.test.tsx` — `LocateSongsetsPopover` block:**
+   - Assert `PopoverContent` receives `positionerClassName="z-[70]"` (e.g. spy on `PopoverContent` or assert rendered output includes the prop).
+   - Keep existing assertions (list has no `max-h-64`/`overflow-y-auto`, `role=list`/`listitem`, no `aria-selected`, focus guards).
+2. **`popover.tsx` unit guard (optional):**
+   - Render `PopoverContent` without `positionerClassName` → positioner className contains `z-50`.
+   - Render with `positionerClassName="z-[70]"` → positioner className contains `z-[70]`.
+3. **Run commands:**
+   ```bash
+   cd delivery/webapp && pnpm test -- --run src/test/components/audio/AudioPlayerBar.test.tsx
+   cd delivery/webapp && pnpm lint && pnpm typecheck
+   ```
+
+## Risks & Considerations
+
+- **Scoped z-index** avoids the v3 concern of globally raising all popovers above the player. Only `LocateSongsetsPopover` is raised.
+- **Visual overlap:** With z-index raised, the popover's bottom rows render *on top of* the player bar in the overlap zone rather than being hidden. This is the intended "not clipped" behavior and matches how menus/selects overlay surrounding UI. If a cleaner separation is later desired, forcing `side="top"`/disabling flip (v3 Change 3) can be added as a follow-up — out of scope for this decision.
+- **`--available-height`** still does not subtract the player's height; the z-index fix is what makes the covered rows visible. The existing `max-h-(--available-height)` cap remains for top-of-viewport overflow.
+
+## Implementation Order
+
+1. Update `delivery/webapp/src/components/ui/popover.tsx` — add `positionerClassName` prop.
+2. Update `delivery/webapp/src/components/audio/LocateSongsetsPopover.tsx` — pass `positionerClassName="z-[70]"`.
+3. Run `pnpm lint` and `pnpm typecheck` from `delivery/webapp/`.
+4. Update/add automated tests as described.
+5. Manual DevTools verification (real 7 results at tall + short viewports, stress test, lyrics open).
+6. Commit and push (`git pull --rebase && git push`).
+
+## Notes
+
+- Player bar z-index: `z-[60]` (`AudioPlayerBar.tsx:160`).
+- Popover positioner default z-index: `z-50` (`popover.tsx:40`).
+- `z-[70]` is chosen to be strictly above the player's `z-[60]` and below the full-screen controller overlay (`z-[70]` in `ControllerPlayer.tsx:864` — verify no conflict; if needed use `z-[65]` or `z-[80]`).

--- a/specs/fix-webapp-player-locate-songsets-popover-clipping-v5.md
+++ b/specs/fix-webapp-player-locate-songsets-popover-clipping-v5.md
@@ -1,0 +1,245 @@
+# Fix: Webapp Player — Locate Songsets Popover Clipping (v5)
+
+## Status
+
+Spec written, **do not implement** until reviewed. Supersedes v3 and v4.
+
+## Revision History
+
+| Version | Date | Key change |
+|---------|------|------------|
+| v1 | — | Initial root cause: wrong CSS var + inner `max-h-64`. |
+| v2 | 2026-08-07 | Fixed CSS var names, removed inner cap, ARIA + focus guards. Implemented as commit c433baa4. |
+| v3 | 2026-08-08 | New root cause: z-index conflict + placement flip. Proposed global `z-50`→`z-[70]` + force `side="top"`/disable flip. Implemented by PR #138. |
+| v4 | 2026-08-08 | **Scoped** z-index fix to `LocateSongsetsPopover` only via `positionerClassName` prop. Proposed but not implemented. |
+| v5 | 2026-08-08 | Incorporates PR #138 review findings. Adopts v4's scoped `positionerClassName` approach with `z-[65]` (not `z-[70]`). Drops prop-spying test pattern. Adds min-height floor and Safari runbook. |
+
+## Problem Statement
+
+PR #138 (head `8870cfaf`, branch `fix_songset_containing_search`) shipped the v3 implementation of the popover clipping fix. The v3 root cause investigation (see `specs/...v3.md` for the full DevTools evidence) identified a z-index conflict: the popover positioner was `z-50`, the player bar was `z-[60]`, and Floating UI's `flip` middleware relocated the popup to `side="right"` when content exceeded ~680px, causing ~80px of bottom rows to be hidden behind the player bar.
+
+PR #138's fix contained two correct changes and two problems:
+
+**Correct:** (1) Destructured `side` and `collisionAvoidance` and forwarded them to `PopoverPrimitive.Positioner` — this was a real bug where `side` was silently dropped onto `Popup` and ignored. (2) Pinned `side="top"` and disabled flip via `collisionAvoidance={{ side: "none", fallbackAxisSide: "none" }}` in `LocateSongsetsPopover` — prevents the flip-to-right overlap.
+
+**Problems:** (1) Globally changed the positioner className from `z-50` to `z-[70]` on the shared `PopoverContent` primitive — collides with `ControllerPlayer` (also `z-[70]`) and inverts the modal layering contract (all other overlays are `z-50`). (2) Added a fragile prop-spying test pattern in `AudioPlayerBar.test.tsx` that breaks on internal refactors.
+
+This v5 spec addresses the two problems and adds hardening (min-height floor, Safari runbook, regression guard).
+
+## What PR #138 Got Right
+
+- **Prop forwarding** (`side`, `collisionAvoidance` forwarded to `Positioner`) — was a real bug where `side` fell into `...props` and was spread onto `Popup` (which ignores it). Fix is correct.
+- **`side="top"` + `collisionAvoidance={{ side: "none", fallbackAxisSide: "none" }}`** for `LocateSongsetsPopover` — correct. Prevents the flip-to-right overlap that caused most of the clipping in v3's DevTools measurements.
+
+## What PR #138 Got Wrong
+
+- **Global `z-[70]`** on shared `PopoverContent` (`popover.tsx:47`). `ControllerPlayer.tsx:864` is `fixed inset-0 z-[70]`. Two elements at the same stacking level produce paint-order ambiguity (DOM-order dependent). Every other overlay primitive in the codebase is `z-50`; bumping the shared `PopoverContent` above them inverts the modal capture contract for any future consumer.
+- **Prop-spying test** in `AudioPlayerBar.test.tsx:16–22, 847–901`. `vi.fn(actual.PopoverContent)` wraps the real component with a spy; assertions read `vi.mocked(PopoverContent).mock.calls[calls.length - 1][0]`. This breaks on internal refactors (e.g., the `positionerClassName` prop addition in this spec), relies on undocumented `calls.length - 1` indexing, and installs the spy module-wide.
+
+## Z-Index Scale (Canonical Reference)
+
+This is the single source of truth for stacking decisions:
+
+| Tier | z-index | Element |
+|------|---------|---------|
+| Standard overlays | `z-50` | Dialog, Sheet, DropdownMenu, Select, Tooltip, AlertDialog, Header, BottomNav, LyricJumpList, OfflineIndicator |
+| Audio player bar | `z-[60]` | `AudioPlayerBar` (fixed bottom bar) |
+| Player-bar popovers | `z-[65]` | `LocateSongsetsPopover` positioner (scoped override) |
+| Fullscreen controller | `z-[70]` | `ControllerPlayer` (fullscreen cast / projection) |
+
+When a new overlay needs a z-index, consult this table. Do not change the shared `PopoverContent` default.
+
+## Changes
+
+### Change 1: Revert global `z-[70]` → `z-50`; add scoped `positionerClassName`
+
+**File:** `delivery/webapp/src/components/ui/popover.tsx`
+
+Revert the positioner className from `"z-[70]"` back to the default `"z-50"`. Add an optional `positionerClassName?: string` prop (default `"z-50"`) that is applied to `PopoverPrimitive.Positioner`'s `className` instead of the hardcoded string. Keep PR #138's correct `side`, `collisionAvoidance`, `align`, `sideOffset` forwarding.
+
+```tsx
+function PopoverContent({
+  className,
+  align = "center",
+  side,
+  sideOffset = 4,
+  collisionAvoidance,
+  positionerClassName = "z-50",
+  ...props
+}: PopoverPrimitive.Popup.Props &
+  Pick<
+    PopoverPrimitive.Positioner.Props,
+    "align" | "sideOffset" | "side" | "collisionAvoidance"
+  > & {
+    positionerClassName?: string;
+  }) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Positioner
+        align={align}
+        side={side}
+        sideOffset={sideOffset}
+        collisionAvoidance={collisionAvoidance}
+        className={positionerClassName}
+      >
+        <PopoverPrimitive.Popup
+          data-slot="popover-content"
+          className={cn(
+            "bg-popover text-popover-foreground data-[starting-style]:data-[state=open]:animate-in data-[starting-style]:data-[state=open]:fade-in-0 data-[starting-style]:data-[state=open]:zoom-in-95 data-[ending-style]:data-[state=closed]:animate-out data-[ending-style]:data-[state=closed]:fade-out-0 data-[ending-style]:data-[state=closed]:zoom-out-95 relative max-h-(--available-height) origin-(--transform-origin) overflow-y-auto overflow-x-hidden rounded-md border p-4 shadow-md outline-none",
+            className
+          )}
+          {...props}
+        />
+      </PopoverPrimitive.Positioner>
+    </PopoverPrimitive.Portal>
+  )
+}
+```
+
+### Change 2: Pass `positionerClassName="z-[65]"` from `LocateSongsetsPopover`
+
+**File:** `delivery/webapp/src/components/audio/LocateSongsetsPopover.tsx`
+
+Add `positionerClassName="z-[65]"` to the existing `<PopoverContent>` call (which already has `side="top"` and `collisionAvoidance`):
+
+```tsx
+<PopoverContent
+  className="w-72 p-0 min-h-[240px]"
+  align="start"
+  side="top"
+  collisionAvoidance={{ side: "none", fallbackAxisSide: "none" }}
+  positionerClassName="z-[65]"
+>
+```
+
+`z-[65]` sits above the player bar (`z-[60]`) and below the fullscreen controller (`z-[70]`).
+
+### Change 3: Add min-height floor to `LocateSongsetsPopover` popup content
+
+**File:** `delivery/webapp/src/components/audio/LocateSongsetsPopover.tsx`
+
+Add `min-h-[240px]` to the `className` prop of `<PopoverContent>` (shown in the Change 2 code block above). This `className` is forwarded to the `Popup` element via `cn(...)`, not the positioner. The popup renders at least 240px tall (≈4 rows + search affordance). When `--available-height` shrinks below this (lyrics expanded, short viewport, mobile landscape), the popup overflows the top of the viewport rather than rendering as a 2-row sliver — a clear visual signal that something is wrong.
+
+Add a comment above the `collisionAvoidance` line in `LocateSongsetsPopover.tsx`:
+
+```tsx
+{/* Disable flip intentionally to avoid v3's side="right" overlap with the player bar. min-h-[240px] on the Popup is the mitigation for short viewports. */}
+```
+
+### Change 4: Drop prop-spying test; move assertions to `popover.test.tsx`
+
+**File:** `delivery/webapp/src/test/components/audio/AudioPlayerBar.test.tsx`
+
+- Delete the `vi.mock("@/components/ui/popover", ...)` block (lines 16–22).
+- Delete the `import { PopoverContent } from "@/components/ui/popover"` import (line 6).
+- Delete the two spy-based tests: "passes side='top' to PopoverContent" (lines 847–872) and "passes collisionAvoidance with side='none'..." (lines 874–901).
+- Keep all other tests (render, focus, lyrics toggle, keyboard shortcuts, list container, ARIA roles, 15 songset names).
+- Add a new test in the `LocateSongsetsPopover` describe block: "popover content has min-h-[240px] class" — open the popover, query `[data-slot='popover-content']`, assert its className contains `min-h-[240px]`. This is a DOM-level assertion, not a spy.
+
+**File:** `delivery/webapp/src/test/components/ui/popover.test.tsx`
+
+- Update existing test: rename "positioner className contains z-[70] (not z-50)" → "default positioner className is z-50". Assert the positioner has `z-50` class and does NOT contain `z-[70]`.
+- Add test: "positionerClassName override is forwarded" — render `<PopoverContent positionerClassName="z-[65]">`, open popover, assert positioner className contains `z-[65]` and does NOT contain `z-50`.
+- Add test: "collisionAvoidance is forwarded to Positioner" — render `<PopoverContent side="top" collisionAvoidance={{ side: "none", fallbackAxisSide: "none" }}>`, open popover, assert `[data-slot='popover-content']` has `data-side="top"` and the positioner element exists.
+
+### Change 5: Add z-index regression guard test
+
+**File:** `delivery/webapp/src/test/components/ui/popover.test.tsx`
+
+Add a test: "stacking-order classname guard (jsdom does not compute stacking; this is a classname regression guard, not a visual stacking test)" — render `PopoverContent` with default props, open popover, assert the positioner has `z-50` class. This catches future PRs that try to bump the global default again.
+
+### Change 6: Add WebKit/Safari runbook + process guard
+
+**File:** `delivery/webapp/AGENTS.md`
+
+Add under the Architecture section:
+
+> When modifying `components/ui/popover.tsx`, you must perform manual DevTools verification at desktop (1280×776) and mobile (375×667) widths, plus Safari iOS Simulator. Paste screenshots in the PR description.
+
+This spec (v5) owns the canonical manual runbook going forward (see Testing Plan below).
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `delivery/webapp/src/components/ui/popover.tsx` | Revert `z-[70]` → `z-50` as default. Add `positionerClassName?: string` prop (default `"z-50"`), apply to `Positioner` className. |
+| `delivery/webapp/src/components/audio/LocateSongsetsPopover.tsx` | Pass `positionerClassName="z-[65]"`. Add `min-h-[240px]` to `className`. Add comment explaining flip-disable tradeoff. |
+| `delivery/webapp/src/test/components/ui/popover.test.tsx` | Update default-z test from `z-[70]` to `z-50`. Add `positionerClassName` override test. Add `collisionAvoidance` forwarding test. Add stacking-order classname guard. |
+| `delivery/webapp/src/test/components/audio/AudioPlayerBar.test.tsx` | Delete `vi.mock` spy + import. Delete 2 spy-based tests. Add `min-h-[240px]` DOM assertion. Keep all other tests. |
+| `delivery/webapp/AGENTS.md` | Add manual-verification requirement note for `popover.tsx` changes. |
+
+## Implementation Order
+
+Changes 1–5 should land in a **single follow-up PR** ("address PR-138 review"). Rationale: the spy-based tests assert `z-[70]`; reverting `z-[70]` without removing the spy would break the tests. Bundling avoids a broken intermediate state.
+
+Order within the PR:
+
+1. Change 1 — revert z + add `positionerClassName`
+2. Change 2 — pass `z-[65]` from `LocateSongsetsPopover`
+3. Change 3 — `min-h-[240px]` + comment
+4. Change 4 — test refactor (drop spy, move to `popover.test.tsx`)
+5. Change 5 — regression guard test
+6. Change 6 — `AGENTS.md` note (runbook is this spec itself)
+
+## Testing Plan
+
+### Automated tests
+
+```bash
+cd delivery/webapp && pnpm test -- --run
+cd delivery/webapp && pnpm lint && pnpm typecheck
+```
+
+**`popover.test.tsx`** covers:
+- Default positioner className is `z-50` (not `z-[70]`).
+- `positionerClassName="z-[65]"` is forwarded and wins over default.
+- `side="top"` produces `data-side="top"` on the popup.
+- `collisionAvoidance` is forwarded (positioner exists, popup renders).
+- Stacking-order classname guard (default still `z-50`).
+
+**`AudioPlayerBar.test.tsx`** covers (in the `LocateSongsetsPopover` describe block):
+- Min-height floor (`min-h-[240px]`) on the popup content.
+- All existing behavior tests retained (render, focus return, list container, ARIA roles, 15 songset names).
+
+### Manual / DevTools verification
+
+This is the canonical runbook (supersedes v3's Testing Plan):
+
+1. **Desktop Chrome 1280×776, 1 / 12 / 15 / 20 songsets** — all rows visible, no clipping. Popup `data-side="top"`, bottom anchored above player bar.
+2. **Desktop Chrome, lyrics panel expanded (`L` key)** — popover must not collapse below ~5 rows. `--available-height` reduced; popup scrolls internally.
+3. **Mobile Chrome 375×667** — popover must show ≥5 rows or scroll comfortably.
+4. **Safari iOS 17+ Simulator, 375×667, player bar visible** — popup must render above the player bar; scrolling within the popup must not scroll the underlying page. `AudioPlayerBar` uses `backdrop-blur` which can promote to a stacking context on Safari — verify no regression.
+5. **Landscape 667×375** — popover must not collapse to a sliver (`min-h-[240px]` active; may overflow top of viewport, which is the intended safe failure mode).
+6. **Z-index check:** inspect positioner element. Computed `z-index` is 65 (above player `z-[60]`, below controller `z-[70]`).
+7. **Other overlays unaffected:** confirm `Dialog`, `Sheet`, `Select`, `DropdownMenu`, `Tooltip` still render at `z-50`.
+
+## Risks & Considerations
+
+- **Visual overlap is intentional.** With `z-[65]`, the popover's bottom rows render on top of the player bar in the overlap zone. This matches v3's `side="top"` design — the popup bottom anchors at `trigger.top - sideOffset`, so overlap is minimal. The z-index ensures any residual overlap paints the popover above the player. This is the same pattern used by menus/selects that overlay surrounding UI.
+- **`z-[65]` election.** Chosen to sit strictly above the player bar (`z-[60]`) and strictly below the fullscreen controller (`z-[70]`). Both v3 and v4 proposed `z-[70]`, which collides with `ControllerPlayer`. `z-[65]` resolves that collision.
+- **Min-height floor tradeoff.** `min-h-[240px]` means the popup overflows the top of the viewport in extreme cases (very short landscape viewports), rather than rendering as a 2-row sliver. Overflow is the safer failure mode — it signals "something is wrong" rather than silently degrading.
+- **WebKit/Safari.** `AudioPlayerBar` uses `backdrop-blur` which can promote it to its own stacking context on Safari. Manual Safari verification is required (see Testing Plan row 4).
+- **Scoped vs global.** This spec adopts the scoped `positionerClassName` approach from v4. The shared `PopoverContent` default returns to `z-50`, restoring parity with all other overlay primitives. Only `LocateSongsetsPopover` overrides to `z-[65]`.
+
+## Out of Scope
+
+- `positionerProps` escape hatch (was considered, dropped — only one consumer, `collisionAvoidance` already typed via `Pick<>`).
+- Tailwind theme-driven z-scale (`z-popover-player`, `z-controller`, etc.) — keep numeric for now; refactor if a third overlay tier emerges.
+- Re-implementing `flip` with a custom `fallbackPlacements` list — revisit only if min-height floor proves worse UX than constrained flip.
+- Modifying `AudioPlayerBar`'s `z-[60]` to use `dvh` units.
+- `--available-height` caching behavior in Base UI.
+
+## Notes
+
+- The `side` and `collisionAvoidance` forwarding (PR #138's Change 1) is retained as-is — it was a correct fix for a real bug.
+- The `side="top"` + `collisionAvoidance={{ side: "none", fallbackAxisSide: "none" }}` (PR #138's Change 3) is retained as-is — correct for avoiding the flip-to-right overlap.
+- Base UI `collisionAvoidance` prop: type `SideFlipMode` with `side: 'flip' | 'none'`, `align: 'flip' | 'shift' | 'none'`, `fallbackAxisSide: 'start' | 'end' | 'none'`. Default `side: 'flip'`, `align: 'flip'`, `fallbackAxisSide: 'end'`.
+- Setting `collisionAvoidance.side = 'none'` disables the `flip` middleware. The `size` middleware still publishes `--available-height`, so `max-h-(--available-height)` still caps the popup.
+
+## Related Specs
+
+- `specs/fix-webapp-player-locate-songsets-popover-clipping.md` (v1)
+- `specs/fix-webapp-player-locate-songsets-popover-clipping-v2.md` (v2, shipped as commit `c433baa4`)
+- `specs/fix-webapp-player-locate-songsets-popover-clipping-v3.md` (v3, PR #138 implemented this — superseded by v5)
+- `specs/fix-webapp-player-locate-songsets-popover-clipping-v4.md` (v4, proposed scoped approach — superseded by v5, which adopts the scoped approach with `z-[65]`)
+- `specs/pr-138-popover-clipping-review-fixes.md` (review of PR #138, fed into this v5 spec)

--- a/specs/pr-138-popover-clipping-review-fixes.md
+++ b/specs/pr-138-popover-clipping-review-fixes.md
@@ -1,0 +1,270 @@
+# PR #138 Review — LocateSongsetsPopover Clipping (v3): Top 5 Critical / High-Priority Items
+
+## Context
+
+PR #138 (head `8870cfaf`, branch `fix_songset_containing_search`) ships the "v3" implementation of the popover clipping fix described in `specs/fix-webapp-player-locate-songsets-popover-clipping-v3.md`. It makes four additive changes:
+
+1. `popover.tsx` now destructures `side` and `collisionAvoidance` and forwards them to `PopoverPrimitive.Positioner` (fixing a real bug where `side` was silently dropped onto `Popup` and ignored).
+2. `popover.tsx` hard-codes the positioner className from `z-50` to `z-[70]` — globally, for every consumer.
+3. `LocateSongsetsPopover.tsx` pins `side="top"` and disables flip via `collisionAvoidance={{ side: "none", fallbackAxisSide: "none" }}`.
+4. New / updated tests assert prop forwarding (`side="top"`, `collisionAvoidance`, `z-[70]` in positioner className) and render 15 mock songsets.
+
+The prop-forwarding fix (#1) and the `side="top"` + anti-flip choice for *this specific popover* (#3) are correct and well-grounded in the v3 spec's DevTools measurements. The concerns below are UX/operational, not "the fix is wrong."
+
+This document is **plan-only**: it identifies the top 5 issues with PR #138 and describes the implementation plan to address them. **Do not implement.** Implementation should happen in a follow-up PR after this plan is reviewed.
+
+Related specs (read first, do not duplicate):
+- `specs/fix-webapp-player-locate-songsets-popover-clipping.md` (v1)
+- `specs/fix-webapp-player-locate-songsets-popover-clipping-v2.md` (v2, shipped as commit `c433baa4`)
+- `specs/fix-webapp-player-locate-songsets-popover-clipping-v3.md` (v3, the spec PR #138 claims to implement)
+- `specs/fix-webapp-player-locate-songsets-popover-clipping-v4.md` (v4, *rejected* alternative — scoped `positionerClassName`)
+
+The v4 spec was already an explicit design decision to **scope** the z-index override rather than change the shared default. PR #138 reimplements v3's global override instead, without addressing why v4 was rejected. That tension is the root of the top finding below.
+
+## Top 5 Critical / High-Priority Items
+
+### 1. CRITICAL — Global z-index bump from `z-50` to `z-[70]` collides with `ControllerPlayer` and inverts the modal layering contract
+
+**Severity:** Critical (UX + runtime).
+**Files affected:** `delivery/webapp/src/components/ui/popover.tsx:47` (PR change), `delivery/webapp/src/components/play/ControllerPlayer.tsx:864`.
+
+**Problem.**
+
+The PR changes the positioner className of the shared `PopoverContent` from `z-50` to `z-[70]`. Two consequences:
+
+- **Same tier as the cast / fullscreen controller.** `ControllerPlayer.tsx:864` is `fixed inset-0 z-[70]`. The v3 spec explicitly noted (`specs/...v3.md` Notes section): *"verify no conflict; if needed use `z-[65]` or `z-[80]`"*. PR #138 did not resolve this — it landed `z-[70]` anyway. When two elements share a stacking level, paint order is determined by DOM order, which is undefined behavior from a design standpoint and depends on Portal mount order. If `LocateSongsetsPopover` is opened while a projection/controller session is active — or while the player bar is mounted inside a route where `ControllerPlayer` is also rendered — we get inconsistent overlap between two `z-[70]` layers.
+- **Inverts the modal contract.** Every other overlay primitive in the codebase is `z-50`:
+  - `components/ui/dialog.tsx:34` (overlay `z-50`), `:56` (content `z-50`)
+  - `components/ui/alert-dialog.tsx:33,55`
+  - `components/ui/sheet.tsx:31,56`
+  - `components/ui/dropdown-menu.tsx:46,54`
+  - `components/ui/select.tsx:81,86`
+  - `components/ui/tooltip.tsx:53,58`
+  - `components/offline/OfflineIndicator.tsx:37`
+
+  Post-PR, if any popover is open when a `Dialog` / `Sheet` / `DropdownMenu` / `Select` is triggered, the `z-[70]` popover paints **above** the modal and its backdrop, breaking the visual "modal captures focus" contract. Today this is mostly theoretical because `LocateSongsetsPopover` is currently the only `PopoverContent` consumer — but `PopoverContent` is exported as a shared primitive (`components/ui/popover.tsx`) and any future consumer inherits the bug.
+
+**Plan.**
+
+(a) **Revert the global default back to `z-50`.** Keep `PopoverContent`'s positioner at `z-50`. This restores parity with the other overlay primitives and removes the contract inversion.
+
+(b) **Introduce a scoped override, then use `z-[65]` (between the player `z-[60]` and controller `z-[70]`).** Adopt the v4 planned API: add an optional `positionerClassName?: string` prop on `PopoverContent` (default `"z-50"`) that is spread onto `PopoverPrimitive.Positioner`'s `className`. Pass `positionerClassName="z-[65]"` from `LocateSongsetsPopover` only.
+
+(c) **Document the z-index scale.** Add a top-of-file comment in `components/ui/popover.tsx` listing the tiers: dropdowns/tooltips/selects/dialogs `z-50`, audio player `z-[60]`, player-bar popovers `z-[65]`, fullscreen controller `z-[70]`. This is the single source of truth for future stacking decisions.
+
+(d) **Tests.** Update `src/test/components/ui/popover.test.tsx` so the default-render case asserts `"z-50"` in the positioner className, and a second case asserts `positionerClassName="z-[65]"` is forwarded and wins. Update `AudioPlayerBar.test.tsx` popover assertions so the prop-spied `PopoverContent` mock expects `positionerClassName: "z-[65]"` (instead of asserting z-[70] on the shared primitive).
+
+**Acceptance.**
+
+- `components/ui/popover.tsx` does not contain `z-[70]`.
+- `ControllerPlayer.tsx` remains the only `z-[70]` in `src/`.
+- `components/audio/LocateSongsetsPopover.tsx` passes `positionerClassName="z-[65]"` and the positioner renders with that class.
+- Dialog/Sheet/DropdownMenu/Select z-indices are unchanged.
+
+---
+
+### 2. HIGH — `collisionAvoidance={{ side: "none", fallbackAxisSide: "none" }}` silently degrades short-viewport / lyrics-open UX instead of failing safely
+
+**Severity:** High (UX ergonomics).
+**Files affected:** `delivery/webapp/src/components/audio/LocateSongsetsPopover.tsx:114`.
+
+**Problem.**
+
+The PR hard-disables Floating UI flip and perpendicular-axis fallback. In Base UI 1.x (`node_modules/@base-ui/react/utils/useAnchorPositioning.js:154`), `collisionAvoidanceSide === 'none'` sets `flipMiddleware = null`. The `size` middleware (`useAnchorPositioning.js:206`) still publishes `--available-height` correctly when flip is disabled, so `max-h-(--available-height)` still caps the popup.
+
+However, this means: when the available space above the trigger collapses — lyrics panel expanded (`AudioPlayerBar` shows a `max-h-[40dvh]` lyrics area, see `handleToggleLyrics`), very short viewport (mobile landscape `h < 480`), or non-`bottom` safe-area-inset cases — the popup is force-anchored at `side="top"` with whatever height is left. Worst case: `--available-height` shrinks to <100px and the user sees a 2–3-row-tall scrollable sliver with no explanatory UI.
+
+The v3 spec assumes "popup bottom anchors at `trigger.top - sideOffset` (~686px), well within the viewport" based on a desktop viewport with default lyrics-off state. It does not test:
+
+- Lyrics panel expanded (raises the trigger anchor point, reduces `--available-height`).
+- 320×568 / 375×667 mobile viewports.
+- 480px-tall landscape viewports.
+
+The non-flip behavior was chosen specifically to avoid the `side="right"` overlap with the player bar, but a bounce-back rule that prefers `bottom` (where there is no space, since the trigger is in the bottom-fixed bar) and then gracefully degrades would have been safer than disabling flip outright.
+
+**Plan.**
+
+(a) **Add a min-height floor.** In `LocateSongsetsPopover`, apply `min-h-[240px]` (≥4 rows + search affordance) to the popup content. If `--available-height` is less than this, the popup will overflow the top of the viewport rather than render as a 2-row sliver — and the user gets a clear visual signal that something is wrong, which is better than a silently-broken UI.
+
+(b) **Add a viewport-height smoke assertion.** Extend `AudioPlayerBar.test.tsx` with one test that: (i) sets `window.innerHeight = 480`, (ii) opens the popover, (iii) asserts the `data-side="top"` attribute is still emitted (no flip occurred), (iv) asserts the content has the `min-h-[240px]` class. We cannot measure real layout in jsdom, so we assert props/classnames as tripwires.
+
+(c) **Add a Playwright / DevTools checklist step.** Update the v3 spec's Testing Plan with two new rows:
+- "Lyrics panel expanded (`L` key) at 1280×776: popover must not collapse below ~5 rows."
+- "Mobile viewport 375×667: popover must show ≥5 rows or scroll comfortably."
+
+(d) **Document the tradeoff.** Add a one-line comment above the `collisionAvoidance={{ side: "none", ... }}` line in `LocateSongsetsPopover.tsx` explaining that this is intentional to avoid the v3 flip-to-right overlap, and that min-height floor (a) is the mitigation.
+
+**Acceptance.**
+
+- With lyrics expanded and at 480p viewport, the popover renders min 240px tall and does not flip to `side="right"`.
+- Tests pass: `pnpm test -- --run AudioPlayerBar popover`.
+- Manual runbook in v3 spec is extended for the two new viewport cases.
+
+---
+
+### 3. HIGH — Prop forwarding opened a long-term footgun: `Positioner.Props` now leak through `Popup`-typed call sites, with no compile-time signal when the Base UI shape diverges
+
+**Severity:** High (operational / maintainability).
+**Files affected:** `delivery/webapp/src/components/ui/popover.tsx:28–58`.
+
+**Problem.**
+
+The PR widens the type of `PopoverContent` from `Popup.Props & Pick<Positioner.Props, "align"|"sideOffset"|"side">` to also include `"collisionAvoidance"`. Functionally this is correct, but the type intersection with `Popup.Props` means callers can pass *any* `Popup.Props` (subtitle props, focus props, event handlers, `data-*`, etc.) **and** any of the picked `Positioner.Props`. We now have a *structural overlap risk*:
+
+- Any future `Positioner.Props` key we want to expose (e.g. `collisionPadding`, `sticky`, `arrowPadding`) requires manually widening the `Pick<>`. If forgotten, TypeScript still compiles because `...rest` swallows them, then they're spread onto `Popup` and silently ignored — the *exact bug this PR fixed for `side`*.
+- The `...props` catch-all still flows onto `PopoverPrimitive.Popup`. `Popup.Props` and `Positioner.Props` share some names (e.g. `style`, `className`, `id`) which makes regressions hard to spot in review.
+
+**Plan.**
+
+(a) **Split into two explicit prop bags.** Refactor `PopoverContent` to accept a single `positionerProps?: Partial<Positioner.Props>` alongside the existing `Popup.Props` spread:
+
+```tsx
+function PopoverContent({
+  className,
+  align = "center",
+  side = "bottom",          // keep Base UI default
+  sideOffset = 4,
+  collisionAvoidance,
+  positionerClassName,      // added by Item 1 plan
+  positionerProps,          // NEW — escape hatch for any Positioner-only prop
+  ...props                   // Popup props
+}: PopoverPrimitive.Popup.Props & Pick<...> & { positionerClassName?: string; positionerProps?: Partial<PopoverPrimitive.Positioner.Props> }) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Positioner
+        align={align}
+        side={side}
+        sideOffset={sideOffset}
+        collisionAvoidance={collisionAvoidance}
+        className={positionerClassName ?? "z-50"}
+        {...positionerProps}  // escape hatch
+      >
+        <PopoverPrimitive.Popup ... />
+      </PopoverPrimitive.Positioner
+    </PopoverPrimitive.Portal>
+  );
+}
+```
+
+This eliminates the silent-drop hazard class (any `Positioner`-only prop has a typed channel) and removes the temptation to keep widening the `Pick<>` over time.
+
+(b) **Add a type-level test.** In `popover.test.tsx` use `expectTypeOf` (already available via Vitest) to assert that `positionerProps` accepts `Positioner.Props` keys. This is a compile-time tripwire for future Base UI upgrades.
+
+(c) **Update `AGENTS.md`** under `delivery/webapp/AGENTS.md` — add a one-line note: "When extending `PopoverContent`, prefer `positionerProps` for `Positioner`-specific keys; do not widen the `Pick<>`." This preserves the team knowledge going forward.
+
+**Acceptance.**
+
+- `PopoverContent` exposes `positionerProps`.
+- All existing call sites (`LocateSongsetsPopover` only) and tests compile with no changes required to their public API.
+- `pnpm typecheck` passes.
+
+---
+
+### 4. HIGH — Prop-spying test on `PopoverContent` makes `AudioPlayerBar.test.tsx` fragile against internal refactors of the shared primitive
+
+**Severity:** High (operational / test hygiene).
+**Files affected:** `delivery/webapp/src/test/components/audio/AudioPlayerBar.test.tsx:15–22, 847–end`.
+
+**Problem.**
+
+The PR adds:
+
+```tsx
+vi.mock("@/components/ui/popover", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/ui/popover")>();
+  return { ...actual, PopoverContent: vi.fn(actual.PopoverContent) };
+});
+```
+
+This pattern replaces the real `PopoverContent` with a spy that wraps it. Three problems:
+
+- **Brittleness.** Any future change to `PopoverContent`'s call signature (including the Item 3 `positionerProps` refactor) requires updating every assertion in this file that reads `vi.mocked(PopoverContent).mock.calls[i][0]`. The test breaks not because behavior changed but because the internal shape did.
+- **Spying loses referential equality.** `vi.fn(actual.PopoverContent)` returns a new function each test run; Base UI's portal rendering + React fiber reconciliation can occasionally remount the popover mid-test, causing `mock.calls.length > 1`. The current tests already paper over this by taking `calls[calls.length - 1]`, but that implicit assumption isn't documented.
+- **Asymmetric coverage.** The mock is installed for the entire `AudioPlayerBar.test.tsx` module — every other test that touches `PopoverContent` (now or in the future) faces the spy being installed whether it cares or not.
+
+**Plan.**
+
+(a) **Move the prop-forwarding assertions into `popover.test.tsx`.** The contract being tested is "LocateSongsetsPopover passes `side="top"` and `collisionAvoidance={...}` to `PopoverContent`." This is really two contracts:
+
+   1. *`PopoverContent` honors the props it's given* — testable directly in `popover.test.tsx` by rendering `PopoverContent side="top" collisionAvoidance={...}` and asserting `data-side="top"` and inspecting the positioner's className / element.
+   2. *`LocateSongsetsPopover` passes the right props* — testable without a spy by asserting the rendered DOM (e.g. `data-side="top"` on the `[data-slot='popover-content']` element, positioner has the overridable z-class from Item 1).
+
+(b) **Drop the spy from `AudioPlayerBar.test.tsx`.** Once (a) covers both halves, delete `vi.mock("@/components/ui/popover", ...)` and the assertions that read `vi.mocked(PopoverContent).mock.calls`. The remaining tests (render count, focus return, listitem visibility) continue to use the real primitive.
+
+(c) **Retire `calls.length - 1` pattern.** This is gone with the spy; no replacement needed.
+
+**Acceptance.**
+
+- `AudioPlayerBar.test.tsx` no longer contains `vi.mock("@/components/ui/popover", ...)`.
+- `popover.test.tsx` directly covers `side` and `collisionAvoidance` forwarding, plus the scoped `positionerClassName` (Item 1).
+- Total test count remains ≥ current; runtime should marginally improve (less per-test render overhead from the spy wrapper).
+
+---
+
+### 5. HIGH — No regression guard for other overlay primitives and no cross-browser / WebKit verification step
+
+**Severity:** High (operational risk).
+**Files affected:** Process / testing, not source code.
+
+**Problem.**
+
+The PR's "Blast Radius" section claims "`PopoverContent` has one consumer in the entire codebase ... the blast radius is zero." This is true today, but it does not protect:
+
+- **Future consumers** of `PopoverContent` (any new feature that imports it) instantly inherit the `z-[70]` default and the layering contract change (Item 1).
+- **WebKit / iOS Safari** behavior. Base UI's anchor positioning + sticky popovers inside a `fixed` parent has had historical Safari stack-order quirks (compositing changes triggered by `backdrop-blur-sm` on the audio player can promote it to its own stacking context). The PR was verified only against Chrome DevTools.
+- **Existing `data-side=right` consumers of other primitives** (e.g. `Select` with `max-h-(--available-height)`) — none are inside a `fixed` bar, but the PR doesn't verify any of them either.
+
+The "Test Plan" checklist shows: `pnpm test`, `pnpm lint`, `pnpm typecheck` all green; **manual DevTools verification is unchecked**.
+
+**Plan.**
+
+(a) **Add an integration smoke test in `popover.test.tsx`** that mounts a `Dialog` and a `Popover` simultaneously and asserts their stacking order via reads of class names — dialog overlay content `z-50` and popover positioner `z-[65]` (post-Item 1). This is a classname-level tripwire that catches future PRs that try to bump the global default again.
+
+(b) **Extend the manual runbook with WebKit checks.** Add a row to the v3 spec's Testing Plan: "Open the popover on Safari iOS 17+ (Simulator is sufficient) at 375×667 with the player bar visible: popup must render above the player bar; scrolling within the popup must not scroll the underlying page."
+
+(c) **Add an unchecked-boxes CI gate for the PR template** (`.github/pull_request_template.md` if present, or `AGENTS.md`): "If your PR modifies `components/ui/popover.tsx`, you must paste a screenshot of manual DevTools verification at desktop and mobile widths." Lightweight process guard.
+
+(d) **Document the z-index scale** (already covered in Item 1(c); cross-reference from this Item).
+
+**Acceptance.**
+
+- `AGENTS.md` or pull request template contains the manual-verification requirement for `popover.tsx` changes.
+- `popover.test.tsx` includes a stacking-order smoke test.
+- v3 spec's Testing Plan includes WebKit/iOS Safari row.
+
+---
+
+## Implementation Order
+
+These items have dependencies; land in the following order:
+
+1. **Item 1** — Revert global `z-[70]`; introduce `positionerClassName`; use `z-[65]` in `LocateSongsetsPopover`. (Unblocks the rest.)
+2. **Item 3** — Add `positionerProps` escape hatch. (Pure additive; low-risk.)
+3. **Item 4** — Move prop-spy tests to `popover.test.tsx`; delete the spy from `AudioPlayerBar.test.tsx`.
+4. **Item 2** — Add `min-h-[240px]` floor + new short-viewport test cases.
+5. **Item 5** — Smoke test + runbook / process guards.
+
+Items 1–3 should land in a single follow-up PR ("address PR-138 review, items 1–3"). Items 4–5 can land in a second follow-up ("hardening"), or together.
+
+## Out of Scope
+
+- Re-implementing `flip` with a custom `fallbackPlacements` list that prefers `top` and never returns `right`. Worth revisiting only if Item 2's min-height floor turns out to be a worse UX than a constrained flip.
+- Modifying `AudioPlayerBar`'s `z-[60]` to use CSS `dvh` units for safer layer math.
+- Removing `--available-height` caching behavior in Base UI.
+
+## Open Questions for Reviewer
+
+- Is `z-[65]` an acceptable middle tier, or do we want to refactor to a Tailwind theme-driven z-scale (`z-popover-player`, `z-controller`, etc.)? Recommendation: keep `z-[65]` numeric for now, scale-refactor in a separate PR if a third overlay tier emerges.
+- Should `positionerProps` be typed as `Partial<Positioner.Props>` or as an explicit allowlist of safe keys (`collisionPadding`, `sticky`, `arrowPadding`)? Recommendation: `Partial<>` for forward-compat — Base UI's `Positioner.Props` is already the authoritative surface.
+
+## Validation Plan
+
+- All existing tests continue to pass: `cd delivery/webapp && pnpm test -- --run`.
+- New tests added in Items 1, 2, 4, 5 pass.
+- `pnpm lint && pnpm typecheck` clean.
+- Manual verification at:
+  - Desktop Chrome, 1280×776, 1 / 12 / 15 / 20 songsets.
+  - Desktop Chrome, lyrics panel expanded (`L` key).
+  - Mobile Safari iOS Simulator, 375×667.
+  - Landscape 667×375.
+- Browser DevTools "Layers" panel confirms popover layer paints above player bar (`z-[60]`) and below `ControllerPlayer` (`z-[70]`).


### PR DESCRIPTION
## Summary

Fixes persistent popover clipping in the Locate Songsets popover where items were hidden behind the audio player bar when a song appeared in 13+ songsets.

Spec: `specs/fix-webapp-player-locate-songsets-popover-clipping-v3.md`

## Root Cause

The v2 fix (commit c433baa4) correctly enabled viewport-aware max-height and single-surface scrolling, but clipping persisted for a different reason:

1. **z-index conflict:** The popover positioner had `z-50` while the audio player bar has `z-60`. When the popover overlapped the player bar, the player bar rendered on top, hiding ~80px (≈1.5 list items) of popover content.

2. **Automatic placement flip:** Base UI's `flip` middleware (enabled by default via `collisionAvoidance.side = 'flip'`) relocated the popup from `side="top"` to `side="right"` when content exceeded the top available height (~680px). With `side="right"`, the popup extended the full viewport height (721px), causing 80px of overlap with the player bar.

3. **`side` prop not forwarded:** `PopoverContent` accepted `side` in its TypeScript type signature but never destructured it — it fell into `...props` which was spread onto `PopoverPrimitive.Popup` (which ignores `side`), not `PopoverPrimitive.Positioner` (which uses it). Callers could not control placement direction.

## Changes

### `popover.tsx` — Fix prop forwarding and z-index
- Destructured `side` and `collisionAvoidance` from function params and pass them to `<PopoverPrimitive.Positioner>` (previously `side` was silently swallowed by `...props` spread onto `Popup`)
- Added `collisionAvoidance` to the `Pick` type from `Positioner.Props`
- Changed positioner className from `z-50` to `z-[70]` (above player bar's `z-[60]`)

### `LocateSongsetsPopover.tsx` — Force `side="top"` and disable flip
- Pass `side="top"` to `PopoverContent` — forces popup to always open above the trigger button (inside the bottom-fixed player bar)
- Pass `collisionAvoidance={{ side: 'none', fallbackAxisSide: 'none' }}` — disables the `flip` middleware so the popup never gets relocated to `side="right"` when content is large, and prevents perpendicular-axis fallback

With `side="top"` active, Base UI's `size` middleware sets `--available-height` to the distance from the top of the viewport to the trigger (~680px). The existing `max-h-(--available-height)` CSS class caps the popup at this value, and `overflow-y: auto` provides internal scrolling for overflow. The popup bottom anchors at `trigger.top - sideOffset` (~686px), well within the viewport and never extending into the player bar area.

### Tests
- **`AudioPlayerBar.test.tsx`:** Increased mock data from 6 to 15 items (the clipping scenario threshold). Added assertions verifying `side="top"` and `collisionAvoidance={{ side: 'none', fallbackAxisSide: 'none' }}` are passed to `PopoverContent`. Added a test asserting all 15 songset names render. Updated existing item count assertion from 6 to 15.
- **`popover.test.tsx` (new):** Asserts positioner className contains `z-[70]` (not `z-50`) and popup has `data-side="top"` when `side="top"` is passed.

## Why not just increase z-index?

Increasing z-index alone (without `side="top"`) would make the popup render on top of the player bar in the overlap zone (80px). The popup's bottom rows would visually cover the player bar controls — functional but ugly. Forcing `side="top"` visually separates the popup from the player bar. The z-index increase is kept as a safety measure for transition animations where the popup might be mid-flight.

## Blast Radius

`PopoverContent` has one consumer in the entire codebase: `LocateSongsetsPopover.tsx`. The `side` and `collisionAvoidance` props default to `undefined` when not passed, so existing callers see no behavior change. The `collisionAvoidance` override is set on `LocateSongsetsPopover` only, not on `popover.tsx` defaults.

## Test Plan

- [x] `pnpm test` — all 1936 tests pass
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [ ] Manual DevTools verification: 1/12/15/20 items, lyrics panel open, short viewport (per spec testing plan)