### PR TITLE
fix(webapp): make migration 0022 breakpoint-split and idempotent

### DIFF
--- a/delivery/webapp/drizzle/0022_add_recording_theme_posture.sql
+++ b/delivery/webapp/drizzle/0022_add_recording_theme_posture.sql
@@ -1,7 +1,22 @@
-ALTER TABLE "recordings" ADD COLUMN "theme" text;
-ALTER TABLE "recordings" ADD COLUMN "vocal_posture" text;
+DO $$ BEGIN
+    ALTER TABLE "recordings" ADD COLUMN IF NOT EXISTS "theme" text;
+    ALTER TABLE "recordings" ADD COLUMN IF NOT EXISTS "vocal_posture" text;
+END $$;
 --> statement-breakpoint
-ALTER TABLE "recordings" ADD CONSTRAINT "recordings_theme_check"
-    CHECK (theme IN ('讚美','感恩','敬拜','奉獻','認罪','差遣','信心','祈禱','復興','聖靈','十字架','跟隨') OR theme IS NULL);
-ALTER TABLE "recordings" ADD CONSTRAINT "recordings_vocal_posture_check"
-    CHECK (vocal_posture IN ('To God','About God','To Congregation') OR vocal_posture IS NULL);
+DO $$ BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'recordings_theme_check'
+    ) THEN
+        ALTER TABLE "recordings" ADD CONSTRAINT "recordings_theme_check"
+            CHECK (theme IN ('讚美','感恩','敬拜','奉獻','認罪','差遣','信心','祈禱','復興','聖靈','十字架','跟隨') OR theme IS NULL);
+    END IF;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'recordings_vocal_posture_check'
+    ) THEN
+        ALTER TABLE "recordings" ADD CONSTRAINT "recordings_vocal_posture_check"
+            CHECK (vocal_posture IN ('To God','About God','To Congregation') OR vocal_posture IS NULL);
+    END IF;
+END $$;


### PR DESCRIPTION
## Summary

Deploy #79 (run 32540803043) and #80 (run 32548006574) both fail at "Run DB Migrations" with:

```
NeonDbError: cannot insert multiple commands into a prepared statement
Failed query: ALTER TABLE "recordings" ADD COLUMN "theme" text;
ALTER TABLE "recordings" ADD COLUMN "vocal_posture" text;
```

The `neon-http` migrator sends each `--> statement-breakpoint`-delimited block as a single Postgres prepared statement; Postgres rejects prepared statements with multiple commands. Migration 0022 had two such multi-statement blocks. Same bug class as 0018 (commit 2748511a).

## Changes

`delivery/webapp/drizzle/0022_add_recording_theme_posture.sql` only:

- Each statement is now its own block (`--> statement-breakpoint` between all three).
- Made **idempotent**: the prod DB already has `theme`/`vocal_posture` columns and both check constraints (added via manual `drizzle-kit push`), so plain `ADD COLUMN` / `ADD CONSTRAINT` would fail with `duplicate_column` / `duplicate_object`. Now:
  - `ADD COLUMN IF NOT EXISTS` inside a `DO` block
  - constraints guarded by `pg_constraint` existence checks inside `DO` blocks

## Verification

- 3 blocks / 2 breakpoint markers; each block is a single statement (verified against `drizzle-orm/migrator.js` split logic).
- Scratch Postgres 16: chunk-per-statement application passes for **both** scenarios:
  - prod-like pre-existing columns + constraints (idempotent no-op, NOTICE "already exists, skipping")
  - pristine schema (columns + constraints created)
- Constraint enforcement intact: invalid `theme`/`vocal_posture` inserts rejected; valid inserts pass.

## Testing

- Local scratch-Postgres application (psql per-chunk, simulating the neon-http migrator split): PASS
- CI "Run DB Migrations" step will be confirmed green after merge.