### PR TITLE
feat(admin-cli): --theme filter for audio list, Theme/Posture in audio show

### DIFF
--- a/ops/admin-cli/src/stream_of_worship/admin/commands/audio.py
+++ b/ops/admin-cli/src/stream_of_worship/admin/commands/audio.py
@@ -33,7 +33,11 @@ from stream_of_worship.admin.commands.catalog import _extract_series_sort_key, g
 from stream_of_worship.admin.config import AdminConfig, get_cache_dir
 from stream_of_worship.admin.db.client import DatabaseClient
 from stream_of_worship.admin.db.models import Recording, Song, SongComponent
-from stream_of_worship.admin.db.schema import RECORDING_COLUMNS_FOR_JOIN, RECORDING_COLUMNS_SELECT
+from stream_of_worship.admin.db.schema import (
+    RECORDING_COLUMNS_FOR_JOIN,
+    RECORDING_COLUMNS_SELECT,
+    SONG_COMPONENT_THEMES,
+)
 from stream_of_worship.db.connection import ConnectionProvider
 from stream_of_worship.admin.services.analysis import (
     AnalysisClient,
@@ -1887,6 +1891,12 @@ def list_recordings(
         "-a",
         help="Filter by album name (substring, case-insensitive; matches album_name or album_series)",
     ),
+    theme: Optional[str] = typer.Option(
+        None,
+        "--theme",
+        "-t",
+        help="Filter by recording-level theme (讚美|感恩|敬拜|奉獻|認罪|差遣|信心|祈禱|復興|聖靈|十字架|跟隨|none where none = no theme set)",
+    ),
     lrc: Optional[str] = typer.Option(
         None,
         "--lrc",
@@ -1933,6 +1943,15 @@ def list_recordings(
             )
             raise typer.Exit(1)
 
+    # Validate theme filter
+    if theme:
+        valid_themes = set(SONG_COMPONENT_THEMES) | {"none"}
+        if theme not in valid_themes:
+            console.print(
+                f"[red]Invalid theme: {theme}. Must be one of: {', '.join(sorted(valid_themes))}[/red]"
+            )
+            raise typer.Exit(1)
+
     # Validate sort option
     valid_sorts = {"album", "series", "title", "imported", "updated"}
     if sort not in valid_sorts:
@@ -1949,6 +1968,7 @@ def list_recordings(
         visibility=visibility,
         lrc_status=lrc,
         album=album,
+        theme=theme,
         sort_by=sort,
         limit=limit,
     )
@@ -1983,6 +2003,8 @@ def list_recordings(
             filter_parts.append(f"album={album}")
         if lrc:
             filter_parts.append(f"lrc={lrc}")
+        if theme:
+            filter_parts.append(f"theme={theme}")
         filter_str = f" ({', '.join(filter_parts)})" if filter_parts else ""
         # Caps keep the flexible text columns from collapsing: Rich gives
         # no_wrap columns their max content width first, starving Album/Title.
@@ -2136,6 +2158,8 @@ def show_recording(
     info_lines.append(
         f"[cyan]Visibility:[/cyan] {_colorize_visibility(recording.visibility_status)}"
     )
+    info_lines.append(f"[cyan]Theme:[/cyan] {recording.theme or '- none -'}")
+    info_lines.append(f"[cyan]Posture:[/cyan] {recording.vocal_posture or '- none -'}")
 
     # Analysis results (only shown when analysis is complete)
     if recording.has_analysis:

--- a/ops/admin-cli/src/stream_of_worship/admin/db/client.py
+++ b/ops/admin-cli/src/stream_of_worship/admin/db/client.py
@@ -812,6 +812,7 @@ class DatabaseClient:
         visibility: Optional[str] = None,
         lrc_status: Optional[str] = None,
         album: Optional[str] = None,
+        theme: Optional[str] = None,
         sort_by: str = "imported",
         limit: Optional[int] = None,
         include_deleted: bool = False,
@@ -825,6 +826,7 @@ class DatabaseClient:
             visibility: Filter by visibility status. Pass "none" to match recordings with NULL visibility_status.
             lrc_status: Filter by LRC status.
             album: Filter by album name (case-insensitive substring).
+            theme: Filter by recording-level theme. Pass "none" to match recordings with NULL theme.
             sort_by: Sort order (``album``, ``series``, ``title``, ``imported``).
             limit: Maximum number of results.
             include_deleted: Whether to include soft-deleted recordings.
@@ -873,6 +875,12 @@ class DatabaseClient:
         if album:
             query += " AND (s.album_name ILIKE %s OR s.album_series ILIKE %s)"
             params.extend([f"%{album}%", f"%{album}%"])
+        if theme:
+            if theme == "none":
+                query += " AND r.theme IS NULL"
+            else:
+                query += " AND r.theme = %s"
+                params.append(theme)
 
         order_map = {
             "album": "s.album_name ASC NULLS LAST, s.title ASC NULLS LAST",

--- a/ops/admin-cli/tests/admin/test_audio_commands.py
+++ b/ops/admin-cli/tests/admin/test_audio_commands.py
@@ -375,6 +375,48 @@ class TestAudioListCommand:
         # Validation passed; failure (if any) is from DB, not from visibility filter.
         assert "Invalid visibility" not in result.output
 
+    def test_list_rejects_invalid_theme(self, tmp_path, monkeypatch):
+        """Invalid theme value is rejected before DB access."""
+        monkeypatch.delenv("SOW_DATABASE_URL", raising=False)
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("[database]\n")
+
+        result = runner.invoke(
+            app,
+            ["audio", "list", "--config", str(config_path), "--theme", "bogus"],
+        )
+
+        assert result.exit_code == 1
+        assert "Invalid theme" in result.output
+
+    def test_list_accepts_theme_none(self, tmp_path, monkeypatch):
+        """`--theme none` passes validation (fails later at DB access, not validation)."""
+        monkeypatch.delenv("SOW_DATABASE_URL", raising=False)
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("[database]\n")
+
+        result = runner.invoke(
+            app,
+            ["audio", "list", "--config", str(config_path), "--theme", "none"],
+        )
+
+        # Validation passed; failure (if any) is from DB, not from theme filter.
+        assert "Invalid theme" not in result.output
+
+    def test_list_accepts_valid_theme_enum(self, tmp_path, monkeypatch):
+        """A canonical SONG_COMPONENT_THEMES value passes validation."""
+        monkeypatch.delenv("SOW_DATABASE_URL", raising=False)
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("[database]\n")
+
+        result = runner.invoke(
+            app,
+            ["audio", "list", "--config", str(config_path), "--theme", "敬拜"],
+        )
+
+        # Validation passed; failure (if any) is from DB, not from theme filter.
+        assert "Invalid theme" not in result.output
+
     @pytest.mark.integration
     def test_list_empty_database(self, make_test_provider, postgres_url, tmp_path):
         """Shows a message when no recordings exist."""


### PR DESCRIPTION
## Summary

Adds recording-level theme filtering to `sow-admin audio list` and theme/posture display to `audio show`, closing the metadata-visibility gap found when auditing published recordings: 34 of 41 published recordings have `theme IS NULL AND vocal_posture IS NULL` at the recording level, with no CLI way to select or even see that state.

## Changes by file/module

**`ops/admin-cli/src/stream_of_worship/admin/db/client.py`** — `DatabaseClient.list_recordings_with_songs`
- New `theme: Optional[str] = None` parameter (after `album`, before `sort_by`).
- `--theme none` → `AND r.theme IS NULL`; any other value → parameterized `AND r.theme = %s`.
- No SELECT change needed: `RECORDING_COLUMNS_FOR_JOIN` already includes `r.theme` and `r.vocal_posture`.

**`ops/admin-cli/src/stream_of_worship/admin/commands/audio.py`**
- `audio list`: new `--theme` / `-t` option; validated against `SONG_COMPONENT_THEMES | {"none"}` (canonical 12-theme enum from `admin/db/schema.py`) before any DB access, mirroring the `--visibility` validation pattern; selected theme appears in the table caption (`theme=...`).
- `audio show`: `Theme:` and `Posture:` lines appended after `Visibility:` in the info panel; `- none -` placeholder when NULL (consistent with the existing YouTube URL line).

**`ops/admin-cli/tests/admin/test_audio_commands.py`** — 3 new non-integration tests in `TestAudioListCommand`:
- `test_list_rejects_invalid_theme`: `--theme bogus` → exit 1, `Invalid theme` in output.
- `test_list_accepts_theme_none`: `--theme none` passes validation (fails later at DB, not validation).
- `test_list_accepts_valid_theme_enum`: `--theme 敬拜` passes validation.

## Migration notes

None. Additive CLI/DB-layer change; all existing callers pass keyword args, no positional-argument breakage. `theme` is an opt-in filter (default `None` = unfiltered).

## Testing notes

- Full admin-cli unit suite: 1165 passed, 175 deselected (integration tests excluded by default).
- Live DB verification (production data):
  - `sow_admin audio list --visibility published --theme none --format ids` → exactly the 34 published recordings with NULL recording-level theme (matches the audit answer 34/41).
  - `sow_admin audio list --visibility published --theme 敬拜 --format ids` → the classified subset (2 recordings).
  - `sow_admin audio list --theme bogus` → exit 1, `Invalid theme: bogus. Must be one of: ...`.
  - `sow_admin audio show <song_id>` → info panel shows `Theme:` / `Posture:` lines.
- Regression: `--album` filter still works after the signature change (verified live against 讚美之泉).