### PR TITLE
fix(webapp): stop playbar audio on controller page entry

### DIFF
--- a/delivery/webapp/src/components/audio/GlobalAudioPlayer.tsx
+++ b/delivery/webapp/src/components/audio/GlobalAudioPlayer.tsx
@@ -1,11 +1,24 @@
 "use client";
 
+import { useEffect } from "react";
 import { usePathname } from "next/navigation";
-import { AudioPlayerProvider } from "@/contexts/AudioPlayerContext";
+import { AudioPlayerProvider, useAudioPlayerContext } from "@/contexts/AudioPlayerContext";
 import { AudioPlayerBar } from "./AudioPlayerBar";
 
 interface GlobalAudioPlayerProps {
   children: React.ReactNode;
+}
+
+function PlaybarRouteGuard({ isControllerPage }: { isControllerPage: boolean }) {
+  const { stop } = useAudioPlayerContext();
+
+  useEffect(() => {
+    if (isControllerPage) {
+      stop();
+    }
+  }, [isControllerPage, stop]);
+
+  return null;
 }
 
 export function GlobalAudioPlayer({ children }: GlobalAudioPlayerProps) {
@@ -14,6 +27,7 @@ export function GlobalAudioPlayer({ children }: GlobalAudioPlayerProps) {
 
   return (
     <AudioPlayerProvider>
+      <PlaybarRouteGuard isControllerPage={isControllerPage} />
       {children}
       {!isControllerPage && <AudioPlayerBar />}
     </AudioPlayerProvider>

--- a/delivery/webapp/src/lib/db/songsets.ts
+++ b/delivery/webapp/src/lib/db/songsets.ts
@@ -437,7 +437,25 @@ export async function listSongsetSummaries(
           eq(songsets.userId, userId),
           or(
             ilike(songsets.name, `%${trimmedSearch}%`),
-            ilike(songsets.description, `%${trimmedSearch}%`)
+            ilike(songsets.description, `%${trimmedSearch}%`),
+            // Fuzzy search across song metadata of any song in the songset:
+            // title, title_pinyin, composer, lyricist, album_name, album_series.
+            // Correlated EXISTS avoids row inflation so the groupBy/aggregates
+            // above are unaffected; the same condition feeds the count query.
+            sql<boolean>`exists (
+              select 1
+              from ${songsetItems}
+              join ${songs} on ${songs.id} = ${songsetItems.songId}
+              where ${songsetItems.songsetId} = ${songsets.id}
+                and (
+                  ${ilike(songs.title, `%${trimmedSearch}%`)}
+                  or ${ilike(songs.titlePinyin, `%${trimmedSearch}%`)}
+                  or ${ilike(songs.composer, `%${trimmedSearch}%`)}
+                  or ${ilike(songs.lyricist, `%${trimmedSearch}%`)}
+                  or ${ilike(songs.albumName, `%${trimmedSearch}%`)}
+                  or ${ilike(songs.albumSeries, `%${trimmedSearch}%`)}
+                )
+            )`
           )
         )
       : eq(songsets.userId, userId);

--- a/delivery/webapp/src/lib/i18n/messages/songsets.ts
+++ b/delivery/webapp/src/lib/i18n/messages/songsets.ts
@@ -85,7 +85,7 @@ export const songsetsBundle = bundle({
     "songsets.placeholder.name": "e.g., Sunday Worship",
     "songsets.placeholder.description": "e.g., Easter service songs",
     "songsets.placeholder.songsetName": "Songset name",
-    "songsets.searchPlaceholder": "Search songsets by name or description...",
+    "songsets.searchPlaceholder": "Search by songset name or song title, artist, album...",
 
     // Empty states
     "songsets.empty.noSongsets": "No songsets yet. Create one to get started.",
@@ -223,7 +223,7 @@ export const songsetsBundle = bundle({
     "songsets.placeholder.name": "例如：主日敬拜",
     "songsets.placeholder.description": "例如：復活節詩歌",
     "songsets.placeholder.songsetName": "詩歌集名稱",
-    "songsets.searchPlaceholder": "依名稱或描述搜尋詩歌集...",
+    "songsets.searchPlaceholder": "依詩歌集名稱或詩歌名稱、作者、專輯搜尋...",
 
     // Empty states
     "songsets.empty.noSongsets": "尚無詩歌集。建立一個以開始使用。",

--- a/delivery/webapp/src/test/components/audio/GlobalAudioPlayer.test.tsx
+++ b/delivery/webapp/src/test/components/audio/GlobalAudioPlayer.test.tsx
@@ -1,11 +1,19 @@
-import { describe, it, expect, vi } from "vitest";
-import { screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { GlobalAudioPlayer } from "@/components/audio/GlobalAudioPlayer";
 import { useAudioPlayer } from "@/hooks/useAudioPlayer";
+import {
+  AudioTrack,
+  useAudioPlayerContext,
+} from "@/contexts/AudioPlayerContext";
 import { renderWithLocale as render } from "@/test/render";
 
+const mockPathname = vi.hoisted(() => vi.fn(() => "/"));
+
 vi.mock("next/navigation", () => ({
-  usePathname: () => "/",
+  usePathname: mockPathname,
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
 }));
 
 // Test component that uses the audio player
@@ -24,6 +32,10 @@ function TestChildComponent() {
 }
 
 describe("GlobalAudioPlayer", () => {
+  beforeEach(() => {
+    mockPathname.mockReturnValue("/");
+  });
+
   it("renders children content", () => {
     render(
       <GlobalAudioPlayer>
@@ -66,5 +78,61 @@ describe("GlobalAudioPlayer", () => {
 
     expect(screen.getByTestId("wrapped-content")).toBeInTheDocument();
     expect(container).toBeTruthy();
+  });
+
+  it("stops playbar audio when entering a controller page", async () => {
+    const user = userEvent.setup();
+    const testTrack: AudioTrack = {
+      id: "track-1",
+      title: "Test Song",
+      artist: "Test Artist",
+      src: "https://example.com/test.mp3",
+      type: "song",
+      duration: 180,
+    };
+
+    function StartPlaybackChild() {
+      const { play } = useAudioPlayerContext();
+      return (
+        <button data-testid="start-playback" onClick={() => play(testTrack)}>
+          Start Playback
+        </button>
+      );
+    }
+
+    function TrackStatusChild() {
+      const { currentTrack } = useAudioPlayerContext();
+      return (
+        <div data-testid="track-status">
+          {currentTrack ? currentTrack.title : "No track"}
+        </div>
+      );
+    }
+
+    const { rerender } = render(
+      <GlobalAudioPlayer>
+        <StartPlaybackChild />
+        <TrackStatusChild />
+      </GlobalAudioPlayer>
+    );
+
+    await user.click(screen.getByTestId("start-playback"));
+    await waitFor(() => {
+      expect(screen.getByTestId("track-status")).toHaveTextContent("Test Song");
+    });
+
+    // Navigate to a controller route; re-render so usePathname() re-evaluates.
+    // The playbar track must be stopped on route entry.
+    mockPathname.mockReturnValue("/songsets/test/play/controller");
+    rerender(
+      <GlobalAudioPlayer>
+        <StartPlaybackChild />
+        <TrackStatusChild />
+      </GlobalAudioPlayer>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("track-status")).toHaveTextContent("No track");
+    });
   });
 });


### PR DESCRIPTION
## Summary

When a user enters the worship controller page (`/play/controller`), the hidden playbar `<audio>` element keeps playing underneath the controller's `<video>` audio, producing doubled/conflicting audio. This PR stops playbar playback on controller page entry.

## Changes

- **`delivery/webapp/src/components/audio/GlobalAudioPlayer.tsx`**: Adds `PlaybarRouteGuard` inside `AudioPlayerProvider` that calls `stop()` via `useAudioPlayerContext()` whenever the current pathname contains `/play/controller`. The player bar itself is already hidden on controller routes; this now also halts audio.
- **`delivery/webapp/src/test/components/audio/GlobalAudioPlayer.test.tsx`**: Adds a test that starts playback, re-renders on a controller route, and asserts the track is stopped.

## Behavior notes

- Playback does **not** resume when leaving the controller page (stop is destructive, matching `stop()` semantics).

## Testing

- New Vitest case: `stops playbar audio when entering a controller page` — run with `pnpm --filter sow-webapp test`.

---

## feat(webapp): fuzzy-search songsets by song metadata

Extends `listSongsetSummaries` search so a single query term ORs across the songset name/description **and** the metadata of any song in the songset (title, title_pinyin, composer, lyricist, album_name, album_series), via a correlated `EXISTS` subquery. Search placeholder copy updated in EN + ZH.

### Changes

- **`delivery/webapp/src/lib/db/songsets.ts`**: Adds a correlated `EXISTS` on `songset_items ⋈ songs` to the search condition. Because it's a boolean `EXISTS` (not a join), the existing `groupBy`/aggregates and the count query stay untouched — no row inflation.
- **`delivery/webapp/src/lib/i18n/messages/songsets.ts`**: Updated `songsets.searchPlaceholder` (EN: "Search by songset name or song title, artist, album..."; ZH: "依詩歌集名稱或詩歌名稱、作者、專輯搜尋...").

### Testing

- Search now matches songs by their song metadata (title, pinyin, composer, lyricist, album) in addition to songset name/description.