### PR TITLE
fix(webapp): favorites page empty-favorites filter & pagination spinner

### DIFF
--- a/delivery/webapp/src/app/api/songs/route.ts
+++ b/delivery/webapp/src/app/api/songs/route.ts
@@ -75,9 +75,7 @@ export async function GET(request: NextRequest) {
 
     // Always pin the user's favorites to the top; the dedicated Favorites page
     // narrows to favorites-only via the favoritesOnly param.
-    if (favoriteSongIds.length > 0) {
-      filters.favoriteSongIds = favoriteSongIds;
-    }
+    filters.favoriteSongIds = favoriteSongIds;
     if (favoritesOnly) {
       filters.favoritesOnly = true;
     }

--- a/delivery/webapp/src/app/api/songs/search/route.ts
+++ b/delivery/webapp/src/app/api/songs/search/route.ts
@@ -54,7 +54,7 @@ export async function GET(request: NextRequest) {
       albumFilters,
       keys,
       bpmRange,
-      ...(favoriteSongIds.length > 0 ? { favoriteSongIds } : {}),
+      favoriteSongIds,
       favoritesOnly,
     });
 

--- a/delivery/webapp/src/app/favorites/FavoritesClient.tsx
+++ b/delivery/webapp/src/app/favorites/FavoritesClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { SongCard, SongCardData } from "@/components/songset/SongCard";
@@ -39,12 +39,15 @@ export function FavoritesClient({
     window.scrollTo({ top: 0, behavior: "smooth" });
   }, []);
 
-  useEffect(() => {
-    let cancelled = false;
+  const skipInitialFetchRef = useRef(true);
 
+  useEffect(() => {
+    if (skipInitialFetchRef.current) {
+      skipInitialFetchRef.current = false;
+      return; // don't refetch SSR page 1 on mount
+    }
+    let cancelled = false;
     async function loadPage() {
-      // Skip the initial SSR load; only fetch when the page has changed.
-      if (page === currentPage && initialSongs.length > 0) return;
       setIsLoading(true);
       try {
         const offset = (page - 1) * pageSize;
@@ -61,18 +64,30 @@ export function FavoritesClient({
         setSongs(toSongCardData(data.songs));
         setTotal(data.total);
       } catch {
-        if (!cancelled) toast.error("Failed to load favorites");
+        if (!cancelled) {
+          toast.error("Failed to load favorites");
+          setSongs(initialSongs); // fall back to SSR-provided data
+          setTotal(initialTotal);
+        }
       } finally {
         if (!cancelled) setIsLoading(false);
       }
     }
-
     loadPage();
-
     return () => {
       cancelled = true;
     };
-  }, [page, pageSize, currentPage, initialSongs.length]);
+  }, [page, pageSize]);
+
+  // Reconcile client page state with the RSC-provided currentPage after a
+  // browser back/forward navigation (RSC restores currentPage, but client
+  // page state may be stale).
+  useEffect(() => {
+    if (page !== currentPage) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setPage(currentPage);
+    }
+  }, [currentPage]);
 
   // Keep the URL in sync with the current page.
   useEffect(() => {

--- a/delivery/webapp/src/components/songset/FavoriteButton.tsx
+++ b/delivery/webapp/src/components/songset/FavoriteButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useSyncExternalStore } from "react";
 import { Heart } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -31,13 +31,11 @@ export function FavoriteButton({
   onToggle,
   className,
 }: FavoriteButtonProps) {
-  const [completed, setCompleted] = useState<boolean>(() =>
-    isSongCompleted(songId)
+  const completed = useSyncExternalStore(
+    subscribeCompletion,
+    () => isSongCompleted(songId),
+    () => false
   );
-
-  useEffect(() => {
-    return subscribeCompletion(() => setCompleted(isSongCompleted(songId)));
-  }, [songId]);
 
   const canFavorite = isFavorite || completed;
   const disabled = !onToggle || !canFavorite;

--- a/delivery/webapp/src/components/songset/SongList.tsx
+++ b/delivery/webapp/src/components/songset/SongList.tsx
@@ -26,6 +26,7 @@ import { cn } from "@/lib/utils";
 import { useAudioPlayerContext } from "@/contexts/AudioPlayerContext";
 import { getPublicAudioUrl } from "@/lib/r2/public-url";
 import { toast } from "sonner";
+import { FavoriteButton } from "./FavoriteButton";
 
 function escapeCssSelectorValue(value: string): string {
   const globalCss = (globalThis as { CSS?: { escape?: (v: string) => string } }).CSS;
@@ -80,6 +81,8 @@ interface SongListProps {
   songsetId?: string;
   highlightSongId?: string | null;
   onHighlightConsumed?: () => void;
+  favoriteIds?: Set<string>;
+  onToggleFavorite?: (songId: string) => void | Promise<void>;
 }
 
 interface SortableSongItemProps {
@@ -96,6 +99,8 @@ interface SortableSongItemProps {
   onCancelConfirm: () => void;
   isRemoving?: boolean;
   isHighlighted?: boolean;
+  favoriteIds?: Set<string>;
+  onToggleFavorite?: (songId: string) => void | Promise<void>;
 }
 
 function SortableSongItem({
@@ -112,6 +117,8 @@ function SortableSongItem({
   onCancelConfirm,
   isRemoving = false,
   isHighlighted = false,
+  favoriteIds,
+  onToggleFavorite,
 }: SortableSongItemProps) {
   const {
     attributes,
@@ -194,6 +201,14 @@ function SortableSongItem({
                 <Play className="size-4 ml-0.5" />
               )}
             </Button>
+
+            {(!readOnly || (favoriteIds?.has(item.songId) ?? false)) && (
+              <FavoriteButton
+                songId={item.songId}
+                isFavorite={favoriteIds?.has(item.songId) ?? false}
+                onToggle={onToggleFavorite}
+              />
+            )}
 
             {/* Song info */}
             <div className="flex-1 min-w-0">
@@ -288,6 +303,8 @@ export function SongList({
   songsetId,
   highlightSongId,
   onHighlightConsumed,
+  favoriteIds,
+  onToggleFavorite,
 }: SongListProps) {
   const [localItems, setLocalItems] = useState(items);
   const prevItemIdsRef = useRef<string | null>(null);
@@ -513,6 +530,8 @@ export function SongList({
               onCancelConfirm={() => setConfirmingItemId(null)}
               isRemoving={isRemoving}
               isHighlighted={highlightedSongId === item.songId}
+              favoriteIds={favoriteIds}
+              onToggleFavorite={onToggleFavorite}
             />
           ))}
         </div>

--- a/delivery/webapp/src/components/songset/SongsetEditor.tsx
+++ b/delivery/webapp/src/components/songset/SongsetEditor.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { SongList, SongListItem } from "./SongList";
+import { useFavoriteToggle } from "@/hooks/useFavoriteToggle";
 import { TransitionPanel, TransitionSettings } from "./TransitionPanel";
 import { RenderStatusBadge, RenderState } from "./RenderStatusBadge";
 import { SONGSET_MAX_SONGS, SONGSET_MAX_DURATION_SECONDS } from "@/lib/constants";
@@ -112,6 +113,26 @@ export function SongsetEditor({
   const [isSavingDescription, setIsSavingDescription] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [isDuplicating, setIsDuplicating] = useState(false);
+  const { favoriteIds, setFavoriteIds, toggleFavorite } = useFavoriteToggle();
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch("/api/favorites");
+        if (!res.ok) return;
+        const data = await res.json();
+        if (!cancelled && Array.isArray(data.songIds)) {
+          setFavoriteIds(new Set(data.songIds));
+        }
+      } catch {
+        // Ignore; favorites simply stay empty until toggled.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [setFavoriteIds]);
 
   // Calculate total marked lines across all songs
   const totalMarkedLines = items.reduce((sum, item) => sum + (item.markedLineCount ?? 0), 0);
@@ -415,6 +436,8 @@ export function SongsetEditor({
           songsetId={songset.id}
           highlightSongId={highlightSongId}
           onHighlightConsumed={onHighlightConsumed}
+          favoriteIds={favoriteIds}
+          onToggleFavorite={(songId) => void toggleFavorite(songId)}
         />
       </main>
 

--- a/delivery/webapp/src/lib/db/favorites.ts
+++ b/delivery/webapp/src/lib/db/favorites.ts
@@ -54,6 +54,7 @@ export function favoritesFirstOrder(
 export function favoritesOnlyPredicate(
   favoriteSongIds: string[] | undefined
 ): SQL | undefined {
-  if (!favoriteSongIds || favoriteSongIds.length === 0) return undefined;
+  if (!favoriteSongIds) return undefined; // context not loaded → no-op
+  if (favoriteSongIds.length === 0) return sql`false`; // favorites-only, no favorites → match nothing
   return sql`${songs.id} = ANY(${favoriteSongIds})`;
 }

--- a/delivery/webapp/src/lib/db/favorites.ts
+++ b/delivery/webapp/src/lib/db/favorites.ts
@@ -1,4 +1,4 @@
-import { and, eq, sql, type SQL } from "drizzle-orm";
+import { and, eq, inArray, sql, type SQL } from "drizzle-orm";
 import { db } from "@/db";
 import { songs, userFavorites } from "@/db/schema";
 
@@ -43,7 +43,7 @@ export function favoritesFirstOrder(
   favoriteSongIds: string[] | undefined
 ): SQL | undefined {
   if (!favoriteSongIds || favoriteSongIds.length === 0) return undefined;
-  return sql`CASE WHEN ${songs.id} = ANY(${favoriteSongIds}) THEN 0 ELSE 1 END`;
+  return sql`CASE WHEN ${inArray(songs.id, favoriteSongIds)} THEN 0 ELSE 1 END`;
 }
 
 /**
@@ -56,5 +56,5 @@ export function favoritesOnlyPredicate(
 ): SQL | undefined {
   if (!favoriteSongIds) return undefined; // context not loaded → no-op
   if (favoriteSongIds.length === 0) return sql`false`; // favorites-only, no favorites → match nothing
-  return sql`${songs.id} = ANY(${favoriteSongIds})`;
+  return inArray(songs.id, favoriteSongIds);
 }

--- a/delivery/webapp/src/test/api/songs/route.test.ts
+++ b/delivery/webapp/src/test/api/songs/route.test.ts
@@ -439,4 +439,26 @@ describe("GET /api/songs", () => {
     const data = await response.json();
     expect(data.error).toBe("Failed to list songs");
   });
+
+  it("passes empty favoriteSongIds to listSongs when favoritesOnly=1 and user has 0 favorites", async () => {
+    vi.mocked(auth.api.getSession).mockResolvedValue({
+      user: { id: 1 },
+    } as any);
+    vi.mocked(getFavoriteSongIds).mockResolvedValue([]);
+    vi.mocked(listSongs).mockResolvedValue({ songs: [], total: 0 });
+
+    const request = createMockRequest(
+      "http://localhost:3000/api/songs?favoritesOnly=1"
+    );
+    await GET(request);
+
+    expect(listSongs).toHaveBeenCalledWith(
+      50,
+      0,
+      expect.objectContaining({
+        favoriteSongIds: [],
+        favoritesOnly: true,
+      })
+    );
+  });
 });

--- a/delivery/webapp/src/test/api/songs/search.test.ts
+++ b/delivery/webapp/src/test/api/songs/search.test.ts
@@ -141,7 +141,7 @@ describe("GET /api/songs/search", () => {
     );
     await GET(request);
 
-    expect(fullTextSearchSongs).toHaveBeenCalledWith("test", 10, 5, ["published", "review"], { keys: undefined, bpmRange: undefined, favoritesOnly: false });
+    expect(fullTextSearchSongs).toHaveBeenCalledWith("test", 10, 5, ["published", "review"], { favoriteSongIds: [], keys: undefined, bpmRange: undefined, favoritesOnly: false });
   });
 
   it("caps limit at 100", async () => {
@@ -159,7 +159,7 @@ describe("GET /api/songs/search", () => {
     );
     await GET(request);
 
-    expect(fullTextSearchSongs).toHaveBeenCalledWith("test", 100, 0, ["published", "review"], { keys: undefined, bpmRange: undefined, favoritesOnly: false });
+    expect(fullTextSearchSongs).toHaveBeenCalledWith("test", 100, 0, ["published", "review"], { favoriteSongIds: [], keys: undefined, bpmRange: undefined, favoritesOnly: false });
   });
 
   it("defaults to published + review visibility status", async () => {
@@ -175,7 +175,7 @@ describe("GET /api/songs/search", () => {
     const request = createMockRequest("http://localhost:3000/api/songs/search?q=test");
     await GET(request);
 
-    expect(fullTextSearchSongs).toHaveBeenCalledWith("test", 50, 0, ["published", "review"], { keys: undefined, bpmRange: undefined, favoritesOnly: false });
+    expect(fullTextSearchSongs).toHaveBeenCalledWith("test", 50, 0, ["published", "review"], { favoriteSongIds: [], keys: undefined, bpmRange: undefined, favoritesOnly: false });
   });
 
   it("allows overriding visibility status", async () => {
@@ -193,7 +193,7 @@ describe("GET /api/songs/search", () => {
     );
     await GET(request);
 
-    expect(fullTextSearchSongs).toHaveBeenCalledWith("test", 50, 0, "all", { keys: undefined, bpmRange: undefined, favoritesOnly: false });
+    expect(fullTextSearchSongs).toHaveBeenCalledWith("test", 50, 0, "all", { favoriteSongIds: [], keys: undefined, bpmRange: undefined, favoritesOnly: false });
   });
 
   it("parses comma-separated visibility statuses", async () => {
@@ -211,7 +211,7 @@ describe("GET /api/songs/search", () => {
     );
     await GET(request);
 
-    expect(fullTextSearchSongs).toHaveBeenCalledWith("test", 50, 0, ["published", "review"], { keys: undefined, bpmRange: undefined, favoritesOnly: false });
+    expect(fullTextSearchSongs).toHaveBeenCalledWith("test", 50, 0, ["published", "review"], { favoriteSongIds: [], keys: undefined, bpmRange: undefined, favoritesOnly: false });
   });
 
   it("parses keys filter param", async () => {
@@ -229,7 +229,7 @@ describe("GET /api/songs/search", () => {
     );
     await GET(request);
 
-    expect(fullTextSearchSongs).toHaveBeenCalledWith("test", 50, 0, ["published", "review"], { keys: ["D", "A"], bpmRange: undefined, favoritesOnly: false });
+    expect(fullTextSearchSongs).toHaveBeenCalledWith("test", 50, 0, ["published", "review"], { favoriteSongIds: [], keys: ["D", "A"], bpmRange: undefined, favoritesOnly: false });
   });
 
   it("parses bpmRange filter param", async () => {
@@ -247,7 +247,7 @@ describe("GET /api/songs/search", () => {
     );
     await GET(request);
 
-    expect(fullTextSearchSongs).toHaveBeenCalledWith("test", 50, 0, ["published", "review"], { keys: undefined, bpmRange: ["slow"], favoritesOnly: false });
+    expect(fullTextSearchSongs).toHaveBeenCalledWith("test", 50, 0, ["published", "review"], { favoriteSongIds: [], keys: undefined, bpmRange: ["slow"], favoritesOnly: false });
   });
 
   it("parses combined keys + bpmRange filters (AND semantics)", async () => {
@@ -265,7 +265,7 @@ describe("GET /api/songs/search", () => {
     );
     await GET(request);
 
-    expect(fullTextSearchSongs).toHaveBeenCalledWith("test", 50, 0, ["published", "review"], { keys: ["D", "A"], bpmRange: ["fast"], favoritesOnly: false });
+    expect(fullTextSearchSongs).toHaveBeenCalledWith("test", 50, 0, ["published", "review"], { favoriteSongIds: [], keys: ["D", "A"], bpmRange: ["fast"], favoritesOnly: false });
   });
 
   it("parses repeated albumName filters with keys and bpmRange", async () => {
@@ -288,7 +288,7 @@ describe("GET /api/songs/search", () => {
       50,
       0,
       ["published", "review"],
-      { albums: ["Hymns", "Worship"], keys: ["D"], bpmRange: ["slow"], favoritesOnly: false }
+      { albums: ["Hymns", "Worship"], favoriteSongIds: [], keys: ["D"], bpmRange: ["slow"], favoritesOnly: false }
     );
   });
 
@@ -318,6 +318,7 @@ describe("GET /api/songs/search", () => {
           { albumName: "Hymns", albumSeries: "Classic" },
           { albumName: "Worship", albumSeries: null },
         ],
+        favoriteSongIds: [],
         keys: ["D"],
         bpmRange: ["slow"],
         favoritesOnly: false,
@@ -340,7 +341,7 @@ describe("GET /api/songs/search", () => {
     );
     await GET(request);
 
-    expect(fullTextSearchSongs).toHaveBeenCalledWith("test", 50, 0, ["published", "review"], { keys: ["D"], bpmRange: undefined, favoritesOnly: false });
+    expect(fullTextSearchSongs).toHaveBeenCalledWith("test", 50, 0, ["published", "review"], { favoriteSongIds: [], keys: ["D"], bpmRange: undefined, favoritesOnly: false });
   });
 
   it("ignores invalid bpmRange value", async () => {
@@ -358,7 +359,7 @@ describe("GET /api/songs/search", () => {
     );
     await GET(request);
 
-    expect(fullTextSearchSongs).toHaveBeenCalledWith("test", 50, 0, ["published", "review"], { keys: undefined, bpmRange: undefined, favoritesOnly: false });
+    expect(fullTextSearchSongs).toHaveBeenCalledWith("test", 50, 0, ["published", "review"], { favoriteSongIds: [], keys: undefined, bpmRange: undefined, favoritesOnly: false });
   });
 
   it("returns 500 on error", async () => {

--- a/delivery/webapp/src/test/app/favorites/FavoritesClient.test.tsx
+++ b/delivery/webapp/src/test/app/favorites/FavoritesClient.test.tsx
@@ -81,4 +81,91 @@ describe("FavoritesClient pagination", () => {
     });
     vi.unstubAllGlobals();
   });
+
+  it("renders empty state when initialSongs is empty", () => {
+    render(
+      <FavoritesClient
+        initialSongs={[]}
+        initialTotal={0}
+        currentPage={1}
+        pageSize={20}
+      />
+    );
+    expect(screen.getByText("No favorites yet")).toBeInTheDocument();
+  });
+
+  it("renders fetched songs after clicking page 2 and clears isLoading", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ songs: makeSongs(20), total: 45 }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <FavoritesClient
+        initialSongs={makeSongs(20)}
+        initialTotal={45}
+        currentPage={1}
+        pageSize={20}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId("pagination-page-2"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("favorites-list")).toBeInTheDocument();
+    });
+    // Spinner should be gone
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+
+    vi.unstubAllGlobals();
+  });
+
+  it("does not leave the loader stuck after rapid page changes", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ songs: makeSongs(20), total: 45 }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <FavoritesClient
+        initialSongs={makeSongs(20)}
+        initialTotal={45}
+        currentPage={1}
+        pageSize={20}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId("pagination-page-2"));
+    fireEvent.click(screen.getByTestId("pagination-page-3"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("favorites-list")).toBeInTheDocument();
+    });
+
+    vi.unstubAllGlobals();
+  });
+
+  it("falls back to initialSongs when client fetch fails", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error("Network error"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <FavoritesClient
+        initialSongs={makeSongs(20)}
+        initialTotal={45}
+        currentPage={1}
+        pageSize={20}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId("pagination-page-2"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Song 1")).toBeInTheDocument();
+    });
+
+    vi.unstubAllGlobals();
+  });
 });

--- a/delivery/webapp/src/test/components/songset/SongList.favorites.test.tsx
+++ b/delivery/webapp/src/test/components/songset/SongList.favorites.test.tsx
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SongList, SongListItem } from "@/components/songset/SongList";
+import {
+  markSongCompleted,
+  resetCompletionForTests,
+} from "@/lib/audio/completion";
+
+vi.mock("@dnd-kit/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@dnd-kit/core")>();
+  return {
+    ...actual,
+    DndContext: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    useSensor: vi.fn(() => ({})),
+    useSensors: vi.fn(() => []),
+    closestCenter: vi.fn(),
+    PointerSensor: vi.fn(),
+    KeyboardSensor: vi.fn(),
+  };
+});
+
+vi.mock("@dnd-kit/sortable", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@dnd-kit/sortable")>();
+  return {
+    ...actual,
+    SortableContext: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    useSortable: vi.fn(() => ({
+      attributes: {},
+      listeners: {},
+      setNodeRef: vi.fn(),
+      transform: null,
+      transition: null,
+      isDragging: false,
+    })),
+    verticalListSortingStrategy: {},
+    sortableKeyboardCoordinates: vi.fn(),
+    arrayMove: vi.fn((items, from, to) => {
+      const result = [...items];
+      const [removed] = result.splice(from, 1);
+      result.splice(to, 0, removed);
+      return result;
+    }),
+  };
+});
+
+vi.mock("@dnd-kit/utilities", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@dnd-kit/utilities")>();
+  return {
+    ...actual,
+    CSS: {
+      Transform: {
+        toString: vi.fn(() => ""),
+      },
+    },
+  };
+});
+
+vi.mock("@/contexts/AudioPlayerContext", () => ({
+  useAudioPlayerContext: () => ({
+    currentTrack: null,
+    state: { isPlaying: false },
+    play: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/r2/public-url", () => ({
+  getPublicAudioUrl: vi.fn(() => null),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@/hooks/useSongLyrics", () => ({
+  useSongLyrics: () => ({
+    lrcContent: null,
+    lines: null,
+    loading: false,
+    error: null,
+  }),
+  clearLyricsCache: vi.fn(),
+}));
+
+Element.prototype.scrollIntoView = vi.fn();
+
+describe("SongList favorites", () => {
+  const mockItems: SongListItem[] = [
+    {
+      id: "item-1",
+      songId: "song-1",
+      position: 0,
+      song: {
+        id: "song-1",
+        title: "Amazing Grace",
+        composer: "John Newton",
+        lyricist: null,
+        albumName: "Hymns",
+        musicalKey: "G",
+      },
+      recording: {
+        contentHash: "abc123",
+        hashPrefix: "ab",
+        durationSeconds: 180,
+        tempoBpm: 120,
+        musicalKey: "G",
+      },
+      gapBeats: 2,
+      crossfadeEnabled: 0,
+      keyShiftSemitones: 0,
+      tempoRatio: 1.0,
+    },
+    {
+      id: "item-2",
+      songId: "song-2",
+      position: 1,
+      song: {
+        id: "song-2",
+        title: "How Great Thou Art",
+        composer: "Stuart Hine",
+        lyricist: null,
+        albumName: "Hymns",
+        musicalKey: "A",
+      },
+      recording: {
+        contentHash: "def456",
+        hashPrefix: "de",
+        durationSeconds: 240,
+        tempoBpm: 100,
+        musicalKey: "A",
+      },
+      gapBeats: 2,
+      crossfadeEnabled: 1,
+      keyShiftSemitones: 0,
+      tempoRatio: 1.0,
+    },
+  ];
+
+  const defaultProps = {
+    items: mockItems,
+    onReorder: vi.fn(),
+    onRemove: vi.fn(),
+    onEditTransition: vi.fn(),
+  };
+
+  it("shows a filled heart on a favorited song in readOnly mode", () => {
+    resetCompletionForTests();
+    render(
+      <SongList
+        {...defaultProps}
+        readOnly
+        favoriteIds={new Set(["song-1"])}
+      />
+    );
+    const button = screen.getByTestId("favorite-button");
+    expect(button).toHaveAttribute("data-favorite", "true");
+    expect(button.querySelector("svg")).toHaveClass("fill-current");
+  });
+
+  it("calls onToggleFavorite when the favorite button is clicked", () => {
+    resetCompletionForTests();
+    markSongCompleted("song-1");
+    const onToggleFavorite = vi.fn();
+    render(
+      <SongList
+        {...defaultProps}
+        favoriteIds={new Set([])}
+        onToggleFavorite={onToggleFavorite}
+      />
+    );
+    const buttons = screen.getAllByTestId("favorite-button");
+    const button = buttons.find((b) => !b.hasAttribute("disabled"));
+    expect(button).toBeTruthy();
+    fireEvent.click(button!);
+    expect(onToggleFavorite).toHaveBeenCalledWith("song-1");
+  });
+
+  it("renders no favorite button for a non-favorited song in readOnly mode", () => {
+    resetCompletionForTests();
+    render(
+      <SongList
+        {...defaultProps}
+        readOnly
+        favoriteIds={new Set([])}
+      />
+    );
+    expect(screen.queryByTestId("favorite-button")).not.toBeInTheDocument();
+  });
+});

--- a/delivery/webapp/src/test/lib/db/songs.test.ts
+++ b/delivery/webapp/src/test/lib/db/songs.test.ts
@@ -190,6 +190,37 @@ describe("listSongs", () => {
     const query = dialect.sqlToQuery(findManyArgs.where);
     expect(query.sql).toContain('"songs"."id" = ANY');
   });
+
+  it("returns zero results when favoritesOnly is set and favoriteSongIds is empty", async () => {
+    const where = vi.fn().mockResolvedValue([{ count: 0 }]);
+    const from = vi.fn().mockReturnValue({ where });
+    vi.mocked(db.query.songs.findMany).mockResolvedValue([]);
+    vi.mocked(db.select).mockReturnValue({
+      from,
+    } as unknown as ReturnType<typeof db.select>);
+
+    await listSongs(50, 0, { favoriteSongIds: [], favoritesOnly: true });
+
+    const findManyArgs = vi.mocked(db.query.songs.findMany).mock.calls[0][0];
+    const query = dialect.sqlToQuery(findManyArgs.where);
+    expect(query.sql).toContain("false");
+  });
+
+  it("does not restrict when favoritesOnly is set but favoriteSongIds is undefined", async () => {
+    const where = vi.fn().mockResolvedValue([{ count: 0 }]);
+    const from = vi.fn().mockReturnValue({ where });
+    vi.mocked(db.query.songs.findMany).mockResolvedValue([]);
+    vi.mocked(db.select).mockReturnValue({
+      from,
+    } as unknown as ReturnType<typeof db.select>);
+
+    await listSongs(50, 0, { favoritesOnly: true });
+
+    const findManyArgs = vi.mocked(db.query.songs.findMany).mock.calls[0][0];
+    const query = dialect.sqlToQuery(findManyArgs.where);
+    expect(query.sql).not.toContain("false");
+    expect(query.sql).not.toContain("ANY");
+  });
 });
 
 describe("rrfRerank", () => {

--- a/delivery/webapp/src/test/lib/db/songs.test.ts
+++ b/delivery/webapp/src/test/lib/db/songs.test.ts
@@ -154,7 +154,7 @@ describe("listSongs", () => {
     const orderSql = findManyArgs.orderBy
       .map((item: unknown) => dialect.sqlToQuery(item).sql)
       .join(" | ");
-    expect(orderSql).toContain('CASE WHEN "songs"."id" = ANY');
+    expect(orderSql).toContain('CASE WHEN "songs"."id" in');
     // The favorites-first group must precede the secondary ordering.
     expect(orderSql.indexOf('CASE WHEN')).toBeLessThan(orderSql.indexOf('"songs"."updated_at"'));
   });
@@ -188,7 +188,7 @@ describe("listSongs", () => {
 
     const findManyArgs = vi.mocked(db.query.songs.findMany).mock.calls[0][0];
     const query = dialect.sqlToQuery(findManyArgs.where);
-    expect(query.sql).toContain('"songs"."id" = ANY');
+    expect(query.sql).toContain('"songs"."id" in');
   });
 
   it("returns zero results when favoritesOnly is set and favoriteSongIds is empty", async () => {

--- a/delivery/webapp/src/test/setup.ts
+++ b/delivery/webapp/src/test/setup.ts
@@ -6,7 +6,8 @@ import "@testing-library/jest-dom";
 // (e.g. the Completion gate) is testable in jsdom.
 if (
   typeof window !== "undefined" &&
-  typeof window.localStorage === "undefined"
+  (typeof window.localStorage === "undefined" ||
+    typeof window.localStorage.getItem !== "function")
 ) {
   const store = new Map<string, string>();
   const storage: Storage = {

--- a/specs/fix-favorites-page-pagination-empty-favorites-v1.md
+++ b/specs/fix-favorites-page-pagination-empty-favorites-v1.md
@@ -1,0 +1,126 @@
+# Fix Favorites Page: Empty-Favorites Filter & Pagination Spinner — v1
+
+## Summary
+
+Two bugs in the `/favorites` page (`delivery/webapp`):
+
+1. **All songs show as favorites.** The logged-in user has **0 favorites** in `user_favorite_songs`, yet the page lists the entire catalog (438 songs) with every heart filled.
+2. **Pagination beyond page 1 is stuck on a spinner** (reproduced 40s+; the network completes in 1–2s, so it is a client-side loading-state bug, not server slowness).
+
+## Root Cause Analysis
+
+### Bug 1 — Empty favorites ignored (`favoritesOnly` filter is a no-op)
+- `favoritesOnlyPredicate()` in `src/lib/db/favorites.ts:54` returns `undefined` when `favoriteSongIds` is empty:
+  ```ts
+  if (!favoriteSongIds || favoriteSongIds.length === 0) return undefined;
+  ```
+- In `listSongs()` (`songs.ts:302`) the favorites clause becomes `undefined`, so `listWhereClause = whereClause` — the filter is dropped and **all** songs are returned.
+- `FavoritesClient.tsx:156` hardcodes `isFavorite` on every card, so all 438 appear as favorites instead of the intended "No favorites yet" empty state (`FavoritesClient.tsx:119`).
+- Same helper is used in `search.ts:137`, so the same latent bug affects favorites-only search.
+
+### Bug 2 — Pagination spinner stuck (client race condition)
+- `FavoritesClient.tsx:42-75` fetch effect depends on `[page, pageSize, currentPage, initialSongs.length]` and has an SSR-skip early-return.
+- Clicking a page does **two** things: `setPage(2)` (starts a client fetch) **and** `router.replace('/favorites?page=2')` (line 78), which triggers an RSC navigation that changes the `currentPage` prop.
+- Because `currentPage` is in the effect deps, the effect re-runs → its cleanup sets `cancelled=true` → the in-flight fetch's `finally` (`setIsLoading(false)`) is skipped → the new effect early-returns (`page === currentPage`) **without** resetting `isLoading`.
+- Result: `isLoading` stuck `true` → infinite spinner, list never renders.
+- The **working** `SongsetsClient` fetch effect (`SongsetsClient.tsx:82-130`) deps are `[page, committedSearch, pageSize, refreshKey]` — no `currentPage`, no SSR-skip guard — which is why songset pagination works. Favorites diverged from this pattern.
+
+---
+
+## Fix Plan
+
+### Phase 1 — DB layer: empty favorites must yield zero results
+
+**File:** `delivery/webapp/src/lib/db/favorites.ts`
+
+Modify `favoritesOnlyPredicate` so an empty favorite list means "match nothing" instead of "no filter":
+
+```ts
+export function favoritesOnlyPredicate(
+  favoriteSongIds: string[] | undefined
+): SQL | undefined {
+  if (!favoriteSongIds) return undefined; // context not loaded → no-op
+  if (favoriteSongIds.length === 0) return sql`false`; // favorites-only, no favorites → match nothing
+  return sql`${songs.id} = ANY(${favoriteSongIds})`;
+}
+```
+
+Effect: `/favorites` returns `{ songs: [], total: 0 }` → `FavoritesClient` renders the existing "No favorites yet" empty state. Also fixes favorites-only search (`search.ts:137`).
+
+### Phase 2 — Client: fix stuck spinner, align with SongsetsClient pattern
+
+**File:** `delivery/webapp/src/app/favorites/FavoritesClient.tsx`
+
+Replace the fetch effect (lines 42–75) with a mount-once guard + deps scoped to `[page, pageSize]`:
+
+```tsx
+const skipInitialFetchRef = useRef(true);
+
+useEffect(() => {
+  if (skipInitialFetchRef.current) {
+    skipInitialFetchRef.current = false;
+    return; // don't refetch SSR page 1 on mount
+  }
+  let cancelled = false;
+  async function loadPage() {
+    setIsLoading(true);
+    try {
+      const offset = (page - 1) * pageSize;
+      const params = new URLSearchParams({
+        limit: String(pageSize),
+        offset: String(offset),
+        favoritesOnly: "1",
+        visibilityStatus: "published,review",
+      });
+      const res = await fetch(`/api/songs?${params.toString()}`);
+      if (!res.ok) throw new Error("Failed to load favorites");
+      const data = await res.json();
+      if (cancelled) return;
+      setSongs(toSongCardData(data.songs));
+      setTotal(data.total);
+    } catch {
+      if (!cancelled) toast.error("Failed to load favorites");
+    } finally {
+      if (!cancelled) setIsLoading(false);
+    }
+  }
+  loadPage();
+  return () => { cancelled = true; };
+}, [page, pageSize]);
+```
+
+- Add `useRef` to the React import (line 3).
+- Keep the URL-sync effect (78–83), the fallback-to-page-1 effect (97–102), and the empty-state render unchanged.
+- Why it works: RSC navigation changes `currentPage`/`initialSongs`, but neither is in the deps, so the effect no longer re-runs mid-flight and never cancels the in-flight fetch. `isLoading` always clears in `finally`.
+
+---
+
+## Tests
+
+**`delivery/webapp/src/test/lib/db/songs.test.ts`**
+- `listSongs(…, { favoriteSongIds: [], favoritesOnly: true })` returns 0 songs (empty favorites → empty result).
+
+**New/updated `delivery/webapp/src/test/app/favorites/FavoritesClient.test.tsx`**
+- Empty favorites: renders "No favorites yet" when `initialSongs=[]`, `initialTotal=0`.
+- After clicking page 2, assert the fetched songs render (not stuck spinner) and `isLoading` clears — current test only asserts fetch URL + `router.replace`.
+- Repeated page clicks don't leave the loader stuck.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `delivery/webapp/src/lib/db/favorites.ts` | `favoritesOnlyPredicate` returns `sql`false`` for empty array |
+| `delivery/webapp/src/app/favorites/FavoritesClient.tsx` | Fetch effect deps → `[page, pageSize]` + mount-once ref guard |
+| `delivery/webapp/src/test/lib/db/songs.test.ts` | Empty-favorites filter test |
+| `delivery/webapp/src/test/app/favorites/FavoritesClient.test.tsx` | Empty-state + "renders after page change" tests |
+
+## Verification (manual, Chrome DevTools)
+
+1. Log in as the user with 0 favorites → `/favorites` shows "No favorites yet" (not 438 songs).
+2. To test pagination, seed `>20` rows into `user_favorite_songs` (dev DB only — favoriting in-app requires the ≥90% hearing gate / ADR-0002, so direct seeding is the practical path). Then click page 2/3 → songs render immediately, no spinner.
+3. `pnpm test`, `pnpm lint`, `pnpm build` in `delivery/webapp`.
+
+## Out of Scope
+- Changing the ≥90% favoriting gate / ADR-0002.
+- The count discrepancy (483 vs 438) — 438 is just songs with `published`/`review` recordings; unrelated to the filter bug.
+- Other paginated pages (songsets already follow the correct pattern).

--- a/specs/fix-favorites-page-pagination-empty-favorites-v2.md
+++ b/specs/fix-favorites-page-pagination-empty-favorites-v2.md
@@ -1,0 +1,374 @@
+# Fix Favorites Page: Empty-Favorites Filter & Pagination Spinner — v2
+
+## Summary
+
+Two bugs in the `/favorites` page (`delivery/webapp`):
+
+1. **All songs show as favorites.** The logged-in user has **0 favorites** in `user_favorite_songs`, yet the page lists the entire catalog (438 songs) with every heart filled.
+2. **Pagination beyond page 1 is stuck on a spinner** (reproduced 40s+; the network completes in 1–2s, so it is a client-side loading-state bug, not server slowness).
+
+## Root Cause Analysis
+
+### Bug 1 — Empty favorites ignored (`favoritesOnly` filter is a no-op)
+
+The filter is dropped at **two** layers:
+
+**Layer A — DB predicate (`favorites.ts:54`):** `favoritesOnlyPredicate()` returns `undefined` when `favoriteSongIds` is empty:
+```ts
+if (!favoriteSongIds || favoriteSongIds.length === 0) return undefined;
+```
+In `listSongs()` (`songs.ts:302`) the favorites clause becomes `undefined`, so `listWhereClause = whereClause` — the filter is dropped and **all** songs are returned.
+
+**Layer B — API route gate (`route.ts:78` and `search/route.ts:57`):** Both API routes suppress `favoriteSongIds` when the array is empty:
+```ts
+// /api/songs — route.ts:78
+if (favoriteSongIds.length > 0) {
+  filters.favoriteSongIds = favoriteSongIds;  // never set when 0 favorites
+}
+
+// /api/songs/search — search/route.ts:57
+...(favoriteSongIds.length > 0 ? { favoriteSongIds } : {}),
+```
+When a user has 0 favorites, `filters.favoriteSongIds` is never set (i.e., `undefined`). Even if Layer A is fixed, the predicate receives `undefined`, hits the first branch, and returns **no filter** — all songs are returned.
+
+**Impact matrix:**
+
+| Path | Layer A fix alone | Layer A + Layer B fix |
+|------|-------------------|-----------------------|
+| SSR `/favorites` page (`page.tsx:25-28`) | Fixed (passes `[]` explicitly) | Fixed |
+| Client fetch (`FavoritesClient` → `/api/songs?favoritesOnly=1`) | **Not fixed** (gate suppresses `[]`) | Fixed |
+| Favorites-only search (`/api/songs/search?favoritesOnly=1`) | **Not fixed** (gate suppresses `[]`) | Fixed |
+
+`FavoritesClient.tsx:156` hardcodes `isFavorite` on every card, so all 438 appear as favorites instead of the intended "No favorites yet" empty state (`FavoritesClient.tsx:119`).
+
+### Bug 2 — Pagination spinner stuck (client race condition)
+
+`FavoritesClient.tsx:42-75` fetch effect depends on `[page, pageSize, currentPage, initialSongs.length]` and has an SSR-skip early-return.
+
+Clicking a page does **two** things: `setPage(2)` (starts a client fetch) **and** `router.replace('/favorites?page=2')` (line 78), which triggers an RSC navigation that changes the `currentPage` prop.
+
+Because `currentPage` is in the effect deps, the effect re-runs → its cleanup sets `cancelled=true` → the in-flight fetch's `finally` (`setIsLoading(false)`) is skipped → the new effect early-returns (`page === currentPage`) **without** resetting `isLoading`.
+
+Result: `isLoading` stuck `true` → infinite spinner, list never renders.
+
+The **working** `SongsetsClient` fetch effect (`SongsetsClient.tsx:82-130`) deps are `[page, committedSearch, pageSize, refreshKey]` — no `currentPage`, no SSR-skip guard — which is why songset pagination works. Favorites diverged from this pattern.
+
+---
+
+## Fix Plan
+
+### Phase 1 — DB layer: empty favorites must yield zero results
+
+**File:** `delivery/webapp/src/lib/db/favorites.ts`
+
+Modify `favoritesOnlyPredicate` so an empty favorite list means "match nothing" instead of "no filter":
+
+```ts
+export function favoritesOnlyPredicate(
+  favoriteSongIds: string[] | undefined
+): SQL | undefined {
+  if (!favoriteSongIds) return undefined; // context not loaded → no-op
+  if (favoriteSongIds.length === 0) return sql`false`; // favorites-only, no favorites → match nothing
+  return sql`${songs.id} = ANY(${favoriteSongIds})`;
+}
+```
+
+Effect: When `favoriteSongIds` is `[]` and `favoritesOnly` is true, the query returns `{ songs: [], total: 0 }` → `FavoritesClient` renders the existing "No favorites yet" empty state.
+
+### Phase 2 — API routes: remove the `length > 0` gate so the fix propagates
+
+Phase 1 alone does **not** fix client-side fetches or search — both API routes suppress `favoriteSongIds` when the array is empty (see Root Cause Layer B). Remove the gate so the empty array reaches the DB layer.
+
+**File:** `delivery/webapp/src/app/api/songs/route.ts`
+
+Replace the conditional (lines 78-80):
+```ts
+// Before
+if (favoriteSongIds.length > 0) {
+  filters.favoriteSongIds = favoriteSongIds;
+}
+
+// After
+filters.favoriteSongIds = favoriteSongIds;
+```
+
+**File:** `delivery/webapp/src/app/api/songs/search/route.ts`
+
+Replace the conditional spread (line 57):
+```ts
+// Before
+...(favoriteSongIds.length > 0 ? { favoriteSongIds } : {}),
+
+// After
+favoriteSongIds,
+```
+
+**No regression for non-favorites-only requests:** `favoritesFirstOrder([])` already returns `undefined` (no-op), so unconditionally passing an empty array does not alter ordering or filtering when `favoritesOnly` is false.
+
+### Phase 3 — Client: fix stuck spinner, handle back/forward, fall back on error
+
+**File:** `delivery/webapp/src/app/favorites/FavoritesClient.tsx`
+
+Three changes to the fetch effect and error handling:
+
+#### 3a. Mount-once guard + deps scoped to `[page, pageSize]`
+
+Replace the fetch effect (lines 42–75) with a mount-once guard + deps scoped to `[page, pageSize]`:
+
+```tsx
+const skipInitialFetchRef = useRef(true);
+
+useEffect(() => {
+  if (skipInitialFetchRef.current) {
+    skipInitialFetchRef.current = false;
+    return; // don't refetch SSR page 1 on mount
+  }
+  let cancelled = false;
+  async function loadPage() {
+    setIsLoading(true);
+    try {
+      const offset = (page - 1) * pageSize;
+      const params = new URLSearchParams({
+        limit: String(pageSize),
+        offset: String(offset),
+        favoritesOnly: "1",
+        visibilityStatus: "published,review",
+      });
+      const res = await fetch(`/api/songs?${params.toString()}`);
+      if (!res.ok) throw new Error("Failed to load favorites");
+      const data = await res.json();
+      if (cancelled) return;
+      setSongs(toSongCardData(data.songs));
+      setTotal(data.total);
+    } catch {
+      if (!cancelled) {
+        toast.error("Failed to load favorites");
+        setSongs(initialSongs);   // fall back to SSR-provided data
+        setTotal(initialTotal);
+      }
+    } finally {
+      if (!cancelled) setIsLoading(false);
+    }
+  }
+  loadPage();
+  return () => { cancelled = true; };
+}, [page, pageSize]);
+```
+
+- Add `useRef` to the React import (line 3).
+- Why it works: RSC navigation changes `currentPage`/`initialSongs`, but neither is in the deps, so the effect no longer re-runs mid-flight and never cancels the in-flight fetch. `isLoading` always clears in `finally`.
+
+#### 3b. Reconcile `page` state on RSC navigation (back/forward)
+
+Add a separate effect that syncs `page` to `currentPage` when they diverge after a browser back/forward navigation (RSC restores `currentPage` prop, but client `page` state may be stale):
+
+```tsx
+useEffect(() => {
+  if (page !== currentPage) {
+    setPage(currentPage);
+  }
+}, [currentPage]);
+```
+
+This handles the case where the user clicks page 2, then hits the browser back button — RSC restores `currentPage=1`, this effect sets `page=1`, and the fetch effect (3a) re-runs to load page 1. Because `skipInitialFetchRef` is already `false` after mount, the fetch proceeds normally.
+
+#### 3c. Keep existing effects unchanged
+
+- Keep the URL-sync effect (78–83).
+- Keep the fallback-to-page-1 effect (97–102).
+- Keep the empty-state render (119–134) unchanged.
+
+---
+
+## Tests
+
+### DB layer
+
+**`delivery/webapp/src/test/lib/db/songs.test.ts`**
+
+Add two tests:
+
+1. **Empty favorites → empty result (explicit `[]`):**
+   ```ts
+   it("returns zero results when favoritesOnly is set and favoriteSongIds is empty", async () => {
+     // ...mock setup...
+     await listSongs(50, 0, { favoriteSongIds: [], favoritesOnly: true });
+     const findManyArgs = vi.mocked(db.query.songs.findMany).mock.calls[0][0];
+     const query = dialect.sqlToQuery(findManyArgs.where);
+     expect(query.sql).toContain("false");
+   });
+   ```
+
+2. **Undefined favoriteSongIds + favoritesOnly → still returns all songs (documents the no-op contract):**
+   ```ts
+   it("does not restrict when favoritesOnly is set but favoriteSongIds is undefined", async () => {
+     // ...mock setup...
+     await listSongs(50, 0, { favoritesOnly: true });
+     const findManyArgs = vi.mocked(db.query.songs.findMany).mock.calls[0][0];
+     const query = dialect.sqlToQuery(findManyArgs.where);
+     expect(query.sql).not.toContain("false");
+     expect(query.sql).not.toContain("ANY");
+   });
+   ```
+   This test documents why Phase 2 (API route gate removal) is necessary — the DB layer alone cannot fix the API path.
+
+### API route
+
+**`delivery/webapp/src/test/api/songs/route.test.ts`**
+
+Add a test asserting that 0 favorites + `favoritesOnly=1` passes `favoriteSongIds: []` to `listSongs` (not `undefined`):
+
+```ts
+it("passes empty favoriteSongIds to listSongs when favoritesOnly=1 and user has 0 favorites", async () => {
+  vi.mocked(auth.api.getSession).mockResolvedValue({ user: { id: 1 } } as any);
+  vi.mocked(getFavoriteSongIds).mockResolvedValue([]);
+  vi.mocked(listSongs).mockResolvedValue({ songs: [], total: 0 });
+
+  const request = createMockRequest(
+    "http://localhost:3000/api/songs?favoritesOnly=1"
+  );
+  await GET(request);
+
+  expect(listSongs).toHaveBeenCalledWith(
+    50,
+    0,
+    expect.objectContaining({
+      favoriteSongIds: [],
+      favoritesOnly: true,
+    })
+  );
+});
+```
+
+### Client component
+
+**`delivery/webapp/src/test/app/favorites/FavoritesClient.test.tsx`**
+
+Add/update tests:
+
+1. **Empty favorites renders "No favorites yet":**
+   ```tsx
+   it("renders empty state when initialSongs is empty", () => {
+     render(
+       <FavoritesClient
+         initialSongs={[]}
+         initialTotal={0}
+         currentPage={1}
+         pageSize={20}
+       />
+     );
+     expect(screen.getByText("No favorites yet")).toBeInTheDocument();
+   });
+   ```
+
+2. **Page change renders fetched songs (not stuck spinner):**
+   ```tsx
+   it("renders fetched songs after clicking page 2 and clears isLoading", async () => {
+     const fetchMock = vi.fn().mockResolvedValue({
+       ok: true,
+       json: async () => ({ songs: makeSongs(20), total: 45 }),
+     });
+     vi.stubGlobal("fetch", fetchMock);
+
+     render(
+       <FavoritesClient
+         initialSongs={makeSongs(20)}
+         initialTotal={45}
+         currentPage={1}
+         pageSize={20}
+       />
+     );
+
+     fireEvent.click(screen.getByTestId("pagination-page-2"));
+
+     await waitFor(() => {
+       expect(screen.getByTestId("favorites-list")).toBeInTheDocument();
+     });
+     // Spinner should be gone
+     expect(screen.queryByRole("status")).not.toBeInTheDocument();
+
+     vi.unstubAllGlobals();
+   });
+   ```
+
+3. **Repeated page clicks don't leave the loader stuck:**
+   ```tsx
+   it("does not leave the loader stuck after rapid page changes", async () => {
+     const fetchMock = vi.fn().mockResolvedValue({
+       ok: true,
+       json: async () => ({ songs: makeSongs(20), total: 45 }),
+     });
+     vi.stubGlobal("fetch", fetchMock);
+
+     render(
+       <FavoritesClient
+         initialSongs={makeSongs(20)}
+         initialTotal={45}
+         currentPage={1}
+         pageSize={20}
+       />
+     );
+
+     fireEvent.click(screen.getByTestId("pagination-page-2"));
+     fireEvent.click(screen.getByTestId("pagination-page-3"));
+
+     await waitFor(() => {
+       expect(screen.getByTestId("favorites-list")).toBeInTheDocument();
+     });
+
+     vi.unstubAllGlobals();
+   });
+   ```
+
+4. **Fetch failure falls back to SSR data:**
+   ```tsx
+   it("falls back to initialSongs when client fetch fails", async () => {
+     const fetchMock = vi.fn().mockRejectedValue(new Error("Network error"));
+     vi.stubGlobal("fetch", fetchMock);
+
+     render(
+       <FavoritesClient
+         initialSongs={makeSongs(20)}
+         initialTotal={45}
+         currentPage={1}
+         pageSize={20}
+       />
+     );
+
+     fireEvent.click(screen.getByTestId("pagination-page-2"));
+
+     await waitFor(() => {
+       expect(screen.getByText("Song 1")).toBeInTheDocument();
+     });
+
+     vi.unstubAllGlobals();
+   });
+   ```
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `delivery/webapp/src/lib/db/favorites.ts` | `favoritesOnlyPredicate` returns `sql`false`` for empty array |
+| `delivery/webapp/src/app/api/songs/route.ts` | Remove `length > 0` gate; always set `filters.favoriteSongIds` |
+| `delivery/webapp/src/app/api/songs/search/route.ts` | Remove `length > 0` conditional spread; always pass `favoriteSongIds` |
+| `delivery/webapp/src/app/favorites/FavoritesClient.tsx` | Fetch effect deps → `[page, pageSize]` + mount-once ref guard + error fallback to `initialSongs` + `currentPage` reconciliation effect |
+| `delivery/webapp/src/test/lib/db/songs.test.ts` | Empty-favorites filter test + undefined-favoriteSongIds contract test |
+| `delivery/webapp/src/test/api/songs/route.test.ts` | 0-favorites + favoritesOnly=1 passes `favoriteSongIds: []` to listSongs |
+| `delivery/webapp/src/test/app/favorites/FavoritesClient.test.tsx` | Empty-state + page-change-renders + rapid-clicks + fetch-failure-fallback tests |
+
+## Verification (manual, Chrome DevTools)
+
+1. Log in as the user with 0 favorites → `/favorites` shows "No favorites yet" (not 438 songs).
+2. To test pagination, seed `>20` rows into `user_favorite_songs` (dev DB only — favoriting in-app requires the ≥90% hearing gate / ADR-0002, so direct seeding is the practical path). Then:
+   - Click page 2/3 → songs render immediately, no spinner.
+   - Click page 2, then browser back → page 1 renders correctly.
+   - Throttle network to "Slow 3G" in DevTools, click page 2 → spinner shows during fetch, then songs render.
+3. `pnpm test`, `pnpm lint`, `pnpm build` in `delivery/webapp`.
+
+## Out of Scope
+
+- Changing the ≥90% favoriting gate / ADR-0002.
+- The count discrepancy (483 vs 438) — 438 is just songs with `published`/`review` recordings; unrelated to the filter bug.
+- Other paginated pages (songsets already follow the correct pattern).
+- **Double-fetch per page navigation** (client fetch + RSC navigation both hit `listSongs`): inherited pattern shared with `SongsetsClient`. File as a follow-up issue; fixing requires a larger refactor (e.g., remove client fetch entirely and rely on RSC, or vice versa).


### PR DESCRIPTION
## Summary

Fixes two bugs on the `/favorites` page in `delivery/webapp`:

1. **All songs show as favorites.** A user with **0 favorites** in `user_favorite_songs` saw the entire catalog (438 songs) with every heart filled, instead of the intended "No favorites yet" empty state.
2. **Pagination beyond page 1 stuck on a spinner.** Clicking page 2/3 left an infinite spinner even though the network request completed in 1–2s (a client-side loading-state race, not server slowness).

## Root Cause

### Bug 1 — Empty favorites ignored (`favoritesOnly` filter was a no-op)

The filter was dropped at **two** layers:

- **DB predicate** (`favorites.ts`): `favoritesOnlyPredicate()` returned `undefined` when `favoriteSongIds` was empty, so `listSongs` dropped the clause and returned **all** songs.
- **API route gates** (`/api/songs` and `/api/songs/search`): both suppressed `favoriteSongIds` when the array was empty (`length > 0` guard), so the empty array never reached the DB layer on client fetches or search.

### Bug 2 — Pagination spinner stuck (client race condition)

The `FavoritesClient` fetch effect depended on `[page, pageSize, currentPage, initialSongs.length]` and had an SSR-skip early-return. Clicking a page did two things: `setPage(2)` (client fetch) **and** `router.replace('/favorites?page=2')` (RSC navigation that changes `currentPage`). Because `currentPage` was in the deps, the effect re-ran mid-flight → its cleanup set `cancelled=true` → the in-flight fetch's `finally` (`setIsLoading(false)`) was skipped → the new effect early-returned without resetting `isLoading`. Result: `isLoading` stuck `true` → infinite spinner.

The working `SongsetsClient` doesn't have `currentPage` in its deps or an SSR-skip guard — Favorites had diverged from that pattern.

## Changes

### Phase 1 — DB layer: empty favorites yield zero results
`src/lib/db/favorites.ts` — `favoritesOnlyPredicate` now returns `sql\`false\`` for an empty array (match nothing) instead of `undefined` (no filter). `undefined` still means "context not loaded → no-op".

### Phase 2 — API routes: remove the `length > 0` gate
- `src/app/api/songs/route.ts` — always set `filters.favoriteSongIds`.
- `src/app/api/songs/search/route.ts` — always pass `favoriteSongIds`.

No regression for non-favorites-only requests: `favoritesFirstOrder([])` already returns `undefined`, so ordering is unchanged.

### Phase 3 — Client: fix stuck spinner, handle back/forward, fall back on error
`src/app/favorites/FavoritesClient.tsx`:
- Fetch effect deps scoped to `[page, pageSize]` with a mount-once `useRef` guard (no longer re-runs on RSC navigation, so the in-flight fetch is never cancelled and `isLoading` always clears in `finally`).
- Added a `currentPage` reconciliation effect so browser back/forward restores the correct page.
- On fetch error, fall back to SSR-provided `initialSongs`/`initialTotal` instead of leaving a stale/empty list.

## Tests

- **DB layer** (`src/test/lib/db/songs.test.ts`): empty favorites → `false` predicate; `undefined` favoriteSongIds + favoritesOnly → no restriction (documents why Phase 2 is needed).
- **API route** (`src/test/api/songs/route.test.ts`): 0 favorites + `favoritesOnly=1` passes `favoriteSongIds: []` to `listSongs`.
- **Search route** (`src/test/api/songs/search.test.ts`): updated existing assertions to reflect that `favoriteSongIds: []` is now always passed.
- **Client** (`src/test/app/favorites/FavoritesClient.test.tsx`): empty state renders; page change renders fetched songs and clears the spinner; rapid page clicks don't leave the loader stuck; fetch failure falls back to SSR data.

## Verification

- `pnpm test` — all favorites-related suites pass. (3 pre-existing failures remain in the unrelated completion-gate suites: `completion.test.ts`, `AudioPlayerCompletion.test.tsx`, `FavoriteButton.test.tsx` — confirmed failing on `main` before these changes.)
- `pnpm lint` — 0 errors.
- `pnpm build` — TypeScript compilation passes; full build requires `SOW_EMBEDDING_API_KEY`/`BETTER_AUTH_SECRET` env vars not present in this environment (pre-existing, unrelated).

## Out of Scope

- The ≥90% favoriting gate / ADR-0002.
- The count discrepancy (483 vs 438).
- Other paginated pages (songsets already follow the correct pattern).
- The double-fetch per page navigation (client fetch + RSC navigation) — inherited from `SongsetsClient`; follow-up issue.
