### PR TITLE
feat(webapp): support Tailscale access via TRUSTED_ORIGINS and configurable env file

### DIFF
--- a/delivery/webapp/.env.example
+++ b/delivery/webapp/.env.example
@@ -16,6 +16,10 @@ NEXT_PUBLIC_R2_PUBLIC_DOMAIN=
 BETTER_AUTH_SECRET=replace-with-at-least-32-random-characters
 BETTER_AUTH_URL=http://localhost:8080
 
+# Comma-separated additional origins to trust for Better Auth (e.g. Tailscale hostname).
+# Example: https://unoccluded.tailscale:8080,http://192.168.1.100:8080
+TRUSTED_ORIGINS=
+
 NEXT_PUBLIC_BASE_URL=http://localhost:8080
 NEXT_PUBLIC_CAST_RECEIVER_APP_ID=
 

--- a/delivery/webapp/.env.production.example
+++ b/delivery/webapp/.env.production.example
@@ -40,6 +40,11 @@ BETTER_AUTH_SECRET=replace-with-at-least-32-random-characters
 # Base URL of the deployed app (no trailing slash).
 BETTER_AUTH_URL=https://your-app.vercel.app
 
+# Comma-separated additional origins to trust for Better Auth (e.g. Tailscale hostname).
+# Leave unset if the app is only accessed via BETTER_AUTH_URL.
+# Example: https://unoccluded.tailscale:8080
+TRUSTED_ORIGINS=
+
 # -----------------------------------------------------------------------------
 # Google Cast SDK — Receiver App ID (Default Media Receiver is the v3 default)
 # -----------------------------------------------------------------------------

--- a/delivery/webapp/README.md
+++ b/delivery/webapp/README.md
@@ -4,16 +4,22 @@ Web application for rendering worship music transitions with synchronized lyrics
 
 ## Prerequisites
 
-- Node.js 18+
+- Node.js 20.9+ (Next.js 16.2.6 requires `>=20.9.0`)
 - pnpm
 - PostgreSQL database (Neon recommended)
 - PostgreSQL `pgvector` extension enabled
 - Cloudflare R2 account
-- Upstash Redis account (for client-error telemetry rate limiting; optional — `POST /api/log-client-error` degrades to allow-all when unset)
+- Upstash Redis account (for client-error telemetry rate limiting; optional — when unset, `POST /api/log-client-error` falls back to a per-instance in-memory token-bucket limiter, not distributed)
 
 ## Environment Setup
 
-Copy `.env.example` to `.env.local` and configure:
+`pnpm dev` loads environment variables from `/opt/sow/.env` via `env-cmd` (see the `dev` script in `package.json`). To use a different file on your host, set `SOW_WEBAPP_ENV_FILE` before starting:
+
+```bash
+SOW_WEBAPP_ENV_FILE=/path/to/your.env pnpm dev
+```
+
+The dev server binds `0.0.0.0` (all interfaces), so it is reachable via any host IP including Tailscale — no bind-IP override needed. Next.js additionally auto-loads `.env.local` / `.env.development` / `.env` from the project directory, but only for keys not already set by `env-cmd` — the `env-cmd` file takes precedence. Required variables:
 
 - `SOW_DATABASE_URL` — PostgreSQL connection string
 - `SOW_R2_ENDPOINT_URL`, `SOW_R2_ACCESS_KEY_ID`, `SOW_R2_SECRET_ACCESS_KEY`, `SOW_R2_BUCKET` — Cloudflare R2 credentials
@@ -123,7 +129,7 @@ npx drizzle-kit migrate    # Run pending migrations
 - `GET /api/share/[token]`
   Public. Validates a share token and returns signed playback URLs. The MP4 is minted with a 14400s (4-hour) expiry for Cast/share playback; revoked (`revokedAt` set → 410) and expired (`expiresAt < now` → 410) tokens are rejected before minting.
 - `POST /api/log-client-error`
-  Best-effort, anonymized client-side telemetry sink for the Cast/Presentation transport layer (`src/hooks/useCast.ts`). Optional Better Auth session accepted but not required. Zod body schema: `{ message, kind: cast_load|cast_transport|presentation|other, meta? }`. Rate-limited via Upstash Redis token bucket (20 req/min per hashed client IP, 429 when exceeded). PII redaction: no full signed URLs, no user IDs; the raw client IP is hashed with a daily-rotating salt. Returns 202 on success. When Upstash env vars are unset the limiter is null and the endpoint degrades to an allow-all fallback (no throttling — fine for dev/test).
+  Best-effort, anonymized client-side telemetry sink for the Cast/Presentation transport layer (`src/hooks/useCast.ts`). Optional Better Auth session accepted but not required. Zod body schema: `{ message, kind: cast_load|cast_transport|presentation|other, meta? }`. Rate-limited via Upstash Redis token bucket (20 req/min per hashed client IP, 429 when exceeded). PII redaction: no full signed URLs, no user IDs; the raw client IP is hashed with a daily-rotating salt. Returns 202 on success. When Upstash env vars are unset the limiter is null and the endpoint falls back to a per-instance in-memory token-bucket limiter (still throttles, but per warm instance rather than distributed).
 
 ## Architecture
 

--- a/delivery/webapp/next.config.ts
+++ b/delivery/webapp/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  allowedDevOrigins: ["192.168.8.102", "100.121.214.94", '192.168.8.139'],
+  allowedDevOrigins: ["192.168.8.102", "100.121.214.94", '192.168.8.139', 'unoccluded.tailscale'],
   serverExternalPackages: ["openai"],
 
   // Image optimization: enable modern formats for any future image usage

--- a/delivery/webapp/package.json
+++ b/delivery/webapp/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "packageManager": "pnpm@10.24.0",
   "scripts": {
-    "dev": "env-cmd -f /opt/sow/.env next dev -p 8080 -H 0.0.0.0",
-    "dev:https": "env-cmd -f /opt/sow/.env next dev -p 8080 -H 0.0.0.0 --experimental-https",
+    "dev": "env-cmd -f \"${SOW_WEBAPP_ENV_FILE:-/opt/sow/.env}\" next dev -p 8080 -H 0.0.0.0",
+    "dev:https": "env-cmd -f \"${SOW_WEBAPP_ENV_FILE:-/opt/sow/.env}\" next dev -p 8080 -H 0.0.0.0 --experimental-https",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",

--- a/delivery/webapp/src/lib/auth.ts
+++ b/delivery/webapp/src/lib/auth.ts
@@ -18,10 +18,15 @@ export const auth = betterAuth({
   trustedOrigins: (request) => {
     if (!request) return [];
     const origin = request.headers.get("origin");
-    if (
-      origin &&
-      /^http:\/\/(192\.168\.|10\.|172\.(1[6-9]|2\d|3[01])\.)/.test(origin)
-    ) {
+    if (!origin) return [];
+    // Allow private/LAN IPs (existing behavior)
+    if (/^http:\/\/(192\.168\.|10\.|172\.(1[6-9]|2\d|3[01])\.)/.test(origin)) {
+      return [origin];
+    }
+    // Allow configured origins (e.g. https://unoccluded.tailscale:8080)
+    const configured =
+      process.env.TRUSTED_ORIGINS?.split(",").map((s) => s.trim()).filter(Boolean) ?? [];
+    if (configured.includes(origin)) {
       return [origin];
     }
     return [];

--- a/delivery/webapp/src/test/deployment/deployment.test.ts
+++ b/delivery/webapp/src/test/deployment/deployment.test.ts
@@ -213,6 +213,11 @@ describe(".env.production.example", () => {
     expect(content).toContain("BETTER_AUTH_URL=");
   });
 
+  it("documents TRUSTED_ORIGINS", () => {
+    const content = readEnvExample();
+    expect(content).toContain("TRUSTED_ORIGINS=");
+  });
+
   it("documents NEXT_PUBLIC_CAST_RECEIVER_APP_ID", () => {
     const content = readEnvExample();
     expect(content).toContain("NEXT_PUBLIC_CAST_RECEIVER_APP_ID=");


### PR DESCRIPTION
## Summary

Makes the webapp usable when accessed over Tailscale (or other non-private-IP origins) and simplifies local startup.

**Motivation:** Next.js dev mode and Better Auth both validate the `Origin` header against an allowlist. The app runs on a LAN box accessed via `http://192.168.x.x` (allowed by the existing private-IP regex), but a Tailscale hostname like `https://unoccluded.tailscale:8080` was rejected, so auth cookies were refused.

## Changes by file

- **`delivery/webapp/src/lib/auth.ts`** — `trustedOrigins` now also returns the request origin when it's listed in the new `TRUSTED_ORIGINS` env var (comma-separated exact matches), on top of the existing private/LAN-IP allowlist.
- **`delivery/webapp/package.json`** — `dev`/`dev:https` scripts use `env-cmd -f "${SOW_WEBAPP_ENV_FILE:-/opt/sow/.env}"` so the env file path is parameterizable, defaulting to the existing `/opt/sow/.env`.
- **`delivery/webapp/next.config.ts`** — added `unoccluded.tailscale` to `allowedDevOrigins` for the dev server.
- **`delivery/webapp/.env.example` / `.env.production.example`** — document `TRUSTED_ORIGINS` with examples.
- **`delivery/webapp/README.md`** — correct Node version requirement (20.9+ for Next.js 16.2.6), document the env-file mechanism, and fix the Upstash Redis fallback description (per-instance in-memory limiter instead of allow-all).
- **`delivery/webapp/src/test/deployment/deployment.test.ts`** — test asserting `.env.production.example` documents `TRUSTED_ORIGINS`.

## Migration notes

None. `TRUSTED_ORIGINS` is optional; behavior is unchanged when unset.

## Testing notes

- `pnpm lint`, `pnpm build`, `pnpm test` (Vitest deployment tests) pass locally.