### PR TITLE
feat(webapp): show album name on songset detail song cards

### DIFF
--- a/delivery/webapp/src/components/songset/SongList.tsx
+++ b/delivery/webapp/src/components/songset/SongList.tsx
@@ -239,6 +239,11 @@ function SortableSongItem({
                 {item.recording?.tempoBpm && (
                   <span>• {Math.round(item.recording.tempoBpm)} {t("browse.bpm")}</span>
                 )}
+                {item.song?.albumName && (
+                  <span className="truncate hidden sm:inline" data-testid="song-album">
+                    • {item.song?.albumName}
+                  </span>
+                )}
               </div>
             </div>
 

--- a/delivery/webapp/src/test/components/songset/SongList.test.tsx
+++ b/delivery/webapp/src/test/components/songset/SongList.test.tsx
@@ -176,6 +176,12 @@ describe("SongList", () => {
       expect(screen.getAllByText(/G/).length).toBeGreaterThan(0);
     });
 
+    it("renders album name", () => {
+      renderList();
+      expect(screen.getAllByTestId("song-album").length).toBe(2);
+      expect(screen.getAllByTestId("song-album")[0]).toHaveTextContent("Hymns");
+    });
+
     it("renders marked lines badge when songs have marked lines", () => {
       renderList();
       expect(screen.getByText(/3 marked/)).toBeInTheDocument();


### PR DESCRIPTION
## Summary

The Songset Detail view (`SongList`) rendered song cards with only 4 metadata fields — artist, duration, key, tempo — while the Favorites and Browse Songs views (`SongCard`) render 5, including album name. The `albumName` field was already populated by the API and test mocks but never rendered. This change displays album name in the Songset Detail song cards so all views show the same metadata fields.

## Changes

- **`delivery/webapp/src/components/songset/SongList.tsx`**
  - Appended a conditional album name span after the tempo span in `SortableSongItem`'s metadata row.
  - Pattern matches `SongCard.tsx` exactly (`truncate hidden sm:inline`, `data-testid="song-album"`, `• ` separator) for visual and test consistency.
  - No new imports; album name renders as a raw DB string with no icon, matching SongCard.

- **`delivery/webapp/src/test/components/songset/SongList.test.tsx`**
  - Added a `renders album name` test asserting two `song-album` elements render with "Hymns" (mock data already set `albumName`).

## Why this approach

- **Consistency**: All three views now render the same 5 metadata fields, reusing SongCard's exact rendering pattern.
- **Responsive behavior**: Album name uses the same `hidden sm:inline` hiding as SongCard — hidden on mobile, visible on sm+ screens.
- **Minimal footprint**: No type, API, i18n, or mock changes required — `albumName` was already wired through end to end; only the render was missing.

## Verification

- Webapp test suite: **2101 passed** (5 skipped, 10 todo), including the new album test and SongCard regression.
- `npx tsc --noEmit`: clean.
- `pnpm lint`: 0 errors (1 pre-existing warning in `FavoritesClient.tsx`, unrelated).
- `git push`: success, branch up to date with origin.